### PR TITLE
Allow some basic iterators like nodes() and edges() to be reversed

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1272,6 +1272,35 @@ class TestTreeSequence(HighLevelTestCase):
                     self.assertEqual(t3.interval, t2.interval)
                     self.assertEqual(t3.parent_dict, t2.parent_dict)
 
+    def test_sequence_iteration(self):
+        for ts in get_example_tree_sequences():
+            for table_name, _ in ts.tables:
+                sequence = getattr(ts, table_name)()
+                length = getattr(ts, "num_" + table_name)
+                # Test __iter__
+                for i, n in enumerate(sequence):
+                    self.assertEqual(i, n.id)
+                self.assertEqual(n.id, length - 1 if length else 0)
+                if table_name == 'mutations':
+                    # Mutations are not currently sequences, so have no len or idx access
+                    self.assertRaises(TypeError, len, sequence)
+                    if length != 0:
+                        with self.assertRaises(TypeError):
+                            sequence[0]
+                else:
+                    # Test __len__
+                    self.assertEqual(len(sequence), length)
+                    # Test __getitem__ on the last item in the sequence
+                    if length != 0:
+                        self.assertEqual(sequence[length - 1], n)  # +ive indexing
+                        self.assertEqual(sequence[-1], n)          # -ive indexing
+                    with self.assertRaises(IndexError):
+                        sequence[length]
+                    # Test reverse
+                    for i, n in enumerate(reversed(sequence)):
+                        self.assertEqual(i, length - 1 - n.id)
+                    self.assertEqual(n.id, 0)
+
 
 class TestFileUuid(HighLevelTestCase):
     """


### PR DESCRIPTION
fixes https://github.com/tskit-dev/tskit/issues/56

I'm not sure if this is overly complicating things (so I haven't written unit tests yet), but it seems like a worthwhile addition. Iterating in reverse over migrations, mutations and edge_diffs is a little less easy to generalize, though (I can imagine the migrations version being useful).

I'm unsure of the right place to put the `_ReversibleIterator` class, though. See https://github.com/tskit-dev/tsinfer/pull/178