### PR TITLE
better error value on general stat

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -3368,6 +3368,13 @@ class TestGeneralStatInterface(StatsTestCase):
         with self.assertRaises(ValueError):
             ts.general_stat(W, lambda x: np.array([1.0]), 1, windows="sites")
 
+    def test_nonnumpy_summary_function(self):
+        ts = self.get_tree_sequence()
+        W = np.ones((ts.num_samples, 3))
+        sigma1 = ts.general_stat(W, lambda x: [0.0], 1)
+        sigma2 = ts.general_stat(W, lambda x: np.array([0.0]), 1)
+        self.assertArrayEqual(sigma1, sigma2)
+
 
 class TestGeneralBranchStats(StatsTestCase):
     """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3554,10 +3554,10 @@ class TreeSequence(object):
             total_weights = np.sum(W, axis=0)
             for x in [total_weights, total_weights * 0.0]:
                 with np.errstate(invalid='ignore', divide='ignore'):
-                    fx = f(x)
+                    fx = np.array(f(x))
                 fx[np.isnan(fx)] = 0.0
                 if not np.allclose(fx, np.zeros((output_dim, ))):
-                    raise ValueError("Summary function does not return zero for both"
+                    raise ValueError("Summary function does not return zero for both "
                                      "zero weight and total weight.")
         return self.__run_windowed_stat(
             windows, self.ll_tree_sequence.general_stat,


### PR DESCRIPTION
The `strict` check was producing an inscrutible numpy-related error if the summary function did not return a numpy array. I've fixed this (so that functions can still return a list) and put a test for this behavior.