### PR TITLE
Removed old pairwise_diversity code.

### DIFF
--- a/c/dev-tools/dev-cli.c
+++ b/c/dev-tools/dev-cli.c
@@ -158,29 +158,6 @@ print_ld_matrix(tsk_treeseq_t *ts)
 }
 
 static void
-print_stats(tsk_treeseq_t *ts)
-{
-    int ret = 0;
-    uint32_t j;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts) / 2;
-    tsk_id_t *sample = malloc(num_samples * sizeof(tsk_id_t));
-    double pi;
-
-    if (sample == NULL) {
-        fatal_error("no memory");
-    }
-    for (j = 0; j < num_samples; j++) {
-        sample[j] = (tsk_id_t) j;
-    }
-    ret = tsk_treeseq_get_pairwise_diversity(ts, sample, num_samples, &pi);
-    if (ret != 0) {
-        fatal_library_error(ret, "get_pairwise_diversity");
-    }
-    printf("pi = %f\n", pi);
-    free(sample);
-}
-
-static void
 print_newick_trees(tsk_treeseq_t *ts)
 {
     int ret = 0;
@@ -293,16 +270,6 @@ run_newick(const char *filename, int TSK_UNUSED(verbose))
 }
 
 static void
-run_stats(const char *filename, int TSK_UNUSED(verbose))
-{
-    tsk_treeseq_t ts;
-
-    load_tree_sequence(&ts, filename);
-    print_stats(&ts);
-    tsk_treeseq_free(&ts);
-}
-
-static void
 run_simplify(const char *input_filename, const char *output_filename, size_t num_samples,
         bool filter_sites, int verbose)
 {
@@ -399,14 +366,6 @@ main(int argc, char** argv)
     void* argtable6[] = {cmd6, verbose6, infiles6, end6};
     int nerrors6;
 
-    /* SYNTAX 7: stats [-v] <input-file> */
-    struct arg_rex *cmd7 = arg_rex1(NULL, NULL, "stats", NULL, REG_ICASE, NULL);
-    struct arg_lit *verbose7 = arg_lit0("v", "verbose", NULL);
-    struct arg_file *infiles7 = arg_file1(NULL, NULL, NULL, NULL);
-    struct arg_end *end7 = arg_end(20);
-    void* argtable7[] = {cmd7, verbose7, infiles7, end7};
-    int nerrors7;
-
     int exitcode = EXIT_SUCCESS;
     const char *progname = "main";
 
@@ -419,7 +378,6 @@ main(int argc, char** argv)
     nerrors4 = arg_parse(argc, argv, argtable4);
     nerrors5 = arg_parse(argc, argv, argtable5);
     nerrors6 = arg_parse(argc, argv, argtable6);
-    nerrors7 = arg_parse(argc, argv, argtable7);
 
     if (nerrors1 == 0) {
         run_simplify(infiles1->filename[0], outfiles1->filename[0],
@@ -432,11 +390,9 @@ main(int argc, char** argv)
     } else if (nerrors4 == 0) {
         run_variants(infiles4->filename[0], verbose4->count);
     } else if (nerrors5 == 0) {
-        run_stats(infiles5->filename[0], verbose5->count);
+        run_print(infiles5->filename[0], verbose5->count);
     } else if (nerrors6 == 0) {
-        run_print(infiles6->filename[0], verbose6->count);
-    } else if (nerrors7 == 0) {
-        run_newick(infiles7->filename[0], verbose7->count);
+        run_newick(infiles6->filename[0], verbose6->count);
     } else {
         /* We get here if the command line matched none of the possible syntaxes */
         if (cmd1->count > 0) {
@@ -463,10 +419,6 @@ main(int argc, char** argv)
             arg_print_errors(stdout, end6, progname);
             printf("usage: %s ", progname);
             arg_print_syntax(stdout, argtable6, "\n");
-        } else if (cmd7->count > 0) {
-            arg_print_errors(stdout, end7, progname);
-            printf("usage: %s ", progname);
-            arg_print_syntax(stdout, argtable7, "\n");
         } else {
             /* no correct cmd literals were given, so we cant presume which syntax was intended */
             printf("%s: missing command.\n",progname);
@@ -476,7 +428,6 @@ main(int argc, char** argv)
             printf("usage 4: %s ", progname);  arg_print_syntax(stdout, argtable4, "\n");
             printf("usage 5: %s ", progname);  arg_print_syntax(stdout, argtable5, "\n");
             printf("usage 6: %s ", progname);  arg_print_syntax(stdout, argtable6, "\n");
-            printf("usage 7: %s ", progname);  arg_print_syntax(stdout, argtable7, "\n");
         }
     }
 
@@ -486,7 +437,6 @@ main(int argc, char** argv)
     arg_freetable(argtable4, sizeof(argtable4) / sizeof(argtable4[0]));
     arg_freetable(argtable5, sizeof(argtable5) / sizeof(argtable5[0]));
     arg_freetable(argtable6, sizeof(argtable6) / sizeof(argtable6[0]));
-    arg_freetable(argtable7, sizeof(argtable7) / sizeof(argtable7[0]));
 
     return exitcode;
 }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -566,66 +566,8 @@ tsk_treeseq_is_sample(tsk_treeseq_t *self, tsk_id_t u)
     return ret;
 }
 
-/* Accessors for records */
+/* Stats functions */
 
-int TSK_WARN_UNUSED
-tsk_treeseq_get_pairwise_diversity(tsk_treeseq_t *self,
-    tsk_id_t *samples, size_t num_samples, double *pi)
-{
-    int ret = 0;
-    tsk_tree_t *tree = NULL;
-    double result, denom, n, count;
-    tsk_site_t *sites;
-    tsk_size_t j, k, num_sites;
-
-    if (num_samples < 2 || num_samples > self->num_samples) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
-        goto out;
-    }
-    n = (double) num_samples;
-    tree = malloc(sizeof(tsk_tree_t));
-    if (tree == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
-        goto out;
-    }
-    ret = tsk_tree_init(tree, self, TSK_SAMPLE_COUNTS);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = tsk_tree_set_tracked_samples(tree, num_samples, samples);
-    if (ret != 0) {
-        goto out;
-    }
-    /* Allocation done; move onto main algorithm. */
-    result = 0.0;
-    for (ret = tsk_tree_first(tree); ret == 1; ret = tsk_tree_next(tree)) {
-        ret = tsk_tree_get_sites(tree, &sites, &num_sites);
-        if (ret != 0) {
-            goto out;
-        }
-        for (j = 0; j < num_sites; j++) {
-            if (sites[j].mutations_length != 1) {
-                ret = TSK_ERR_ONLY_INFINITE_SITES;
-                goto out;
-            }
-            for (k = 0; k < sites[j].mutations_length; k++) {
-                count = (double) tree->num_tracked_samples[sites[j].mutations[k].node];
-                result += count * (n - count);
-            }
-        }
-    }
-    if (ret != 0) {
-        goto out;
-    }
-    denom = (n * (n - 1)) / 2.0;
-    *pi = result / denom;
-out:
-    if (tree != NULL) {
-        tsk_tree_free(tree);
-        free(tree);
-    }
-    return ret;
-}
 
 #define GET_2D_ROW(array, row_len, row) (array + (((size_t) (row_len)) * (size_t) row))
 

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -196,8 +196,6 @@ int tsk_treeseq_simplify(tsk_treeseq_t *self, tsk_id_t *samples,
 /* TODO do these belong in trees or stats? They should probably be in stats.
  * Keep them here for now until we figure out the correct interface.
  */
-int tsk_treeseq_get_pairwise_diversity(tsk_treeseq_t *self,
-    tsk_id_t *samples, size_t num_samples, double *pi);
 int tsk_treeseq_genealogical_nearest_neighbours(tsk_treeseq_t *self,
         tsk_id_t *focal, size_t num_focal,
         tsk_id_t **reference_sets, size_t *reference_set_size, size_t num_reference_sets,

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -362,24 +362,6 @@ class TestTreeSequence(LowLevelTestCase):
             self.assertTrue(np.array_equal(
                 np.arange(ts.get_num_samples(), dtype=np.int32), ts.get_samples()))
 
-    def test_pairwise_diversity(self):
-        for ts in self.get_example_tree_sequences():
-            for bad_type in ["", None, {}]:
-                self.assertRaises(TypeError, ts.get_pairwise_diversity, bad_type)
-                self.assertRaises(TypeError, ts.get_pairwise_diversity, [0, bad_type])
-            self.assertRaises(
-                ValueError, ts.get_pairwise_diversity, [])
-            self.assertRaises(
-                ValueError, ts.get_pairwise_diversity, [0])
-            self.assertRaises(
-                ValueError, ts.get_pairwise_diversity,
-                [0, ts.get_num_samples()])
-            self.assertRaises(
-                _tskit.LibraryError, ts.get_pairwise_diversity, [0, 0])
-            samples = list(range(ts.get_num_samples()))
-            pi1 = ts.get_pairwise_diversity(samples)
-            self.assertGreaterEqual(pi1, 0)
-
     def test_genealogical_nearest_neighbours(self):
         for ts in self.get_example_tree_sequences():
             self.assertRaises(TypeError, ts.genealogical_nearest_neighbours)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2822,16 +2822,17 @@ class TreeSequence(object):
 
     def pairwise_diversity(self, samples=None):
         """
-        Returns the value of :math:`\\pi`, the pairwise nucleotide site
-        diversity, the average number of mutations per unit of genome length
+        Returns the pairwise nucleotide site diversity, the average number of sites
         that differ between a randomly chosen pair of samples.  If `samples` is
         specified, calculate the diversity within this set.
 
-         .. warning:: This method is deprecated; please use :meth:`.diversity`.
-
-        .. note:: This method does not support sites that have more
-            than one mutation. Using it on such a tree sequence will raise
-            a LibraryError with an "Unsupported operation" message.
+         .. deprecated:: 0.2.0
+             please use :meth:`.diversity` instead. Since version 0.2.0 the error
+             semantics have also changed slightly. It is no longer an error
+             when there is one sample and a tskit.LibraryError is raised
+             when non-sample IDs are provided rather than a ValueError. It is
+             also no longer an error to compute pairwise diversity at sites
+             with multiple mutations.
 
         :param iterable samples: The set of samples within which we calculate
             the diversity. If None, calculate diversity within the entire sample.
@@ -2840,7 +2841,8 @@ class TreeSequence(object):
         """
         if samples is None:
             samples = self.samples()
-        return self._ll_tree_sequence.get_pairwise_diversity(list(samples))
+        return float(self.diversity(
+            [samples], windows=[0, self.sequence_length], span_normalise=False)[0])
 
     def mean_descendants(self, reference_sets):
         """


### PR DESCRIPTION
Deprecate the Python TreeSequence.pairwise_diversity method.

Closes #215.