### PR TITLE
Remove redundant asdict method

### DIFF
--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -602,14 +602,6 @@ class EdgeTable(BaseTable):
         self.ll_table.append_columns(dict(
             left=left, right=right, parent=parent, child=child))
 
-    def asdict(self):
-        return {
-            "left": self.left,
-            "right": self.right,
-            "parent": self.parent,
-            "child": self.child,
-        }
-
     def squash(self):
         """
         Sorts, then condenses the table into the smallest possible number of rows by


### PR DESCRIPTION
Not sure why this got left in during https://github.com/tskit-dev/tskit/pull/307, but it seems redundant to me.