### PR TITLE
Add function to JSONify command args

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -940,7 +940,7 @@ class TestSortTables(unittest.TestCase):
             tables.edges.add_row(e.left, e.right, e.parent, e.child)
         # Verify that import fails for randomised edges
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
-        tables.sort()
+        tables.sort(record_provenance=False)
         self.assertEqual(tables, ts.dump_tables())
 
         tables.sites.clear()
@@ -962,7 +962,7 @@ class TestSortTables(unittest.TestCase):
         if ts.num_sites > 1:
             # Verify that import fails for randomised sites
             self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
-        tables.sort()
+        tables.sort(record_provenance=False)
         self.assertEqual(tables, ts.dump_tables())
 
         ts_new = tables.tree_sequence()
@@ -1667,7 +1667,7 @@ class TestDeduplicateSites(unittest.TestCase):
     """
     def test_empty(self):
         tables = tskit.TableCollection(1)
-        tables.deduplicate_sites()
+        tables.deduplicate_sites(record_provenance=False)
         self.assertEqual(tables, tskit.TableCollection(1))
 
     def test_unsorted(self):

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1381,8 +1381,12 @@ class TestSimplifyTables(unittest.TestCase):
         self.assertRaises(_tskit.LibraryError, tables.simplify, [])
 
     def test_samples_interface(self):
+        # Test that we allow ints and int arrays of all reasonable types
         ts = msprime.simulate(50, random_seed=1)
-        for good_form in [[], [0, 1], (0, 1), np.array([0, 1], dtype=np.int32)]:
+        for good_form in [
+                [], [0, 1], (0, 1), set([0, 1]),  # standard list formats
+                (np.int64(0), np.uint32(1)),  # numpy scalars
+                np.array([0, 1], dtype=np.int32), np.array([0, 1], dtype=np.int64)]:
             tables = ts.dump_tables()
             tables.simplify(good_form)
         tables = ts.dump_tables()
@@ -1394,6 +1398,9 @@ class TestSimplifyTables(unittest.TestCase):
         for bad_node in [np.iinfo(np.int32).min-1, np.iinfo(np.int32).max+1]:
             self.assertRaises(
                 OverflowError, tables.simplify, samples=np.array([0, bad_node]))
+
+    def test_provenance_recapitulation(self):
+        pass
 
 
 class TestTableCollection(unittest.TestCase):

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -1153,7 +1153,11 @@ class TestSimplifyExamples(TopologyTestCase):
             print(before)
             print("after")
             print(after)
-        self.assertEqual(before, after)
+        for t_b, t_a in zip(before, after):
+            if t_b[0] == 'provenances':
+                self.assertEqual(t_b[1].record, t_a[1].record)
+            else:
+                self.assertEqual(t_b, t_a)
 
     def test_unsorted_edges(self):
         # We have two nodes at the same time and interleave edges for
@@ -4085,13 +4089,11 @@ class TestSlice(TopologyTestCase):
                             stop = max(a, b)
                             x = slice(ts, start, stop, reset_coords, simplify, rec_prov)
                             y = ts.slice(start, stop, reset_coords, simplify, rec_prov)
-                            t1 = x.dump_tables()
-                            t2 = y.dump_tables()
-                            # Provenances may differ using timestamps, so ignore them
-                            # (this is a hack, as we prob want to compare their contents)
-                            t1.provenances.clear()
-                            t2.provenances.clear()
-                            self.assertEqual(t1, t2)
+                            for t1, t2 in zip(x.tables, y.tables):
+                                if t1[0] == 'provenance':
+                                    self.assertEqual(t1[1].record, t2[1].record)
+                                else:
+                                    assert self.assertEqual(t1, t2)
 
     def test_slice_by_tree_positions(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)

--- a/python/tskit/provenance.py
+++ b/python/tskit/provenance.py
@@ -153,7 +153,8 @@ def provenance_command_JSON(exclude_args=[]):
     """
     def serialize_numpy_array(arg):
         if type(arg) == np.ndarray:
-            return np.array_repr(arg)
+            # NB: we might also want to strip whitespace from the stringified array
+            return np.array_repr(arg, max_line_width=np.inf)
         return json.dumps(arg)
 
     exclude_args.append('self')

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1645,8 +1645,8 @@ class TableCollection(object):
         :rtype: numpy array (dtype=np.int32).
         """
         if record_provenance:
-            provenance_JSON = tskit.provenance.provenance_command_JSON(
-                exclude_args='filter_zero_mutation_sites')
+            provenance_JSON = tskit.provenance.function_args_to_json(
+                exclude_args=['filter_zero_mutation_sites'])
         if filter_zero_mutation_sites is not None:
             # Deprecated in 0.6.1.
             warnings.warn(
@@ -1711,7 +1711,7 @@ class TableCollection(object):
         """
         self.ll_tables.sort(edge_start)
         if record_provenance:
-            self.provenances.add_row(record=tskit.provenance.provenance_command_JSON())
+            self.provenances.add_row(record=tskit.provenance.function_args_to_json())
 
     def compute_mutation_parents(self, record_provenance=True):
         """
@@ -1729,7 +1729,7 @@ class TableCollection(object):
         """
         self.ll_tables.compute_mutation_parents()
         if record_provenance:
-            self.provenances.add_row(record=tskit.provenance.provenance_command_JSON())
+            self.provenances.add_row(record=tskit.provenance.function_args_to_json())
 
     def deduplicate_sites(self, record_provenance=True):
         """
@@ -1740,7 +1740,7 @@ class TableCollection(object):
         """
         self.ll_tables.deduplicate_sites()
         if record_provenance:
-            self.provenances.add_row(record=tskit.provenance.provenance_command_JSON())
+            self.provenances.add_row(record=tskit.provenance.function_args_to_json())
 
     def has_index(self):
         """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3046,10 +3046,6 @@ class TreeSequence(object):
         :rtype: .TreeSequence or a (.TreeSequence, numpy.array) tuple
         """
         tables = self.dump_tables()
-        if samples is None:
-            samples = self.get_samples()
-        # Force convert to int32 so that provenances are saved in a consistent format
-        samples = util.safe_np_int_cast(samples, np.int32)
         assert tables.sequence_length == self.sequence_length
         node_map = tables.simplify(
             samples=samples,

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3045,8 +3045,6 @@ class TreeSequence(object):
             sequence.
         :rtype: .TreeSequence or a (.TreeSequence, numpy.array) tuple
         """
-        if record_provenance:
-            provenance_JSON = provenance.function_args_to_json()
         tables = self.dump_tables()
         if samples is None:
             samples = self.get_samples()
@@ -3060,11 +3058,10 @@ class TreeSequence(object):
             filter_populations=filter_populations,
             filter_individuals=filter_individuals,
             filter_sites=filter_sites,
+            record_provenance=record_provenance,
             keep_unary=keep_unary)
         new_ts = tables.tree_sequence()
         assert new_ts.sequence_length == self.sequence_length
-        if record_provenance:
-            tables.provenances.add_row(record=provenance_JSON)
         if map_nodes:
             return new_ts, node_map
         else:


### PR DESCRIPTION
This should allow us to encode the arguments passed e.g. to `simplify()` in the provenances data. This is currently [listed as a TO DO](https://github.com/tskit-dev/tskit/blob/57ff0abe4173611a396e9715632d544195880a75/python/tskit/trees.py#L3057).

I'm not sure if this is the right approach or not - it seems a bit magic to simply call (e.g. within `simplify()`)

    tables.provenances.add_row(record=provenance.provenance_command_JSON())

and have the whole thing constructed for you. Using `inspect.currentframe().f_back` within the new function, to get at the outer calling function, seems potentially fragile. Other possible ways to do this are welcome.