### PR TITLE
check for error when indexes=None

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -3188,13 +3188,13 @@ class TestSampleSets(StatsTestCase):
     def test_non_samples(self):
         ts = self.get_example_ts()
         with self.assertRaises(exceptions.LibraryError):
-            ts.diversity([[10]])
+            ts.diversity([[ts.num_samples]])
 
         with self.assertRaises(exceptions.LibraryError):
-            ts.divergence([[10], [1, 2]])
+            ts.divergence([[ts.num_samples], [1, 2]])
 
         with self.assertRaises(ValueError):
-            ts.sample_count_stat([[10]], self.identity_f(ts), 1)
+            ts.sample_count_stat([[ts.num_samples]], self.identity_f(ts), 1)
 
     def test_span_normalise(self):
         ts = self.get_example_ts()
@@ -3245,7 +3245,7 @@ class TestSampleSetIndexes(StatsTestCase):
         with self.assertRaises(ValueError):
             _ = ts.divergence(sample_sets)
         with self.assertRaises(ValueError):
-            _ = ts.divergence(sample_sets[0])
+            _ = ts.divergence([sample_sets[0]])
 
     def test_3_way_default(self):
         ts = self.get_example_ts()

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -1128,7 +1128,6 @@ class TestDiversity(StatsTestCase, SampleSetStatsMixin):
     mode = None
 
     def verify_sample_sets(self, ts, sample_sets, windows):
-        # print("verify", ts, sample_sets, windows)
         n = np.array([len(x) for x in sample_sets])
 
         def f(x):
@@ -2606,6 +2605,9 @@ class Testf4(StatsTestCase, FourWaySampleSetStatsMixin):
             return numer / denom
         self.verify_definition(ts, sample_sets, indexes, windows, f, ts.f4, f4)
 
+    def verify_interface(self, ts):
+        self.verify_interface_method(ts.f4)
+
 
 class TestBranchf4(Testf4, TopologyExamplesMixin):
     mode = "branch"
@@ -3239,6 +3241,11 @@ class TestSampleSetIndexes(StatsTestCase):
         self.assertEqual(S1.shape, S2.shape)
         self.assertArrayAlmostEqual(S1, S2)
         self.assertArrayAlmostEqual(S1, S3)
+        sample_sets = np.array_split(ts.samples(), 3)
+        with self.assertRaises(ValueError):
+            _ = ts.divergence(sample_sets)
+        with self.assertRaises(ValueError):
+            _ = ts.divergence(sample_sets[0])
 
     def test_3_way_default(self):
         ts = self.get_example_ts()
@@ -3249,6 +3256,9 @@ class TestSampleSetIndexes(StatsTestCase):
         self.assertEqual(S1.shape, S2.shape)
         self.assertArrayAlmostEqual(S1, S2)
         self.assertArrayAlmostEqual(S1, S3)
+        sample_sets = np.array_split(ts.samples(), 4)
+        with self.assertRaises(ValueError):
+            _ = ts.f3(sample_sets)
 
     def test_4_way_default(self):
         ts = self.get_example_ts()
@@ -3259,6 +3269,9 @@ class TestSampleSetIndexes(StatsTestCase):
         self.assertEqual(S1.shape, S2.shape)
         self.assertArrayAlmostEqual(S1, S2)
         self.assertArrayAlmostEqual(S1, S3)
+        sample_sets = np.array_split(ts.samples(), 5)
+        with self.assertRaises(ValueError):
+            _ = ts.f4(sample_sets)
 
     def test_2_way_combinations(self):
         ts = self.get_example_ts()

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3463,8 +3463,8 @@ class TreeSequence(object):
         flattened = util.safe_np_int_cast(np.hstack(sample_sets), np.int32)
         windows = self.parse_windows(windows)
         if indexes is None:
-            if len(sample_sets) == k:
-                raise ValueError("Must specify indexes"
+            if len(sample_sets) != k:
+                raise ValueError("Must specify indexes "
                                  "if there are not exactly {} sample sets.".format(k))
             else:
                 indexes = [np.arange(k, dtype=np.int32)]

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3463,7 +3463,11 @@ class TreeSequence(object):
         flattened = util.safe_np_int_cast(np.hstack(sample_sets), np.int32)
         windows = self.parse_windows(windows)
         if indexes is None:
-            indexes = [np.arange(k, dtype=np.int32)]
+            if len(sample_sets) == k:
+                raise ValueError("Must specify indexes"
+                                 "if there are not exactly {} sample sets.".format(k))
+            else:
+                indexes = [np.arange(k, dtype=np.int32)]
         indexes = util.safe_np_int_cast(indexes, np.int32)
         if len(indexes.shape) != 2 or indexes.shape[1] != k:
             raise ValueError("Indexes must be convertable to a 2D numpy array"


### PR DESCRIPTION
We *do* have sensible behavior when `indexes=None`, but we weren't checking that this made sense given the sample_sets passed in. This does that.