### PR TITLE
linear regression

### DIFF
--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -223,6 +223,11 @@ int tsk_treeseq_trait_covariance(tsk_treeseq_t *self,
 int tsk_treeseq_trait_correlation(tsk_treeseq_t *self,
     tsk_size_t num_weights, double *weights,
     tsk_size_t num_windows, double *windows, double *result, tsk_flags_t options);
+/* One way weighted stats with covariates */
+int tsk_treeseq_trait_regression(tsk_treeseq_t *self,
+    tsk_size_t num_weights, double *weights,
+    tsk_size_t num_covariates, double *covariates,
+    tsk_size_t num_windows, double *windows, double *result, tsk_flags_t options);
 
 /* One way sample set stats */
 int tsk_treeseq_diversity(tsk_treeseq_t *self,

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6794,6 +6794,100 @@ out:
     return ret;
 }
 
+typedef int one_way_covariates_method(tsk_treeseq_t *self,
+        tsk_size_t num_weights, double *weights,
+        tsk_size_t num_covariates, double *covariates,
+        tsk_size_t num_windows, double *windows, double *result, tsk_flags_t options);
+
+static PyObject *
+TreeSequence_one_way_covariates_method(TreeSequence *self, PyObject *args, PyObject *kwds,
+        one_way_covariates_method *method)
+{
+    PyObject *ret = NULL;
+    static char *kwlist[] = {"weights", "covariates", "windows", "mode", "polarised",
+        "span_normalise", NULL};
+    PyObject *weights = NULL;
+    PyObject *covariates = NULL;
+    PyObject *windows = NULL;
+    PyArrayObject *weights_array = NULL;
+    PyArrayObject *covariates_array = NULL;
+    PyArrayObject *windows_array = NULL;
+    PyArrayObject *result_array = NULL;
+    char *mode = NULL;
+    int polarised = 0;
+    int span_normalise = 0;
+    tsk_size_t num_windows;
+    npy_intp *w_shape, *z_shape;
+    tsk_flags_t options = 0;
+    int err;
+
+    if (TreeSequence_check_tree_sequence(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO|sii", kwlist,
+            &weights, &covariates, &windows, &mode, &polarised, &span_normalise)) {
+        goto out;
+    }
+    if (parse_stats_mode(mode, &options) != 0) {
+        goto out;
+    }
+    if (polarised) {
+        options |= TSK_STAT_POLARISED;
+    }
+    if (span_normalise) {
+        options |= TSK_STAT_SPAN_NORMALISE;
+    }
+    if (parse_windows(windows, &windows_array, &num_windows) != 0) {
+        goto out;
+    }
+
+    weights_array = (PyArrayObject *) PyArray_FROMANY(weights, NPY_FLOAT64,
+            2, 2, NPY_ARRAY_IN_ARRAY);
+    if (weights_array == NULL) {
+        goto out;
+    }
+    w_shape = PyArray_DIMS(weights_array);
+    if (w_shape[0] != tsk_treeseq_get_num_samples(self->tree_sequence)) {
+        PyErr_SetString(PyExc_ValueError, "First dimension of weights must be num_samples");
+        goto out;
+    }
+    covariates_array = (PyArrayObject *) PyArray_FROMANY(covariates, NPY_FLOAT64,
+            2, 2, NPY_ARRAY_IN_ARRAY);
+    if (covariates_array == NULL) {
+        goto out;
+    }
+    z_shape = PyArray_DIMS(covariates_array);
+    if (z_shape[0] != tsk_treeseq_get_num_samples(self->tree_sequence)) {
+        PyErr_SetString(PyExc_ValueError, "First dimension of covariates must be num_samples");
+        goto out;
+    }
+    result_array = TreeSequence_allocate_results_array(self, options,
+            num_windows, w_shape[1]);
+    if (result_array == NULL) {
+        goto out;
+    }
+
+    err = method(self->tree_sequence,
+            w_shape[1], PyArray_DATA(weights_array),
+            z_shape[1], PyArray_DATA(covariates_array),
+            num_windows, PyArray_DATA(windows_array),
+            PyArray_DATA(result_array), options);
+    if (err == TSK_PYTHON_CALLBACK_ERROR) {
+        goto out;
+    } else if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = (PyObject *) result_array;
+    result_array = NULL;
+out:
+    Py_XDECREF(weights_array);
+    Py_XDECREF(covariates_array);
+    Py_XDECREF(windows_array);
+    Py_XDECREF(result_array);
+    return ret;
+}
+
 typedef int one_way_sample_stat_method(tsk_treeseq_t *self,
         tsk_size_t num_sample_sets, tsk_size_t *sample_set_sizes, tsk_id_t *sample_sets,
         tsk_size_t num_windows, double *windows, double *result, tsk_flags_t options);
@@ -6880,6 +6974,12 @@ static PyObject *
 TreeSequence_trait_correlation(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     return TreeSequence_one_way_weighted_method(self, args, kwds, tsk_treeseq_trait_correlation);
+}
+
+static PyObject *
+TreeSequence_trait_regression(TreeSequence *self, PyObject *args, PyObject *kwds)
+{
+    return TreeSequence_one_way_covariates_method(self, args, kwds, tsk_treeseq_trait_regression);
 }
 
 static PyObject *
@@ -7210,10 +7310,13 @@ static PyMethodDef TreeSequence_methods[] = {
         METH_VARARGS|METH_KEYWORDS, "Computes diversity within sample sets." },
     {"trait_covariance",
         (PyCFunction) TreeSequence_trait_covariance,
-        METH_VARARGS|METH_KEYWORDS, "Computes covariance with the phenotypes." },
+        METH_VARARGS|METH_KEYWORDS, "Computes covariance with traits." },
     {"trait_correlation",
         (PyCFunction) TreeSequence_trait_correlation,
-        METH_VARARGS|METH_KEYWORDS, "Computes correlation with the phenotypes." },
+        METH_VARARGS|METH_KEYWORDS, "Computes correlation with traits." },
+    {"trait_regression",
+        (PyCFunction) TreeSequence_trait_regression,
+        METH_VARARGS|METH_KEYWORDS, "Computes regression coefficients of each trait." },
     {"segregating_sites",
         (PyCFunction) TreeSequence_segregating_sites,
         METH_VARARGS|METH_KEYWORDS, "Computes density of segregating sites within sample sets." },

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3403,8 +3403,9 @@ class TreeSequence(object):
         """
         Computes the mean squared covariances between each of the columns of ``W``
         (the "phenotypes") and inheritance along the tree sequence.  See
-        :ref:`sec_general_stats` for details of ``windows``, ``mode`` and
-        return value.  Operates on ``k = 1`` sample set at a time.
+        :ref:`sec_general_stats` for details of ``windows``, ``mode``,
+        ``span_normalise`` and return value.  Operates on all samples in the tree
+        sequence.
 
         Concretely, if `g` is a binary vector that indicates inheritance from an allele,
         branch, or node and `w` is a column of W, normalised to have mean zero,
@@ -3446,6 +3447,8 @@ class TreeSequence(object):
             window (defaults to True).
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
+        if W.shape[0] != self.num_samples:
+            raise ValueError("First trait dimension must be equal to number of samples.")
         windows = self.parse_windows(windows)
         return self._ll_tree_sequence.trait_covariance(
                         W, windows=windows,
@@ -3455,8 +3458,9 @@ class TreeSequence(object):
         """
         Computes the mean squared correlations between each of the columns of ``W``
         (the "phenotypes") and inheritance along the tree sequence.  See
-        :ref:`sec_general_stats` for details of ``windows``, ``mode`` and
-        return value.  Operates on ``k = 1`` sample set at a time.
+        :ref:`sec_general_stats` for details of ``windows``, ``mode``,
+        ``span_normalise`` and return value.  Operates on all samples in the
+        tree sequence.
 
         This is computed as squared covariance in
         :meth:`trait_covariance <.TreeSequence.trait_covarance>`,
@@ -3499,6 +3503,8 @@ class TreeSequence(object):
             window (defaults to True).
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
+        if W.shape[0] != self.num_samples:
+            raise ValueError("First trait dimension must be equal to number of samples.")
         sds = np.std(W, axis=0)
         if np.any(sds == 0):
             raise ValueError("Weight columns must have positive variance",
@@ -3506,6 +3512,75 @@ class TreeSequence(object):
         windows = self.parse_windows(windows)
         return self._ll_tree_sequence.trait_correlation(
                         W, windows=windows,
+                        mode=mode, span_normalise=span_normalise)
+
+    def trait_regression(self, W, Z, windows=None, mode="site", span_normalise=True):
+        """
+        For each trait w (i.e., each column of W), performs the least-squares
+        linear regression :math:`w ~ g + Z`,
+        where :math:`g` is inheritance in the tree sequence and the columns of :math:`Z`
+        are covariates, and computes the squared coefficient of :math:`g` in this
+        regression.  See :ref:`sec_general_stats` for details of ``windows``, ``mode``,
+        ``span_normalise`` and return value.  Operates on all samples in the
+        tree sequence.
+
+        Concretely, if `g` is a binary vector that indicates inheritance from an allele,
+        branch, or node and `w` is a column of W, there are :math:`k` columns of
+        :math:`Z`, and the :math:`k+2`-vector :math:`b` minimises
+        :math:`\\sum_i (w_i - b_0 - b_1 g_i - b_2 z_{2,i} - ... b_{k+2} z_{k+2,i})^2`
+        then this returns the number :math:`b_1^2`. If :math:`g` lies in the linear span
+        of the columns of :math:`Z`, then :math:`b_1` is set to 0.
+
+        What is computed depends on ``mode``:
+
+        "site"
+            Computes the sum of :math:`b_1^2/2` for each allele in the window,
+            as above with :math:`g` indicating presence/absence of the allele,
+            then divided by the length of the window if ``span_normalise=True``.
+            (For biallelic loci, this number is the same for both alleles, and so summing
+            over each cancels the factor of two.)
+
+        "branch"
+            The squared coefficient `b_1^2`, computed for the split induced by each
+            branch (i.e., with :math:`g` indicating inheritance from that branch),
+            multiplied by branch length and tree span, summed over all trees
+            in the window, and divided by the length of the window if
+            ``span_normalise=True``.
+
+        "node"
+            For each node, the squared coefficient `b_1^2`, computed for the property of
+            inheriting from this node, as in "branch".
+
+        :param ndarray W: An array of values with one row for each sample and one column
+            for each "phenotype".
+        :param ndarray Z: An array of values with one row for each sample and one column
+            for each "covariate", or None. Columns of `Z` must be linearly independent.
+        :param iterable windows: An increasing list of breakpoints between the windows
+            to compute the statistic in.
+        :param str mode: A string giving the "type" of the statistic to be computed
+            (defaults to "site").
+        :param bool span_normalise: Whether to divide the result by the span of the
+            window (defaults to True).
+        :return: A ndarray with shape equal to (num windows, num statistics).
+        """
+        windows = self.parse_windows(windows)
+        if W.shape[0] != self.num_samples:
+            raise ValueError("First trait dimension must be equal to number of samples.")
+        if Z is None:
+            Z = np.ones((self.num_samples, 1))
+        else:
+            tZ = np.column_stack([Z, np.ones((Z.shape[0], 1))])
+            if np.linalg.matrix_rank(tZ) == tZ.shape[1]:
+                Z = tZ
+        if Z.shape[0] != self.num_samples:
+            raise ValueError("First dimension of Z must equal the number of samples.")
+        if np.linalg.matrix_rank(Z) < Z.shape[1]:
+            raise ValueError("Matrix of covariates is computationally singular.")
+        # numpy returns a lower-triangular cholesky
+        K = np.linalg.cholesky(np.matmul(Z.T, Z)).T
+        Z = np.matmul(Z, np.linalg.inv(K))
+        return self._ll_tree_sequence.trait_regression(
+                        W, Z, windows=windows,
                         mode=mode, span_normalise=span_normalise)
 
     def segregating_sites(self, sample_sets, windows=None, mode="site",

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3225,7 +3225,8 @@ class TreeSequence(object):
                     raise ValueError("Not all elements of sample_sets are samples.")
 
         W = np.array([[float(u in A) for A in sample_sets] for u in self.samples()])
-        return self.general_stat(W, f, windows=windows, polarised=polarised, mode=mode)
+        return self.general_stat(W, f, windows=windows, polarised=polarised, mode=mode,
+                                 span_normalise=span_normalise)
 
     def parse_windows(self, windows):
         # Note: need to make sure windows is a string or we try to compare the


### PR DESCRIPTION
The math is in the treestats paper; I think all the bits are there but with some errors yet.

I ended up duplicating a moderate amount of code, from the "weighted_stats" because this case is different to covariance and correlation (in that it has another argument, "covariates"). I haven't thought of a better way to do this yet - hampered by a lack of examples. So maybe it's fine; when/if we have more examples we can generalise appropriately.