### PR TITLE
phenotype correlation

### DIFF
--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -217,6 +217,14 @@ int tsk_treeseq_general_stat(tsk_treeseq_t *self,
         size_t num_windows, double *windows, double *sigma,
         tsk_flags_t options);
 
+/* One way weighted stats */
+int tsk_treeseq_trait_covariance(tsk_treeseq_t *self,
+    tsk_size_t num_weights, double *weights,
+    tsk_size_t num_windows, double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_trait_correlation(tsk_treeseq_t *self,
+    tsk_size_t num_weights, double *weights,
+    tsk_size_t num_windows, double *windows, double *result, tsk_flags_t options);
+
 /* One way sample set stats */
 int tsk_treeseq_diversity(tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, tsk_size_t *sample_set_sizes, tsk_id_t *sample_sets,


### PR DESCRIPTION
In the paper we've described a statistic that is "phenotype correlation", which is basically the correlation of a weight with the inheritance pattern of the site/branch/node. So far I've implemented covariance; doing correlation (dividing by `sqrt(p(1-p))`) won't be hard.  Just 'cause it sounds catchy I've called it "inheritance covariance", but should probably rename it "phenotype covariance" or even just "weight covariance".

In doing this I've had to make another route from python to c that parallels the "sample set" machinery. It's probably not quite the right API yet to be useful in a bunch of different situations.

To-do:
- implement correlation also
- write c tests
- write lowlevel python tests

Also see #238 which I realized while doing this.