### PR TITLE
Stop "RuntimeWarning: invalid value encountered in true_divide"

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -1185,7 +1185,8 @@ class TestDiversity(StatsTestCase, SampleSetStatsMixin):
         n = np.array([len(x) for x in sample_sets])
 
         def f(x):
-            return x * (n - x) / (n * (n - 1))
+            with np.errstate(invalid='ignore'):
+                return x * (n - x) / (n * (n - 1))
 
         self.verify_definition(
             ts, sample_sets, windows, f, ts.diversity, diversity)


### PR DESCRIPTION
I was getting a little annoyed by "invalid value encountered in true_divide" warnings during the unit tests in some of the `TestDiversity` derived classes. This stops the errors, but perhaps we want to work out why they are happing in the first place. I guess this is a @petrelharp thing?