### PR TITLE
Update C code to deal with missing data

### DIFF
--- a/c/tskit/genotypes.h
+++ b/c/tskit/genotypes.h
@@ -43,6 +43,7 @@ typedef struct {
     tsk_id_t *sample_index_map;
     char *output_haplotype;
     char *haplotype_matrix;
+    char missing_data_character;
     tsk_tree_t tree;
 } tsk_hapgen_t;
 
@@ -74,7 +75,7 @@ typedef struct {
 } tsk_vargen_t;
 
 int tsk_hapgen_init(tsk_hapgen_t *self, tsk_treeseq_t *tree_sequence,
-        tsk_flags_t options);
+        tsk_flags_t options, char missing_data_character);
 /* FIXME this is inconsistent with the tables API which uses size_t for
  * IDs in functions. Not clear which is better */
 int tsk_hapgen_get_haplotype(tsk_hapgen_t *self, tsk_id_t j, char **haplotype);

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -8694,15 +8694,17 @@ HaplotypeGenerator_init(HaplotypeGenerator *self, PyObject *args, PyObject *kwds
 {
     int ret = -1;
     int err;
-    static char *kwlist[] = {"tree_sequence", "impute_missing_data", NULL};
+    static char *kwlist[] = {
+        "tree_sequence", "impute_missing_data", "missing_data_character", NULL};
     TreeSequence *tree_sequence;
     int impute_missing_data = 0;
     tsk_flags_t options = 0;
+    char missing_data_character = '-';
 
     self->haplotype_generator = NULL;
     self->tree_sequence = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|i", kwlist,
-            &TreeSequenceType, &tree_sequence, &impute_missing_data)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|ic", kwlist, &TreeSequenceType,
+            &tree_sequence, &impute_missing_data, &missing_data_character)) {
         goto out;
     }
     self->tree_sequence = tree_sequence;
@@ -8719,7 +8721,7 @@ HaplotypeGenerator_init(HaplotypeGenerator *self, PyObject *args, PyObject *kwds
         options |= TSK_IMPUTE_MISSING_DATA;
     }
     err = tsk_hapgen_init(self->haplotype_generator,
-            self->tree_sequence->tree_sequence, options);
+            self->tree_sequence->tree_sequence, options, missing_data_character);
     if (err != 0) {
         handle_library_error(err);
         goto out;


### PR DESCRIPTION
@jeromekelleher thought it might be simpler (and possibly more efficient) to code this up using in Python using `ts.genotype_matrix`, but by that time I had essentially done the C coding.

However, this code sets all the ancestral states, then whizzes through the trees again setting missing whenever it finds isolated nodes. So it might be not very efficient.