### PR TITLE
moved stats functions to stats.rst

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -26,10 +26,11 @@ Top level-classes
 
 
 .. autoclass:: tskit.TreeSequence()
-    :members:
+   :members:
+   :exclude-members: general_stat, sample_count_stat, diversity, divergence, allele_frequency_spectrum, segregating_sites, Fst, Tajimas_D, f2, f3, f4, Y1, Y2, Y3, trait_covariance, trait_correlation, trait_regression, parse_windows
 
 .. autoclass:: tskit.Tree
-    :members:
+   :members:
 
 
 +++++++++

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -235,23 +235,11 @@ That said, you should **not** rely on the specific behavior of whether ``0`` or 
 for "empty" cases like these: it is subject to change.
 
 
-.. Commenting these out for now as they are duplicates of the methods in the TreeSequence
-   and sphinx is unhappy.
+********************
+Statistics functions
+********************
 
-.. ********************
-.. Statistics functions
-.. ********************
+.. autoclass:: tskit.TreeSequence()
+   :noindex:
+   :members: general_stat, sample_count_stat, diversity, divergence, allele_frequency_spectrum, segregating_sites, Fst, Tajimas_D, f2, f3, f4, Y1, Y2, Y3, trait_covariance, trait_correlation, trait_regression, parse_windows
 
-.. .. autofunction:: tskit.TreeSequence.diversity
-
-.. .. autofunction:: tskit.TreeSequence.divergence
-
-.. .. autofunction:: tskit.TreeSequence.f4
-
-.. .. autofunction:: tskit.TreeSequence.f3
-
-.. .. autofunction:: tskit.TreeSequence.f2
-
-.. .. autofunction:: tskit.TreeSequence.Y3
-
-.. .. autofunction:: tskit.TreeSequence.Y2

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -241,5 +241,5 @@ Statistics functions
 
 .. autoclass:: tskit.TreeSequence()
    :noindex:
-   :members: general_stat, sample_count_stat, diversity, divergence, allele_frequency_spectrum, segregating_sites, Fst, Tajimas_D, f2, f3, f4, Y1, Y2, Y3, trait_covariance, trait_correlation, trait_regression, parse_windows
+   :members: general_stat, sample_count_stat, diversity, divergence, allele_frequency_spectrum, segregating_sites, Fst, Tajimas_D, f4, f3, f2, Y3, Y2, Y1, trait_covariance, trait_correlation, trait_regression, parse_windows
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2747,6 +2747,8 @@ class TreeSequence(object):
         that differ between a randomly chosen pair of samples.  If `samples` is
         specified, calculate the diversity within this set.
 
+        .. warning:: This method is deprecated; please use :meth:`.diversity`.
+
         .. note:: This method does not currently support sites that have more
             than one mutation. Using it on such a tree sequence will raise
             a LibraryError with an "Unsupported operation" message.


### PR DESCRIPTION
Here's the sphinx magic to move that over.  Other things that we could maybe do now:

1. I deprecated `pairwise_diversity` but should probably move that over to `stats.rst` also?
2. I also think we should move `genealogical_nearest_neighbors` and `mean_descendants` over to `stats.rst`; perhaps in a separate section? There's definately overlap between the topics; maybe the page gets called something like "Statistics and other genealogical descriptors"?
3. `mean_descendants` could be easily implemented as a node statistic, and we'd have use for the corresponding site and branch statistic, also. Maybe the most natural is that `mode="site", windows="sites", polarised=True` gives the derived allele frequency at each site. Given this, maybe a better name is `descendant_frequency` or just `frequency`?