### PR TITLE
Add node traversal methods based on time ordering

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1621,6 +1621,23 @@ class TestTree(HighLevelTestCase):
             tree = next(ts.trees())
             self.verify_traversals(tree)
 
+            # To verify time-ordered traversal we can't use the method used for the
+            # other traversals above, it checks for one-to-one correspondence.
+            # As more than one ordering is valid for time, we do it separately here
+            for root in tree.roots:
+                time_ordered = tree.nodes(root, order="timeasc")
+                t = tree.time(next(time_ordered))
+                for u in time_ordered:
+                    next_t = tree.time(u)
+                    self.assertGreaterEqual(next_t, t)
+                    t = next_t
+                time_ordered = tree.nodes(root, order="timedesc")
+                t = tree.time(next(time_ordered))
+                for u in time_ordered:
+                    next_t = tree.time(u)
+                    self.assertLessEqual(next_t, t)
+                    t = next_t
+
     def verify_traversals(self, tree):
         t1 = tree
         t2 = tests.PythonTree.from_tree(t1)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1449,6 +1449,12 @@ class Tree(object):
                 queue.extend(self.children(v))
             yield v
 
+    def _timeasc_traversal(self, u):
+        yield from sorted(self.nodes(u, order="levelorder"), key=self.time)
+
+    def _timedesc_traversal(self, u):
+        yield from sorted(self.nodes(u, order="levelorder"), key=self.time, reverse=True)
+
     def nodes(self, root=None, order="preorder"):
         """
         Returns an iterator over the nodes in this tree. If the root parameter
@@ -1458,8 +1464,8 @@ class Tree(object):
 
         :param int root: The root of the subtree we are traversing.
         :param str order: The traversal ordering. Currently 'preorder',
-            'inorder', 'postorder' and 'levelorder' ('breadthfirst')
-            are supported.
+            'inorder', 'postorder', 'levelorder' ('breadthfirst'), 'timeasc' and
+            'timedesc' are supported.
         :return: An iterator over the nodes in the tree in some traversal order.
         :rtype: iterator
         """
@@ -1468,7 +1474,9 @@ class Tree(object):
             "inorder": self._inorder_traversal,
             "postorder": self._postorder_traversal,
             "levelorder": self._levelorder_traversal,
-            "breadthfirst": self._levelorder_traversal
+            "breadthfirst": self._levelorder_traversal,
+            "timeasc": self._timeasc_traversal,
+            "timedesc": self._timedesc_traversal
         }
         try:
             iterator = methods[order]


### PR DESCRIPTION
Addresses #246 using a very simple implementation as discussed. I went with `timeasc` and `timedesc` as the possible values for `order=` as they seemed to fit the existing values.