### PR TITLE
Retain unary nodes with simplify()

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -1,4 +1,15 @@
 ---------------------
+[0.99.3] - 2019-XX-XX
+---------------------
+
+In development.
+
+**New features**
+
+- Add the ``TSK_KEEP_UNARY`` option to simplify (:user:`gtsambos`). See :issue:`1`
+  and :pr:`143`.
+
+---------------------
 [0.99.2] - 2019-03-27
 ---------------------
 

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -872,7 +872,9 @@ test_simplest_records(void)
         "0  1   0";
     const char *edges =
         "0  1   2   0,1\n";
-    tsk_treeseq_t ts;
+    tsk_treeseq_t ts, simplified;
+    tsk_id_t sample_ids[] = {0, 1};
+    int ret;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
@@ -880,6 +882,17 @@ test_simplest_records(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 1);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, 0, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, TSK_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
 }
 
@@ -894,7 +907,9 @@ test_simplest_nonbinary_records(void)
         "0  1   0";
     const char *edges =
         "0  1   4   0,1,2,3\n";
-    tsk_treeseq_t ts;
+    tsk_treeseq_t ts, simplified;
+    tsk_id_t sample_ids[] = {0, 1, 2, 3};
+    int ret;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
@@ -902,6 +917,17 @@ test_simplest_nonbinary_records(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 1);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 4, 0, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 4, TSK_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
 }
 
@@ -935,11 +961,17 @@ test_simplest_unary_records(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&simplified), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&simplified), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&simplified), 3);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_edges(&simplified), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&simplified), 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&simplified), 1);
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, TSK_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
 
     tsk_treeseq_free(&ts);
-    tsk_treeseq_free(&simplified);
 }
 
 static void
@@ -1072,8 +1104,13 @@ test_simplest_degenerate_multiple_root_records(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&simplified), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&simplified), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&simplified), 2);
-
     tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, TSK_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
     tsk_tree_free(&t);
 }
@@ -1370,7 +1407,8 @@ test_simplest_holey_tree_sequence(void)
     char *haplotype;
     unsigned int j;
     int ret;
-    tsk_treeseq_t ts;
+    tsk_treeseq_t ts, simplified;
+    tsk_id_t sample_ids[] = {0, 1};
     tsk_hapgen_t hapgen;
 
     tsk_treeseq_from_text(&ts, 3, nodes_txt, edges_txt, NULL, sites_txt,
@@ -1390,8 +1428,18 @@ test_simplest_holey_tree_sequence(void)
         CU_ASSERT_EQUAL(ret, 0);
         CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
     }
-
     tsk_hapgen_free(&hapgen);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, 0, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, TSK_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
 }
 
@@ -1462,14 +1510,15 @@ test_simplest_initial_gap_tree_sequence(void)
     char *haplotype;
     unsigned int j;
     int ret;
-    tsk_treeseq_t ts;
+    tsk_treeseq_t ts, simplified;
     tsk_hapgen_t hapgen;
     const tsk_id_t z = TSK_NULL;
     tsk_id_t parents[] = {
         z, z, z,
         2, 2, z,
     };
-    uint32_t num_trees = 2;
+    tsk_size_t num_trees = 2;
+    tsk_id_t sample_ids[] = {0, 1};
 
     tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
@@ -1490,6 +1539,17 @@ test_simplest_initial_gap_tree_sequence(void)
         CU_ASSERT_STRING_EQUAL(haplotype, haplotypes[j]);
     }
     tsk_hapgen_free(&hapgen);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, 0, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, TSK_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
 }
 

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -586,6 +586,7 @@ typedef struct {
 #define TSK_FILTER_POPULATIONS           (1 << 1)
 #define TSK_FILTER_INDIVIDUALS           (1 << 2)
 #define TSK_REDUCE_TO_SITE_TOPOLOGY      (1 << 3)
+#define TSK_KEEP_UNARY                   (1 << 4)
 
 /* Flags for check_integrity */
 #define TSK_CHECK_OFFSETS                (1 << 0)
@@ -2134,6 +2135,10 @@ TSK_REDUCE_TO_SITE_TOPOLOGY
     For a given site, the topology of the tree containing that site will be 
     identical (up to node ID remapping) to the topology of the corresponding tree 
     in the input.
+TSK_KEEP_UNARY
+    By default simplify removes unary nodes (i.e., nodes with exactly one child) 
+    along the path from samples to root. If this option is specified such unary
+    nodes will be preserved in the output.
 
 .. note:: Migrations are currently not supported by simplify, and an error will
     be raised if we attempt call simplify on a table collection with greater

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,4 +1,15 @@
 --------------------
+[0.1.6] - 2019-XX-XX
+--------------------
+
+In development.
+
+**New features**
+
+- Add the ``keep_unary`` option to simplify (:user:`gtsambos`). See :issue:`1`
+  and :pr:`143`.
+
+--------------------
 [0.1.5] - 2019-03-27
 --------------------
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -5410,14 +5410,15 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     int filter_sites = true;
     int filter_individuals = false;
     int filter_populations = false;
+    int keep_unary = false;
     int reduce_to_site_topology = false;
     static char *kwlist[] = {
         "samples", "filter_sites", "filter_populations", "filter_individuals",
-        "reduce_to_site_topology", NULL};
+        "reduce_to_site_topology", "keep_unary", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiii", kwlist,
             &samples, &filter_sites, &filter_populations, &filter_individuals,
-            &reduce_to_site_topology)) {
+            &reduce_to_site_topology, &keep_unary)) {
         goto out;
     }
     samples_array = (PyArrayObject *) PyArray_FROMANY(samples, NPY_INT32, 1, 1,
@@ -5438,6 +5439,9 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     if (reduce_to_site_topology) {
         options |= TSK_REDUCE_TO_SITE_TOPOLOGY;
+    }
+    if (keep_unary) {
+        options |= TSK_KEEP_UNARY;
     }
 
     /* Allocate a new array to hold the node map. */

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -98,7 +98,7 @@ class Simplifier(object):
     """
     def __init__(
             self, ts, sample, reduce_to_site_topology=False, filter_sites=True,
-            filter_populations=True, filter_individuals=True):
+            filter_populations=True, filter_individuals=True, filter_unary=True):
         self.ts = ts
         self.n = len(sample)
         self.reduce_to_site_topology = reduce_to_site_topology
@@ -106,6 +106,7 @@ class Simplifier(object):
         self.filter_sites = filter_sites
         self.filter_populations = filter_populations
         self.filter_individuals = filter_individuals
+        self.filter_unary = filter_unary
         self.num_mutations = ts.num_mutations
         self.input_sites = list(ts.sites())
         self.A_head = [None for _ in range(ts.num_nodes)]
@@ -244,6 +245,7 @@ class Simplifier(object):
         All ancestry segments in S come together into a new parent.
         The new parent must be assigned and any overlapping segments coalesced.
         """
+
         output_id = self.node_id_map[input_id]
         is_sample = output_id != -1
         if is_sample:
@@ -260,6 +262,11 @@ class Simplifier(object):
                 if is_sample:
                     self.record_edge(left, right, output_id, ancestry_node)
                     ancestry_node = output_id
+                elif not self.filter_unary:
+                    if output_id == -1:
+                        output_id = self.record_node(input_id)
+                    self.record_edge(left, right, output_id, ancestry_node)
+
             else:
                 if output_id == -1:
                     output_id = self.record_node(input_id)
@@ -269,7 +276,11 @@ class Simplifier(object):
             if is_sample and left != prev_right:
                 # Fill in any gaps in the ancestry for the sample
                 self.add_ancestry(input_id, prev_right, left, output_id)
-            self.add_ancestry(input_id, left, right, ancestry_node)
+
+            if self.filter_unary:
+                self.add_ancestry(input_id, left, right, ancestry_node)
+            else:
+                self.add_ancestry(input_id, left, right, output_id)
             prev_right = right
 
         if is_sample and prev_right != self.sequence_length:
@@ -291,7 +302,8 @@ class Simplifier(object):
             x = self.A_head[edge.child]
             while x is not None:
                 if x.right > edge.left and edge.right > x.left:
-                    y = Segment(max(x.left, edge.left), min(x.right, edge.right), x.node)
+                    y = Segment(
+                        max(x.left, edge.left), min(x.right, edge.right), x.node)
                     S.append(y)
                 x = x.next
         self.merge_labeled_ancestors(S, parent)
@@ -408,6 +420,7 @@ class Simplifier(object):
             edges = all_edges[:1]
             for e in all_edges[1:]:
                 if e.parent != edges[0].parent:
+                    # print('input_id:', edges[0].parent)
                     self.process_parent_edges(edges)
                     edges = []
                 edges.append(e)
@@ -446,7 +459,22 @@ if __name__ == "__main__":
     # Simple CLI for running simplifier above.
     ts = tskit.load(sys.argv[1])
     samples = list(map(int, sys.argv[2:]))
-    s = Simplifier(ts, samples)
+
+    # When filter_unary = True
+    print('When filter_unary = True:')
+    s = Simplifier(ts, samples, filter_unary=True)
+    # s.print_state()
+    tss, _ = s.simplify()
+    tables = tss.dump_tables()
+    print("Output:")
+    print(tables.nodes)
+    print(tables.edges)
+    print(tables.sites)
+    print(tables.mutations)
+
+    # When filter_unary = False
+    print('\nWhen filter_unary = False:')
+    s = Simplifier(ts, samples, filter_unary=False)
     # s.print_state()
     tss, _ = s.simplify()
     tables = tss.dump_tables()

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1580,7 +1580,8 @@ class TableCollection(object):
             self, samples=None,
             filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
             reduce_to_site_topology=False,
-            filter_populations=True, filter_individuals=True, filter_sites=True):
+            filter_populations=True, filter_individuals=True, filter_sites=True,
+            keep_unary=False):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
@@ -1621,6 +1622,9 @@ class TableCollection(object):
             not referenced by mutations after simplification; new site IDs are
             allocated sequentially from zero. If False, the site table will not
             be altered in any way. (Default: True)
+        :param bool keep_unary: If True, any unary nodes (i.e. nodes with exactly
+            one child) that exist on the path from samples to root will be preserved
+            in the output. (Default: False)
         :return: A numpy array mapping node IDs in the input tables to their
             corresponding node IDs in the output tables.
         :rtype: numpy array (dtype=np.int32).
@@ -1639,7 +1643,8 @@ class TableCollection(object):
             samples, filter_sites=filter_sites,
             filter_individuals=filter_individuals,
             filter_populations=filter_populations,
-            reduce_to_site_topology=reduce_to_site_topology)
+            reduce_to_site_topology=reduce_to_site_topology,
+            keep_unary=keep_unary)
 
     def sort(self, edge_start=0):
         """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2890,7 +2890,7 @@ class TreeSequence(object):
             map_nodes=False,
             reduce_to_site_topology=False,
             filter_populations=True, filter_individuals=True, filter_sites=True,
-            record_provenance=True):
+            record_provenance=True, keep_unary=False):
         """
         Returns a simplified tree sequence that retains only the history of
         the nodes given in the list ``samples``. If ``map_nodes`` is true,
@@ -2949,6 +2949,9 @@ class TreeSequence(object):
         :param bool record_provenance: If True, record details of this call to
             simplify in the returned tree sequence's provenance information
             (Default: True).
+        :param bool keep_unary: If True, any unary nodes (i.e. nodes with exactly
+            one child) that exist on the path from samples to root will be preserved
+            in the output. (Default: False)
         :return: The simplified tree sequence, or (if ``map_nodes`` is True)
             a tuple consisting of the simplified tree sequence and a numpy array
             mapping source node IDs to their corresponding IDs in the new tree
@@ -2965,7 +2968,8 @@ class TreeSequence(object):
             reduce_to_site_topology=reduce_to_site_topology,
             filter_populations=filter_populations,
             filter_individuals=filter_individuals,
-            filter_sites=filter_sites)
+            filter_sites=filter_sites,
+            keep_unary=keep_unary)
         if record_provenance:
             # TODO add simplify arguments here
             # TODO also make sure we convert all the arguments so that they are


### PR DESCRIPTION
simplify() now takes a filter_unary argument (default: True). If False, all unary nodes are retained in the simplification.

The Python implementation in `python/tests/simplify.py` is now more or less finished; the tests in `python/tests/test_topology.py` are still under heavy development.