### PR TITLE
Properly export constants

### DIFF
--- a/python/tskit/__init__.py
+++ b/python/tskit/__init__.py
@@ -21,6 +21,9 @@
 # SOFTWARE.
 
 import _tskit
+NULL = _tskit.NULL
+MISSING_DATA = _tskit.MISSING_DATA
+NODE_IS_SAMPLE = _tskit.NODE_IS_SAMPLE
 FORWARD = _tskit.FORWARD
 REVERSE = _tskit.REVERSE
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -42,8 +42,8 @@ import tskit.tables as tables
 import tskit.formats as formats
 import tskit.util as util
 
-from _tskit import NODE_IS_SAMPLE
-from _tskit import NULL
+from tskit import NODE_IS_SAMPLE
+from tskit import NULL
 
 
 CoalescenceRecord = collections.namedtuple(


### PR DESCRIPTION
At the moment `tskit.NULL` comes because we do `from _tskit import NULL` within trees.py, then in `__init.py__` we do `from tskit.trees import *`. This indirect import seems nasty to me. So I've changed this so that all constants are explicitly exported via a line in `__init.py__` instead. 