### PR TITLE
Return SimpleContainers as table rows where possible

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1262,6 +1262,18 @@ class TestTreeSequence(HighLevelTestCase):
                     self.assertEqual(t3.interval, t2.interval)
                     self.assertEqual(t3.parent_dict, t2.parent_dict)
 
+    def test_reversible_iterators(self):
+        for ts in get_example_tree_sequences():
+            for table_name, _ in ts.tables:
+                if table_name not in ['individuals', 'sites', 'mutations']:
+                    # ts.individuals(), ts.sites() and ts.mutations() are not currently
+                    # reversible, as they do not return the equivalent tables
+                    ts_iterator = getattr(ts, table_name)()
+                    n_rows = ts_iterator.num_rows
+                    for i, n in enumerate(reversed(ts_iterator)):
+                        self.assertEqual(i, n_rows - 1 - n.id)
+                    self.assertEqual(n.id, 0)
+
 
 class TestFileUuid(HighLevelTestCase):
     """

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -754,8 +754,12 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, 0, b"123"))
-        self.assertEqual(t[1], (1, 2, 3, 1, b"\xf0"))
+        self.assertEqual(
+            t[0]._asdict(),
+            dict(flags=0, time=1, population=2, individual=0, metadata=b"123"))
+        self.assertEqual(
+            t[1]._asdict(),
+            dict(flags=1, time=2, population=3, individual=1, metadata=b"\xf0"))
         self.assertEqual(t[0].flags, 0)
         self.assertEqual(t[0].time, 1)
         self.assertEqual(t[0].population, 2)
@@ -828,8 +832,8 @@ class TestEdgeTable(unittest.TestCase, CommonTestsMixin):
         t.add_row(left=0, right=1, parent=2, child=3)
         t.add_row(1, 2, 3, 4)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, 3))
-        self.assertEqual(t[1], (1, 2, 3, 4))
+        self.assertEqual(t[0]._asdict(), dict(left=0, right=1, parent=2, child=3))
+        self.assertEqual(t[1]._asdict(), dict(left=1, right=2, parent=3, child=4))
         self.assertEqual(t[0].left, 0)
         self.assertEqual(t[0].right, 1)
         self.assertEqual(t[0].parent, 2)
@@ -923,8 +927,12 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin)
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, "2", 3, b"4"))
-        self.assertEqual(t[1], (1, 2, "3", 4, b"\xf0"))
+        self.assertEqual(
+            t[0]._asdict(),
+            dict(site=0, node=1, derived_state='2', parent=3, metadata=b"4"))
+        self.assertEqual(
+            t[1]._asdict(),
+            dict(site=1, node=2, derived_state='3', parent=4, metadata=b"\xf0"))
         self.assertEqual(t[0].site, 0)
         self.assertEqual(t[0].node, 1)
         self.assertEqual(t[0].derived_state, "2")
@@ -981,8 +989,12 @@ class TestMigrationTable(unittest.TestCase, CommonTestsMixin):
         t.add_row(left=0, right=1, node=2, source=3, dest=4, time=5)
         t.add_row(1, 2, 3, 4, 5, 6)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, 3, 4, 5))
-        self.assertEqual(t[1], (1, 2, 3, 4, 5, 6))
+        self.assertEqual(
+            t[0]._asdict(),
+            dict(left=0, right=1, node=2, source=3, dest=4, time=5))
+        self.assertEqual(
+            t[1]._asdict(),
+            dict(left=1, right=2, node=3, source=4, dest=5, time=6))
         self.assertEqual(t[0].left, 0)
         self.assertEqual(t[0].right, 1)
         self.assertEqual(t[0].node, 2)
@@ -1017,8 +1029,8 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
         t.add_row(timestamp="0", record="1")
         t.add_row("2", "1")  # The orders are reversed for default timestamp.
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], ("0", "1"))
-        self.assertEqual(t[1], ("1", "2"))
+        self.assertEqual(t[0]._asdict(), {"timestamp": "0", "record": "1"})
+        self.assertEqual(t[1]._asdict(), {"timestamp": "1", "record": "2"})
         self.assertEqual(t[0].timestamp, "0")
         self.assertEqual(t[0].record, "1")
         self.assertEqual(t[0], t[-2])
@@ -1067,9 +1079,9 @@ class TestPopulationTable(unittest.TestCase, CommonTestsMixin):
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (b"\xf0",))
+        self.assertEqual(t[0]._asdict(), {"metadata": b"\xf0"})
         self.assertEqual(t[0].metadata, b"\xf0")
-        self.assertEqual(t[1], (b"1",))
+        self.assertEqual(t[1]._asdict(), {"metadata": b"1"})
         self.assertRaises(IndexError, t.__getitem__, -3)
 
     def test_add_row_bad_data(self):


### PR DESCRIPTION
Fixes #304 in another manner (see https://github.com/tskit-dev/tskit/pull/304#issuecomment-542188917)

This is for review only. It replaces the TableRow namedtuples with their equivalent container classes where possible, which allows functions like `ts.edges()` and `ts.nodes()` to simply return the appropriate table, which (when iterated over) returns the correct classes, as before.

Two SimpleContainer classes are actually more complicated than the corresponding TableRow object. These are `Individuals` (which contains the nodes belonging to an individual, which is not data present in the individuals table) and `Sites` (which contains the mutations present in each site too). These have to retain their own "TableRow" objects, which I've renamed `SimpleIndividual` and `SimpleSite`.

Two SimpleContainer objects, `Edge` and `Migration`, have their `id_` parameter appear as the *last* rather than *first* parameter in the `__init__()` method. This annoyingly means we have to code a bespoke version of `__getitem__()` for getting the rows from those tables. Moving `_id` to the start of the parameter list for these SimpleContainers would make the order consistent and allow us to remove this bespoke code, but would be a breaking change in parameter order, so I haven't done it (yet).

The docstrings will need a little adjusting to point out that instead of returning iterators, functions like `ts.edges()` return the tables whose rows can be iterated over.