### PR TITLE
Add the Bio module for test_parsimony

### DIFF
--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -19,3 +19,4 @@ pysam
 PyVCF
 python_jsonschema_objects
 biopython
+Bio


### PR DESCRIPTION
For some reason this didn't auto-install for me using `setup.py`. Not sure why it works in the CI testing suite, but it can't harm to add it to the dev requirements, surely.