### PR TITLE
Remove doc references to deprecated sort_tables() function

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1019,7 +1019,7 @@ class TestBytePacking(unittest.TestCase):
 
 class TestSortTables(unittest.TestCase):
     """
-    Tests for the sort_tables method.
+    Tests for the TableCollection.sort() method.
     """
     random_seed = 12345
 
@@ -1228,7 +1228,7 @@ class TestSortTables(unittest.TestCase):
 
 class TestSortMutations(unittest.TestCase):
     """
-    Tests that mutations are correctly sorted by sort_tables.
+    Tests that mutations are correctly ordered when sorting tables.
     """
 
     def test_sort_mutations_stability(self):
@@ -1255,7 +1255,7 @@ class TestSortMutations(unittest.TestCase):
         ts = tskit.load_text(
             nodes=nodes, edges=edges, sites=sites, mutations=mutations,
             sequence_length=1, strict=False)
-        # Load text automatically calls sort tables, so we can test the
+        # Load text automatically calls tables.sort(), so we can test the
         # output directly.
         sites = ts.tables.sites
         mutations = ts.tables.mutations

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1611,7 +1611,7 @@ class TableCollection(object):
         the output tables, this mapping will equal ``-1``.
 
         Tables operated on by this function must: be sorted (see
-        :meth:`TableCollection.sort`)), have children be born strictly after their
+        :meth:`TableCollection.sort`), have children be born strictly after their
         parents, and the intervals on which any individual is a child must be
         disjoint. Other than this the tables need not satisfy remaining
         requirements to specify a valid tree sequence (but the resulting tables

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1887,7 +1887,7 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
     example, if a deletion is encoded in the mutation table this will not
     be parseable when ``strict=False``.
 
-    After parsing the tables, :func:`sort_tables` is called to ensure that
+    After parsing the tables, :meth:`TableCollection.sort` is called to ensure that
     the loaded tables satisfy the tree sequence :ref:`ordering requirements
     <sec_valid_tree_sequence_requirements>`. Note that this may result in the
     IDs of various entities changing from their positions in the input file.


### PR DESCRIPTION
And remove an extraneous close brace