### PR TITLE
Use np.allclose instead of array_almost_equal

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -571,8 +571,8 @@ class StatsTestCase(unittest.TestCase):
     def assertArrayEqual(self, x, y):
         nt.assert_equal(x, y)
 
-    def assertArrayAlmostEqual(self, x, y):
-        nt.assert_array_almost_equal(x, y)
+    def assertArrayAlmostEqual(self, x, y, atol=1e-6, rtol=1e-7):
+        nt.assert_allclose(x, y, atol=atol, rtol=rtol)
 
 
 class TopologyExamplesMixin(object):


### PR DESCRIPTION
The array_almost_equal implementation requires values to be within an
absolute difference of 1e-6, which results in occasional failures
in trait regression tests when values are large. np.allclose uses
a relative error instead, and is recommended in the documentation.

cc @petrelharp - this should fix the sporadic failures we're seeing on Appveyor.