### PR TITLE
Fixes issue #8

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -951,7 +951,7 @@ class TestNumpyInt32Conversion(unittest.TestCase):
             self.assertRaises(TypeError, tskit.tables.to_np_int32, bad_type)
 
     def test_overflow(self):
-        for bad_node in [np.iinfo(np.int32).min-1, np.iinfo(np.int32).max+1]:
+        for bad_node in [np.iinfo(np.int32).min - 1, np.iinfo(np.int32).max + 1]:
             self.assertRaises(  # Test plain array
                 OverflowError, tskit.tables.to_np_int32, [0, bad_node])
             self.assertRaises(  # Test numpy array

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -921,6 +921,51 @@ class TestBytePacking(unittest.TestCase):
         self.assertEqual(data, unpickled)
 
 
+class TestNumpyInt32Conversion(unittest.TestCase):
+    """
+    Tests the function that converts integer arrays to np.int32 for input to functions.
+    """
+    def test_arrays(self):
+        # Simple array
+        target = np.array([0, 1], dtype=np.int32)
+        for identical_array in [[0, 1], (0, 1), np.array([0, 1]), target]:
+            converted = tskit.tables.to_np_int32(identical_array)
+            # Use pickle to test exact equality including dtype
+            self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+        # Nested array
+        target = np.array([[0, 1], [2, 3]], dtype=np.int32)
+        for identical_array in [[[0, 1], [2, 3]], np.array([[0, 1], [2, 3]]), target]:
+            converted = tskit.tables.to_np_int32(identical_array)
+            self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+
+    def test_empty_arrays(self):
+        target = np.array([], dtype=np.int32)
+        converted = tskit.tables.to_np_int32([])
+        self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+        target = np.array([[]], dtype=np.int32)
+        converted = tskit.tables.to_np_int32([[]])
+        self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+
+    def test_bad_types(self):
+        for bad_type in [[0.1], ['string'], {}, [{}], np.array([0, 1], dtype=np.float)]:
+            self.assertRaises(TypeError, tskit.tables.to_np_int32, bad_type)
+
+    def test_overflow(self):
+        for bad_node in [np.iinfo(np.int32).min-1, np.iinfo(np.int32).max+1]:
+            self.assertRaises(  # Test plain array
+                OverflowError, tskit.tables.to_np_int32, [0, bad_node])
+            self.assertRaises(  # Test numpy array
+                OverflowError, tskit.tables.to_np_int32, np.array([0, bad_node]))
+        for good_node in [np.iinfo(np.int32).min, np.iinfo(np.int32).max]:
+            target = np.array([good_node], dtype=np.int32)
+            self.assertEqual(  # Test plain array
+                pickle.dumps(target),
+                pickle.dumps(tskit.tables.to_np_int32([good_node])))
+            self.assertEqual(  # Test numpy array
+                pickle.dumps(target),
+                pickle.dumps(tskit.tables.to_np_int32(np.array([good_node]))))
+
+
 class TestSortTables(unittest.TestCase):
     """
     Tests for the sort_tables method.
@@ -1385,14 +1430,14 @@ class TestSimplifyTables(unittest.TestCase):
             tables = ts.dump_tables()
             tables.simplify(good_form)
         tables = ts.dump_tables()
-        for bad_type in [[[[]]], {}]:
-            self.assertRaises(ValueError, tables.simplify, bad_type)
-        # We only accept numpy arrays of the right type
-        for bad_dtype in [np.uint32, np.int64, np.float64]:
+        for bad_values in [[[[]]], np.array([[0, 1], [2, 3]], dtype=np.int32)]:
+            self.assertRaises(ValueError, tables.simplify, bad_values)
+        for bad_type in [[0.1], ['string'], {}, [{}]]:
+            self.assertRaises(TypeError, tables.simplify, bad_type)
+        # We only convert to int if we don't overflow
+        for bad_node in [np.iinfo(np.int32).min-1, np.iinfo(np.int32).max+1]:
             self.assertRaises(
-                TypeError, tables.simplify, np.array([0, 1], dtype=bad_dtype))
-        bad_samples = np.array([[0, 1], [2, 3]], dtype=np.int32)
-        self.assertRaises(ValueError, tables.simplify, bad_samples)
+                OverflowError, tables.simplify, samples=np.array([0, bad_node]))
 
 
 class TestTableCollection(unittest.TestCase):

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1832,8 +1832,8 @@ def to_np_int32(int_array):
         return int_array.astype(np.int32, casting='safe')
     except TypeError:
         int32bounds = np.iinfo(np.int32)
-        if (int_array >= int32bounds.min).all() and (int_array <= int32bounds.max).all():
-            # This should raise the correct error on conversion from e.g. a float array
+        if np.all(int_array >= int32bounds.min) and np.all(int_array <= int32bounds.max):
+            # Raises a TypeError when we try to convert from, e.g., a float.
             return int_array.astype(np.int32, casting='same_kind')
         else:
             raise OverflowError("Cannot convert safely to int32 type")

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1639,6 +1639,8 @@ class TableCollection(object):
             flags = self.nodes.flags
             samples = np.where(
                 np.bitwise_and(flags, _tskit.NODE_IS_SAMPLE) != 0)[0].astype(np.int32)
+        else:
+            samples = to_np_int32(samples)
         return self.ll_tables.simplify(
             samples, filter_sites=filter_sites,
             filter_individuals=filter_individuals,
@@ -1815,3 +1817,23 @@ def unpack_strings(packed, offset, encoding="utf8"):
     :rtype: list[str]
     """
     return [b.decode(encoding) for b in unpack_bytes(packed, offset)]
+
+
+def to_np_int32(int_array):
+    """
+    A few functions require arrays of type np.int32. To allow passing standard numpy
+    integer arrays (dtype=np.int64) we cast but check bounds to avoid wrap-around
+    conversion errors (numpy doesn't seem to provide this functionality)
+    """
+    int_array = np.array(int_array)
+    if int_array.size == 0:
+        return int_array.astype(np.int32)  # Allow empty arrays of any type
+    try:
+        return int_array.astype(np.int32, casting='safe')
+    except TypeError:
+        int32bounds = np.iinfo(np.int32)
+        if (int_array >= int32bounds.min).all() and (int_array <= int32bounds.max).all():
+            # This should raise the correct error on conversion from e.g. a float array
+            return int_array.astype(np.int32, casting='same_kind')
+        else:
+            raise OverflowError("Cannot convert safely to int32 type")


### PR DESCRIPTION
Solving https://github.com/tskit-dev/tskit/issues/8 seems a bit more convoluted than I had expected, but we need to allow passing `[]`, which by default is of dtype `np.float64`, and it seems as if numpy doesn't have any built-in bounds checking. I've created a function `to_np_int32` as I imagine we might want to use this in other python functions, as per the `set_columns` example by @petrelharp. But perhaps there's a neater solution.

As a bonus, this now catches errors like `ts.simplify([0.1,1.3])` which used to convert silently to ints, and it also returns a TypeError for `ts.simplify({})` rather than ValueError, which seems more correct to me. I've also added a few more test cases.