### PR TITLE
Bump to 0.2.1

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,9 +1,12 @@
 --------------------
-[0.2.0] - 2019-08-23
+[0.2.1] - 2019-08-23
 --------------------
 
 Major feature release, adding support for population genetic statistics,
 improved VCF output and many other features.
+
+**Note:** Version 0.2.0 was skipped because of an error uploading to PyPI
+which could not be undone.
 
 **Breaking changes**
 

--- a/python/tskit/_version.py
+++ b/python/tskit/_version.py
@@ -1,3 +1,3 @@
 # Definitive location for the version number.
 # During development, should be x.y.z.devN
-tskit_version = "0.2.0"
+tskit_version = "0.2.1"


### PR DESCRIPTION
Forced to increment the version number after a snafu with PyPI.