### PR TITLE
kc-distance with branch lengths

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -89,6 +89,8 @@ if not meson.is_subproject()
         sources: ['examples/tree_iteration.c'], link_with: [tskit_lib], dependencies: lib_deps)
     executable('tree_traversal', 
         sources: ['examples/tree_traversal.c'], link_with: [tskit_lib], dependencies: lib_deps)
+    executable('kc_distance',
+        sources: ['examples/kc_distance.c'], link_with: [tskit_lib], dependencies: lib_deps)
 
     gsl_dep = dependency('gsl', required: false)
     if gsl_dep.found()

--- a/c/meson.build
+++ b/c/meson.build
@@ -89,8 +89,6 @@ if not meson.is_subproject()
         sources: ['examples/tree_iteration.c'], link_with: [tskit_lib], dependencies: lib_deps)
     executable('tree_traversal', 
         sources: ['examples/tree_traversal.c'], link_with: [tskit_lib], dependencies: lib_deps)
-    executable('kc_distance',
-        sources: ['examples/kc_distance.c'], link_with: [tskit_lib], dependencies: lib_deps)
 
     gsl_dep = dependency('gsl', required: false)
     if gsl_dep.found()

--- a/c/tests/test_core.c
+++ b/c/tests/test_core.c
@@ -32,7 +32,7 @@ test_strerror(void)
 {
     int j;
     const char *msg;
-    int max_error_code = 1024; /* totally arbitrary */
+    int max_error_code = 8192; /* totally arbitrary */
 
     for (j = 0; j < max_error_code; j++) {
         msg = tsk_strerror(-j);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -4420,6 +4420,192 @@ test_internal_sample_sample_sets(void)
 }
 
 
+
+/*=======================================================
+ * KC Distance tests.
+ *=======================================================*/
+
+static void
+test_single_tree_kc(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_tree_t t, other_t;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
+            NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_init(&other_t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&other_t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_copy(&t, &other_t, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    check_trees_identical(&t, &other_t);
+    ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+    tsk_treeseq_free(&ts);
+    tsk_tree_free(&t);
+    tsk_tree_free(&other_t);
+}
+
+static void
+test_two_trees_kc(void)
+{
+    const char *nodes =
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "0  2   0\n"
+        "0  3   0\n";
+    const char *nodes_other =
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "0  4   0\n"
+        "0  6   0\n";
+    const char *edges =
+        "0 1  3 0,1\n"
+        "0 1  4 2,3\n";
+    int ret;
+    tsk_treeseq_t ts, other_ts;
+    tsk_tree_t t, other_t;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    tsk_treeseq_from_text(&other_ts, 1, nodes_other, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&other_t, &other_ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&other_t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+    ret = tsk_tree_kc_distance(&t, &other_t, 1, &result);
+    CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 4.243, 1e-2);
+    tsk_treeseq_free(&ts);
+    tsk_treeseq_free(&other_ts);
+    tsk_tree_free(&t);
+    tsk_tree_free(&other_t);
+}
+
+static void
+test_empty_tree_kc(void)
+{
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_tree_t t;
+    tsk_id_t v;
+    int ret;
+    double result = 0;
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SEQUENCE_LENGTH);
+    tsk_treeseq_free(&ts);
+    tables.sequence_length = 1.0;
+    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    verify_empty_tree_sequence(&ts, 1.0);
+
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL_FATAL(t.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(t.left, 0);
+    CU_ASSERT_EQUAL_FATAL(t.right, 1);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_get_parent(&t, 0, &v), TSK_ERR_NODE_OUT_OF_BOUNDS);
+    
+    ret = tsk_tree_kc_distance(&t, &t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_PARAM_VALUE); 
+    
+    tsk_tree_free(&t);
+    tsk_treeseq_free(&ts);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_nonbinary_tree_kc(void)
+{
+    const char *nodes =
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "0  1   0";
+    const char *edges =
+        "0  1   4   0,1,2,3\n";
+    tsk_treeseq_t ts;
+    tsk_tree_t t;
+    int ret;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    tsk_tree_kc_distance(&t, &t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+    tsk_treeseq_free(&ts);
+    tsk_tree_free(&t);
+}
+
+static void
+test_unequal_samples_kc(void)
+{
+    const char *nodes =
+        "1  0   0\n"
+        "1  0   0\n"
+        "1  0   0\n"
+        "0  2   0\n"
+        "0  3   0\n";
+    const char *nodes_other =
+        "1  0   0\n"
+        "1  0   0\n"
+        "0  1   0\n";
+    const char *edges =
+        "0 1  3 0,1\n"
+        "0 1  4 2,3\n";
+    const char *edges_other =
+        "0 1  2 0,1\n";
+    int ret;
+    tsk_treeseq_t ts, other_ts;
+    tsk_tree_t t, other_t;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    tsk_treeseq_from_text(&other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&other_t, &other_ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&other_t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_PARAM_VALUE);
+    tsk_treeseq_free(&ts);
+    tsk_treeseq_free(&other_ts);
+    tsk_tree_free(&t);
+    tsk_tree_free(&other_t);
+}  
+
+
+
 /*=======================================================
  * Miscellaneous tests.
  *======================================================*/
@@ -5107,6 +5293,13 @@ main(int argc, char **argv)
         {"test_simple_sample_sets", test_simple_sample_sets},
         {"test_nonbinary_sample_sets", test_nonbinary_sample_sets},
         {"test_internal_sample_sample_sets", test_internal_sample_sample_sets},
+
+        /*KC_Distance tests */
+        {"test_single_tree_kc", test_single_tree_kc},
+        {"test_two_trees_kc", test_two_trees_kc},
+        {"test_empty_tree_kc", test_empty_tree_kc},
+        {"test_nonbinary_tree_kc", test_nonbinary_tree_kc},
+        {"test_unequal_samples_kc", test_unequal_samples_kc},
 
         /* Misc */
         {"test_tree_errors", test_tree_errors},

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -373,6 +373,20 @@ tsk_strerror_internal(int err)
                 "represented. Either generate variants (which support missing "
                 "data) or use the impute missing data option.";
             break;
+
+        /* Distance metric errors */
+        case TSK_ERR_SAMPLE_SIZE_MISMATCH:
+            ret = "Cannot compare trees with different numbers of samples.";
+            break;
+        case TSK_ERR_SAMPLES_NOT_EQUAL:
+            ret = "Samples must be identical in trees to compare.";
+            break;
+        case TSK_ERR_INTERNAL_SAMPLES:
+            ret = "Internal samples are not supported.";
+            break;
+        case TSK_ERR_MULTIPLE_ROOTS:
+            ret = "Trees with multiple roots not supported.";
+            break;
     }
     return ret;
 }

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -223,6 +223,12 @@ of tskit.
 #define TSK_ERR_MUST_IMPUTE_NON_SAMPLES                            -1100
 #define TSK_ERR_MUST_IMPUTE_HAPLOTYPES                             -1101
 
+/* Distance metric errors */
+#define TSK_ERR_SAMPLE_SIZE_MISMATCH                               -1200
+#define TSK_ERR_SAMPLES_NOT_EQUAL                                  -1201
+#define TSK_ERR_INTERNAL_SAMPLES                                   -1202
+#define TSK_ERR_MULTIPLE_ROOTS                                     -1203
+
 
 /* This bit is 0 for any errors originating from kastore */
 #define TSK_KAS_ERR_BIT 14

--- a/c/tskit/stats.h
+++ b/c/tskit/stats.h
@@ -48,14 +48,6 @@ int tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
         tsk_size_t max_sites, double max_distance,
         double *r2, tsk_size_t *num_r2_values);
 
-typedef struct stack_elmt {
-    tsk_id_t node;
-    int path_depth;
-    double time_depth;
-} stack_elmt;
-
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/c/tskit/stats.h
+++ b/c/tskit/stats.h
@@ -48,6 +48,13 @@ int tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
         tsk_size_t max_sites, double max_distance,
         double *r2, tsk_size_t *num_r2_values);
 
+typedef struct stack_elmt {
+    tsk_id_t node;
+    int path_depth;
+    double time_depth;
+} stack_elmt;
+
+
 
 #ifdef __cplusplus
 }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4431,42 +4431,44 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
 int
 tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double *result)
 {
-    tsk_size_t num_nodes_self, num_nodes_other;
-    int ret = 0, stack_top = 0;
-    int path_depth, tree_index, pair_index, i;
-    double vT1, vT2, distance_sum, time_depth, root_time;
-    int *m[2], *path_distance[2];
-    double *M[2], *times, *time_distance[2];
-    tsk_id_t N, u, v, mrca, n1, n2, num_samples;
-    tsk_tree_t *trees[2], *tree;
-
     struct stack_elmt {
         tsk_id_t node;
         int path_depth;
         double time_depth;
     };
 
-    trees[0] = self;
-    trees[1] = other;
-   
+    tsk_size_t num_nodes_self, num_nodes_other;
+    int ret = 0;
+    int stack_top = 0;
+    int path_depth, tree_index, pair_index, i;
+    double vT1, vT2, distance_sum, time_depth, root_time;
+    int *m[2], *path_distance[2];
+    double *M[2], *time_distance[2];
+    tsk_id_t N, u, v, mrca, n1, n2, num_samples, u_index;
+    tsk_tree_t *trees[2] = {self, other};
+    tsk_tree_t *tree;
+    const tsk_id_t *samples = self->tree_sequence->samples;
+    const tsk_id_t *other_samples = other->tree_sequence->samples;
+    const double *times;
+    const tsk_id_t *sample_index_map;
     struct stack_elmt* stack = NULL;
+
     memset(path_distance, 0, sizeof(path_distance));
     memset(time_distance, 0, sizeof(time_distance));
     memset(m, 0, sizeof(m));
     memset(M, 0, sizeof(M));
 
     if (tsk_tree_get_num_roots(self) != 1 || tsk_tree_get_num_roots(other) != 1) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
-        goto out; 
+        ret = TSK_ERR_MULTIPLE_ROOTS;
+        goto out;
     }
-
     if (self->tree_sequence->num_samples != other->tree_sequence->num_samples) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = TSK_ERR_SAMPLE_SIZE_MISMATCH;
         goto out;
     }
 
     num_samples = (tsk_id_t) self->tree_sequence->num_samples;
-    N = (num_samples * (num_samples - 1)) / 2; 
+    N = (num_samples * (num_samples - 1)) / 2;
     num_nodes_self = self->num_nodes;
     num_nodes_other = other->num_nodes;
     stack = malloc(TSK_MAX(num_nodes_self, num_nodes_other) * sizeof(*stack));
@@ -4478,8 +4480,7 @@ tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double 
     path_distance[1] = malloc(num_nodes_other * sizeof(path_distance[1]));
     time_distance[0] = malloc(num_nodes_self * sizeof(time_distance[0]));
     time_distance[1] = malloc(num_nodes_other * sizeof(time_distance[1]));
-    
-    if (stack == NULL 
+    if (stack == NULL
             || m[0] == NULL
             || m[1] == NULL
             || M[0] == NULL
@@ -4489,15 +4490,30 @@ tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double 
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
- 
-    for (i=0; i <= N + num_samples; i++) {
+
+    for (i = 0; i < num_samples; i++) {
+        if (samples[i] != other_samples[i]) {
+            ret = TSK_ERR_SAMPLES_NOT_EQUAL;
+            goto out;
+        }
+        u = samples[i];
+        if (self->left_child[u] != TSK_NULL || other->left_child[u] != TSK_NULL) {
+            /* It's probably possible to support this, but it's too awkward
+             * to deal with and seems like a fairly niche requirement. */
+            ret = TSK_ERR_INTERNAL_SAMPLES;
+            goto out;
+        }
+    }
+
+    for (i = 0; i <= N + num_samples; i++) {
         m[0][i] = 1;
         m[1][i] = 1;
     }
 
-    for (tree_index=0; tree_index != 2; tree_index++) {
+    for (tree_index = 0; tree_index < 2; tree_index++) {
         tree = trees[tree_index];
         times = tree->tree_sequence->tables->nodes.time;
+        sample_index_map = tree->tree_sequence->sample_index_map;
         stack_top = 0;
         u = tree->left_root;
         root_time = times[u];
@@ -4509,8 +4525,7 @@ tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double 
             path_depth = stack[stack_top].path_depth;
             time_depth = stack[stack_top].time_depth;
             stack_top--;
-            for (v = tree->left_child[u]; v != TSK_NULL;
-                v = tree->right_sib[v]) {
+            for (v = tree->left_child[u]; v != TSK_NULL; v = tree->right_sib[v]) {
                 stack_top++;
                 stack[stack_top].node = v;
                 stack[stack_top].path_depth = path_depth + 1;
@@ -4518,17 +4533,18 @@ tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double 
             }
             path_distance[tree_index][u] = path_depth;
             time_distance[tree_index][u] = root_time - time_depth;
-            if (tree->left_child[u] == TSK_NULL) {
-                M[tree_index][u + N] = times[tree->parent[u]] - times[u];
+            u_index = sample_index_map[u];
+            if (u_index != TSK_NULL) {
+                M[tree_index][u_index + N] = times[tree->parent[u]] - times[u];
             }
         }
-        for (n1 = 0; n1 != num_samples; n1++) {
-            for (n2 = n1 + 1; n2 != num_samples; n2++){
-                ret = tsk_tree_get_mrca(tree, n1, n2, &mrca);
+        for (n1 = 0; n1 < num_samples; n1++) {
+            for (n2 = n1 + 1; n2 < num_samples; n2++){
+                ret = tsk_tree_get_mrca(tree, samples[n1], samples[n2], &mrca);
                 if (ret != 0) {
                     goto out;
                 }
-                pair_index = (n1 * (n1 - 2 * num_samples + 1)) / (-2) + n2 - n1 -1;
+                pair_index = n2 - n1 - 1 + (-1 * n1 * (n1 - 2 * num_samples + 1)) / 2;
                 assert (m[tree_index][pair_index] == 1);
                 m[tree_index][pair_index] = path_distance[tree_index][mrca];
                 M[tree_index][pair_index] = time_distance[tree_index][mrca];
@@ -4539,25 +4555,20 @@ tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double 
     vT1 = 0;
     vT2 = 0;
     distance_sum=0;
-
-    for (i = 0; i != N + num_samples; i++) {
+    for (i = 0; i < N + num_samples; i++) {
         vT1 = (m[0][i] * (1 - lambda)) + (lambda * M[0][i]);
         vT2 = (m[1][i] * (1 - lambda)) + (lambda * M[1][i]);
         distance_sum += (vT1 - vT2) * (vT1 - vT2);
     }
-  
+
     *result = sqrt(distance_sum);
 out:
     tsk_safe_free(stack);
-    tsk_safe_free(m[0]);
-    tsk_safe_free(m[1]);
-    tsk_safe_free(M[0]);
-    tsk_safe_free(M[1]);
-    tsk_safe_free(path_distance[0]);
-    tsk_safe_free(path_distance[1]);
-    tsk_safe_free(time_distance[0]);
-    tsk_safe_free(time_distance[1]);
+    for (i = 0; i < 2; i++) {
+        tsk_safe_free(m[i]);
+        tsk_safe_free(M[i]);
+        tsk_safe_free(path_distance[i]);
+        tsk_safe_free(time_distance[i]);
+    }
     return ret;
 }
-
-

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -384,6 +384,7 @@ int tsk_tree_map_mutations(tsk_tree_t *self, int8_t *genotypes,
         int8_t *ancestral_state,
         tsk_size_t *num_transitions, tsk_state_transition_t **transitions);
 
+int tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double *result);
 
 /****************************************************************************/
 /* Diff iterator */

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -8352,6 +8352,30 @@ out:
     return ret;
 }
 
+static PyObject *
+Tree_get_kc_distance(Tree *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *ret = NULL;
+    Tree *other = NULL;
+    static char *kwlist[] = {"other", "lambda_", NULL};
+    double lambda = 0;
+    double result;
+    int err;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!d", kwlist,
+                &TreeType, &other, &lambda)) {
+        goto out;
+    }
+    err = tsk_tree_kc_distance(self->tree, other->tree, lambda, &result);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("d", result);
+out:
+    return ret;
+}
+
 static PyMemberDef Tree_members[] = {
     {NULL}  /* Sentinel */
 };
@@ -8430,6 +8454,10 @@ static PyMethodDef Tree_methods[] = {
             "Returns True if this tree is equal to the parameter tree." },
     {"copy", (PyCFunction) Tree_copy, METH_NOARGS,
             "Returns a copy of this tree." },
+    {"get_kc_distance", (PyCFunction) Tree_get_kc_distance,
+            METH_VARARGS|METH_KEYWORDS,
+            "Returns the KC distance between this tree and another." },
+
     {NULL}  /* Sentinel */
 };
 

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -120,6 +120,531 @@ def generate_segments(n, sequence_length=100, seed=None):
     return segs
 
 
+def kc_distance_tree(tree1, tree2, topo_v_age=0):
+    """
+    Returns the Kendall-Colijn distance between the specified pair of trees.
+    topo_v_age determines weight of topology vs branch lengths in calculating
+    the distance. Set topo_v_age at 0 to only consider topology, set at 1 to
+    only consider branch lengths. See Kendall & Colijn (2016):
+    https://academic.oup.com/mbe/article/33/10/2735/2925548
+    """
+    samples = tree1.tree_sequence.samples()
+    if not np.array_equal(samples, tree2.tree_sequence.samples()):
+        raise ValueError("Trees must have the same samples")
+    if not len(tree1.roots) == len(tree2.roots) == 1:
+        raise ValueError("Trees must have one root")
+    k = samples.shape[0]
+    n = (k * (k - 1)) // 2
+    m = [np.ones(n + k), np.ones(n + k)]
+    M = [np.zeros(n + k), np.zeros(n + k)]
+    for tree_index, tree in enumerate([tree1, tree2]):
+        stack = [(tree.root, 0, tree.time(tree.root))]
+        while len(stack) > 0:
+            u, depth, time = stack.pop()
+            children = tree.children(u)
+            for v in children:
+                stack.append((v, depth + 1, tree.time(v)))
+            for c1, c2 in itertools.combinations(children, 2):
+                for u in tree.samples(c1):
+                    for v in tree.samples(c2):
+                        a = min(u, v)
+                        b = max(u, v)
+                        pair_index = a * (a - 2 * k + 1) // -2 + b - a - 1
+                        assert m[tree_index][pair_index] == 1
+                        m[tree_index][pair_index] = depth
+                        M[tree_index][pair_index] = tree.time(tree.root) - time
+            if len(tree.children(u)) == 0:
+                M[tree_index][u + n] = tree.branch_length(u)
+    return np.linalg.norm((1 - topo_v_age) * (m[0] - m[1]) + topo_v_age * (M[0] - M[1]))
+
+
+class TestKCMetric(unittest.TestCase):
+    """
+    Tests on the KC metric distances.
+    """
+    def test_same_tree_zero_distance(self):
+        for n in range(2, 10):
+            for seed in range(1, 10):
+                ts = msprime.simulate(n, random_seed=seed)
+                tree = ts.first()
+                self.assertEqual(kc_distance_tree(tree, tree), 0)
+                ts = msprime.simulate(n, random_seed=seed)
+                tree2 = ts.first()
+                self.assertEqual(kc_distance_tree(tree, tree2), 0)
+
+    def test_sample_2_zero_distance(self):
+        # All trees with 2 leaves must be equal distance from each other.
+        for seed in range(1, 10):
+            tree1 = msprime.simulate(2, random_seed=seed).first()
+            tree2 = msprime.simulate(2, random_seed=seed + 1).first()
+            self.assertEqual(kc_distance_tree(tree1, tree2), 0)
+
+    def test_different_samples_error(self):
+        tree1 = msprime.simulate(10, random_seed=1).first()
+        tree2 = msprime.simulate(2, random_seed=1).first()
+        self.assertRaises(ValueError, kc_distance_tree, tree1, tree2)
+
+    def validate_trees(self, n):
+        for seed in range(1, 10):
+            tree1 = msprime.simulate(n, random_seed=seed).first()
+            tree2 = msprime.simulate(n, random_seed=seed + 1).first()
+            self.assertAlmostEqual(
+                kc_distance_tree(tree1, tree2), kc_distance_tree(tree1, tree2))
+
+    def test_sample_3(self):
+        self.validate_trees(3)
+
+    def test_sample_4(self):
+        self.validate_trees(4)
+
+    def test_sample_10(self):
+        self.validate_trees(10)
+
+    def test_sample_20(self):
+        self.validate_trees(20)
+
+    def validate_nonbinary_trees(self, n):
+        demographic_events = [
+            msprime.SimpleBottleneck(0.02, 0, proportion=0.25),
+            msprime.SimpleBottleneck(0.2, 0, proportion=1)]
+
+        for seed in range(1, 10):
+            ts = msprime.simulate(
+                n, random_seed=seed, demographic_events=demographic_events)
+            # Check if this is really nonbinary
+            found = False
+            for edgeset in ts.edgesets():
+                if len(edgeset.children) > 2:
+                    found = True
+                    break
+            self.assertTrue(found)
+            tree1 = ts.first()
+
+            ts = msprime.simulate(
+                n, random_seed=seed + 1, demographic_events=demographic_events)
+            tree2 = ts.first()
+            self.assertAlmostEqual(
+                kc_distance_tree(tree1, tree2), kc_distance_tree(tree1, tree2))
+            self.assertAlmostEqual(
+                kc_distance_tree(tree2, tree1), kc_distance_tree(tree2, tree1))
+            # compare to a binary tree also
+            tree2 = msprime.simulate(n, random_seed=seed + 1).first()
+            self.assertAlmostEqual(
+                kc_distance_tree(tree1, tree2), kc_distance_tree(tree1, tree2))
+            self.assertAlmostEqual(
+                kc_distance_tree(tree2, tree1), kc_distance_tree(tree2, tree1))
+
+    def test_non_binary_sample_10(self):
+        self.validate_nonbinary_trees(10)
+
+    def test_non_binary_sample_20(self):
+        self.validate_nonbinary_trees(20)
+
+    def test_non_binary_sample_30(self):
+        self.validate_nonbinary_trees(30)
+
+    def test_known_kc_sample_3(self):
+        """
+        Test with hardcoded known values
+        """
+        tables_1 = tskit.TableCollection(sequence_length=1.0)
+        tables_2 = tskit.TableCollection(sequence_length=1.0)
+
+        # Nodes
+        sv = [True, True, True, False, False]
+        tv_1 = [0.0, 0.0, 0.0, 2.0, 3.0]
+        tv_2 = [0.0, 0.0, 0.0, 4.0, 6.0]
+
+        for is_sample, t1, t2 in zip(sv, tv_1, tv_2):
+            flags = tskit.NODE_IS_SAMPLE if is_sample else 0
+            tables_1.nodes.add_row(flags=flags, time=t1)
+            tables_2.nodes.add_row(flags=flags, time=t2)
+
+        # Edges
+        lv = [0.0, 0.0, 0.0, 0.0]
+        rv = [1.0, 1.0, 1.0, 1.0]
+        pv = [3, 3, 4, 4]
+        cv = [0, 1, 2, 3]
+
+        for l, r, p, c in zip(lv, rv, pv, cv):
+            tables_1.edges.add_row(left=l, right=r, parent=p, child=c)
+            tables_2.edges.add_row(left=l, right=r, parent=p, child=c)
+
+        tree_1 = tables_1.tree_sequence().first()
+        tree_2 = tables_2.tree_sequence().first()
+
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 0), 0)
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 1), 4.243, places=3)
+
+    def test_10_samples(self):
+        nodes_1 = io.StringIO("""\
+        id  is_sample   time    population  individual  metadata
+        0   1   0.000000    0   -1  b''
+        1   1   0.000000    0   -1  b''
+        2   1   0.000000    0   -1  b''
+        3   1   0.000000    0   -1  b''
+        4   1   0.000000    0   -1  b''
+        5   1   0.000000    0   -1  b''
+        6   1   0.000000    0   -1  b''
+        7   1   0.000000    0   -1  b''
+        8   1   0.000000    0   -1  b''
+        9   1   0.000000    0   -1  b''
+        10  0   0.047734    0   -1  b''
+        11  0   0.061603    0   -1  b''
+        12  0   0.189503    0   -1  b''
+        13  0   0.275885    0   -1  b''
+        14  0   0.518301    0   -1  b''
+        15  0   0.543143    0   -1  b''
+        16  0   0.865193    0   -1  b''
+        17  0   1.643658    0   -1  b''
+        18  0   2.942350    0   -1  b''
+        """)
+        edges_1 = io.StringIO("""\
+        left    right   parent  child
+        0.000000    10000.000000    10  0
+        0.000000    10000.000000    10  2
+        0.000000    10000.000000    11  9
+        0.000000    10000.000000    11  10
+        0.000000    10000.000000    12  3
+        0.000000    10000.000000    12  7
+        0.000000    10000.000000    13  5
+        0.000000    10000.000000    13  11
+        0.000000    10000.000000    14  1
+        0.000000    10000.000000    14  8
+        0.000000    10000.000000    15  4
+        0.000000    10000.000000    15  14
+        0.000000    10000.000000    16  13
+        0.000000    10000.000000    16  15
+        0.000000    10000.000000    17  6
+        0.000000    10000.000000    17  12
+        0.000000    10000.000000    18  16
+        0.000000    10000.000000    18  17
+        """)
+        ts_1 = tskit.load_text(nodes_1, edges_1, sequence_length=10000,
+                               strict=False, base64_metadata=False)
+        nodes_2 = io.StringIO("""\
+        id  is_sample   time    population  individual  metadata
+        0   1   0.000000    0   -1  b''
+        1   1   0.000000    0   -1  b''
+        2   1   0.000000    0   -1  b''
+        3   1   0.000000    0   -1  b''
+        4   1   0.000000    0   -1  b''
+        5   1   0.000000    0   -1  b''
+        6   1   0.000000    0   -1  b''
+        7   1   0.000000    0   -1  b''
+        8   1   0.000000    0   -1  b''
+        9   1   0.000000    0   -1  b''
+        10  0   0.210194    0   -1  b''
+        11  0   0.212217    0   -1  b''
+        12  0   0.223341    0   -1  b''
+        13  0   0.272703    0   -1  b''
+        14  0   0.443553    0   -1  b''
+        15  0   0.491653    0   -1  b''
+        16  0   0.729369    0   -1  b''
+        17  0   1.604113    0   -1  b''
+        18  0   1.896332    0   -1  b''
+        """)
+        edges_2 = io.StringIO("""\
+        left    right   parent  child
+        0.000000    10000.000000    10  5
+        0.000000    10000.000000    10  7
+        0.000000    10000.000000    11  3
+        0.000000    10000.000000    11  4
+        0.000000    10000.000000    12  6
+        0.000000    10000.000000    12  9
+        0.000000    10000.000000    13  10
+        0.000000    10000.000000    13  12
+        0.000000    10000.000000    14  8
+        0.000000    10000.000000    14  11
+        0.000000    10000.000000    15  1
+        0.000000    10000.000000    15  2
+        0.000000    10000.000000    16  13
+        0.000000    10000.000000    16  14
+        0.000000    10000.000000    17  0
+        0.000000    10000.000000    17  16
+        0.000000    10000.000000    18  15
+        0.000000    10000.000000    18  17
+        """)
+        ts_2 = tskit.load_text(nodes_2, edges_2, sequence_length=10000,
+                               strict=False, base64_metadata=False)
+
+        tree_1 = ts_1.first()
+        tree_2 = ts_2.first()
+
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 0), 12.85, places=2)
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 1), 10.64, places=2)
+
+    def test_15_samples(self):
+        nodes_1 = io.StringIO("""\
+        id  is_sample   time    population  individual  metadata
+        0   1   0.000000    0   -1
+        1   1   0.000000    0   -1
+        2   1   0.000000    0   -1
+        3   1   0.000000    0   -1
+        4   1   0.000000    0   -1
+        5   1   0.000000    0   -1
+        6   1   0.000000    0   -1
+        7   1   0.000000    0   -1
+        8   1   0.000000    0   -1
+        9   1   0.000000    0   -1
+        10  1   0.000000    0   -1
+        11  1   0.000000    0   -1
+        12  1   0.000000    0   -1
+        13  1   0.000000    0   -1
+        14  1   0.000000    0   -1
+        15  0   0.026043    0   -1
+        16  0   0.032662    0   -1
+        17  0   0.072032    0   -1
+        18  0   0.086792    0   -1
+        19  0   0.130699    0   -1
+        20  0   0.177640    0   -1
+        21  0   0.199800    0   -1
+        22  0   0.236391    0   -1
+        23  0   0.342445    0   -1
+        24  0   0.380356    0   -1
+        25  0   0.438502    0   -1
+        26  0   0.525632    0   -1
+        27  0   1.180078    0   -1
+        28  0   2.548099    0   -1
+        """)
+        edges_1 = io.StringIO("""\
+        left    right   parent  child
+        0.000000    10000.000000    15  6
+        0.000000    10000.000000    15  13
+        0.000000    10000.000000    16  1
+        0.000000    10000.000000    16  4
+        0.000000    10000.000000    17  0
+        0.000000    10000.000000    17  7
+        0.000000    10000.000000    18  2
+        0.000000    10000.000000    18  17
+        0.000000    10000.000000    19  5
+        0.000000    10000.000000    19  9
+        0.000000    10000.000000    20  12
+        0.000000    10000.000000    20  15
+        0.000000    10000.000000    21  8
+        0.000000    10000.000000    21  20
+        0.000000    10000.000000    22  11
+        0.000000    10000.000000    22  21
+        0.000000    10000.000000    23  10
+        0.000000    10000.000000    23  22
+        0.000000    10000.000000    24  14
+        0.000000    10000.000000    24  16
+        0.000000    10000.000000    25  18
+        0.000000    10000.000000    25  19
+        0.000000    10000.000000    26  23
+        0.000000    10000.000000    26  24
+        0.000000    10000.000000    27  25
+        0.000000    10000.000000    27  26
+        0.000000    10000.000000    28  3
+        0.000000    10000.000000    28  27
+        """)
+        ts_1 = tskit.load_text(nodes_1, edges_1, sequence_length=10000,
+                               strict=False, base64_metadata=False)
+
+        nodes_2 = io.StringIO("""\
+        id  is_sample   time    population  individual  metadata
+        0   1   0.000000    0   -1
+        1   1   0.000000    0   -1
+        2   1   0.000000    0   -1
+        3   1   0.000000    0   -1
+        4   1   0.000000    0   -1
+        5   1   0.000000    0   -1
+        6   1   0.000000    0   -1
+        7   1   0.000000    0   -1
+        8   1   0.000000    0   -1
+        9   1   0.000000    0   -1
+        10  1   0.000000    0   -1
+        11  1   0.000000    0   -1
+        12  1   0.000000    0   -1
+        13  1   0.000000    0   -1
+        14  1   0.000000    0   -1
+        15  0   0.011443    0   -1
+        16  0   0.055694    0   -1
+        17  0   0.061677    0   -1
+        18  0   0.063416    0   -1
+        19  0   0.163014    0   -1
+        20  0   0.223445    0   -1
+        21  0   0.251724    0   -1
+        22  0   0.268749    0   -1
+        23  0   0.352039    0   -1
+        24  0   0.356134    0   -1
+        25  0   0.399454    0   -1
+        26  0   0.409174    0   -1
+        27  0   2.090839    0   -1
+        28  0   3.772716    0   -1
+        """)
+        edges_2 = io.StringIO("""\
+        left    right   parent  child
+        0.000000    10000.000000    15  6
+        0.000000    10000.000000    15  8
+        0.000000    10000.000000    16  9
+        0.000000    10000.000000    16  12
+        0.000000    10000.000000    17  3
+        0.000000    10000.000000    17  4
+        0.000000    10000.000000    18  13
+        0.000000    10000.000000    18  16
+        0.000000    10000.000000    19  2
+        0.000000    10000.000000    19  11
+        0.000000    10000.000000    20  1
+        0.000000    10000.000000    20  17
+        0.000000    10000.000000    21  0
+        0.000000    10000.000000    21  18
+        0.000000    10000.000000    22  10
+        0.000000    10000.000000    22  15
+        0.000000    10000.000000    23  14
+        0.000000    10000.000000    23  21
+        0.000000    10000.000000    24  5
+        0.000000    10000.000000    24  7
+        0.000000    10000.000000    25  19
+        0.000000    10000.000000    25  22
+        0.000000    10000.000000    26  24
+        0.000000    10000.000000    26  25
+        0.000000    10000.000000    27  20
+        0.000000    10000.000000    27  23
+        0.000000    10000.000000    28  26
+        0.000000    10000.000000    28  27
+        """)
+        ts_2 = tskit.load_text(nodes_2, edges_2, sequence_length=10000,
+                               strict=False, base64_metadata=False)
+
+        tree_1 = ts_1.first()
+        tree_2 = ts_2.first()
+
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 0), 19.95, places=2)
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 1), 17.74, places=2)
+
+    def test_nobinary_trees(self):
+        nodes_1 = io.StringIO("""\
+        id  is_sample   time    population  individual  metadata
+        0   1   0.000000    -1  -1   e30=
+        1   1   0.000000    -1  -1   e30=
+        2   1   0.000000    -1  -1   e30=
+        3   1   0.000000    -1  -1   e30=
+        4   1   0.000000    -1  -1   e30=
+        5   1   0.000000    -1  -1   e30=
+        6   1   0.000000    -1  -1   e30=
+        7   1   0.000000    -1  -1   e30=
+        8   1   0.000000    -1  -1   e30=
+        9   1   0.000000    -1  -1
+        10  1   0.000000    -1  -1
+        11  1   0.000000    -1  -1
+        12  1   0.000000    -1  -1
+        13  1   0.000000    -1  -1
+        14  1   0.000000    -1  -1
+        15  0   2.000000    -1  -1
+        16  0   4.000000    -1  -1
+        17  0   11.000000   -1  -1
+        18  0   12.000000   -1  -1
+        """)
+        edges_1 = io.StringIO("""\
+        left    right   parent  child
+        0.000000    10000.000000    15  8
+        0.000000    10000.000000    15  10
+        0.000000    10000.000000    16  6
+        0.000000    10000.000000    16  12
+        0.000000    10000.000000    16  15
+        0.000000    10000.000000    17  0
+        0.000000    10000.000000    17  1
+        0.000000    10000.000000    17  2
+        0.000000    10000.000000    17  3
+        0.000000    10000.000000    17  4
+        0.000000    10000.000000    17  5
+        0.000000    10000.000000    17  7
+        0.000000    10000.000000    17  9
+        0.000000    10000.000000    17  11
+        0.000000    10000.000000    17  13
+        0.000000    10000.000000    17  14
+        0.000000    10000.000000    18  16
+        0.000000    10000.000000    18  17
+        """)
+        ts_1 = tskit.load_text(nodes_1, edges_1, sequence_length=10000,
+                               strict=False, base64_metadata=False)
+
+        nodes_2 = io.StringIO("""\
+        id  is_sample   time    population  individual  metadata
+        0   1   0.000000    -1  -1   e30=
+        1   1   0.000000    -1  -1   e30=
+        2   1   0.000000    -1  -1   e30=
+        3   1   0.000000    -1  -1   e30=
+        4   1   0.000000    -1  -1   e30=
+        5   1   0.000000    -1  -1   e30=
+        6   1   0.000000    -1  -1   e30=
+        7   1   0.000000    -1  -1   e30=
+        8   1   0.000000    -1  -1   e30=
+        9   1   0.000000    -1  -1   e30=
+        10  1   0.000000    -1  -1  e30=
+        11  1   0.000000    -1  -1  e30=
+        12  1   0.000000    -1  -1  e30=
+        13  1   0.000000    -1  -1  e30=
+        14  1   0.000000    -1  -1  e30=
+        15  0   2.000000    -1  -1
+        16  0   2.000000    -1  -1
+        17  0   3.000000    -1  -1
+        18  0   3.000000    -1  -1
+        19  0   4.000000    -1  -1
+        20  0   4.000000    -1  -1
+        21  0   11.000000   -1  -1
+        22  0   12.000000   -1  -1
+        """)
+        edges_2 = io.StringIO("""\
+        left    right   parent  child
+        0.000000    10000.000000    15  12
+        0.000000    10000.000000    15  14
+        0.000000    10000.000000    16  0
+        0.000000    10000.000000    16  7
+        0.000000    10000.000000    17  6
+        0.000000    10000.000000    17  15
+        0.000000    10000.000000    18  4
+        0.000000    10000.000000    18  8
+        0.000000    10000.000000    18  13
+        0.000000    10000.000000    19  11
+        0.000000    10000.000000    19  18
+        0.000000    10000.000000    20  1
+        0.000000    10000.000000    20  5
+        0.000000    10000.000000    20  9
+        0.000000    10000.000000    20  10
+        0.000000    10000.000000    21  2
+        0.000000    10000.000000    21  3
+        0.000000    10000.000000    21  16
+        0.000000    10000.000000    21  17
+        0.000000    10000.000000    21  20
+        0.000000    10000.000000    22  19
+        0.000000    10000.000000    22  21
+        """)
+        ts_2 = tskit.load_text(nodes_2, edges_2, sequence_length=10000,
+                               strict=False, base64_metadata=False)
+
+        tree_1 = ts_1.first()
+        tree_2 = ts_2.first()
+
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 0), 9.434, places=3)
+        self.assertAlmostEqual(
+            kc_distance_tree(tree_1, tree_2, 1), 44, places=1)
+
+    def test_multiple_roots(self):
+        tables = tskit.TableCollection(sequence_length=1.0)
+
+        # Nodes
+        sv = [True, True]
+        tv = [0.0, 0.0]
+
+        for is_sample, t in zip(sv, tv):
+            flags = tskit.NODE_IS_SAMPLE if is_sample else 0
+            tables.nodes.add_row(flags=flags, time=t)
+
+        ts = tables.tree_sequence()
+
+        with self.assertRaises(ValueError):
+            kc_distance_tree(ts.first(), ts.first(), 0)
+
+
 class TestOverlappingSegments(unittest.TestCase):
     """
     Tests for the overlapping segments algorithm required for simplify.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1628,6 +1628,26 @@ class Tree(object):
             for node, parent, derived_state in transitions]
         return ancestral_state, mutations
 
+    def kc_distance(self, other, lambda_=0.0):
+        """
+        Returns the Kendall-Colijn distance between the specified pair of trees.
+        The ``lambda_`` parameter  determines the relative weight of topology
+        vs branch lengths in calculating the distance. If ``lambda_`` is 0
+        (the default) we only consider topology, and if it is 1 we only
+        consider branch lengths. See `Kendall & Colijn (2016)
+        <https://academic.oup.com/mbe/article/33/10/2735/2925548>`_ for details.
+
+        The trees we are comparing to must have identical lists of sample
+        nodes (i.e., the same IDs in the same order).
+
+        :param Tree other: The other tree to compare to.
+        :param float lambda_: The KC metric lambda parameter determining the
+            relative weight of topology and branch length.
+        :return: The computed KC distance between this tree and other.
+        :rtype: float
+        """
+        return self._ll_tree.get_kc_distance(other._ll_tree, lambda_)
+
 
 def load(path):
     """


### PR DESCRIPTION
Modified kc_distance to consider branch lengths via the lambda parameter (0 = only topological comparison, 1 = only branch lengths). Renamed to kc_distance_tree as it compares two trees.
Also added kc_distance_ts, which calcualtes kc_distance across a tree sequence.