### PR TITLE
Trim functions

### DIFF
--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -708,13 +708,20 @@ Schema section (TODO).
 Table transformation methods
 ============================
 
-The following methods operate *in place* on a :class:`.TableCollection`,
-transforming them while preserving information.
+In general, table methods operate *in place* on a :class:`.TableCollection`,
+directly altering the data stored within its constituent tables.
+
 In some applications, tables may most naturally be produced in a way that is
 logically consistent, but not meeting all the requirements for validity that
-are established for algorithmic and efficiency reasons.
-These methods (while having other uses), can be used to make such a set of
-tables valid, and thus ready to be loaded into a tree sequence.
+are established for algorithmic and efficiency reasons. Several of the methods
+below (while also having other uses), can be used to make such a set of tables
+valid, and thus ready to be loaded into a tree sequence.
+
+Some of the other methods described in this section also have an equivalant
+:class:`.TreeSequence` version: an important distinction is that unlike the
+methods here, :class:`.TreeSequence` methods do *not* operate in place, but
+rather act in a functional way, returning a new tree sequence while leaving
+the original one unchanged.
 
 This section is best skipped unless you are writing a program that records
 tables directly.

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -410,7 +410,8 @@ class TestVariantGenerator(unittest.TestCase):
 
     def test_zero_edge_missing_data(self):
         ts = msprime.simulate(10, random_seed=2, mutation_rate=2)
-        tables = ts.tables.keep_intervals([[0.25, 0.75]])
+        tables = ts.dump_tables()
+        tables.keep_intervals([[0.25, 0.75]])
         # add some sites in the deleted regions
         tables.sites.add_row(0.1, "A")
         tables.sites.add_row(0.2, "A")

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -40,23 +40,24 @@ import tests.tsutil as tsutil
 import tests.test_wright_fisher as wf
 
 
-def ts_equal(ts_1, ts_2):
+def ts_equal(ts_1, ts_2, compare_provenances=True):
     """
     Check equality of tree sequences, ignoring provenance timestamps (but not contents)
     """
-    return tables_equal(ts_1.tables, ts_2.tables)
+    return tables_equal(ts_1.tables, ts_2.tables, compare_provenances)
 
 
-def tables_equal(table_collection_1, table_collection_2):
+def tables_equal(table_collection_1, table_collection_2, compare_provenances=True):
     """
     Check equality of tables, ignoring provenance timestamps (but not contents)
     """
     for (_, table_1), (_, table_2) in zip(table_collection_1, table_collection_2):
         if isinstance(table_1, tskit.ProvenanceTable):
-            if any(table_1.record != table_2.record):
-                return False
-            if any(table_1.record_offset != table_2.record_offset):
-                return False
+            if compare_provenances:
+                if np.any(table_1.record != table_2.record):
+                    return False
+                if np.any(table_1.record_offset != table_2.record_offset):
+                    return False
         else:
             if table_1 != table_2:
                 return False
@@ -4841,9 +4842,9 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
     def test_tables_single_tree_keep_middle(self):
         ts = msprime.simulate(10, random_seed=2)
         t_keep = ts.dump_tables()
-        t_keep.keep_intervals([[0.25, 0.5]])
+        t_keep.keep_intervals([[0.25, 0.5]], record_provenance=False)
         t_delete = ts.dump_tables()
-        t_delete.delete_intervals([[0, 0.25], [0.5, 1.0]])
+        t_delete.delete_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
         t_keep.provenances.clear()
         t_delete.provenances.clear()
         self.assertEqual(t_keep, t_delete)
@@ -4851,21 +4852,22 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
     def test_tables_single_tree_delete_middle(self):
         ts = msprime.simulate(10, random_seed=2)
         t_keep = ts.dump_tables()
-        t_keep.delete_intervals([[0.25, 0.5]])
+        t_keep.delete_intervals([[0.25, 0.5]], record_provenance=False)
         t_delete = ts.dump_tables()
-        t_delete.keep_intervals([[0, 0.25], [0.5, 1.0]])
+        t_delete.keep_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
         t_keep.provenances.clear()
         t_delete.provenances.clear()
         self.assertEqual(t_keep, t_delete)
 
     def test_ts_single_tree_keep_middle(self):
         ts = msprime.simulate(10, random_seed=2)
-        ts_keep = ts.keep_intervals([[0.25, 0.5]])
-        ts_delete = ts.delete_intervals([[0, 0.25], [0.5, 1.0]])
+        ts_keep = ts.keep_intervals([[0.25, 0.5]], record_provenance=False)
+        ts_delete = ts.delete_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
         self.assertTrue(ts_equal(ts_keep, ts_delete))
 
     def test_ts_single_tree_delete_middle(self):
         ts = msprime.simulate(10, random_seed=2)
-        ts_keep = ts.delete_intervals([[0.25, 0.5]])
-        ts_delete = ts.keep_intervals([[0, 0.25], [0.5, 1.0]])
+        ts_keep = ts.delete_intervals([[0.25, 0.5]], record_provenance=False)
+        ts_delete = ts.keep_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
+        #  One provenance should have "delete_intervals", the other "keep_intervals")
         self.assertTrue(ts_equal(ts_keep, ts_delete))

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -4871,3 +4871,62 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
         ts_delete = ts.keep_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
         #  One provenance should have "delete_intervals", the other "keep_intervals")
         self.assertTrue(ts_equal(ts_keep, ts_delete))
+
+
+class TestTrim(unittest.TestCase):
+    """
+    Test the trimming functionality
+    """
+    def test_rtrim_simple(self):
+        ts = msprime.simulate(10, recombination_rate=2, random_seed=2)
+        tables = ts.dump_tables()
+        tables.keep_intervals([[0.25, 0.5]])
+        tables.rtrim()
+        self.assertTrue(np.all(tables.edges.right <= tables.sequence_length))
+        new_ts = tables.tree_sequence()
+        self.assertAlmostEqual(new_ts.sequence_length, 0.5)
+
+    def test_rtrim_no_effect(self):
+        ts = msprime.simulate(10, recombination_rate=2, random_seed=2)
+        tables = ts.dump_tables()
+        tables.delete_intervals([[0.25, 0.5]])
+        trimmed_tables = tables.copy()
+        trimmed_tables.rtrim(record_provenance=False)
+        self.assertTrue(tables_equal(tables, trimmed_tables))
+
+    def test_ltrim_simple(self):
+        ts = msprime.simulate(10, recombination_rate=2, random_seed=2)
+        tables = ts.dump_tables()
+        tables.keep_intervals([[0.25, 0.5]])
+        self.assertNotEqual(np.min(tables.edges.left), 0)
+        tables.ltrim()
+        self.assertEqual(np.min(tables.edges.left), 0)
+        new_ts = tables.tree_sequence()
+        self.assertAlmostEqual(new_ts.sequence_length, 0.75)
+
+    def test_ltrim_no_effect(self):
+        ts = msprime.simulate(10, recombination_rate=2, random_seed=2)
+        tables = ts.dump_tables()
+        tables.delete_intervals([[0.25, 0.5]])
+        trimmed_tables = tables.copy()
+        trimmed_tables.ltrim(record_provenance=False)
+        self.assertTrue(tables_equal(tables, trimmed_tables))
+
+    def test_trim_simple(self):
+        ts = msprime.simulate(10, recombination_rate=2, random_seed=2)
+        tables = ts.dump_tables()
+        tables.keep_intervals([[0.25, 0.5]])
+        self.assertNotEqual(np.min(tables.edges.left), 0)
+        tables.trim()
+        self.assertEqual(np.min(tables.edges.left), 0)
+        self.assertTrue(np.all(tables.edges.right <= tables.sequence_length))
+        new_ts = tables.tree_sequence()
+        self.assertAlmostEqual(new_ts.sequence_length, 0.25)
+
+    def test_trim_no_effect(self):
+        ts = msprime.simulate(10, recombination_rate=2, random_seed=2)
+        tables = ts.dump_tables()
+        tables.delete_intervals([[0.25, 0.5]])
+        trimmed_tables = tables.copy()
+        trimmed_tables.ltrim(record_provenance=False)
+        self.assertTrue(tables_equal(tables, trimmed_tables))

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1745,7 +1745,14 @@ class TableCollection(object):
         """
         self.keep_intervals(
             util.negate_intervals(intervals, 0, self.sequence_length),
-            simplify=simplify, record_provenance=record_provenance)
+            simplify=simplify, record_provenance=False)
+        if record_provenance:
+            parameters = {
+                "command": "delete_intervals",
+                "TODO": "add parameters"
+            }
+            self.provenances.add_row(record=json.dumps(
+                provenance.get_provenance_dict(parameters)))
 
     def keep_intervals(self, intervals, simplify=True, record_provenance=True):
         """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3213,6 +3213,64 @@ class TreeSequence(object):
         else:
             return new_ts
 
+    def delete_intervals(self, intervals, simplify=True, record_provenance=True):
+        """
+        Returns a copy of this tree sequence for which information in the
+        specified list of genomic intervals has been deleted. Edges spanning these
+        intervals are truncated or deleted, and sites and mutations falling within
+        them are discarded.
+
+        Note that node IDs may change as a result of this operation,
+        as by default :meth:`.simplify` is called on the returned tree sequence
+        to remove redundant nodes. If you wish to map node IDs onto the same
+        nodes before and after this method has been called, specify ``simplify=False``.
+
+        See also :meth:`.keep_intervals`.
+
+        :param array_like intervals: A list (start, end) pairs describing the
+            genomic intervals to delete. Intervals must be non-overlapping and
+            in increasing order. The list of intervals must be interpretable as a
+            2D numpy array with shape (N, 2), where N is the number of intervals.
+        :param bool simplify: If True, return a simplified tree sequence where nodes
+            no longer used are discarded. (Default: True).
+        :param bool record_provenance: If True, record details of this operation
+            in the tree sequence's provenance information.
+            (Default: True).
+        :rtype: .TreeSequence
+        """
+        tables = self.dump_tables()
+        tables.delete_intervals(intervals, simplify, record_provenance)
+        return tables.tree_sequence()
+
+    def keep_intervals(self, intervals, simplify=True, record_provenance=True):
+        """
+        Returns a copy of this tree sequence which includes only information in
+        the specified list of genomic intervals. Edges are truncated to lie within
+        these intervals, and sites and mutations falling outside these intervals
+        are discarded.
+
+        Note that node IDs may change as a result of this operation,
+        as by default :meth:`.simplify` is called on the returned tree sequence
+        to remove redundant nodes. If you wish to map node IDs onto the same
+        nodes before and after this method has been called, specify ``simplify=False``.
+
+        See also :meth:`.delete_intervals`.
+
+        :param array_like intervals: A list (start, end) pairs describing the
+            genomic intervals to keep. Intervals must be non-overlapping and
+            in increasing order. The list of intervals must be interpretable as a
+            2D numpy array with shape (N, 2), where N is the number of intervals.
+        :param bool simplify: If True, return a simplified tree sequence where nodes
+            no longer used are discarded. (Default: True).
+        :param bool record_provenance: If True, record details of this operation
+            in the tree sequence's provenance information.
+            (Default: True).
+        :rtype: .TreeSequence
+        """
+        tables = self.dump_tables()
+        tables.keep_intervals(intervals, simplify, record_provenance)
+        return tables.tree_sequence()
+
     def draw_svg(self, path=None, **kwargs):
         # TODO document this method, including semantic details of the
         # returned SVG object.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3271,6 +3271,49 @@ class TreeSequence(object):
         tables.keep_intervals(intervals, simplify, record_provenance)
         return tables.tree_sequence()
 
+    def ltrim(self, record_provenance=True):
+        """
+        Returns a copy of this tree sequence with a potentially changed coordinate
+        system, such that empty regions at the start of the tree sequence are trimmed
+        away, and the leftmost edge starts at position 0. This affects the reported
+        position of sites and edges. Additionally, sites and their
+        associated mutations to the left of the new zero point are thrown away.
+
+        :param bool record_provenance: If True, record details of this call to
+            ``ltrim`` in the returned tree sequence's provenance information.
+            (Default: True).
+        """
+        tables = self.dump_tables()
+        tables.rtrim(record_provenance)
+        return tables.tree_sequence()
+
+    def rtrim(self, record_provenance=True):
+        """
+        Returns a copy of this tree sequence with the ``sequence_length`` property reset
+        so that the sequence ends at the end of the rightmost edge. Additionally, sites
+        and their associated mutations at positions greater than the new
+        ``sequence_length`` are thrown away.
+
+        :param bool record_provenance: If True, record details of this call to
+            ``rtrim`` in the returned tree sequence's provenance information.
+            (Default: True).
+        """
+        tables = self.dump_tables()
+        tables.rtrim(record_provenance)
+        return tables.tree_sequence()
+
+    def trim(self, record_provenance=True):
+        """
+        Returns a copy of this tree sequence with any empty regions on the right and left
+        trimmed away. This may reset both the coordinate system and the
+        ``sequence_length`` property. It is exactly equivalent to :meth:`.rtrim` followed
+        by :meth:`.ltrim`. Sites and their associated mutations in the empty regions are
+        thrown away.
+        """
+        tables = self.dump_tables()
+        tables.trim(record_provenance)
+        return tables.tree_sequence()
+
     def draw_svg(self, path=None, **kwargs):
         # TODO document this method, including semantic details of the
         # returned SVG object.


### PR DESCRIPTION
Replaces #292 
Fixes #288

Test coverage not yet complete, as I'm not sure if we want the (now relatively trivial) `splice()` functionality, although it was present in a previous tskit alpha see (https://github.com/tskit-dev/tskit/pull/261#issuecomment-513201321). If people like having that shortcut, I can leave it in and add tests. Otherwise I'll pull it.