### PR TITLE
minor testing cleanups

### DIFF
--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -99,6 +99,19 @@ class TestNumpyArrayCasting(unittest.TestCase):
                     pickle.dumps(target),
                     pickle.dumps(util.safe_np_int_cast(np.array([good_node]), dtype)))
 
+    def test_nonrectangular_input(self):
+        bad_inputs = [
+                [0, 1, [2]],
+                [[0, 1, 2], []],
+                [(0, 1, 2), [2, 3]],
+                [(0, 1, 2), tuple()],
+                [(0, 1, 2), (2, )],
+                [(0, 1, 2), [2, 3]]]
+        for dtype in self.dtypes_to_test:
+            for bad_input in bad_inputs:
+                with self.assertRaises(TypeError):
+                    util.safe_np_int_cast(bad_input, dtype)
+
 
 class TestIntervalOps(unittest.TestCase):
     """

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -47,6 +47,9 @@ def safe_np_int_cast(int_array, dtype, copy=False):
     try:
         return int_array.astype(dtype, casting='safe', copy=copy)
     except TypeError:
+        if int_array.dtype == np.dtype('O'):
+            # this occurs e.g. if we're passed a list of lists of different lengths
+            raise TypeError("Cannot convert to a rectangular array.")
         bounds = np.iinfo(dtype)
         if np.any(int_array < bounds.min) or np.any(int_array > bounds.max):
             raise OverflowError("Cannot convert safely to {} type".format(dtype))


### PR DESCRIPTION
We've got both [naive_general_branch_stats](https://github.com/tskit-dev/tskit/blob/75c1c307b09f6bf269bb893ce7f5180567acddca/python/tests/test_tree_stats.py#L72) and [naive_branch_general_stat](https://github.com/tskit-dev/tskit/blob/75c1c307b09f6bf269bb893ce7f5180567acddca/python/tests/test_tree_stats.py#L190); and similarly for `site` defined. We use the second version, not the first.  Any reason not to remove these?

Other notes:
 - I had to add the `NOQA` to make flake8 happy; not sure why others didn't hit this?
 - sorry, forgot to do this on my own fork