### PR TITLE
More flexible tree API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             PYTHONPATH=python nosetests -v --with-coverage --cover-package tskit \
               --cover-branches --cover-erase --cover-xml \
               --cover-inclusive python/tests
-            python3 -m codecov -F python-tests
+            python3 -m codecov -F python_tests
 
       - run:
           name: Build Python package
@@ -97,7 +97,7 @@ jobs:
             gcov -pb tskit@sta/tskit_convert.c.gcno ../c/tskit/convert.c
             gcov -pb tskit@sta/tskit_stats.c.gcno ../c/tskit/stats.c
             cd ..
-            codecov -X gcov -F c-tests
+            codecov -X gcov -F c_tests
 
       - run:
           name: Valgrind for C tests.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             PYTHONPATH=python nosetests -v --with-coverage --cover-package tskit \
               --cover-branches --cover-erase --cover-xml \
               --cover-inclusive python/tests
-            python3 -m codecov -F python_tests
+            python3 -m codecov -F python_tests -X gcov
 
       - run:
           name: Build Python package

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       python-tests:
         target: 95%
-        flags: python-tests
+        flags: python_tests
       c-tests:
         target: 85%
-        flags: c-tests
+        flags: c_tests

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -192,13 +192,6 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
     for (ret = tsk_tree_last(&t); ret == 1; ret = tsk_tree_prev(&t)) {
         CU_ASSERT_EQUAL_FATAL(j - 1, t.index);
         ret = tsk_tree_equal(&t, &trees[t.index]);
-        if (ret != 0) {
-            printf("trees differ\n");
-            printf("REVERSE tree::\n");
-            tsk_tree_print_state(&t, stdout);
-            printf("FORWARD tree::\n");
-            tsk_tree_print_state(&trees[t.index], stdout);
-        }
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         j--;
     }
@@ -282,6 +275,37 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
         ret = tsk_tree_equal(&t, &trees[t.index]);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
     }
+
+    ret = tsk_tree_free(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_init(&t, ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    /* Calling next() on an uninitialised tree should be the same as first() */
+    j = 0;
+    while ((ret = tsk_tree_next(&t)) == 1) {
+        CU_ASSERT_EQUAL_FATAL(j, t.index);
+        ret = tsk_tree_equal(&t, &trees[t.index]);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        j++;
+    }
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(j, num_trees);
+
+    ret = tsk_tree_free(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_init(&t, ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    /* Calling prev() on an uninitialised tree should be the same as last() */
+
+    j = num_trees;
+    while ((ret = tsk_tree_prev(&t)) == 1) {
+        CU_ASSERT_EQUAL_FATAL(j - 1, t.index);
+        ret = tsk_tree_equal(&t, &trees[t.index]);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        j--;
+    }
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(j, 0);
 
     /* Free the trees. */
     ret = tsk_tree_free(&t);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -283,11 +283,9 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
         CU_ASSERT_EQUAL_FATAL(ret, 1);
     }
 
-    ret = tsk_tree_free(&t);
+    ret = tsk_tree_clear(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_tree_init(&t, ts, 0);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    /* Calling next() on an uninitialised tree should be the same as first() */
+    /* Calling next() on a cleared tree should be the same as first() */
     j = 0;
     while ((ret = tsk_tree_next(&t)) == 1) {
         CU_ASSERT_EQUAL_FATAL(j, t.index);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -98,6 +98,7 @@ verify_trees(tsk_treeseq_t *ts, uint32_t num_trees, tsk_id_t* parents)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(ts), num_trees);
 
+    CU_ASSERT_EQUAL(tree.index, -1);
     site_index = 0;
     mutation_index = 0;
     j = 0;
@@ -126,9 +127,7 @@ verify_trees(tsk_treeseq_t *ts, uint32_t num_trees, tsk_id_t* parents)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(site_index, num_sites);
     CU_ASSERT_EQUAL(mutation_index, num_mutations);
-
-    ret = tsk_tree_next(&tree);
-    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(tree.index, -1);
 
     tsk_tree_free(&tree);
 }
@@ -208,7 +207,6 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
     }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(j, num_trees);
-    j--;
     while ((ret = tsk_tree_prev(&t)) == 1) {
         CU_ASSERT_EQUAL_FATAL(j - 1, t.index);
         ret = tsk_tree_equal(&t, &trees[t.index]);
@@ -217,15 +215,7 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
     }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(j, 0);
-    CU_ASSERT_EQUAL_FATAL(t.index, 0);
-    /* Calling prev should return 0 and have no effect. */
-    for (j = 0; j < 10; j++) {
-        ret = tsk_tree_prev(&t);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(t.index, 0);
-        ret = tsk_tree_equal(&t, &trees[t.index]);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-    }
+    CU_ASSERT_EQUAL_FATAL(t.index, -1);
 
     /* Full reverse then forward */
     j = num_trees;
@@ -237,7 +227,6 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
     }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(j, 0);
-    j++;
     while ((ret = tsk_tree_next(&t)) == 1) {
         CU_ASSERT_EQUAL_FATAL(j, t.index);
         ret = tsk_tree_equal(&t, &trees[t.index]);
@@ -246,15 +235,7 @@ verify_tree_next_prev(tsk_treeseq_t *ts)
     }
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(j, num_trees);
-    CU_ASSERT_EQUAL_FATAL(t.index, num_trees - 1);
-    /* Calling next should return 0 and have no effect. */
-    for (j = 0; j < 10; j++) {
-        ret = tsk_tree_next(&t);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        CU_ASSERT_EQUAL_FATAL(t.index, num_trees - 1);
-        ret = tsk_tree_equal(&t, &trees[t.index]);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-    }
+    CU_ASSERT_EQUAL_FATAL(t.index, -1);
 
     /* Do a zigzagging traversal */
     ret = tsk_tree_first(&t);
@@ -375,8 +356,6 @@ verify_tree_diffs(tsk_treeseq_t *ts)
     }
     CU_ASSERT_EQUAL(num_trees, tsk_treeseq_get_num_trees(ts));
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_tree_next(&tree);
-    CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_diff_iter_free(&iter);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_free(&tree);

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -2065,14 +2065,14 @@ tsk_tree_next(tsk_tree_t *self)
     tsk_id_t num_trees = (tsk_id_t) tsk_treeseq_get_num_trees(ts);
 
     if (self->index == -1) {
-        /* As a convenience, we allow next() to be called on a init'ed tree
-         * which as the same effect as first() */
         ret = tsk_tree_first(self);
     } else if (self->index < num_trees - 1) {
         ret = tsk_tree_advance(self, TSK_DIR_FORWARD,
                 tables->edges.right, tables->indexes.edge_removal_order,
                 &self->right_index, tables->edges.left,
                 tables->indexes.edge_insertion_order, &self->left_index);
+    } else {
+        ret = tsk_tree_clear(self);
     }
     return ret;
 }
@@ -2084,14 +2084,14 @@ tsk_tree_prev(tsk_tree_t *self)
     const tsk_table_collection_t *tables = self->tree_sequence->tables;
 
     if (self->index == -1) {
-        /* As a convenience, we allow prev() to be called on a init'ed tree
-         * which as the same effect as last() */
         ret = tsk_tree_last(self);
     } else if (self->index > 0) {
         ret = tsk_tree_advance(self, TSK_DIR_REVERSE,
                 tables->edges.left, tables->indexes.edge_insertion_order,
                 &self->left_index, tables->edges.right,
                 tables->indexes.edge_removal_order, &self->right_index);
+    } else {
+        ret = tsk_tree_clear(self);
     }
     return ret;
 }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1351,39 +1351,14 @@ out:
     return ret;
 }
 
-/* Returns 0 if the specified sparse trees are equal, 1 if they are
- * not equal, and < 0 if an error occurs.
- *
- * We only consider topological properties of the tree. Optional
- * counts and sample lists are not considered for equality.
- */
-int TSK_WARN_UNUSED
-tsk_tree_equal(tsk_tree_t *self, tsk_tree_t *other)
+bool TSK_WARN_UNUSED
+tsk_tree_equals(tsk_tree_t *self, tsk_tree_t *other)
 {
-    int ret = 1;
-    int condition;
-    size_t N = self->num_nodes;
+    bool ret = false;
 
-    if (self->tree_sequence != other->tree_sequence) {
-        /* It is an error to compare trees from different tree sequences. */
-        ret = TSK_ERR_BAD_PARAM_VALUE;
-        goto out;
+    if (self->tree_sequence == other->tree_sequence) {
+        ret = self->index == other->index;
     }
-    condition = self->index == other->index
-        && self->left == other->left
-        && self->right == other->right
-        && self->sites_length == other->sites_length
-        && self->sites == other->sites
-        && memcmp(self->parent, other->parent, N * sizeof(tsk_id_t)) == 0;
-    /* We do not check the children for equality here because
-     * the ordering of the children within a parent are essentially irrelevant
-     * in terms of topology. Depending on the way in which we approach a given
-     * tree we can get different orderings within the children, and so the
-     * same tree would not be equal to itself. */
-    if (condition) {
-        ret = 0;
-    }
-out:
     return ret;
 }
 

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -2064,7 +2064,11 @@ tsk_tree_next(tsk_tree_t *self)
     const tsk_table_collection_t *tables = ts->tables;
     tsk_id_t num_trees = (tsk_id_t) tsk_treeseq_get_num_trees(ts);
 
-    if (self->index < num_trees - 1) {
+    if (self->index == -1) {
+        /* As a convenience, we allow next() to be called on a init'ed tree
+         * which as the same effect as first() */
+        ret = tsk_tree_first(self);
+    } else if (self->index < num_trees - 1) {
         ret = tsk_tree_advance(self, TSK_DIR_FORWARD,
                 tables->edges.right, tables->indexes.edge_removal_order,
                 &self->right_index, tables->edges.left,
@@ -2079,7 +2083,11 @@ tsk_tree_prev(tsk_tree_t *self)
     int ret = 0;
     const tsk_table_collection_t *tables = self->tree_sequence->tables;
 
-    if (self->index > 0) {
+    if (self->index == -1) {
+        /* As a convenience, we allow prev() to be called on a init'ed tree
+         * which as the same effect as last() */
+        ret = tsk_tree_last(self);
+    } else if (self->index > 0) {
         ret = tsk_tree_advance(self, TSK_DIR_REVERSE,
                 tables->edges.left, tables->indexes.edge_insertion_order,
                 &self->left_index, tables->edges.right,

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1052,7 +1052,7 @@ out:
  * Tree
  * ======================================================== */
 
-static int TSK_WARN_UNUSED
+int TSK_WARN_UNUSED
 tsk_tree_clear(tsk_tree_t *self)
 {
     int ret = 0;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -217,6 +217,7 @@ int tsk_tree_first(tsk_tree_t *self);
 int tsk_tree_last(tsk_tree_t *self);
 int tsk_tree_next(tsk_tree_t *self);
 int tsk_tree_prev(tsk_tree_t *self);
+int tsk_tree_clear(tsk_tree_t *self);
 
 void tsk_tree_print_state(tsk_tree_t *self, FILE *out);
 /** @} */

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -223,8 +223,8 @@ void tsk_tree_print_state(tsk_tree_t *self, FILE *out);
 
 bool tsk_tree_has_sample_lists(tsk_tree_t *self);
 bool tsk_tree_has_sample_counts(tsk_tree_t *self);
+bool tsk_tree_equals(tsk_tree_t *self, tsk_tree_t *other);
 int tsk_tree_copy(tsk_tree_t *self, tsk_tree_t *source);
-int tsk_tree_equal(tsk_tree_t *self, tsk_tree_t *other);
 int tsk_tree_set_tracked_samples(tsk_tree_t *self,
         size_t num_tracked_samples, tsk_id_t *tracked_samples);
 int tsk_tree_set_tracked_samples_from_sample_list(tsk_tree_t *self,

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -29,23 +29,26 @@ def moving_along_tree_sequence():
             tree.index, *tree.interval, id(tree)))
 
     print()
-    for tree in list(ts):
+    for tree in ts.aslist():
         print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
             tree.index, *tree.interval, id(tree)))
 
     print()
-    tree = ts[0]
+    tree = ts.at(0.5)
     print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
         tree.index, *tree.interval, id(tree)))
-    tree = ts[-1]
+    tree = ts.at_index(0)
+    print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+        tree.index, *tree.interval, id(tree)))
+    tree = ts.at_index(-1)
     print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
         tree.index, *tree.interval, id(tree)))
 
     print()
     tree = tskit.Tree(ts)
-    tree.seek_index(len(ts) // 2)
+    tree.seek_index(ts.num_trees // 2)
     print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-    tree.seek_position(0.95)
+    tree.seek(0.95)
     print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
 
     print()

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -6,6 +6,7 @@ import sys
 sys.path.insert(0, os.path.abspath('../python'))
 
 import msprime
+import tskit
 
 def moving_along_tree_sequence():
     ts = msprime.simulate(5, recombination_rate=1, random_seed=42)
@@ -39,6 +40,35 @@ def moving_along_tree_sequence():
     tree = ts[-1]
     print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
         tree.index, *tree.interval, id(tree)))
+
+    print()
+    tree = tskit.Tree(ts)
+    tree.seek_index(len(ts) // 2)
+    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
+    tree.seek_position(0.95)
+    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
+
+    print()
+    tree.prev()
+    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
+    tree.next()
+    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
+
+    print()
+    tree = tskit.Tree(ts)
+    print("Tree {}: parent_dict = {}".format(tree.index, tree.parent_dict))
+    tree.first()
+    print("Tree {}: parent_dict = {}".format(tree.index, tree.parent_dict))
+    tree.prev()
+    print("Tree {}: parent_dict = {}".format(tree.index, tree.parent_dict))
+
+    tree = tskit.Tree(ts)
+    while tree.next():
+        print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
+    print("After loop: tree index =", tree.index)
+    while tree.prev():
+        print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
+
 
 
 moving_along_tree_sequence()

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -1,0 +1,44 @@
+"""
+Examples for the tutorial.
+"""
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../python'))
+
+import msprime
+
+def moving_along_tree_sequence():
+    ts = msprime.simulate(5, recombination_rate=1, random_seed=42)
+
+    print("Tree sequence has {} trees".format(ts.num_trees))
+    print()
+    for tree in ts.trees():
+        print("Tree {} covers [{:.2f}, {:.2f}); TMRCA = {:.4f}".format(
+            tree.index, *tree.interval, tree.time(tree.root)))
+
+    print()
+    for tree in reversed(ts.trees()):
+        print("Tree {} covers [{:.2f}, {:.2f}); TMRCA = {:.4f}".format(
+
+            tree.index, *tree.interval, tree.time(tree.root)))
+
+    print()
+    for tree in list(ts.trees()):
+        print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+            tree.index, *tree.interval, id(tree)))
+
+    print()
+    for tree in list(ts):
+        print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+            tree.index, *tree.interval, id(tree)))
+
+    print()
+    tree = ts[0]
+    print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+        tree.index, *tree.interval, id(tree)))
+    tree = ts[-1]
+    print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+        tree.index, *tree.interval, id(tree)))
+
+
+moving_along_tree_sequence()

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -28,7 +28,7 @@ Top level-classes
 .. autoclass:: tskit.TreeSequence()
     :members:
 
-.. autoclass:: tskit.Tree()
+.. autoclass:: tskit.Tree
     :members:
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -37,10 +37,6 @@ is possible using the :meth:`.Tree.nodes` iterator.
 Moving along a tree sequence
 ****************************
 
-----------
-High level
-----------
-
 Most of the time we will want to iterate over all the trees in a tree sequence
 sequentially as efficiently as possible. The simplest way to do this is to
 use the :meth:`.TreeSequence.trees` method:
@@ -121,17 +117,17 @@ list, we will get unexpected results:
     Tree -1 covers [0.00, 0.00): id=7f290becb3c8
     Tree -1 covers [0.00, 0.00): id=7f290becb3c8
 
-Thus, we have stored seven copies of the same :class:`Tree` instance in the
+We have stored seven copies of the same :class:`Tree` instance in the
 list. Because iteration has ended, this tree is in the "null" state (see
 below for more details) which means that it doesn't represent any of the
 trees in the tree sequence.
 
-If we do wish to obtain a list of the trees, we can do so by simply calling
-``list(ts)``:
+If we do wish to obtain a list of the trees, we can do so by using the
+:meth:`.TreeSequence.aslist` method:
 
 .. code-block:: python
 
-    for tree in list(ts)):
+    for tree in ts.aslist():
         print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
             tree.index, *tree.interval, id(tree)))
 
@@ -147,151 +143,41 @@ If we do wish to obtain a list of the trees, we can do so by simply calling
 
 Note that we now have a different object for each tree in the list. Please
 note that this is **much** less efficient than iterating over the trees
-using the :meth:`.TreeSequence.trees` method (and use far more memory!),
+using the :meth:`.TreeSequence.trees` method (and uses far more memory!),
 and should only be used as a convenience when working with small trees.
 
-The :class:`.TreeSequence` class is regarded literally as a sequence of
-trees from a Python perspective and so we can use the familiar list access
-notation to get trees at a given index:
+We can also obtain specific trees along the sequence, using the
+:meth:`.TreeSequence.first`,
+:meth:`.TreeSequence.last`
+:meth:`.TreeSequence.at` and
+:meth:`.TreeSequence.at_index` methods. The ``first()`` and ``last()``
+methods return the first and last trees in the sequence, as might be
+imagined. The ``at()`` method returns the tree that covers a
+given genomic location, and the ``at_index()`` method returns the
+tree at a given index along the sequence:
 
 .. code-block:: python
 
-    tree = ts[0]
+    tree = ts.at(0.5)
     print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
         tree.index, *tree.interval, id(tree)))
-    tree = ts[-1]
+    tree = ts.at_index(0)
+    print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+        tree.index, *tree.interval, id(tree)))
+    tree = ts.at_index(-1)
     print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
         tree.index, *tree.interval, id(tree)))
 
 ::
 
-    Tree 0 covers [0.00, 0.08): id=7f232277f208
-    Tree 6 covers [0.75, 1.00): id=7f23210bf0b8
+    Tree 3 covers [0.37, 0.66): id=7f9fdb469630
+    Tree 0 covers [0.00, 0.08): id=7f9fdb46d160
+    Tree 6 covers [0.75, 1.00): id=7f9fdb469630
 
-Note that each call to ``ts[index]`` returns a different :class:`.Tree` instance
+Note that each call to these methods return a different :class:`.Tree` instance
 and so it is much, much less efficient to sequentially access trees
 by their index values than it is to use the :meth:`.TreeSequence.trees`
 iterator.
-
----------
-Low level
----------
-
-The high-level operations described in the previous section provide a
-convenient interface to obtain the trees along a sequence in various
-different ways in the :class:`.TreeSequence` class.
-These operations are all built on the lower-level :class:`.Tree` class
-which provides the efficient primitive operations required. For most
-applications the higher-level :class:`.TreeSequence` API is more
-appropriate, but it is sometimes useful to work directly with the
-:class:`.Tree` API also.
-
-The :class:`.Tree` class represents individual trees along a tree
-sequence and is *mutable*: it provides method to "seek" along the
-sequence and transform its state to represent the tree at a given position.
-Continuing the example above,
-
-.. code-block:: python
-
-    tree = tskit.Tree(ts)
-    tree.seek_index(len(ts) // 2)
-    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-    tree.seek_position(0.95)
-    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-
-::
-
-    Tree 3 covers [0.37, 0.66)
-    Tree 6 covers [0.75, 1.00)
-
-
-Here, we allocate a new :class:`.Tree` for the tree sequence in our example,
-and we tell it to seek to two different locations. In the first, we change
-the state to the tree at index 3. In the second, we seek to the tree that
-covers position 0.95, which turns out to be tree index 6. Notice that we are
-still using the same :class:`.Tree` instance, we have just changed its internal
-state to represent different trees along the sequence. We also have the
-:meth:`.Tree.next` and :meth:`.Tree.prev` methods, which transform the tree
-into the next and previous trees along the sequence, respectively:
-
-
-.. code-block:: python
-
-    tree.prev()
-    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-    tree.next()
-    print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-
-::
-
-    Tree 5 covers [0.71, 0.75)
-    Tree 6 covers [0.75, 1.00)
-
-At the end of the last code block, the tree object represented the state of tree
-index 6 on the sequence, and so when we call ``prev`` on this it transforms
-the state to represent the tree at index 5. Afterwards, we call ``next``, and
-we transform the state back to the tree at index 6.
-
-Thus, the :class:`.Tree` class is a state-machine which has a state corresponding
-to each of the trees in the parent tree sequence. We transition between these
-states by using the seek functions like :meth:`.Tree.first`,
-:meth:`.Tree.last`, :meth:`.Tree.seek_index` and :meth:`.Tree.seek_position`. There
-is one more state, the so-called "null" or "cleared" state. This is the state
-that a :class:`.Tree` is in immediately after initialisation;  it has
-an index of -1, and no edges. We can also enter the null state by
-calling :meth:`.Tree.next` on the last tree in a sequence, calling
-:meth:`.Tree.prev` on the first tree in a sequence or calling
-calling the :meth:`.Tree.clear` method at any time.
-
-.. code-block:: python
-
-    tree = tskit.Tree(ts)
-    print("Tree {}: parent_dict = {}".format(tree.index, tree.parent_dict))
-    tree.first()
-    print("Tree {}: parent_dict = {}".format(tree.index, tree.parent_dict))
-    tree.prev()
-    print("Tree {}: parent_dict = {}".format(tree.index, tree.parent_dict))
-
-::
-
-    Tree -1: parent_dict = {}
-    Tree 0: parent_dict = {0: 9, 1: 11, 2: 6, 3: 6, 4: 9, 6: 12, 9: 11, 11: 12}
-    Tree -1: parent_dict = {}
-
-The :meth:`.Tree.next` and :meth:`.Tree.prev` methods provide two short-cuts
-allow for easy iteration over the trees in a sequence. First, if ``next`` is
-called on a :class:`.Tree` in the null state, this changes the state to
-represent the first tree in the sequence (or last tree, if calling ``prev``).
-Secondly, the ``next`` and ``prev`` methods return True if the tree
-has just been transformed into a non-null state. This gives us a
-neat idiom for iteratively visiting all the trees along a sequence:
-
-.. code-block:: python
-
-    tree = tskit.Tree(ts)
-    while tree.next():
-        print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-    print("After loop: tree index =", tree.index)
-    while tree.prev():
-        print("Tree {} covers [{:.2f}, {:.2f})".format(tree.index, *tree.interval))
-
-::
-
-    Tree 0 covers [0.00, 0.08)
-    Tree 1 covers [0.08, 0.27)
-    Tree 2 covers [0.27, 0.37)
-    Tree 3 covers [0.37, 0.66)
-    Tree 4 covers [0.66, 0.71)
-    Tree 5 covers [0.71, 0.75)
-    Tree 6 covers [0.75, 1.00)
-    After loop: tree index = -1
-    Tree 6 covers [0.75, 1.00)
-    Tree 5 covers [0.71, 0.75)
-    Tree 4 covers [0.66, 0.71)
-    Tree 3 covers [0.37, 0.66)
-    Tree 2 covers [0.27, 0.37)
-    Tree 1 covers [0.08, 0.27)
-    Tree 0 covers [0.00, 0.08)
 
 
 **********************

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -7,6 +7,172 @@ Tutorial
 .. todo:: The content here has been ported from the msprime tutorial and
     needs to be reorganised to make a coherent narrative.
 
+
+.. _sec_tutorial_traversing_trees:
+
+****************
+Traversing trees
+****************
+
+A :class:`.Tree` represents a single tree in a :class:`.TreeSequence`.
+The ``tskit`` Tree implementation differs from most tree libraries by
+using **integer IDs** to refer to nodes rather than objects. Thus, when we wish to
+find the parent of the node with ID '0', we use ``tree.parent(0)``, which
+returns another integer. If '0' does not have a parent in the current tree
+(e.g., if it is a root), then the special value :const:`.NULL`
+(:math:`-1`) is returned. The children of a node are found using the
+:meth:`.Tree.children` method. To obtain information about a particular node,
+one may either use ``tree.tree_sequence.node(u)`` to which returns the
+corresponding :class:`Node` instance, or use the :meth:`.Tree.time` or
+:meth:`.Tree.population` shorthands. Tree traversals in various orders
+is possible using the :meth:`.Tree.nodes` iterator.
+
+.. todo:: Add tree diagram and example. Also describe the left_child,
+    right_child, left_sib, right_sib functions.
+
+
+.. _sec_tutorial_moving_along_a_tree_sequence:
+
+****************************
+Moving along a tree sequence
+****************************
+
+Most of the time we will want to iterate over all the trees in a tree sequence
+sequentially as efficiently as possible. The simplest way to do this is to
+use the :meth:`.TreeSequence.trees` method:
+
+.. code-block:: python
+
+    import msprime
+
+    ts = msprime.simulate(5, recombination_rate=1, random_seed=42)
+
+    print("Tree sequence has {} trees".format(ts.num_trees))
+    print()
+    for tree in ts.trees():
+        print("Tree {} covers [{:.2f}, {:.2f}); TMRCA = {:.4f}".format(
+            tree.index, *tree.interval, tree.time(tree.root)))
+
+Running the code, we get::
+
+    Tree sequence has 7 trees
+
+    Tree 0 covers [0.00, 0.08); TMRCA = 4.2542
+    Tree 1 covers [0.08, 0.27); TMRCA = 2.5973
+    Tree 2 covers [0.27, 0.37); TMRCA = 4.2542
+    Tree 3 covers [0.37, 0.66); TMRCA = 2.5973
+    Tree 4 covers [0.66, 0.71); TMRCA = 4.2542
+    Tree 5 covers [0.71, 0.75); TMRCA = 2.5973
+    Tree 6 covers [0.75, 1.00); TMRCA = 2.5973
+
+Here we run a small simulation using `msprime <https://msprime.readthedocs.io>`_
+which results in 7 distinct trees along a genome of length 1. We then iterate
+over these trees sequentially using the :meth:`.TreeSequence.trees` method,
+and print out each tree's index, the interval over which the tree applies
+and the time of the most recent common ancestor of all the samples. This
+method is very efficient, and allows us to quickly iterate over very large
+tree sequences.
+
+We can also efficiently iterate over the trees backwards, using Python's
+:func:`reversed` function:
+
+.. code-block:: python
+
+    for tree in reversed(ts.trees()):
+        print("Tree {} covers [{:.2f}, {:.2f}); TMRCA = {:.4f}".format(
+            tree.index, *tree.interval, tree.time(tree.root)))
+
+giving::
+
+    Tree 6 covers [0.75, 1.00); TMRCA = 2.5973
+    Tree 5 covers [0.71, 0.75); TMRCA = 2.5973
+    Tree 4 covers [0.66, 0.71); TMRCA = 4.2542
+    Tree 3 covers [0.37, 0.66); TMRCA = 2.5973
+    Tree 2 covers [0.27, 0.37); TMRCA = 4.2542
+    Tree 1 covers [0.08, 0.27); TMRCA = 2.5973
+    Tree 0 covers [0.00, 0.08); TMRCA = 4.2542
+
+One of the reasons that the ``trees`` iterator allows us to access
+the trees in a tree sequence so efficiently is because we use the
+same underlying instance of the ``.Tree`` class each time. That is,
+each time the iterator returns a value, it is actually the same tree
+instance each time which has been updated internally to reflect the
+(usually small) changes in the tree along the sequence. As a
+result of this, if we store the results of the tree iterator in a
+list, we will get unexpected results:
+
+.. code-block:: python
+
+    for tree in list(ts.trees()):
+        print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+            tree.index, *tree.interval, id(tree)))
+
+::
+
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+    Tree -1 covers [0.00, 0.00): id=7f290becb3c8
+
+Thus, we have stored seven copies of the same :class:`Tree` instance in the
+list. Because iteration has ended, this tree is in the "cleared" state (see
+below for more details) which means that it doesn't represent any of the
+trees in the tree sequence.
+
+If we do wish to obtain a list of the trees, we can do so by simply calling
+``list(ts)``:
+
+.. code-block:: python
+
+    for tree in list(ts)):
+        print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+            tree.index, *tree.interval, id(tree)))
+
+::
+
+    Tree 0 covers [0.00, 0.08): id=7fd2c50a40f0
+    Tree 1 covers [0.08, 0.27): id=7fd2b2aca6d8
+    Tree 2 covers [0.27, 0.37): id=7fd2b2adde10
+    Tree 3 covers [0.37, 0.66): id=7fd2b2adddd8
+    Tree 4 covers [0.66, 0.71): id=7fd2b2addd68
+    Tree 5 covers [0.71, 0.75): id=7fd2b2addcf8
+    Tree 6 covers [0.75, 1.00): id=7fd2b2addeb8
+
+Note that we now have a different object for each tree in the list. Please
+note that this is **much** less efficient than iterating over the trees
+using the :meth:`.TreeSequence.trees` method, and should only be used as a
+convenience when working with small trees.
+
+The :class:`.TreeSequence` class is regarded literally as a sequence of
+trees from a Python perspective and so we can use the familiar list access
+notation to get trees at a given index:
+
+.. code-block:: python
+
+    tree = ts[0]
+    print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+        tree.index, *tree.interval, id(tree)))
+    tree = ts[-1]
+    print("Tree {} covers [{:.2f}, {:.2f}): id={:x}".format(
+        tree.index, *tree.interval, id(tree)))
+
+::
+
+    Tree 0 covers [0.00, 0.08): id=7f232277f208
+    Tree 6 covers [0.75, 1.00): id=7f23210bf0b8
+
+Note that each call to ``ts[index]`` returns a different :class:`.Tree` instance
+and so it is much, much less efficient to sequentially access trees
+by their index values than it is to use the :meth:`.TreeSequence.trees`
+iterator.
+
+.. todo:: Add discussion on manually iterating over trees using the
+    next, prev methods.
+
+
 **********************
 Editing tree sequences
 **********************

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7358,6 +7358,23 @@ out:
     return ret;
 }
 
+/* Forward declaration */
+static PyTypeObject TreeType;
+
+static PyObject *
+Tree_equals(Tree *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Tree *other = NULL;
+
+    if (!PyArg_ParseTuple(args, "O!", &TreeType, &other)) {
+        goto out;
+    }
+    ret = Py_BuildValue("i", tsk_tree_equals(self->tree, other->tree));
+out:
+    return ret;
+}
+
 static PyMemberDef Tree_members[] = {
     {NULL}  /* Sentinel */
 };
@@ -7425,6 +7442,8 @@ static PyMethodDef Tree_methods[] = {
     {"get_newick", (PyCFunction) Tree_get_newick,
             METH_VARARGS|METH_KEYWORDS,
             "Returns the newick representation of this tree." },
+    {"equals", (PyCFunction) Tree_equals, METH_VARARGS,
+            "Returns True if this tree is equal to the parameter tree." },
     {NULL}  /* Sentinel */
 };
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6696,21 +6696,12 @@ Tree_dealloc(Tree* self)
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-/* TODO this API should be updated to remove the TreeIterator object
- * and instead support the first(), last() etc methods. Until some seeking
- * function has been called, we should be in a state that errors if any
- * methods are called.
- *
- * The _free method below is also probably redundant now and should be
- * removed.
- */
 static int
 Tree_init(Tree *self, PyObject *args, PyObject *kwds)
 {
     int ret = -1;
     int err;
-    static char *kwlist[] = {"tree_sequence", "options", "tracked_samples",
-        NULL};
+    static char *kwlist[] = {"tree_sequence", "options", "tracked_samples", NULL};
     PyObject *py_tracked_samples = NULL;
     TreeSequence *tree_sequence = NULL;
     tsk_id_t *tracked_samples = NULL;
@@ -6782,22 +6773,78 @@ out:
     return ret;
 }
 
-/* TODO this should be redundant; remove */
 static PyObject *
-Tree_free(Tree *self)
+Tree_first(Tree *self)
 {
     PyObject *ret = NULL;
+    int err;
 
     if (Tree_check_tree(self) != 0) {
         goto out;
     }
-    /* This method is need because we have dangling references to
-     * trees after a for loop and we can't run set_sites.
-     */
-    tsk_tree_free(self->tree);
-    PyMem_Free(self->tree);
-    self->tree = NULL;
+    err = tsk_tree_first(self->tree);
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
     ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
+Tree_last(Tree *self)
+{
+    PyObject *ret = NULL;
+    int err;
+
+    if (Tree_check_tree(self) != 0) {
+        goto out;
+    }
+    err = tsk_tree_last(self->tree);
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
+Tree_next(Tree *self)
+{
+    PyObject *ret = NULL;
+    int err;
+
+    if (Tree_check_tree(self) != 0) {
+        goto out;
+    }
+    err = tsk_tree_next(self->tree);
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("i", err == 1);
+out:
+    return ret;
+}
+
+static PyObject *
+Tree_prev(Tree *self)
+{
+    PyObject *ret = NULL;
+    int err;
+
+    if (Tree_check_tree(self) != 0) {
+        goto out;
+    }
+    err = tsk_tree_prev(self->tree);
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("i", err == 1);
 out:
     return ret;
 }
@@ -7316,8 +7363,14 @@ static PyMemberDef Tree_members[] = {
 };
 
 static PyMethodDef Tree_methods[] = {
-    {"free", (PyCFunction) Tree_free, METH_NOARGS,
-            "Frees the underlying tree object." },
+    {"first", (PyCFunction) Tree_first, METH_NOARGS,
+            "Sets this tree to the first in the sequence." },
+    {"last", (PyCFunction) Tree_last, METH_NOARGS,
+            "Sets this tree to the last in the sequence." },
+    {"prev", (PyCFunction) Tree_prev, METH_NOARGS,
+            "Sets this tree to the previous one in the sequence." },
+    {"next", (PyCFunction) Tree_next, METH_NOARGS,
+            "Sets this tree to the next one in the sequence." },
     {"get_sample_size", (PyCFunction) Tree_get_sample_size, METH_NOARGS,
             "Returns the number of samples in this tree." },
     {"get_num_nodes", (PyCFunction) Tree_get_num_nodes, METH_NOARGS,
@@ -7601,123 +7654,6 @@ static PyTypeObject TreeDiffIteratorType = {
     0,                         /* tp_descr_set */
     0,                         /* tp_dictoffset */
     (initproc)TreeDiffIterator_init,      /* tp_init */
-};
-
-/*===================================================================
- * TreeIterator
- *===================================================================
- */
-
-static int
-TreeIterator_check_state(TreeIterator *self)
-{
-    int ret = 0;
-    return ret;
-}
-
-static void
-TreeIterator_dealloc(TreeIterator* self)
-{
-    Py_XDECREF(self->tree);
-    Py_TYPE(self)->tp_free((PyObject*)self);
-}
-
-static int
-TreeIterator_init(TreeIterator *self, PyObject *args, PyObject *kwds)
-{
-    int ret = -1;
-    static char *kwlist[] = {"tree", NULL};
-    Tree *tree;
-
-    self->first = 1;
-    self->tree = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist,
-            &TreeType, &tree)) {
-        goto out;
-    }
-    self->tree = tree;
-    Py_INCREF(self->tree);
-    if (Tree_check_tree(self->tree) != 0) {
-        goto out;
-    }
-    ret = 0;
-out:
-    return ret;
-}
-
-static PyObject *
-TreeIterator_next(TreeIterator  *self)
-{
-    PyObject *ret = NULL;
-    int err;
-
-    if (TreeIterator_check_state(self) != 0) {
-        goto out;
-    }
-
-    if (self->first) {
-        err = tsk_tree_first(self->tree->tree);
-        self->first = 0;
-    } else {
-        err = tsk_tree_next(self->tree->tree);
-    }
-    if (err < 0) {
-        handle_library_error(err);
-        goto out;
-    }
-    if (err == 1) {
-        ret = (PyObject *) self->tree;
-        Py_INCREF(ret);
-    }
-out:
-    return ret;
-}
-
-static PyMemberDef TreeIterator_members[] = {
-    {NULL}  /* Sentinel */
-};
-
-static PyMethodDef TreeIterator_methods[] = {
-    {NULL}  /* Sentinel */
-};
-
-static PyTypeObject TreeIteratorType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "_tskit.TreeIterator",             /* tp_name */
-    sizeof(TreeIterator),             /* tp_basicsize */
-    0,                         /* tp_itemsize */
-    (destructor)TreeIterator_dealloc, /* tp_dealloc */
-    0,                         /* tp_print */
-    0,                         /* tp_getattr */
-    0,                         /* tp_setattr */
-    0,                         /* tp_reserved */
-    0,                         /* tp_repr */
-    0,                         /* tp_as_number */
-    0,                         /* tp_as_sequence */
-    0,                         /* tp_as_mapping */
-    0,                         /* tp_hash  */
-    0,                         /* tp_call */
-    0,                         /* tp_str */
-    0,                         /* tp_getattro */
-    0,                         /* tp_setattro */
-    0,                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,        /* tp_flags */
-    "TreeIterator objects",           /* tp_doc */
-    0,                     /* tp_traverse */
-    0,                     /* tp_clear */
-    0,                     /* tp_richcompare */
-    0,                     /* tp_weaklistoffset */
-    PyObject_SelfIter,                    /* tp_iter */
-    (iternextfunc) TreeIterator_next, /* tp_iternext */
-    TreeIterator_methods,             /* tp_methods */
-    TreeIterator_members,             /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)TreeIterator_init,      /* tp_init */
 };
 
 /*===================================================================
@@ -8550,14 +8486,6 @@ init_tskit(void)
     }
     Py_INCREF(&TreeType);
     PyModule_AddObject(module, "Tree", (PyObject *) &TreeType);
-
-    /* TreeIterator type */
-    TreeIteratorType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&TreeIteratorType) < 0) {
-        INITERROR;
-    }
-    Py_INCREF(&TreeIteratorType);
-    PyModule_AddObject(module, "TreeIterator", (PyObject *) &TreeIteratorType);
 
     /* TreeDiffIterator type */
     TreeDiffIteratorType.tp_new = PyType_GenericNew;

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6850,6 +6850,25 @@ out:
 }
 
 static PyObject *
+Tree_clear(Tree *self)
+{
+    PyObject *ret = NULL;
+    int err;
+
+    if (Tree_check_tree(self) != 0) {
+        goto out;
+    }
+    err = tsk_tree_clear(self->tree);
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 Tree_get_sample_size(Tree *self)
 {
     PyObject *ret = NULL;
@@ -7388,6 +7407,8 @@ static PyMethodDef Tree_methods[] = {
             "Sets this tree to the previous one in the sequence." },
     {"next", (PyCFunction) Tree_next, METH_NOARGS,
             "Sets this tree to the next one in the sequence." },
+    {"clear", (PyCFunction) Tree_clear, METH_NOARGS,
+            "Resets this tree back to the cleared null state." },
     {"get_sample_size", (PyCFunction) Tree_get_sample_size, METH_NOARGS,
             "Returns the number of samples in this tree." },
     {"get_num_nodes", (PyCFunction) Tree_get_num_nodes, METH_NOARGS,

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1155,10 +1155,8 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertRaises(RuntimeError, t.get_num_tracked_samples, 0)
             self.assertEqual(list(t.samples(0)), [0])
 
-        # This is a bit weird as we don't seem to actually execute the
-        # method until it is iterated.
         self.assertRaises(
-            ValueError, list, ts.trees(sample_counts=False, tracked_samples=[0]))
+            ValueError, ts.trees, sample_counts=False, tracked_samples=[0])
 
     def test_get_pairwise_diversity(self):
         for ts in get_example_tree_sequences():
@@ -1524,6 +1522,43 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(migration.left, 0)
             self.assertEqual(migration.right, 1)
             self.assertTrue(0 <= migration.node < ts.num_nodes)
+
+    def test_get_item(self):
+        for ts in get_example_tree_sequences():
+            tree1 = ts[-1]
+            self.assertEqual(tree1.index, len(ts) - 1)
+            with self.assertRaises(IndexError):
+                ts[len(ts)]
+            with self.assertRaises(IndexError):
+                ts[len(ts) + 1]
+            with self.assertRaises(IndexError):
+                ts[-len(ts) - 1]
+
+            for index, tree1 in enumerate(ts.trees()):
+                self.assertEqual(index, tree1.index)
+                tree2 = ts[index]
+                self.assertIsNot(tree1, tree2)
+                self.assertEqual(tree1, tree2)
+                self.assertEqual(tree1.parent_dict, tree2.parent_dict)
+
+    def test_list(self):
+        for ts in get_example_tree_sequences():
+            tree_list = list(ts)
+            self.assertEqual(len(tree_list), len(ts))
+            self.assertEqual(len(tree_list), ts.num_trees)
+            self.assertEqual(len(set(map(id, tree_list))), len(ts))
+            for index, tree in enumerate(tree_list):
+                self.assertEqual(index, tree.index)
+
+    def test_reversed_trees(self):
+        for ts in get_example_tree_sequences():
+            index = len(ts) - 1
+            for tree in reversed(ts.trees()):
+                self.assertEqual(tree.index, index)
+                t2 = ts[index]
+                self.assertEqual(tree.interval, t2.interval)
+                self.assertEqual(tree.parent_dict, t2.parent_dict)
+                index -= 1
 
 
 class TestFileUuid(HighLevelTestCase):

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -2080,6 +2080,27 @@ class TestTree(HighLevelTestCase):
         tree.next()
         self.assertEqual(tree.index, -1)
 
+    def test_seek_position(self):
+        L = 10
+        ts = msprime.simulate(10, recombination_rate=3, length=L, random_seed=42)
+        self.assertGreater(ts.num_trees, 5)
+        same_tree = tskit.Tree(ts)
+        for tree in [same_tree, tskit.Tree(ts)]:
+            for j in range(L):
+                tree.seek_position(j)
+                index = tree.index
+                self.assertTrue(tree.interval[0] <= j < tree.interval[1])
+                tree.seek_position(tree.interval[0])
+                self.assertEqual(tree.index, index)
+                if tree.interval[1] < L:
+                    tree.seek_position(tree.interval[1])
+                    self.assertEqual(tree.index, index + 1)
+            for j in reversed(range(L)):
+                tree.seek_position(j)
+                self.assertTrue(tree.interval[0] <= j < tree.interval[1])
+        for bad_position in [-1, L, L + 1, -L]:
+            self.assertRaises(ValueError, tree.seek_position, bad_position)
+
     def verify_empty_tree(self, tree):
         ts = tree.tree_sequence
         self.assertEqual(tree.index, -1)

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1113,12 +1113,19 @@ class TestTreeSequence(HighLevelTestCase):
                         if node.population == pop and node.is_sample()])
             self.assertRaises(ValueError, ts.samples, population=0, population_id=0)
 
-    def test_first(self):
+    def test_first_last(self):
         for ts in get_example_tree_sequences():
             t1 = ts.first()
             t2 = next(ts.trees())
             self.assertFalse(t1 is t2)
             self.assertEqual(t1.parent_dict, t2.parent_dict)
+            self.assertEqual(t1.index, 0)
+
+            t1 = ts.last()
+            t2 = next(reversed(ts.trees()))
+            self.assertFalse(t1 is t2)
+            self.assertEqual(t1.parent_dict, t2.parent_dict)
+            self.assertEqual(t1.index, len(ts) - 1)
 
     def test_trees_interface(self):
         ts = list(get_example_tree_sequences())[0]
@@ -2066,6 +2073,12 @@ class TestTree(HighLevelTestCase):
                 self.assertEqual(tree.index, j)
             self.assertEqual(tree.index, -1)
             self.assertEqual(j, 0)
+        tree.first()
+        tree.prev()
+        self.assertEqual(tree.index, -1)
+        tree.last()
+        tree.next()
+        self.assertEqual(tree.index, -1)
 
     def verify_empty_tree(self, tree):
         ts = tree.tree_sequence
@@ -2097,6 +2110,20 @@ class TestTree(HighLevelTestCase):
         self.verify_empty_tree(tree)
         while tree.prev():
             pass
+        self.verify_empty_tree(tree)
+
+    def test_clear(self):
+        ts = msprime.simulate(10, recombination_rate=3, length=3, random_seed=42)
+        self.assertGreater(ts.num_trees, 5)
+        tree = tskit.Tree(ts)
+        tree.first()
+        tree.clear()
+        self.verify_empty_tree(tree)
+        tree.last()
+        tree.clear()
+        self.verify_empty_tree(tree)
+        tree.seek_index(ts.num_trees // 2)
+        tree.clear()
         self.verify_empty_tree(tree)
 
 

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -792,17 +792,38 @@ class TestTree(LowLevelTestCase):
                         point = t.find(".")
                         self.assertEqual(precision, len(t) - point - 1)
 
-    @unittest.skip("Correct initialisation for sparse tree.")
+    def test_cleared_tree(self):
+        ts = self.get_example_tree_sequence()
+        samples = ts.get_samples()
+
+        def check_tree(tree):
+            self.assertEqual(tree.get_index(), -1)
+            self.assertEqual(tree.get_left_root(), samples[0])
+            self.assertEqual(tree.get_mrca(0, 1), _tskit.NULL)
+            for u in range(ts.get_num_nodes()):
+                self.assertEqual(tree.get_parent(u), _tskit.NULL)
+                self.assertEqual(tree.get_left_child(u), _tskit.NULL)
+                self.assertEqual(tree.get_right_child(u), _tskit.NULL)
+
+        tree = _tskit.Tree(ts)
+        check_tree(tree)
+        while tree.next():
+            pass
+        check_tree(tree)
+        while tree.prev():
+            pass
+        check_tree(tree)
+
     def test_newick_interface(self):
-        ts = self.get_tree_sequence(num_loci=10, num_samples=10)
+        ts = self.get_example_tree_sequence()
         st = _tskit.Tree(ts)
         # TODO this will break when we correctly handle multiple roots.
-        self.assertEqual(st.get_newick(), b"1;")
+        self.assertEqual(st.get_newick(0), b"1;")
         for bad_type in [None, "", [], {}]:
             self.assertRaises(TypeError, st.get_newick, precision=bad_type)
             self.assertRaises(TypeError, st.get_newick, ts, time_scale=bad_type)
         while st.next():
-            newick = st.get_newick()
+            newick = st.get_newick(st.get_left_root())
             self.assertTrue(newick.endswith(b";"))
 
     def test_index(self):

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -904,6 +904,29 @@ class TestTree(LowLevelTestCase):
                     u = t.get_right_sib(u)
                 self.assertEqual(sorted(samples), list(range(ts.get_num_samples())))
 
+    def test_equality(self):
+        last_ts = None
+        for ts in self.get_example_tree_sequences():
+            t1 = _tskit.Tree(ts)
+            t2 = _tskit.Tree(ts)
+            self.assertTrue(t1.equals(t2))
+            self.assertTrue(t2.equals(t1))
+            while True:
+                self.assertTrue(t1.equals(t2))
+                self.assertTrue(t2.equals(t1))
+                n1 = t1.next()
+                self.assertFalse(t1.equals(t2))
+                self.assertFalse(t2.equals(t1))
+                n2 = t2.next()
+                self.assertEqual(n1, n2)
+                if not n1:
+                    break
+            if last_ts is not None:
+                t2 = _tskit.Tree(last_ts)
+                self.assertFalse(t1.equals(t2))
+                self.assertFalse(t2.equals(t1))
+            last_ts = ts
+
 
 class TestModuleFunctions(unittest.TestCase):
     """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -419,14 +419,21 @@ class Tree(object):
     error to use the ``tracked_samples`` parameter when the ``sample_counts``
     flag is False.
 
-    The tree is initially in a "null" or "cleared" state, in which it does
-    not represent the state of any of the trees in the tree sequence. The
-    null tree has an ``index`` value of -1 and no edges; each sample in the
-    parent tree sequence is a root in this tree. To update a tree to represent
-    the state of a given tree in the tree sequence, you must use one of the
-    "seeking" methods (e.g., :meth:`.first`, :meth:`.last`, :meth:`.seek`
-    or :meth:`.seek_index`). The :meth:`.clear` method can be used to return
-    the tree to this null state at any time.
+    The :class:`.Tree` class is a state-machine which has a state
+    corresponding to each of the trees in the parent tree sequence. We
+    transition between these states by using the seek functions like
+    :meth:`.Tree.first`, :meth:`.Tree.last`, :meth:`.Tree.seek` and
+    :meth:`.Tree.seek_index`. There is one more state, the so-called "null"
+    or "cleared" state. This is the state that a :class:`.Tree` is in
+    immediately after initialisation;  it has an index of -1, and no edges. We
+    can also enter the null state by calling :meth:`.Tree.next` on the last
+    tree in a sequence, calling :meth:`.Tree.prev` on the first tree in a
+    sequence or calling calling the :meth:`.Tree.clear` method at any time.
+
+    The high-level TreeSequence seeking and iterations methods (e.g,
+    :class:`.TreeSequence.trees`) are built on these low-level state-machine
+    seek operations. We recommend these higher level operations for most
+    users.
 
     :param TreeSequence tree_sequence: The parent tree sequence.
     :param list tracked_samples: The list of samples to be tracked and
@@ -2454,11 +2461,10 @@ class TreeSequence(object):
            For performance reasons, the same underlying object is used
            for every tree returned which will most likely lead to unexpected
            behaviour. If you wish to obtain a list of trees in a tree sequence
-           please use ``list(ts)`` instead.
+           please use ``ts.aslist()`` instead.
 
         :param list tracked_samples: The list of samples to be tracked and
-            counted using the :meth:`.Tree.get_num_tracked_samples`
-            method.
+            counted using the :meth:`.Tree.get_num_tracked_samples` method.
         :param bool sample_counts: If True, support constant time sample counts
             via the :meth:`.Tree.num_samples` and
             :meth:`.Tree.get_num_tracked_samples` methods.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -582,7 +582,7 @@ class Tree(object):
         # No point in complicating the current implementation by trying
         # to seek from the correct direction.
         self.first()
-        while self.interval[0] < position:
+        while self.interval[1] <= position:
             self.next()
 
     def get_branch_length(self, u):

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -432,6 +432,12 @@ class Tree(object):
         """
         return self._tree_sequence
 
+    def first(self):
+        self._ll_tree.first()
+
+    def next(self):
+        return bool(self._ll_tree.next())
+
     def get_branch_length(self, u):
         # Deprecated alias for branch_length
         return self.branch_length(u)
@@ -2260,9 +2266,8 @@ class TreeSequence(object):
             # TODO remove this when we allow numpy arrays in the low-level API.
             kwargs["tracked_samples"] = list(tracked_samples)
         ll_tree = _tskit.Tree(self._ll_tree_sequence, **kwargs)
-        iterator = _tskit.TreeIterator(ll_tree)
         tree = Tree(ll_tree, self)
-        for _ in iterator:
+        while tree.next():
             yield tree
 
     def haplotypes(self):


### PR DESCRIPTION
We need better ways of getting at trees in a tree sequence. Specifically, I want to be able to go backwards through the trees in Python. Since we're nailing down the C API also we should try to finalise the capabilities now (even if some of them aren't as efficiently implemented as they might be).

This is a WIP to do that. Should 

- Close #60 

The low-level API is good I think, and the changes are welcome improvements. I need to think a bit more about what the high-level Python API will look like.