### PR TITLE
simplify() takes an input list of ancestral nodes

### DIFF
--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -1829,30 +1829,30 @@ test_map_ancestors_input_errors(void)
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, NULL, 2, ancestors, 2, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, NULL, 2, ancestors, 2, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_PARAM_VALUE);
 
     /* Bad sample IDs */
     samples[0] = -1;
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     /* Bad ancestor IDs */
     samples[0] = 0;
     ancestors[0] = -1;
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);  
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
-    /* Duplicate sample IDs */ 
-    ancestors[0] = 4; 
+    /* Duplicate sample IDs */
+    ancestors[0] = 4;
     samples[0] = 1;
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
 
-    /* Duplicate sample IDs */ 
-    ancestors[0] = 6; 
+    /* Duplicate sample IDs */
+    ancestors[0] = 6;
     samples[0] = 0;
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
 
     /* TODO more tests! */
@@ -1871,6 +1871,9 @@ test_map_ancestors_single_tree(void)
     tsk_edge_table_t result;
     tsk_id_t samples[] = {0, 1};
     tsk_id_t ancestors[] = {4, 6};
+    size_t i;
+    double res_left = 0;
+    double res_right = 1;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
             NULL, NULL, NULL, NULL, NULL);
@@ -1879,18 +1882,13 @@ test_map_ancestors_single_tree(void)
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-
-    // tsk_edge_table_print_state(&result, stdout);
 
     // Check we get the right result.
     CU_ASSERT_EQUAL(result.num_rows, 3);
-    size_t i;
     tsk_id_t res_parent[] = {4, 4, 6};
     tsk_id_t res_child[] = {0, 1, 4};
-    double res_left = 0;
-    double res_right = 1;
     for (i = 0; i < result.num_rows; i++) {
         CU_ASSERT_EQUAL(res_parent[i], result.parent[i]);
         CU_ASSERT_EQUAL(res_child[i], result.child[i]);
@@ -1921,7 +1919,7 @@ test_map_ancestors_no_edges(void)
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 1, ancestors, 1, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 1, ancestors, 1, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tsk_table_collection_free(&tables);
@@ -1947,7 +1945,7 @@ test_map_ancestors_samples_and_ancestors_overlap(void)
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 4, ancestors, 1, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 4, ancestors, 1, 0, &result);
 
     // tsk_edge_table_print_state(&result, stdout);
 
@@ -1988,7 +1986,7 @@ test_map_ancestors_paper(void)
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 3, ancestors, 3, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 3, ancestors, 3, 0, &result);
 
     // tsk_edge_table_print_state(&result, stdout);
 
@@ -2028,7 +2026,7 @@ test_map_ancestors_multiple_to_single_tree(void)
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 1, &result);
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 1, 0, &result);
 
     // tsk_edge_table_print_state(&result, stdout);
 
@@ -2462,7 +2460,7 @@ main(int argc, char **argv)
         {"test_map_ancestors_paper", test_map_ancestors_paper},
         {"test_map_ancestors_samples_and_ancestors_overlap",
             test_map_ancestors_samples_and_ancestors_overlap},
-        {"test_map_ancestors_multiple_to_single_tree", 
+        {"test_map_ancestors_multiple_to_single_tree",
         test_map_ancestors_multiple_to_single_tree},
         {"test_sort_tables_drops_indexes", test_sort_tables_drops_indexes},
         {"test_copy_table_collection", test_copy_table_collection},

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -1813,6 +1813,27 @@ test_provenance_table(void)
 }
 
 static void
+test_map_ancestors(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_id_t samples[] = {0, 1};
+    tsk_id_t ancestors[] = {4, 6};
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
+            NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2);
+    // CU_ASSERT_EQUAL_FATAL(ret, 0); // causing errors but don't know why
+
+    tsk_table_collection_free(&tables);
+    tsk_treeseq_free(&ts);
+}
+
+static void
 test_simplify_tables_drops_indexes(void)
 {
     int ret;
@@ -2216,6 +2237,7 @@ main(int argc, char **argv)
         {"test_load_tsk_node_table_errors", test_load_tsk_node_table_errors},
         {"test_simplify_tables_drops_indexes", test_simplify_tables_drops_indexes},
         {"test_simplify_empty_tables", test_simplify_empty_tables},
+        {"test_map_ancestors", test_map_ancestors},
         {"test_sort_tables_drops_indexes", test_sort_tables_drops_indexes},
         {"test_copy_table_collection", test_copy_table_collection},
         {"test_sort_tables_errors", test_sort_tables_errors},

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -1813,11 +1813,12 @@ test_provenance_table(void)
 }
 
 static void
-test_map_ancestors(void)
+test_map_ancestors_input_errors(void)
 {
     int ret;
     tsk_treeseq_t ts;
     tsk_table_collection_t tables;
+    tsk_edge_table_t result;
     tsk_id_t samples[] = {0, 1};
     tsk_id_t ancestors[] = {4, 6};
 
@@ -1825,11 +1826,228 @@ test_map_ancestors(void)
             NULL, NULL, NULL, NULL, NULL);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2);
-    // CU_ASSERT_EQUAL_FATAL(ret, 0); // causing errors but don't know why
+    ret = tsk_table_collection_map_ancestors(&tables, NULL, 2, ancestors, 2, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_PARAM_VALUE);
+
+    /* Bad sample IDs */
+    samples[0] = -1;
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+
+    /* Bad ancestor IDs */
+    samples[0] = 0;
+    ancestors[0] = -1;
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);  
+
+    /* Duplicate sample IDs */ 
+    ancestors[0] = 4; 
+    samples[0] = 1;
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
+
+    /* Duplicate sample IDs */ 
+    ancestors[0] = 6; 
+    samples[0] = 0;
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
+
+    /* TODO more tests! */
 
     tsk_table_collection_free(&tables);
+    tsk_treeseq_free(&ts);
+    tsk_edge_table_free(&result);
+}
+
+static void
+test_map_ancestors_single_tree(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_edge_table_t result;
+    tsk_id_t samples[] = {0, 1};
+    tsk_id_t ancestors[] = {4, 6};
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
+            NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 2, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    // tsk_edge_table_print_state(&result, stdout);
+
+    // Check we get the right result.
+    CU_ASSERT_EQUAL(result.num_rows, 3);
+    size_t i;
+    tsk_id_t res_parent[] = {4, 4, 6};
+    tsk_id_t res_child[] = {0, 1, 4};
+    double res_left = 0;
+    double res_right = 1;
+    for (i = 0; i < result.num_rows; i++) {
+        CU_ASSERT_EQUAL(res_parent[i], result.parent[i]);
+        CU_ASSERT_EQUAL(res_child[i], result.child[i]);
+        CU_ASSERT_EQUAL(res_left, result.left[i]);
+        CU_ASSERT_EQUAL(res_right, result.right[i]);
+    }
+
+    tsk_table_collection_free(&tables);
+    tsk_treeseq_free(&ts);
+    tsk_edge_table_free(&result);
+
+}
+
+static void
+test_map_ancestors_no_edges(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_edge_table_t result;
+    tsk_id_t samples[] = {2};
+    tsk_id_t ancestors[] = {4};
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
+            NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 1, ancestors, 1, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    tsk_table_collection_free(&tables);
+    tsk_edge_table_free(&result);
+    tsk_treeseq_free(&ts);
+
+}
+
+static void
+test_map_ancestors_samples_and_ancestors_overlap(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_edge_table_t result;
+    tsk_id_t samples[] = {0,1,2,4};
+    tsk_id_t ancestors[] = {4};
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
+            NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 4, ancestors, 1, &result);
+
+    // tsk_edge_table_print_state(&result, stdout);
+
+    // Check we get the right result.
+    CU_ASSERT_EQUAL(result.num_rows, 2);
+    size_t i;
+    tsk_id_t res_parent = 4;
+    tsk_id_t res_child[] = {0, 1};
+    double res_left = 0;
+    double res_right = 1;
+    for (i = 0; i < result.num_rows; i++) {
+        CU_ASSERT_EQUAL(res_parent, result.parent[i]);
+        CU_ASSERT_EQUAL(res_child[i], result.child[i]);
+        CU_ASSERT_EQUAL(res_left, result.left[i]);
+        CU_ASSERT_EQUAL(res_right, result.right[i]);
+    }
+
+    tsk_table_collection_free(&tables);
+    tsk_edge_table_free(&result);
+    tsk_treeseq_free(&ts);
+
+}
+
+static void
+test_map_ancestors_paper(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_edge_table_t result;
+    tsk_id_t samples[] = {0, 1, 2};
+    tsk_id_t ancestors[] = {5, 6, 7};
+
+    tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL,
+            paper_ex_sites, paper_ex_mutations, paper_ex_individuals, NULL);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 3, ancestors, 3, &result);
+
+    // tsk_edge_table_print_state(&result, stdout);
+
+   // Check we get the right result.
+    CU_ASSERT_EQUAL(result.num_rows, 6);
+    size_t i;
+    tsk_id_t res_parent[] = {5, 5, 6, 6, 7, 7};
+    tsk_id_t res_child[] = {1, 2, 0, 5, 0, 5};
+    double res_left[] = {0, 2, 0, 0, 7, 7};
+    double res_right[] = {10, 10, 7, 7, 10, 10};
+    for (i = 0; i < result.num_rows; i++) {
+        CU_ASSERT_EQUAL(res_parent[i], result.parent[i]);
+        CU_ASSERT_EQUAL(res_child[i], result.child[i]);
+        CU_ASSERT_EQUAL(res_left[i], result.left[i]);
+        CU_ASSERT_EQUAL(res_right[i], result.right[i]);
+    }
+
+    tsk_table_collection_free(&tables);
+    tsk_edge_table_free(&result);
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_map_ancestors_multiple_to_single_tree(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_table_collection_t tables;
+    tsk_edge_table_t result;
+    tsk_id_t samples[] = {1, 3};
+    tsk_id_t ancestors[] = {5};
+
+    tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL,
+            paper_ex_sites, paper_ex_mutations, paper_ex_individuals, NULL);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_table_collection_map_ancestors(&tables, samples, 2, ancestors, 1, &result);
+
+    // tsk_edge_table_print_state(&result, stdout);
+
+  // Check we get the right result.
+    CU_ASSERT_EQUAL(result.num_rows, 2);
+    size_t i;
+    tsk_id_t res_parent = 5;
+    tsk_id_t res_child[] = {1, 3};
+    double res_left = 0;
+    double res_right = 10;
+    for (i = 0; i < result.num_rows; i++) {
+        CU_ASSERT_EQUAL(res_parent, result.parent[i]);
+        CU_ASSERT_EQUAL(res_child[i], result.child[i]);
+        CU_ASSERT_EQUAL(res_left, result.left[i]);
+        CU_ASSERT_EQUAL(res_right, result.right[i]);
+    }
+
+    tsk_table_collection_free(&tables);
+    tsk_edge_table_free(&result);
     tsk_treeseq_free(&ts);
 }
 
@@ -1864,7 +2082,8 @@ test_simplify_empty_tables(void)
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
-    ret = tsk_table_collection_simplify(&tables, NULL, 0, 0, NULL);
+
+    // ret = tsk_table_collection_simplify(&tables, NULL, 0, 0, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(tables.nodes.num_rows, 0);
     CU_ASSERT_EQUAL_FATAL(tables.edges.num_rows, 0);
@@ -2237,7 +2456,14 @@ main(int argc, char **argv)
         {"test_load_tsk_node_table_errors", test_load_tsk_node_table_errors},
         {"test_simplify_tables_drops_indexes", test_simplify_tables_drops_indexes},
         {"test_simplify_empty_tables", test_simplify_empty_tables},
-        {"test_map_ancestors", test_map_ancestors},
+        {"test_map_ancestors_no_edges", test_map_ancestors_no_edges},
+        {"test_map_ancestors_input_errors", test_map_ancestors_input_errors},
+        {"test_map_ancestors_single_tree", test_map_ancestors_single_tree},
+        {"test_map_ancestors_paper", test_map_ancestors_paper},
+        {"test_map_ancestors_samples_and_ancestors_overlap",
+            test_map_ancestors_samples_and_ancestors_overlap},
+        {"test_map_ancestors_multiple_to_single_tree", 
+        test_map_ancestors_multiple_to_single_tree},
         {"test_sort_tables_drops_indexes", test_sort_tables_drops_indexes},
         {"test_copy_table_collection", test_copy_table_collection},
         {"test_sort_tables_errors", test_sort_tables_errors},
@@ -2248,7 +2474,6 @@ main(int argc, char **argv)
         {"test_column_overflow", test_column_overflow},
         {NULL, NULL},
     };
-
 
     return test_main(tests, argc, argv);
 }

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -3756,30 +3756,6 @@ typedef struct {
     double *position_lookup;
 } simplifier_t;
 
-typedef struct {
-    tsk_id_t *samples;
-    size_t num_samples;
-    tsk_id_t *ancestors;
-    size_t num_ancestors;
-    tsk_table_collection_t *tables;
-    tsk_table_collection_t input_tables;
-    simplify_segment_t **ancestor_map_head;
-    simplify_segment_t **ancestor_map_tail;
-    bool *is_sample;
-    bool *is_ancestor;
-    simplify_segment_t *segment_queue;
-    size_t segment_queue_size;
-    size_t max_segment_queue_size;
-    segment_overlapper_t segment_overlapper;
-    tsk_blkalloc_t segment_heap;
-    tsk_blkalloc_t interval_list_heap;
-    interval_list_t **child_edge_map_head;
-    interval_list_t **child_edge_map_tail;
-    tsk_id_t *buffered_children;
-    size_t num_buffered_children;
-    // double *position_lookup;
-} ancestor_mapper_t;
-
 static int
 cmp_segment(const void *a, const void *b) {
     const simplify_segment_t *ia = (const simplify_segment_t *) a;
@@ -3916,9 +3892,6 @@ segment_overlapper_next(segment_overlapper_t *self,
     return ret;
 }
 
-/*************************
- * simplifier
- *************************/
 
 static int
 cmp_node_id(const void *a, const void *b) {
@@ -3926,6 +3899,492 @@ cmp_node_id(const void *a, const void *b) {
     const tsk_id_t *ib = (const tsk_id_t *) b;
     return (*ia > *ib) - (*ia < *ib);
 }
+
+/*************************
+ * Ancestor mapper
+ *************************/
+
+typedef struct {
+    tsk_id_t *samples;
+    size_t num_samples;
+    tsk_id_t *ancestors;
+    size_t num_ancestors;
+    tsk_table_collection_t *tables;
+    tsk_edge_table_t *result;
+    simplify_segment_t **ancestor_map_head;
+    simplify_segment_t **ancestor_map_tail;
+    bool *is_sample;
+    bool *is_ancestor;
+    simplify_segment_t *segment_queue;
+    size_t segment_queue_size;
+    size_t max_segment_queue_size;
+    segment_overlapper_t segment_overlapper;
+    tsk_blkalloc_t segment_heap;
+    tsk_blkalloc_t interval_list_heap;
+    interval_list_t **child_edge_map_head;
+    interval_list_t **child_edge_map_tail;
+    tsk_id_t *buffered_children;
+    size_t num_buffered_children;
+    double sequence_length;
+} ancestor_mapper_t;
+
+static simplify_segment_t * TSK_WARN_UNUSED
+ancestor_mapper_alloc_segment(ancestor_mapper_t *self, double left, double right, tsk_id_t node)
+{
+    simplify_segment_t *seg = NULL;
+
+    seg = tsk_blkalloc_get(&self->segment_heap, sizeof(*seg));
+    if (seg == NULL) {
+        goto out;
+    }
+    seg->next = NULL;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+out:
+    return seg;
+}
+
+static interval_list_t * TSK_WARN_UNUSED
+ancestor_mapper_alloc_interval_list(ancestor_mapper_t *self, double left, double right)
+{
+    interval_list_t *x = NULL;
+
+    x = tsk_blkalloc_get(&self->interval_list_heap, sizeof(*x));
+    if (x == NULL) {
+        goto out;
+    }
+    x->next = NULL;
+    x->left = left;
+    x->right = right;
+out:
+    return x;
+}
+
+static int
+ancestor_mapper_flush_edges(ancestor_mapper_t *self, tsk_id_t parent,
+    size_t *ret_num_edges)
+{
+    int ret = 0;
+    size_t j;
+    tsk_id_t child;
+    interval_list_t *x;
+    size_t num_edges = 0;
+
+    qsort(self->buffered_children, self->num_buffered_children,
+            sizeof(tsk_id_t), cmp_node_id);
+    for (j = 0; j < self->num_buffered_children; j++) {
+        child = self->buffered_children[j];
+        for (x = self->child_edge_map_head[child]; x != NULL; x = x->next) {
+            // printf("Adding edge %f %f %i %i\n", x->left, x->right, parent, child);
+            ret = tsk_edge_table_add_row(self->result, x->left, x->right, parent, child);
+            if (ret < 0) {
+                goto out;
+            }
+            num_edges++;
+        }
+        self->child_edge_map_head[child] = NULL;
+        self->child_edge_map_tail[child] = NULL;
+    }
+    self->num_buffered_children = 0;
+    *ret_num_edges = num_edges;
+    ret = tsk_blkalloc_reset(&self->interval_list_heap);
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_record_edge(ancestor_mapper_t *self, double left, double right,
+    tsk_id_t child)
+{
+    int ret = 0;
+    interval_list_t *tail, *x;
+
+    tail = self->child_edge_map_tail[child];
+    if (tail == NULL) {
+        assert(self->num_buffered_children < self->tables->nodes.num_rows);
+        self->buffered_children[self->num_buffered_children] = child;
+        self->num_buffered_children++;
+        x = ancestor_mapper_alloc_interval_list(self, left, right);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->child_edge_map_head[child] = x;
+        self->child_edge_map_tail[child] = x;
+    } else {
+        if (tail->right == left) {
+            tail->right = right;
+        } else {
+            x = ancestor_mapper_alloc_interval_list(self, left, right);
+            if (x == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            tail->next = x;
+            self->child_edge_map_tail[child] = x;
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_add_ancestry(ancestor_mapper_t *self, tsk_id_t input_id,
+    double left, double right, tsk_id_t output_id)
+{
+    int ret = 0;
+    simplify_segment_t *tail = self->ancestor_map_tail[input_id];
+    simplify_segment_t *x;
+
+    assert(left < right);
+    if (tail == NULL) {
+        x = ancestor_mapper_alloc_segment(self, left, right, output_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->ancestor_map_head[input_id] = x;
+        self->ancestor_map_tail[input_id] = x;
+    } else {
+        if (tail->right == left && tail->node == output_id) {
+            tail->right = right;
+        } else {
+            x = ancestor_mapper_alloc_segment(self, left, right, output_id);
+            if (x == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            tail->next = x;
+            self->ancestor_map_tail[input_id] = x;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_init_samples(ancestor_mapper_t *self, tsk_id_t *samples)
+{
+    int ret = 0;
+    size_t j;
+
+    /* Go through the samples to check for errors. */
+    for (j = 0; j < self->num_samples; j++) {
+        if (samples[j] < 0 || samples[j] > (tsk_id_t) self->tables->nodes.num_rows) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->is_sample[samples[j]]) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        self->is_sample[samples[j]] = true;
+        ret = ancestor_mapper_add_ancestry(self, samples[j], 0,
+            self->tables->sequence_length, samples[j]);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_init_ancestors(ancestor_mapper_t *self, tsk_id_t *ancestors)
+{
+    int ret = 0;
+    size_t j;
+
+    /* Go through the samples to check for errors. */
+    for (j = 0; j < self->num_ancestors; j++) {
+        if (ancestors[j] < 0 || ancestors[j] > (tsk_id_t) self->tables->nodes.num_rows) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->is_ancestor[ancestors[j]]) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        self->is_ancestor[ancestors[j]] = true;
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_init(ancestor_mapper_t *self, tsk_id_t *samples, size_t num_samples,
+    tsk_id_t *ancestors, size_t num_ancestors, tsk_table_collection_t *tables,
+    tsk_edge_table_t *result)
+{
+    int ret = 0;
+    size_t num_nodes_alloc;
+
+    memset(self, 0, sizeof(ancestor_mapper_t));
+    self->num_samples = num_samples;
+    self->num_ancestors = num_ancestors;
+    self->samples = samples;
+    self->ancestors = ancestors;
+    self->tables = tables;
+    self->result = result;
+    self->sequence_length = self->tables->sequence_length;
+
+    if (samples == NULL || num_samples == 0 || ancestors == NULL || num_ancestors == 0) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+
+    /* Allocate the heaps used for small objects-> Assuming 8K is a good chunk size */
+    ret = tsk_blkalloc_init(&self->segment_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_blkalloc_init(&self->interval_list_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = segment_overlapper_alloc(&self->segment_overlapper);
+    if (ret != 0) {
+        goto out;
+    }
+
+    /* Need to avoid malloc(0) so make sure we have at least 1. */
+    num_nodes_alloc = 1 + tables->nodes.num_rows;
+    /* Make the maps and set the intial state */
+    self->ancestor_map_head = calloc(num_nodes_alloc, sizeof(simplify_segment_t *));
+    self->ancestor_map_tail = calloc(num_nodes_alloc, sizeof(simplify_segment_t *));
+    self->child_edge_map_head = calloc(num_nodes_alloc, sizeof(interval_list_t *));
+    self->child_edge_map_tail = calloc(num_nodes_alloc, sizeof(interval_list_t *));
+    self->buffered_children = malloc(num_nodes_alloc * sizeof(tsk_id_t));
+    self->is_sample = calloc(num_nodes_alloc, sizeof(bool));
+    self->is_ancestor = calloc(num_nodes_alloc, sizeof(bool));
+    self->max_segment_queue_size = 64;
+    self->segment_queue = malloc(self->max_segment_queue_size
+            * sizeof(simplify_segment_t));
+    if (self->ancestor_map_head == NULL || self->ancestor_map_tail == NULL
+            || self->child_edge_map_head == NULL || self->child_edge_map_tail == NULL
+            || self->is_sample == NULL || self->is_ancestor == NULL
+            || self->segment_queue == NULL || self->buffered_children == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    // Clear memory.
+    ret = ancestor_mapper_init_samples(self, samples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = ancestor_mapper_init_ancestors(self, ancestors);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_clear(self->result);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_free(ancestor_mapper_t *self)
+{
+    tsk_blkalloc_free(&self->segment_heap);
+    tsk_blkalloc_free(&self->interval_list_heap);
+    segment_overlapper_free(&self->segment_overlapper);
+    tsk_safe_free(self->ancestor_map_head);
+    tsk_safe_free(self->ancestor_map_tail);
+    tsk_safe_free(self->child_edge_map_head);
+    tsk_safe_free(self->child_edge_map_tail);
+    tsk_safe_free(self->segment_queue);
+    tsk_safe_free(self->is_sample);
+    tsk_safe_free(self->is_ancestor);
+    tsk_safe_free(self->buffered_children);
+    return 0;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_enqueue_segment(ancestor_mapper_t *self, double left, double right,
+    tsk_id_t node)
+{
+    int ret = 0;
+    simplify_segment_t *seg;
+    void *p;
+
+    assert(left < right);
+    /* Make sure we always have room for one more segment in the queue so we
+     * can put a tail sentinel on it */
+    if (self->segment_queue_size == self->max_segment_queue_size - 1) {
+        self->max_segment_queue_size *= 2;
+        p = realloc(self->segment_queue,
+                self->max_segment_queue_size * sizeof(*self->segment_queue));
+        if (p == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->segment_queue = p;
+    }
+    seg = self->segment_queue + self->segment_queue_size;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+    self->segment_queue_size++;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_merge_ancestors(ancestor_mapper_t *self, tsk_id_t input_id)
+{
+    int ret = 0;
+    simplify_segment_t **X, *x;
+    size_t j, num_overlapping, num_flushed_edges;
+    double left, right, prev_right;
+    bool is_sample = self->is_sample[input_id];
+    bool is_ancestor = self->is_ancestor[input_id];
+
+    if (is_sample) {
+        /* Free up the existing ancestry mapping. */
+        x = self->ancestor_map_tail[input_id];
+        assert(x->left == 0 && x->right == self->sequence_length);
+        self->ancestor_map_head[input_id] = NULL;
+        self->ancestor_map_tail[input_id] = NULL;
+    }
+    ret = segment_overlapper_start(&self->segment_overlapper,
+            self->segment_queue, self->segment_queue_size);
+    if (ret != 0) {
+        goto out;
+    }
+
+    prev_right = 0;
+    while ((ret = segment_overlapper_next(&self->segment_overlapper,
+                    &left, &right, &X, &num_overlapping)) == 1) {
+        assert(left < right);
+        assert(num_overlapping > 0);
+        if (is_ancestor || is_sample) {
+            for (j = 0; j < num_overlapping; j++) {
+                ret = ancestor_mapper_record_edge(self, left, right, X[j]->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            ret = ancestor_mapper_add_ancestry(self, input_id, left, right,
+                input_id);
+            if (ret != 0) {
+                goto out;
+            }
+            if (is_sample && left != prev_right) {
+                /* Fill in any gaps in ancestry for the sample */
+                ret = ancestor_mapper_add_ancestry(self, input_id, prev_right,
+                    left, input_id);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        } else {
+            for (j = 0; j < num_overlapping; j++) {
+                ret = ancestor_mapper_add_ancestry(self, input_id, left,
+                        right, X[j]->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+        prev_right = right;
+    }
+    if (is_sample && prev_right != self->tables->sequence_length) {
+        /* If a trailing gap exists in the sample ancestry, fill it in. */
+        ret = ancestor_mapper_add_ancestry(self, input_id, prev_right,
+                self->sequence_length, input_id);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (input_id != TSK_NULL) {
+        ret = ancestor_mapper_flush_edges(self, input_id, &num_flushed_edges);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_process_parent_edges(ancestor_mapper_t *self, tsk_id_t parent,
+    size_t start, size_t end)
+{
+    int ret = 0;
+    size_t j;
+    simplify_segment_t *x;
+    const tsk_edge_table_t *input_edges = &self->tables->edges;
+    tsk_id_t child;
+    double left, right;
+
+    /* Go through the edges and queue up ancestry segments for processing. */
+    self->segment_queue_size = 0;
+    for (j = start; j < end; j++) {
+        assert(parent == input_edges->parent[j]);
+        child = input_edges->child[j];
+        left = input_edges->left[j];
+        right = input_edges->right[j];
+        // printf("C: %i, L: %f, R: %f\n", child, left, right);
+        for (x = self->ancestor_map_head[child]; x != NULL; x = x->next) {
+            if (x->right > left && right > x->left) {
+                ret = ancestor_mapper_enqueue_segment(self,
+                        TSK_MAX(x->left, left), TSK_MIN(x->right, right), x->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+    }
+     // We can now merge the ancestral segments for the parent
+    ret = ancestor_mapper_merge_ancestors(self, parent);
+    if (ret != 0) {
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_run(ancestor_mapper_t *self)
+{
+    int ret = 0;
+    size_t j, start;
+    tsk_id_t parent, current_parent;
+    const tsk_edge_table_t *input_edges = &self->tables->edges;
+    size_t num_edges = input_edges->num_rows;
+
+    if (num_edges > 0) {
+        start = 0;
+        current_parent = input_edges->parent[0];
+        for (j = 0; j < num_edges; j++) {
+            parent = input_edges->parent[j];
+            if (parent != current_parent) {
+                ret = ancestor_mapper_process_parent_edges(self, current_parent,
+                    start, j);
+                if (ret != 0) {
+                    goto out;
+                }
+                current_parent = parent;
+                start = j;
+            }
+        }
+        ret = ancestor_mapper_process_parent_edges(self, current_parent, start,
+            num_edges);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * simplifier
+ *************************/
 
 static void
 simplifier_check_state(simplifier_t *self)
@@ -4111,41 +4570,8 @@ out:
     return seg;
 }
 
-static simplify_segment_t * TSK_WARN_UNUSED
-ancestor_mapper_alloc_segment(ancestor_mapper_t *self, double left, double right, tsk_id_t node)
-{
-    simplify_segment_t *seg = NULL;
-
-    seg = tsk_blkalloc_get(&self->segment_heap, sizeof(*seg));
-    if (seg == NULL) {
-        goto out;
-    }
-    seg->next = NULL;
-    seg->left = left;
-    seg->right = right;
-    seg->node = node;
-out:
-    return seg;
-}
-
 static interval_list_t * TSK_WARN_UNUSED
 simplifier_alloc_interval_list(simplifier_t *self, double left, double right)
-{
-    interval_list_t *x = NULL;
-
-    x = tsk_blkalloc_get(&self->interval_list_heap, sizeof(*x));
-    if (x == NULL) {
-        goto out;
-    }
-    x->next = NULL;
-    x->left = left;
-    x->right = right;
-out:
-    return x;
-}
-
-static interval_list_t * TSK_WARN_UNUSED
-ancestor_mapper_alloc_interval_list(ancestor_mapper_t *self, double left, double right)
 {
     interval_list_t *x = NULL;
 
@@ -4186,30 +4612,6 @@ out:
     return ret;
 }
 
-static int TSK_WARN_UNUSED
-ancestor_mapper_record_node(ancestor_mapper_t *self, tsk_id_t input_id, 
-    bool is_sample)
-{
-    int ret = 0;
-    tsk_node_t node;
-    tsk_flags_t flags;
-
-    ret = tsk_node_table_get_row(&self->input_tables.nodes, (tsk_id_t) input_id, &node);
-    if (ret != 0) {
-        goto out;
-    }
-    /* Zero out the sample bit */
-    flags = node.flags & (tsk_flags_t) ~TSK_NODE_IS_SAMPLE;
-    if (is_sample) {
-        flags |= TSK_NODE_IS_SAMPLE;
-    }
-    ret = tsk_node_table_add_row(&self->tables->nodes, flags,
-            node.time, node.population, node.individual,
-            node.metadata, node.metadata_length);
-out:
-    return ret;    
-}
-
 /* Remove the mapping for the last recorded node. */
 static int
 simplifier_rewind_node(simplifier_t *self, tsk_id_t input_id, tsk_id_t output_id)
@@ -4220,37 +4622,6 @@ simplifier_rewind_node(simplifier_t *self, tsk_id_t input_id, tsk_id_t output_id
 
 static int
 simplifier_flush_edges(simplifier_t *self, tsk_id_t parent, size_t *ret_num_edges)
-{
-    int ret = 0;
-    size_t j;
-    tsk_id_t child;
-    interval_list_t *x;
-    size_t num_edges = 0;
-
-    qsort(self->buffered_children, self->num_buffered_children,
-            sizeof(tsk_id_t), cmp_node_id);
-    for (j = 0; j < self->num_buffered_children; j++) {
-        child = self->buffered_children[j];
-        for (x = self->child_edge_map_head[child]; x != NULL; x = x->next) {
-            ret = tsk_edge_table_add_row(&self->tables->edges, x->left, x->right, parent, child);
-            if (ret < 0) {
-                goto out;
-            }
-            num_edges++;
-        }
-        self->child_edge_map_head[child] = NULL;
-        self->child_edge_map_tail[child] = NULL;
-    }
-    self->num_buffered_children = 0;
-    *ret_num_edges = num_edges;
-    ret = tsk_blkalloc_reset(&self->interval_list_heap);
-out:
-    return ret;
-}
-
-static int
-ancestor_mapper_flush_edges(ancestor_mapper_t *self, tsk_id_t parent, 
-    size_t *ret_num_edges)
 {
     int ret = 0;
     size_t j;
@@ -4376,42 +4747,6 @@ out:
 }
 
 static int
-ancestor_mapper_record_edge(ancestor_mapper_t *self, double left, double right, 
-    tsk_id_t child)
-{
-    int ret = 0;
-    interval_list_t *tail, *x;
-
-    tail = self->child_edge_map_tail[child];
-    if (tail == NULL) {
-        assert(self->num_buffered_children < self->input_tables.nodes.num_rows);
-        self->buffered_children[self->num_buffered_children] = child;
-        self->num_buffered_children++;
-        x = ancestor_mapper_alloc_interval_list(self, left, right);
-        if (x == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
-            goto out;
-        }
-        self->child_edge_map_head[child] = x;
-        self->child_edge_map_tail[child] = x;
-    } else {
-        if (tail->right == left) {
-            tail->right = right;
-        } else {
-            x = ancestor_mapper_alloc_interval_list(self, left, right);
-            if (x == NULL) {
-                ret = TSK_ERR_NO_MEMORY;
-                goto out;
-            }
-            tail->next = x;
-            self->child_edge_map_tail[child] = x;
-        }
-    }
-out:
-    return ret;
-}
-
-static int
 simplifier_init_sites(simplifier_t *self)
 {
     int ret = 0;
@@ -4492,40 +4827,6 @@ out:
     return ret;
 }
 
-static int TSK_WARN_UNUSED
-ancestor_mapper_add_ancestry(ancestor_mapper_t *self, tsk_id_t input_id, 
-    double left, double right, tsk_id_t output_id)
-{
-    int ret = 0;
-    simplify_segment_t *tail = self->ancestor_map_tail[input_id];
-    simplify_segment_t *x;
-
-    assert(left < right);
-    if (tail == NULL) {
-        x = ancestor_mapper_alloc_segment(self, left, right, output_id);
-        if (x == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
-            goto out;
-        }
-        self->ancestor_map_head[input_id] = x;
-        self->ancestor_map_tail[input_id] = x;
-    } else {
-        if (tail->right == left && tail->node == output_id) {
-            tail->right = right;
-        } else {
-            x = ancestor_mapper_alloc_segment(self, left, right, output_id);
-            if (x == NULL) {
-                ret = TSK_ERR_NO_MEMORY;
-                goto out;
-            }
-            tail->next = x;
-            self->ancestor_map_tail[input_id] = x;
-        }
-    }
-out:
-    return ret;
-}
-
 static int
 simplifier_init_samples(simplifier_t *self, tsk_id_t *samples)
 {
@@ -4552,68 +4853,6 @@ simplifier_init_samples(simplifier_t *self, tsk_id_t *samples)
         if (ret != 0) {
             goto out;
         }
-    }
-out:
-    return ret;
-}
-
-static int
-ancestor_mapper_init_samples(ancestor_mapper_t *self, tsk_id_t *samples)
-{
-    int ret = 0;
-    size_t j;
-
-    /* Go through the samples to check for errors. */
-    for (j = 0; j < self->num_samples; j++) {
-        if (samples[j] < 0 || samples[j] > (tsk_id_t) self->input_tables.nodes.num_rows) {
-            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
-            goto out;
-        }
-        if (self->is_sample[samples[j]]) {
-            ret = TSK_ERR_DUPLICATE_SAMPLE;
-            goto out;
-        }
-        self->is_sample[samples[j]] = true;
-        ret = ancestor_mapper_record_node(self, samples[j], true);
-        if (ret < 0) {
-            goto out;
-        }
-        ret = ancestor_mapper_add_ancestry(self, samples[j], 0, 
-            self->tables->sequence_length, (tsk_id_t) ret);
-        if (ret != 0) {
-            goto out;
-        }
-    }
-out:
-    return ret;
-}
-
-static int
-ancestor_mapper_init_ancestors(ancestor_mapper_t *self, tsk_id_t *ancestors)
-{
-    int ret = 0;
-    size_t j;
-
-    /* Go through the samples to check for errors. */
-    for (j = 0; j < self->num_ancestors; j++) {
-        if (ancestors[j] < 0 || ancestors[j] > (tsk_id_t) self->input_tables.nodes.num_rows) {
-            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
-            goto out;
-        }
-        if (self->is_ancestor[ancestors[j]]) {
-            ret = TSK_ERR_DUPLICATE_SAMPLE;
-            goto out;
-        }
-        self->is_ancestor[ancestors[j]] = true;
-        // ret = ancestor_mapper_record_node(self, samples[j], true);
-        // if (ret < 0) {
-        //     goto out;
-        // }
-        // ret = ancestor_mapper_add_ancestry(self, samples[j], 0, 
-        //     self->tables->sequence_length, (tsk_id_t) ret);
-        // if (ret != 0) {
-        //     goto out;
-        // }
     }
 out:
     return ret;
@@ -4714,84 +4953,6 @@ out:
 }
 
 static int
-ancestor_mapper_init(ancestor_mapper_t *self, tsk_id_t *samples, size_t num_samples,
-    tsk_id_t *ancestors, size_t num_ancestors, tsk_table_collection_t *tables) 
-{
-    int ret = 0;
-    size_t num_nodes_alloc;
-
-    memset(self, 0, sizeof(ancestor_mapper_t));
-    self->num_samples = num_samples;
-    self->num_ancestors = num_ancestors;
-    self->tables = tables;
-
-    /* Take a copy of the input samples and ancestors */
-    self->samples = malloc(num_samples * sizeof(tsk_id_t));
-    if (self->samples == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
-        goto out;
-    } 
-    self->ancestors = malloc(num_ancestors * sizeof(tsk_id_t));
-    if (self->ancestors == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
-        goto out;
-    } 
-    //Confused as to why the bottom is needed?
-    memcpy(self->samples, samples, num_samples * sizeof(tsk_id_t));
-    memcpy(self->ancestors, ancestors, num_ancestors * sizeof(tsk_id_t)); 
-
-    /* Allocate the heaps used for small objects-> Assuming 8K is a good chunk size */
-    ret = tsk_blkalloc_init(&self->segment_heap, 8192);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = tsk_blkalloc_init(&self->interval_list_heap, 8192);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = segment_overlapper_alloc(&self->segment_overlapper);
-    if (ret != 0) {
-        goto out;
-    }
-
-    /* Need to avoid malloc(0) so make sure we have at least 1. */
-    num_nodes_alloc = 1 + tables->nodes.num_rows;
-    /* Make the maps and set the intial state */
-    self->ancestor_map_head = calloc(num_nodes_alloc, sizeof(simplify_segment_t *));
-    self->ancestor_map_tail = calloc(num_nodes_alloc, sizeof(simplify_segment_t *));
-    self->child_edge_map_head = calloc(num_nodes_alloc, sizeof(interval_list_t *));
-    self->child_edge_map_tail = calloc(num_nodes_alloc, sizeof(interval_list_t *));
-    self->buffered_children = malloc(num_nodes_alloc * sizeof(tsk_id_t));
-    self->is_sample = calloc(num_nodes_alloc, sizeof(bool));
-    self->is_ancestor = calloc(num_nodes_alloc, sizeof(bool));
-    self->max_segment_queue_size = 64;
-    self->segment_queue = malloc(self->max_segment_queue_size
-            * sizeof(simplify_segment_t));
-    if (self->ancestor_map_head == NULL || self->ancestor_map_tail == NULL
-            || self->child_edge_map_head == NULL || self->child_edge_map_tail == NULL
-            || self->is_sample == NULL || self->is_ancestor == NULL
-            || self->segment_queue == NULL || self->buffered_children == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
-        goto out;
-    }
-    // Clear memory.
-    ret = tsk_table_collection_clear(self->tables);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = ancestor_mapper_init_samples(self, samples);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = ancestor_mapper_init_ancestors(self, ancestors);
-    if (ret != 0) {
-        goto out;
-    }
-out:
-    return ret; 
-}
-
-static int
 simplifier_free(simplifier_t *self)
 {
     tsk_table_collection_free(&self->input_tables);
@@ -4816,58 +4977,8 @@ simplifier_free(simplifier_t *self)
     return 0;
 }
 
-static int
-ancestor_mapper_free(ancestor_mapper_t *self)
-{
-    tsk_table_collection_free(&self->input_tables);
-    tsk_blkalloc_free(&self->segment_heap);
-    tsk_blkalloc_free(&self->interval_list_heap);
-    segment_overlapper_free(&self->segment_overlapper);
-    tsk_safe_free(self->samples);
-    tsk_safe_free(self->ancestors);
-    tsk_safe_free(self->ancestor_map_head);
-    tsk_safe_free(self->ancestor_map_tail);
-    tsk_safe_free(self->child_edge_map_head);
-    tsk_safe_free(self->child_edge_map_tail);
-    tsk_safe_free(self->segment_queue);
-    tsk_safe_free(self->is_sample);
-    tsk_safe_free(self->is_ancestor);
-    tsk_safe_free(self->buffered_children);
-    return 0;
-}
-
 static int TSK_WARN_UNUSED
 simplifier_enqueue_segment(simplifier_t *self, double left, double right, tsk_id_t node)
-{
-    int ret = 0;
-    simplify_segment_t *seg;
-    void *p;
-
-    assert(left < right);
-    /* Make sure we always have room for one more segment in the queue so we
-     * can put a tail sentinel on it */
-    if (self->segment_queue_size == self->max_segment_queue_size - 1) {
-        self->max_segment_queue_size *= 2;
-        p = realloc(self->segment_queue,
-                self->max_segment_queue_size * sizeof(*self->segment_queue));
-        if (p == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
-            goto out;
-        }
-        self->segment_queue = p;
-    }
-    seg = self->segment_queue + self->segment_queue_size;
-    seg->left = left;
-    seg->right = right;
-    seg->node = node;
-    self->segment_queue_size++;
-out:
-    return ret;
-}
-
-static int TSK_WARN_UNUSED
-ancestor_mapper_enqueue_segment(ancestor_mapper_t *self, double left, double right, 
-    tsk_id_t node)
 {
     int ret = 0;
     simplify_segment_t *seg;
@@ -5001,85 +5112,6 @@ out:
 }
 
 static int TSK_WARN_UNUSED
-ancestor_mapper_merge_ancestors(ancestor_mapper_t *self, tsk_id_t input_id)
-{
-    int ret = 0;
-    simplify_segment_t **X, *x;
-    size_t j, num_overlapping, num_flushed_edges;
-    double left, right, prev_right;
-    // tsk_id_t ancestry_node;
-    bool is_sample = input_id != TSK_NULL;
-    bool is_ancestor = self->is_ancestor[input_id];
-
-    if (is_sample) {
-        /* Free up the existing ancestry mapping. */
-        x = self->ancestor_map_tail[input_id];
-        assert(x->left == 0 && x->right == self->tables->sequence_length);
-        self->ancestor_map_head[input_id] = NULL;
-        self->ancestor_map_tail[input_id] = NULL;
-    }
-
-    ret = segment_overlapper_start(&self->segment_overlapper,
-            self->segment_queue, self->segment_queue_size);
-    if (ret != 0) {
-        goto out;
-    }
-    prev_right = 0;
-    printf("%i", (int) prev_right);
-    while ((ret = segment_overlapper_next(&self->segment_overlapper,
-                    &left, &right, &X, &num_overlapping)) == 1) {
-        assert(left < right);
-        assert(num_overlapping > 0);
-        if (is_ancestor || is_sample) {
-            for (j = 0; j < num_overlapping; j++) {
-                ret = ancestor_mapper_record_edge(self, left, right, X[j]->node);
-                if (ret != 0) {
-                    goto out;
-                }
-            ret = ancestor_mapper_add_ancestry(self, input_id, prev_right, left, 
-                input_id);
-            if (ret != 0) {
-                goto out;
-            }
-                if (is_sample && left != prev_right) {
-                    /* Fill in any gaps in ancestry for the sample */
-                    ret = ancestor_mapper_add_ancestry(self, input_id, prev_right, 
-                        left, input_id);
-                    if (ret != 0) {
-                        goto out;
-                    }
-                }
-            }
-        } else {
-            for (j = 0; j < num_overlapping; j++) {
-                ret = ancestor_mapper_add_ancestry(self, input_id, prev_right, 
-                        left, X[j]->node);
-                if (ret != 0) {
-                    goto out;
-                } 
-            }
-            prev_right = right;
-        }
-    }
-    if (is_sample && prev_right != self->tables->sequence_length) {
-        /* If a trailing gap exists in the sample ancestry, fill it in. */
-        ret = ancestor_mapper_add_ancestry(self, input_id, prev_right,
-                self->tables->sequence_length, input_id);
-        if (ret != 0) {
-            goto out;
-        }
-    }
-    if (input_id != TSK_NULL) {
-        ret = ancestor_mapper_flush_edges(self, input_id, &num_flushed_edges);
-        if (ret != 0) {
-            goto out;
-        }
-    }
-out:
-    return ret;
-}
-
-static int TSK_WARN_UNUSED
 simplifier_process_parent_edges(simplifier_t *self, tsk_id_t parent, size_t start,
         size_t end)
 {
@@ -5097,6 +5129,7 @@ simplifier_process_parent_edges(simplifier_t *self, tsk_id_t parent, size_t star
         child = input_edges->child[j];
         left = input_edges->left[j];
         right = input_edges->right[j];
+        // printf("C: %i, L: %f, R: %f\n", child, left, right);
         for (x = self->ancestor_map_head[child]; x != NULL; x = x->next) {
             if (x->right > left && right > x->left) {
                 ret = simplifier_enqueue_segment(self,
@@ -5109,43 +5142,6 @@ simplifier_process_parent_edges(simplifier_t *self, tsk_id_t parent, size_t star
     }
     /* We can now merge the ancestral segments for the parent */
     ret = simplifier_merge_ancestors(self, parent);
-    if (ret != 0) {
-        goto out;
-    }
-out:
-    return ret;
-}
-
-static int TSK_WARN_UNUSED
-ancestor_mapper_process_parent_edges(ancestor_mapper_t *self, tsk_id_t parent, 
-    size_t start, size_t end)
-{
-    int ret = 0;
-    size_t j;
-    simplify_segment_t *x;
-    const tsk_edge_table_t *input_edges = &self->input_tables.edges;
-    tsk_id_t child;
-    double left, right;
-
-    /* Go through the edges and queue up ancestry segments for processing. */
-    self->segment_queue_size = 0;
-    for (j = start; j < end; j++) {
-        assert(parent == input_edges->parent[j]);
-        child = input_edges->child[j];
-        left = input_edges->left[j];
-        right = input_edges->right[j];
-        for (x = self->ancestor_map_head[child]; x != NULL; x = x->next) {
-            if (x->right > left && right > x->left) {
-                ret = ancestor_mapper_enqueue_segment(self,
-                        TSK_MAX(x->left, left), TSK_MIN(x->right, right), x->node);
-                if (ret != 0) {
-                    goto out;
-                }
-            }
-        }
-    }
-     // We can now merge the ancestral segments for the parent 
-    ret = ancestor_mapper_merge_ancestors(self, parent);
     if (ret != 0) {
         goto out;
     }
@@ -5438,43 +5434,6 @@ simplifier_run(simplifier_t *self, tsk_id_t *node_map)
         memcpy(node_map, self->node_id_map,
                 self->input_tables.nodes.num_rows * sizeof(tsk_id_t));
     }
-out:
-    return ret;
-}
-
-static int TSK_WARN_UNUSED
-ancestor_mapper_run(ancestor_mapper_t *self)
-{
-    int ret = 0;
-    size_t j, start;
-    tsk_id_t parent, current_parent;
-    const tsk_edge_table_t *input_edges = &self->input_tables.edges;
-    size_t num_edges = input_edges->num_rows;
-    printf("%p", (void *) self);
-
-    if (num_edges > 0) {
-        start = 0;
-        printf("%i", (int) start);
-        current_parent = input_edges->parent[0];
-        for (j = 0; j < num_edges; j++) {
-            parent = input_edges->parent[j];
-            if (parent != current_parent) {
-                ret = ancestor_mapper_process_parent_edges(self, current_parent, 
-                    start, j);
-                if (ret != 0) {
-                    goto out;
-                }
-                current_parent = parent;
-                start = j;
-            }
-        }
-        ret = ancestor_mapper_process_parent_edges(self, current_parent, start, 
-            num_edges);
-        if (ret != 0) {
-            goto out;
-        }
-    }
-
 out:
     return ret;
 }
@@ -6018,6 +5977,13 @@ tsk_table_collection_has_index(tsk_table_collection_t *self, tsk_flags_t TSK_UNU
         && self->indexes.edge_removal_order != NULL;
 }
 
+// bool
+// tsk_edge_table_has_index(tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
+// {
+//     return self->indexes.edge_insertion_order != NULL
+//         && self->indexes.edge_removal_order != NULL;
+// }
+
 int
 tsk_table_collection_drop_index(tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
 {
@@ -6453,33 +6419,15 @@ out:
 }
 
 int TSK_WARN_UNUSED
-tsk_table_collection_map_ancestors(tsk_table_collection_t *self, tsk_id_t *samples, 
-        tsk_size_t num_samples, tsk_id_t *ancestors, tsk_size_t num_ancestors)
+tsk_table_collection_map_ancestors(tsk_table_collection_t *self, tsk_id_t *samples,
+        tsk_size_t num_samples, tsk_id_t *ancestors, tsk_size_t num_ancestors,
+        tsk_edge_table_t *result)
 {
     int ret = 0;
     ancestor_mapper_t ancestor_mapper;
-    tsk_id_t *local_samples = NULL;
-    tsk_id_t u;
 
-    if (samples == NULL) {
-        /* Avoid issue with mallocing zero bytes */
-        local_samples = malloc((1 + self->nodes.num_rows) * sizeof(*local_samples));
-        if (local_samples == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
-            goto out;
-        }
-        num_samples = 0;
-        for (u = 0; u < (tsk_id_t) self->nodes.num_rows; u++) {
-            if (!!(self->nodes.flags[u] & TSK_NODE_IS_SAMPLE)) {
-                local_samples[num_samples] = u;
-                num_samples++;
-            }
-        }
-        samples = local_samples;
-    }
-
-    ret = ancestor_mapper_init(&ancestor_mapper, samples, (size_t) num_samples, 
-        ancestors, (size_t) num_ancestors, self);
+    ret = ancestor_mapper_init(&ancestor_mapper, samples, (size_t) num_samples,
+        ancestors, (size_t) num_ancestors, self, result);
     if (ret != 0) {
         goto out;
     }
@@ -6489,7 +6437,6 @@ tsk_table_collection_map_ancestors(tsk_table_collection_t *self, tsk_id_t *sampl
     }
 out:
     ancestor_mapper_free(&ancestor_mapper);
-    tsk_safe_free(local_samples);
     return ret;
 }
 
@@ -6833,3 +6780,4 @@ tsk_squash_edges(tsk_edge_t *edges, size_t num_edges, size_t *num_output_edges)
     *num_output_edges = l + 1;
     return ret;
 }
+

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -3892,7 +3892,6 @@ segment_overlapper_next(segment_overlapper_t *self,
     return ret;
 }
 
-
 static int
 cmp_node_id(const void *a, const void *b) {
     const tsk_id_t *ia = (const tsk_id_t *) a;
@@ -3904,6 +3903,11 @@ cmp_node_id(const void *a, const void *b) {
  * Ancestor mapper
  *************************/
 
+/* NOTE: this struct shares a lot with the simplifier_t, mostly in
+ * terms of infrastructure for managing the list of intervals, saving
+ * edges etc. We should try to abstract the common functionality out
+ * into a separate class, which handles this.
+ */
 typedef struct {
     tsk_id_t *samples;
     size_t num_samples;
@@ -6421,7 +6425,7 @@ out:
 int TSK_WARN_UNUSED
 tsk_table_collection_map_ancestors(tsk_table_collection_t *self, tsk_id_t *samples,
         tsk_size_t num_samples, tsk_id_t *ancestors, tsk_size_t num_ancestors,
-        tsk_edge_table_t *result)
+        tsk_flags_t TSK_UNUSED(options), tsk_edge_table_t *result)
 {
     int ret = 0;
     ancestor_mapper_t ancestor_mapper;

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -2166,6 +2166,10 @@ completes.
 int tsk_table_collection_simplify(tsk_table_collection_t *self,
     tsk_id_t *samples, tsk_size_t num_samples, tsk_flags_t options, tsk_id_t *node_map);
 
+int tsk_table_collection_map_ancestors(tsk_table_collection_t *self,
+    tsk_id_t *samples, tsk_size_t num_samples,
+    tsk_id_t *ancestors, tsk_size_t num_ancestors);
+
 /**
 @brief Returns true if this table collection is indexed.
 

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -2166,10 +2166,6 @@ completes.
 int tsk_table_collection_simplify(tsk_table_collection_t *self,
     tsk_id_t *samples, tsk_size_t num_samples, tsk_flags_t options, tsk_id_t *node_map);
 
-int tsk_table_collection_map_ancestors(tsk_table_collection_t *self,
-    tsk_id_t *samples, tsk_size_t num_samples,
-    tsk_id_t *ancestors, tsk_size_t num_ancestors, tsk_edge_table_t *result);
-
 /**
 @brief Returns true if this table collection is indexed.
 
@@ -2212,6 +2208,11 @@ int tsk_table_collection_build_index(tsk_table_collection_t *self, tsk_flags_t o
 /** @} */
 
 /* Undocumented methods */
+
+int tsk_table_collection_map_ancestors(tsk_table_collection_t *self,
+    tsk_id_t *samples, tsk_size_t num_samples,
+    tsk_id_t *ancestors, tsk_size_t num_ancestors, tsk_flags_t options,
+    tsk_edge_table_t *result);
 
 int tsk_table_collection_deduplicate_sites(tsk_table_collection_t *tables, tsk_flags_t options);
 int tsk_table_collection_compute_mutation_parents(tsk_table_collection_t *self, tsk_flags_t options);

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -2168,7 +2168,7 @@ int tsk_table_collection_simplify(tsk_table_collection_t *self,
 
 int tsk_table_collection_map_ancestors(tsk_table_collection_t *self,
     tsk_id_t *samples, tsk_size_t num_samples,
-    tsk_id_t *ancestors, tsk_size_t num_ancestors);
+    tsk_id_t *ancestors, tsk_size_t num_ancestors, tsk_edge_table_t *result);
 
 /**
 @brief Returns true if this table collection is indexed.

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -458,7 +458,9 @@ class AncestorMap(object):
     def __init__(self, ts, sample, ancestors):
         self.ts = ts
         self.samples = set(sample)
+        assert (self.samples).issubset(set(range(0, ts.num_nodes)))
         self.ancestors = set(ancestors)
+        assert (self.ancestors).issubset(set(range(0, ts.num_nodes)))
         self.table = tskit.EdgeTable()
         self.sequence_length = ts.sequence_length
         self.A_head = [None for _ in range(ts.num_nodes)]

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -469,7 +469,7 @@ class AncestorMap(object):
             self.add_ancestry(0, self.sequence_length, sample_id, sample_id)
         self.edge_buffer = {}
 
-    def simplify(self):
+    def map_ancestors(self):
         if self.ts.num_edges > 0:
             all_edges = list(self.ts.edges())
             edges = all_edges[:1]
@@ -659,7 +659,7 @@ if __name__ == "__main__":
         ancestors = list(map(int, ancestors))
 
         s = AncestorMap(ts, samples, ancestors)
-        tss = s.simplify()
+        tss = s.map_ancestors()
         # tables = tss.dump_tables()
         # print(tables.nodes)
         print(tss)

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -170,6 +170,42 @@ class TestTableCollection(LowLevelTestCase):
             tables.sequence_length = value
             self.assertEqual(tables.sequence_length, value)
 
+    def test_simplify_bad_args(self):
+        ts = msprime.simulate(10, random_seed=1)
+        tc = ts.tables.ll_tables
+        with self.assertRaises(TypeError):
+            tc.simplify()
+        with self.assertRaises(ValueError):
+            tc.simplify("asdf")
+        with self.assertRaises(TypeError):
+            tc.simplify([0, 1], filter_populations="x")
+        with self.assertRaises(_tskit.LibraryError):
+            tc.simplify([0, -1])
+
+    def test_map_ancestors_bad_args(self):
+        ts = msprime.simulate(10, random_seed=1)
+        tc = ts.tables.ll_tables
+        with self.assertRaises(TypeError):
+            tc.map_ancestors()
+        with self.assertRaises(TypeError):
+            tc.map_ancestors([0, 1])
+        with self.assertRaises(ValueError):
+            tc.map_ancestors(samples=[0, 1], ancestors="sdf")
+        with self.assertRaises(ValueError):
+            tc.map_ancestors(samples="sdf", ancestors=[0, 1])
+        with self.assertRaises(_tskit.LibraryError):
+            tc.map_ancestors(samples=[0, 1], ancestors=[11, -1])
+        with self.assertRaises(_tskit.LibraryError):
+            tc.map_ancestors(samples=[0, -1], ancestors=[11])
+
+    def test_map_ancestors(self):
+        ts = msprime.simulate(2, random_seed=1)
+        tc = ts.tables.ll_tables
+        edges = tc.map_ancestors([0, 1], [3])
+        self.assertIsInstance(edges, _tskit.EdgeTable)
+        del edges
+        self.assertEqual(tc.edges.num_rows, 2)
+
 
 class TestTreeSequence(LowLevelTestCase):
     """

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -3688,7 +3688,7 @@ class TestMapToAncestors(unittest.TestCase):
 
     def verify(self, ts, sample_nodes, ancestral_nodes):
         tss = self.do_simplify(ts, ancestors=ancestral_nodes, samples=sample_nodes)
-        ancestors = list(set(tss.parent))
+        # ancestors = list(set(tss.parent))
         # Loop through the rows of the ancestral branch table.
         current_ancestor = tss.parent[0]
         current_descendants = [tss.child[0]]

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -3590,7 +3590,6 @@ class TestMapToAncestors(unittest.TestCase):
         tss = self.do_map(ts, samples=[2, 3], ancestors=[7])
         self.assertEqual(tss.num_rows, 0)
 
-    # @unittest.skip("FIXME @gtsambos")
     def test_single_tree_samples_or_ancestors_not_in_tree(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1663,6 +1663,13 @@ class TableCollection(object):
             reduce_to_site_topology=reduce_to_site_topology,
             keep_unary=keep_unary)
 
+    def map_ancestors(self, samples, ancestors):
+        # TODO document
+        samples = util.safe_np_int_cast(samples, np.int32)
+        ancestors = util.safe_np_int_cast(ancestors, np.int32)
+        ll_edge_table = self.ll_tables.map_ancestors(samples, ancestors)
+        return EdgeTable(ll_table=ll_edge_table)
+
     def sort(self, edge_start=0):
         """
         Sorts the tables in place. This ensures that all tree sequence ordering

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1664,7 +1664,22 @@ class TableCollection(object):
             keep_unary=keep_unary)
 
     def map_ancestors(self, samples, ancestors):
-        # TODO document
+        """
+        Returns an :class:`EdgeTable` instance displaying all relationships between
+        the nodes supplied in `samples` and `ancestors`.
+        Relationships between different nodes in `ancestors` are also shown.
+        The supplied nodes must be a subset of the node IDs in the tree sequence.
+        Other than this, the procedure is flexible; overlap between the lists of samples
+        and ancestors is permitted, and the nodes need not be ordered by time.
+        Node IDs are not changed in the output.
+        If none of the nodes in `ancestors` are ancestral to `samples` anywhere in
+        the tree sequence, an empty table will be returned.
+
+        :param list[int] samples: A list of node IDs to retain as samples.
+        :param list[int] ancestors: A list of node IDs to use as ancestors.
+        :return: An :class:`EdgeTable` instance displaying relationships between
+            the `samples` and `ancestors`.
+        """
         samples = util.safe_np_int_cast(samples, np.int32)
         ancestors = util.safe_np_int_cast(ancestors, np.int32)
         ll_edge_table = self.ll_tables.map_ancestors(samples, ancestors)

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1665,13 +1665,25 @@ class TableCollection(object):
 
     def map_ancestors(self, samples, ancestors):
         """
-        Returns an :class:`EdgeTable` instance displaying all relationships between
-        the nodes supplied in `samples` and `ancestors`.
-        Relationships between different nodes in `ancestors` are also shown.
+        Returns an :class:`EdgeTable` instance describing how ``samples`` are descended
+        from ``ancestors`` (and how ``ancestors`` are descended from each other).
+        Each row ``parent, child, left, right`` in the output table indicates that
+        ``child`` (which is either in ``samples`` or in ``ancestors``) has inherited the
+        segment ``[left, right)`` from ``parent`` (which is in ``ancestors``) more
+        recently than from any other node in ``ancestors``. Every segment of the
+        genome on which each of ``samples`` has inherited from any of ``ancestors``
+        is described in this way, as well as any segment of the genomes of ``ancestors``
+        that has been inherited by any of ``samples``.  The node IDs in ``parent`` and
+        ``child`` refer to the node table in the original tree sequence. In other words,
+        the tree constructed at a position with the output edge table has the property
+        that the parent of any node in ``samples``, if there is one, is the most recent
+        ancestor of that node at that position out of all possible ancestors in
+        ``ancestors``, and the same is true for any node in ``ancestors`` that is
+        ancestral to any of ``samples``.
+
         The supplied nodes must be a subset of the node IDs in the tree sequence.
         Other than this, the procedure is flexible; overlap between the lists of samples
         and ancestors is permitted, and the nodes need not be ordered by time.
-        Node IDs are not changed in the output.
         If none of the nodes in `ancestors` are ancestral to `samples` anywhere in
         the tree sequence, an empty table will be returned.
 


### PR DESCRIPTION
The `Simplifier` object now takes an optional list of node IDs, `ancestors`.
If this is provided, `simplify()` will only retain nodes that are ancestors or samples, and will simplify the topology accordingly.

NB: This is still nowhere near ready. Here are some things I need to change before this is pulled in:

- ~Combine edges with overlapping endpoints (see comment below).~
- ~Ensure that edges are created in the right order (see comment below)~
- ~Add tests that are specific to this simplify method~
    - ~If a node has no ancestor, record no edges.~
- ~Remove the big `if: else` statement from `merge_labelled_ancestors` so that less code is repeated.~
- Make C version.

I can also envisage making a 'cleaner' version of this `simplify.py` script that structures the operations in these alternate versions of `simplify()` in a more general manner, particularly within the `merge_labelled_ancestors` method. As written, this method is still structured around the assumption that the most important distinction when deciding how to process nodes is whether the node is unary or not - this isn't the case for the two newer versions of `simplify()`.
However, this is probably best left for another pull request.

Commenting in @dvukcevic.