### PR TITLE
Remove object declaration from classes

### DIFF
--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -106,7 +106,7 @@ def draw_tree(
         return str(text_tree)
 
 
-class SvgTreeSequence(object):
+class SvgTreeSequence():
     """
     Draw a TreeSequence in SVG.
     """
@@ -178,7 +178,7 @@ class SvgTreeSequence(object):
                 font_size=14, text_anchor="middle", font_weight="bold"))
 
 
-class SvgTree(object):
+class SvgTree():
     """
     An SVG representation of a single tree.
 
@@ -403,7 +403,7 @@ class SvgTree(object):
                 y -= delta
 
 
-class TextTreeSequence(object):
+class TextTreeSequence():
     """
     Draw a tree sequence as horizontal line of trees.
     """
@@ -565,7 +565,7 @@ def node_time_depth(tree, min_branch_length=None, max_tree_height="tree"):
     return depth, current_depth
 
 
-class TextTree(object):
+class TextTree():
     """
     Draws a reprentation of a tree using unicode drawing characters written
     to a 2D array.

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -31,7 +31,7 @@ import numpy as np
 import _tskit
 
 
-class LdCalculator(object):
+class LdCalculator():
     """
     Class for calculating `linkage disequilibrium
     <https://en.wikipedia.org/wiki/Linkage_disequilibrium>`_ coefficients

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -81,7 +81,7 @@ ProvenanceTableRow = collections.namedtuple(
     ["timestamp", "record"])
 
 
-class BaseTable(object):
+class BaseTable():
     """
     Superclass of high-level tables. Not intended for direct instantiation.
     """
@@ -134,7 +134,7 @@ class BaseTable(object):
             d[name] = value
             self.set_columns(**d)
         else:
-            object.__setattr__(self, name, value)
+            super().__setattr__(name, value)
 
     def __getitem__(self, index):
         if index < 0:
@@ -194,7 +194,7 @@ class BaseTable(object):
         raise NotImplementedError()
 
 
-class MetadataMixin(object):
+class MetadataMixin():
     """
     Mixin class for tables that have a metadata column.
     """
@@ -1239,7 +1239,7 @@ class ProvenanceTable(BaseTable):
         self.set_columns(**d)
 
 
-class TableCollection(object):
+class TableCollection():
     """
     A collection of mutable tables defining a tree sequence. See the
     :ref:`sec_data_model` section for definition on the various tables

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -55,7 +55,7 @@ CoalescenceRecord = collections.namedtuple(
 
 # TODO this interface is rubbish. Should have much better printing options.
 # TODO we should be use __slots__ here probably.
-class SimpleContainer(object):
+class SimpleContainer():
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -414,7 +414,7 @@ def add_deprecated_mutation_attrs(site, mutation):
     return mutation
 
 
-class Tree(object):
+class Tree():
     """
     A single tree in a :class:`.TreeSequence`. Please see the
     :ref:`sec_tutorial_moving_along_a_tree_sequence` section for information
@@ -1956,7 +1956,7 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
     return tc.tree_sequence()
 
 
-class TreeIterator(object):
+class TreeIterator():
     """
     Simple class providing forward and backward iteration over a tree sequence.
     """
@@ -1982,7 +1982,7 @@ class TreeIterator(object):
         return self.tree
 
 
-class TreeSequence(object):
+class TreeSequence():
     """
     A single tree sequence, as defined by the :ref:`data model <sec_data_model>`.
     A TreeSequence instance can be created from a set of

--- a/python/tskit/vcf.py
+++ b/python/tskit/vcf.py
@@ -44,7 +44,7 @@ def legacy_position_transform(positions):
     return transformed
 
 
-class VcfWriter(object):
+class VcfWriter():
     """
     Writes a VCF representation of the genotypes tree sequence to a
     file-like object.


### PR DESCRIPTION
Now that we insist upon python 3, we can simply remove these, assuming that the increased brevity makes the code more readable.