### PR TITLE
Improve stat docs

### DIFF
--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -276,6 +276,17 @@ pairwise) and Patterson's f statistics (which are four-way).
 - :meth:`.TreeSequence.Y3`
 - :meth:`.TreeSequence.Y2`
 
+------------------
+Trait correlations
+------------------
+
+These methods compute correlations and covariances of traits (i.e., an
+arbitrary vector) with allelic state, possibly in the context of a multivariate
+regression with other covariates (as in GWAS).
+
+- :meth:`.TreeSequence.trait_covariance`
+- :meth:`.TreeSequence.trait_correlation`
+
 ---------------
 General methods
 ---------------

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3321,6 +3321,27 @@ class TreeSequence(object):
         below the node that ``f`` is being evaluated for. See
         :meth:`.general_stat`  for more details.
 
+        Here is a contrived example: suppose that ``A`` and ``B`` are two sets
+        of samples with ``nA`` and ``nB`` elements, respectively. Passing these
+        as sample sets will give ``f`` an argument of length two, giving the number
+        of samples in ``A`` and ``B`` below the node in question. So, if we define
+
+            def f(x):
+                pA = x[0] / nA
+                pB = x[1] / nB
+                return np.array([pA * pB])
+
+        then if all sites are biallelic,
+
+            ts.sample_count_stat([A, B], f, windows="site",
+                                 polarised=False, mode="site")
+
+        would compute, for each site, the product of the derived allele
+        frequencies in the two sample sets, in a (num sites, 1) array.  If
+        instead ``f`` returns ``np.array([pA, pB, pA * pB])``, then the
+        output would be a (num sites, 3) array, with the first two columns
+        giving the allele frequencies in ``A`` and ``B``, respectively.
+
         :param list sample_sets: A list of lists of Node IDs, specifying the
             groups of individuals to compute the statistic with.
         :param function f: A function that takes a one-dimensional array of length


### PR DESCRIPTION
This is for discussion and iteration on the docs. I've fixed the links as pointed out by @molpopgen and as suggested on email:

> a Python example showing exactly what 'f' must do would be really useful.  Likewise, for sample_count_stat.  The docs state that f returns a 1d array, but it isn't clear (to me) if that array is of length 1 in the case of 1 sample set, but it seems like it must be, else it would have to be  higher dimension for > 1 sample set?

I made an example for sample counts; I was having a hard time coming up with a not-super-wierd example for general_stat; any suggestions?