### PR TITLE
Address #148

### DIFF
--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -729,7 +729,7 @@ tsk_treeseq_genealogical_nearest_neighbours(tsk_treeseq_t *self,
             u = focal[j];
             focal_reference_set = reference_set_map[u];
             delta = focal_reference_set != -1;
-            p = parent[u];
+            p = u;
             while (p != TSK_NULL) {
                 row = GET_2D_ROW(ref_count, K, p);
                 total = row[K - 1];

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -692,7 +692,7 @@ def genealogical_nearest_neighbours(ts, focal, reference_sets):
     parent = np.zeros(ts.num_nodes, dtype=int) - 1
     sample_count = np.zeros((ts.num_nodes, K), dtype=int)
 
-    # Set the intitial conditions.
+    # Set the initial conditions.
     for j in range(K):
         sample_count[reference_sets[j], j] = 1
 
@@ -714,7 +714,7 @@ def genealogical_nearest_neighbours(ts, focal, reference_sets):
         for j, u in enumerate(focal):
             focal_reference_set = reference_set_map[u]
             delta = int(focal_reference_set != -1)
-            p = parent[u]
+            p = u
             while p != tskit.NULL:
                 total = np.sum(sample_count[p])
                 if total > delta:


### PR DESCRIPTION
If we ask for the GNN of an internal node then we need not go to the parent before looking for descendants. Note that the word "neighbour" in GNN might be a bit misleading here, but it is the most logical thing to do. Indeed, if we ask for the GNN of the root node there is no defined behaviour otherwise (as it has no parent).