### PR TITLE
Strip empty first dimension for default windows.

### DIFF
--- a/docs/examples.py
+++ b/docs/examples.py
@@ -175,7 +175,58 @@ def missing_data():
     tree = ts.first()
     tree.draw("_static/missing_data1.svg")
 
+
+def stats():
+    ts = msprime.simulate(
+        10**4, Ne=10**4, recombination_rate=1e-8, mutation_rate=1e-8, length=10**7,
+        random_seed=42)
+    print("num_trees = ", ts.num_trees, ", num_sites = ", ts.num_sites, sep="")
+
+    x = ts.diversity()
+    print("Average diversity per unit sequence length = {:.3G}".format(x))
+
+    windows = np.linspace(0, ts.sequence_length, num=5)
+    x = ts.diversity(windows=windows)
+    print(windows)
+    print(x)
+
+    A = ts.samples()[:100]
+    x = ts.diversity(sample_sets=A)
+    print(x)
+
+    B = ts.samples()[100:200]
+    C = ts.samples()[200:300]
+    x = ts.diversity(sample_sets=[A, B, C])
+    print(x)
+
+    x = ts.diversity(sample_sets=[A, B, C], windows=windows)
+    print("shape = ", x.shape)
+    print(x)
+
+    A = ts.samples()[:100]
+    B = ts.samples()[:100]
+    x = ts.divergence([A, B])
+    print(x)
+
+    x = ts.divergence([A, B], windows=windows)
+    print(x)
+
+    x = ts.divergence([A, B, C], indexes=[(0, 1), (0, 2)])
+    print(x)
+
+    x = ts.divergence([A, B, C], indexes=(0, 1))
+    print(x)
+
+    x = ts.divergence([A, B, C], indexes=[(0, 1)])
+    print(x)
+
+    x = ts.divergence([A, B, C], indexes=[(0, 1), (0, 2)], windows=windows)
+    print(x)
+
 # moving_along_tree_sequence()
 # parsimony()
 # allele_frequency_spectra()
-missing_data()
+# missing_data()
+
+stats()
+

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -70,6 +70,12 @@ e.g., the sites of the SNPs.
 Windowing
 *********
 
+By default, statistics
+
+``windows = None``
+   This is the default, and equivalent to passing ``windows = [0.0, ts.sequence_length]``.
+   The output will still be a two-dimensional array, but with only one row.
+
 Each statistic has an argument, ``windows``,
 which defines a collection of contiguous windows along the genome.
 If ``windows`` is a list of ``n+1`` increasing numbers between 0 and the ``sequence_length``,
@@ -88,10 +94,6 @@ would be equivalent to averaging the rows of ``S``,
 obtaining ``((b - a) * S[0] + (c - b) * S[1]) / (c - a)``.
 
 There are some shortcuts to other useful options:
-
-``windows = None``
-   This is the default, and equivalent to passing ``windows = [0.0, ts.sequence_length]``.
-   The output will still be a two-dimensional array, but with only one row.
 
 ``windows = "trees"``
    This says that you want statistics computed separately on the portion of the genome

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3453,13 +3453,20 @@ class TreeSequence(object):
             polarised=False):
         if sample_sets is None:
             sample_sets = self.samples()
+
         # First try to convert to a 1D numpy array. If it is, then we strip off
         # the corresponding dimension from the output.
         drop_dimension = False
-        sample_sets = np.array(sample_sets)
-        if len(sample_sets.shape) == 1:
-            sample_sets = [sample_sets]
-            drop_dimension = True
+        try:
+            sample_sets = np.array(sample_sets, dtype=np.int32)
+        except ValueError:
+            pass
+        else:
+            # If we've successfully converted sample_sets to a 1D numpy array
+            # of integers then drop the dimension
+            if len(sample_sets.shape) == 1:
+                sample_sets = [sample_sets]
+                drop_dimension = True
 
         sample_set_sizes = np.array(
             [len(sample_set) for sample_set in sample_sets], dtype=np.uint32)
@@ -4006,6 +4013,9 @@ class TreeSequence(object):
             window (defaults to True).
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
+        # TODO recast this as a two-way stat by pushing the computations down
+        # into another function. This will do the dimension stripping automatically
+        # then.
         windows = self.parse_windows(windows)
         if indexes is None:
             raise ValueError("indexes must be a list of pairs of indexes.")


### PR DESCRIPTION
This implements a subset of #200. The idea is that, when we don't specify windows then it's a pain to have to write ``stat[0]`` to get what you actually want. This seems like a good usablilty feature to add, to me --- this is what you'd actually want the library to do, right?

More concretely, take the following example:
```
afs = ts.allele_frequency_spectrum(mode="branch")
print("afs: ", afs)
print("diversity", ts.diversity([ts.samples()], mode="branch"))

afs = ts.allele_frequency_spectrum(mode="branch", windows=[0, ts.sequence_length])
print("afs:", afs)
print("diversity",
    ts.diversity([ts.samples()], mode="branch", windows=[0, ts.sequence_length]))
```
gives
```
afs:  [0.  2.5 0.  0. ]
diversity [3.33333333]
afs: [[0.  2.5 0.  0. ]]
diversity [[3.33333333]]
```

In the first case, we don't specify any windows so we're only interested in a single window and we remove the empty first dimension.  In the second case, we explicitly specify the windows and so we keep the dimension in place.

I agree this is going to be a bit confusing to explain, but it seems worth it. The mistakes that are made will be less annoying, in the long run, than having to add an extra ``[0]`` to the end of each call when you just want one window. If, as @petrelharp says people are rarely interested in a single window, then they won't be affected by this default behaviour.

The reason I'm bringing this up now is because it **is** a long-term decision. Because we've specified the default value for windows, we can't change the default behaviour after we ship 0.2.0. So we're making the decision here that we'll **never** want to do this, which to me seems a real shame as it's quite neat and elegant (IMO). 

Because we don't have a default value for, e.g., ``diversity`` now we don't have to worry about the other half of #200 (stripping off the empty dimensions when we're only looking at one sample set in, e.g., ``diversity`` until later).

FWIW, the implementation is easy and it doesn't break many of the tests.