### PR TITLE
Use Sphinx currentmodule to rationalise & allow :attr: refs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = #-W
+SPHINXOPTS    = -W
 SPHINXBUILD   = python3 -m sphinx
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: tskit
 .. _sec_data_model:
 
 ##########
@@ -20,6 +21,8 @@ store tree sequences on disk in the `Tree sequence file format`_ section.
 
 
 .. _sec_data_model_definitions:
+
+
 
 ***********
 Definitions
@@ -50,7 +53,7 @@ node
 individual
     In certain situations we are interested in how nodes (representing
     individual homologous genomes) are grouped together into individuals
-    (e.g., two nodes per diploid individual). For example, when we are working
+    (e.g. two nodes per diploid individual). For example, when we are working
     with polyploid samples it is useful to associate metadata with a specific
     individual rather than duplicate this information on the constituent nodes.
     See :ref:`sec_nodes_or_individuals` for more discussion on this point.
@@ -58,9 +61,9 @@ individual
 sample
     The focal nodes of a tree sequence, usually thought of as those that we
     have obtained data from. The specification of these affects various
-    methods: (1) :meth:`.TreeSequence.variants` and
-    :meth:`.TreeSequence.haplotypes` will output the genotypes of the samples,
-    and :attr:`.Tree.roots` only return roots ancestral to at least one
+    methods: (1) :meth:`TreeSequence.variants` and 
+    :meth:`TreeSequence.haplotypes` will output the genotypes of the samples,
+    and :attr:`Tree.roots` only return roots ancestral to at least one
     sample. (See the :ref:`node table definitions <sec_node_table_definition>`
     for information on how the sample
     status a node is encoded in the ``flags`` column.)
@@ -214,7 +217,7 @@ is composed of 32 bitwise boolean values. Currently, the only flag defined
 is ``IS_SAMPLE = 1``, which defines the *sample* status of nodes. Marking
 a particular node as a "sample" means, for example, that the mutational state
 of the node will be included in the genotypes produced by
-:meth:`.TreeSequence.variants`.
+:meth:`TreeSequence.variants`.
 
 Bits 0-15 (inclusive) of the ``flags`` column are reserved for internal use by
 ``tskit`` and should not be used by applications for anything other
@@ -511,14 +514,14 @@ Valid tree sequence requirements
 ================================
 
 Arbitrary data can be stored in tables using the classes in the
-:ref:`sec_tables_api`. However, only a :class:`.TableCollection`
+:ref:`sec_tables_api`. However, only a :class:`TableCollection`
 that fulfils a set of requirements represents
-a valid :class:`.TreeSequence` object which can be obtained
-using the :meth:`.TableCollection.tree_sequence` method. In this
+a valid :class:`TreeSequence` object which can be obtained
+using the :meth:`TableCollection.tree_sequence` method. In this
 section we list these requirements, and explain their rationale.
 Violations of most of these requirements are detected when the
-user attempts to load a tree sequence via :func:`.load` or
-:meth:`.TableCollection.tree_sequence`, raising an informative
+user attempts to load a tree sequence via :func:`tskit.load` or
+:meth:`TableCollection.tree_sequence`, raising an informative
 error message. Some more complex requirements may not be detectable at load-time,
 and errors may not occur until certain operations are attempted.
 These are documented below.
@@ -536,7 +539,7 @@ respect to any other tables. Therefore, there are no requirements on
 individuals.
 
 There are no requirements regarding the ordering of individuals.
-Sorting a set of tables using :meth:`.TableCollection.sort` has
+Sorting a set of tables using :meth:`TableCollection.sort` has
 no effect on the individuals.
 
 .. _sec_node_requirements:
@@ -558,7 +561,7 @@ There are no requirements regarding the ordering of nodes with respect to time.
 For simplicity and algorithmic efficiency, all nodes referring to the same
 (non-null) individual must be contiguous.
 
-Sorting a set of tables using :meth:`.TableCollection.sort`
+Sorting a set of tables using :meth:`TableCollection.sort`
 has no effect on nodes.
 
 .. _sec_edge_requirements:
@@ -587,7 +590,7 @@ where a node ``a`` is a child of both ``b`` and ``c``), and ensures that
 at each point on the sequence we have a well-formed forest of trees.
 Because this is a more complex semantic requirement, it is **not** detected
 at load time. This error is detected during tree traversal, via, e.g.,
-the :meth:`.TreeSequence.trees` iterator.
+the :meth:`TreeSequence.trees` iterator.
 
 In the interest of algorithmic efficiency, edges must have the following
 sortedness properties:
@@ -598,7 +601,7 @@ sortedness properties:
   first by ``child`` ID and then by ``left`` coordinate.
 
 Violations of these requirements are detected at load time.
-The :meth:`.TableCollection.sort` method will ensure that these sortedness
+The :meth:`TableCollection.sort` method will ensure that these sortedness
 properties are fulfilled.
 
 .. _sec_site_requirements:
@@ -617,7 +620,7 @@ For simplicity and algorithmic efficiency, sites must also:
 - Be sorted in increasing order of ``position``.
 
 Violations of these requirements are detected at load time.
-The :meth:`.TableCollection.sort` method ensures that sites are sorted
+The :meth:`TableCollection.sort` method ensures that sites are sorted
 according to these criteria.
 
 .. _sec_mutation_requirements:
@@ -646,7 +649,7 @@ For simplicity and algorithmic efficiency, mutations must also:
   ``parent`` with ID :math:`y`, then we must have :math:`y < x`).
 
 Violations of these sorting requirements are detected at load time.
-The :meth:`.TableCollection.sort` method ensures that mutations are sorted
+The :meth:`TableCollection.sort` method ensures that mutations are sorted
 according site ID, but does not at present enforce that mutations occur
 after their parent mutations.
 
@@ -655,7 +658,7 @@ change of state. For example, if we have a site with ancestral state
 of "A" and a single mutation with derived state "A", then this
 mutation does not result in any change of state. This error is
 raised at run-time when we reconstruct sample genotypes, for example
-in the :meth:`.TreeSequence.variants` iterator.
+in the :meth:`TreeSequence.variants` iterator.
 
 .. _sec_migration_requirements:
 
@@ -708,7 +711,7 @@ Schema section (TODO).
 Table transformation methods
 ============================
 
-In general, table methods operate *in place* on a :class:`.TableCollection`,
+In general, table methods operate *in place* on a :class:`TableCollection`,
 directly altering the data stored within its constituent tables.
 
 In some applications, tables may most naturally be produced in a way that is
@@ -718,8 +721,8 @@ below (while also having other uses), can be used to make such a set of tables
 valid, and thus ready to be loaded into a tree sequence.
 
 Some of the other methods described in this section also have an equivalant
-:class:`.TreeSequence` version: an important distinction is that unlike the
-methods here, :class:`.TreeSequence` methods do *not* operate in place, but
+:class:`TreeSequence` version: an important distinction is that unlike the
+methods here, :class:`TreeSequence` methods do *not* operate in place, but
 rather act in a functional way, returning a new tree sequence while leaving
 the original one unchanged.
 
@@ -732,8 +735,8 @@ Simplification
 --------------
 
 Simplification of a tree sequence is in fact a transformation method applied
-to the underlying tables: the method :meth:`.TreeSequence.simplify` calls
-:meth:`.TableCollection.simplify` on the tables, and loads a new tree sequence.
+to the underlying tables: the method :meth:`TreeSequence.simplify` calls
+:meth:`TableCollection.simplify` on the tables, and loads a new tree sequence.
 The main purpose of this method is to remove redundant information,
 only retaining the minimal tree sequence necessary to describe the genealogical
 history of the ``samples`` provided.
@@ -743,7 +746,7 @@ Furthermore, ``simplify`` is guaranteed to:
 - preserve relative ordering of any rows in the Site and Mutation tables
   that are not discarded.
 
-The :meth:`.TableCollection.simplify` method can be applied to a collection of
+The :meth:`TableCollection.simplify` method can be applied to a collection of
 tables that does not have the ``mutations.parent`` entries filled in, as long
 as all other validity requirements are satisfied.
 
@@ -754,7 +757,7 @@ Sorting
 
 The validity requirements for a set of tables to be loaded into a tree sequence
 listed in :ref:`sec_table_definitions` are of two sorts: logical consistency,
-and sortedness. The :meth:`.TableCollection.sort` method can be used to make
+and sortedness. The :meth:`TableCollection.sort` method can be used to make
 completely valid a set of tables that satisfies all requirements other than
 sortedness.
 
@@ -765,7 +768,7 @@ be sorted. The method has two additional properties:
 - it preserves relative ordering between sites at the same position, and
 - it preserves relative ordering between mutations at the same site.
 
-:meth:`.TableCollection.sort` does not check the validity of the `parent`
+:meth:`TableCollection.sort` does not check the validity of the `parent`
 property of the mutation table. However, because the method preserves mutation
 order among mutations at the same site, if mutations are already sorted so that
 each mutation comes after its parent (e.g., if they are ordered by time of
@@ -786,7 +789,7 @@ the tables must be indexed.
 Removing duplicate sites
 ------------------------
 
-The :meth:`.TableCollection.deduplicate_sites` method can be used to save a tree
+The :meth:`TableCollection.deduplicate_sites` method can be used to save a tree
 sequence recording method the bother of checking to see if a given site already
 exists in the site table. If there is more than one site with the same
 position, all but the first is removed, and all mutations referring to the
@@ -802,7 +805,7 @@ of the mutation table would be easily inferred from the tree at that mutation's
 site. If mutations are entered into the mutation table ordered by time of
 appearance, then this sortedness allows us to infer the parent of each mutation
 even for mutations occurring on the same branch. The
-:meth:`.TableCollection.compute_mutation_parents` method will take advantage
+:meth:`TableCollection.compute_mutation_parents` method will take advantage
 of this fact to compute the ``parent`` column of a mutation table, if all
 other information is valid.
 
@@ -982,8 +985,8 @@ Consider the following example:
 
 In this tree, node 4 is isolated, and therefore for any sites that are
 on this tree, the state that it is assigned is a special value
-``tskit.MISSING_DATA``, or ``-1``. See the :meth:`.TreeSequence.variants`
-method and :class:`.Variant` class for more information on how missing
+``tskit.MISSING_DATA``, or ``-1``. See the :meth:`TreeSequence.variants`
+method and :class:`Variant` class for more information on how missing
 data is represented.
 
 .. _sec_text_file_format:

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: tskit
 .. _sec_python_api:
 
 ==========
@@ -10,14 +11,14 @@ This page provides detailed documentation for the ``tskit`` Python API.
 Trees and tree sequences
 ************************
 
-The :class:`.TreeSequence` class represents a sequence of correlated trees
-output by a simulation. The :class:`.Tree` class represents a single
+The :class:`TreeSequence` class represents a sequence of correlated trees
+output by a simulation. The :class:`Tree` class represents a single
 tree in this sequence.
 These classes are the interfaces used to interact with the trees
 and mutational information stored in a tree sequence returned from a simulation.
 There are also methods for loading data into these objects, either from the native
 format using :func:`tskit.load`, or from another sources
-using :func:`tskit.load_text` or :meth:`.TableCollection.tree_sequence`.
+using :func:`tskit.load_text` or :meth:`TableCollection.tree_sequence`.
 
 
 +++++++++++++++++
@@ -28,7 +29,7 @@ Top level-classes
 .. autoclass:: tskit.TreeSequence()
     :members:
 
-.. autoclass:: tskit.Tree
+.. autoclass:: tskit.Tree()
     :members:
 
 
@@ -59,7 +60,7 @@ Simple container classes
 These classes are simple shallow containers representing the entities defined
 in the :ref:`sec_data_model_definitions`. These classes are not intended to be instantiated
 directly, but are the return types for the various iterators provided by the
-:class:`.TreeSequence` and :class:`.Tree` classes.
+:class:`TreeSequence` and :class:`Tree` classes.
 
 .. autoclass:: tskit.Individual()
     :members:
@@ -92,13 +93,13 @@ directly, but are the return types for the various iterators provided by the
 Loading data
 ++++++++++++
 
-There are several methods for loading data into a :class:`.TreeSequence`
+There are several methods for loading data into a :class:`TreeSequence`
 instance. The simplest and most convenient is the use the :func:`tskit.load`
 function to load a :ref:`tree sequence file <sec_tree_sequence_file_format>`. For small
 scale data and debugging, it is often convenient to use the
 :func:`tskit.load_text` to read data in the :ref:`text file format
-<sec_text_file_format>`. The :meth:`.TableCollection.tree_sequence` function
-efficiently creates a :class:`.TreeSequence` object from a set of tables
+<sec_text_file_format>`. The :meth:`TableCollection.tree_sequence` function
+efficiently creates a :class:`TreeSequence` object from a set of tables
 using the :ref:`Tables API <sec_tables_api>`.
 
 
@@ -115,7 +116,7 @@ Tables
 
 The :ref:`tables API <sec_binary_interchange>` provides an efficient way of working
 with and interchanging :ref:`tree sequence data <sec_data_model>`. Each table
-class (e.g, :class:`.NodeTable`, :class:`.EdgeTable`) has a specific set of
+class (e.g, :class:`NodeTable`, :class:`EdgeTable`) has a specific set of
 columns with fixed types, and a set of methods for setting and getting the data
 in these columns. The number of rows in the table ``t`` is given by ``len(t)``.
 Each table supports accessing the data either by row or column. To access the
@@ -214,7 +215,7 @@ Consider the following example::
     >>> t[3]
     SiteTableRow(position=3.0, ancestral_state='CCC', metadata=b'')
 
-Here we create a :class:`.SiteTable` and add four rows, each with a different
+Here we create a :class:`SiteTable` and add four rows, each with a different
 ``ancestral_state``. We can then access this information from each
 row in a straightforward manner. Working with the data in the columns
 is a little trickier, however::
@@ -228,9 +229,9 @@ is a little trickier, however::
 
 Here, the ``ancestral_state`` array is the UTF8 encoded bytes of the flattened
 strings, and the ``ancestral_state_offset`` is the offset into this array
-for each row. The :func:`.unpack_strings` function, however, is a convient
+for each row. The :func:`tskit.unpack_strings` function, however, is a convient
 way to recover the original strings from this encoding. We can also use the
-:func:`.pack_strings` to insert data using this approach::
+:func:`tskit.pack_strings` to insert data using this approach::
 
     >>> a, off = tskit.pack_strings(["0", "12", ""])
     >>> t.set_columns(position=[0, 1, 2], ancestral_state=a, ancestral_state_offset=off)
@@ -243,7 +244,7 @@ way to recover the original strings from this encoding. We can also use the
 When inserting many rows with standard infinite sites mutations (i.e.,
 ancestral state is "0"), it is more efficient to construct the
 numpy arrays directly than to create a list of strings and use
-:func:`.pack_strings`. When doing this, it is important to note that
+:func:`pack_strings`. When doing this, it is important to note that
 it is the **encoded** byte values that are stored; by default, we
 use UTF8 (which corresponds to ASCII for simple printable characters).::
 
@@ -332,7 +333,7 @@ decoding is done on the data. Consider the following example::
     array([ 0,  9, 33], dtype=uint32)
 
 
-Here we add two rows to a :class:`.NodeTable`, with different
+Here we add two rows to a :class:`NodeTable`, with different
 :ref:`metadata <sec_metadata_definition>`. The first row contains a simple
 byte string, and the second contains a Python dictionary serialised using
 :mod:`pickle`. We then show several different (and seemingly incompatible!)
@@ -356,8 +357,8 @@ encoded as signed integers. As for :ref:`sec_tables_api_text_columns`,
 the ``metadata_offset`` column encodes the offsets into this array. So, we
 see that the first metadata value is 9 bytes long and the second is 24.
 
-The :func:`.pack_bytes` and :func:`.unpack_bytes` functions are also useful
-for encoding data in these columns.
+The :func:`tskit.pack_bytes` and :func:`tskit.unpack_bytes` functions are
+also useful for encoding data in these columns.
 
 +++++++++++++
 Table classes
@@ -410,7 +411,7 @@ Each of the table classes defines a different aspect of the structure of
 a tree sequence. It is convenient to be able to refer to a set of these
 tables which together define a tree sequence. We
 refer to this grouping of related tables as a ``TableCollection``.
-The :class:`.TableCollection` and :class:`.TreeSequence` classes are
+The :class:`TableCollection` and :class:`TreeSequence` classes are
 deeply related. A ``TreeSequence`` instance is based on the information
 encoded in a ``TableCollection``. Tree sequences are **immutable**, and
 provide methods for obtaining trees from the sequence. A ``TableCollection``

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: tskit
 .. _sec_stats:
 
 ##########
@@ -38,10 +39,10 @@ grouped by basic classification and type.
 Single site statistics
 ++++++++++++++++++++++
 
-- :meth:`.TreeSequence.diversity`
-- :meth:`.TreeSequence.divergence`
-- :meth:`.TreeSequence.segregating_sites`
-- :meth:`.TreeSequence.allele_frequency_spectrum`
+- :meth:`TreeSequence.diversity`
+- :meth:`TreeSequence.divergence`
+- :meth:`TreeSequence.segregating_sites`
+- :meth:`TreeSequence.allele_frequency_spectrum`
 
 ------------------------
 Patterson's f statistics
@@ -53,9 +54,9 @@ See the documentation (link below) for the definition,
 and `Peter (2016) <https://www.genetics.org/content/202/4/1485>`_ for readable
 discussion of their use.
 
-- :meth:`.TreeSequence.f4`
-- :meth:`.TreeSequence.f3`
-- :meth:`.TreeSequence.f2`
+- :meth:`TreeSequence.f4`
+- :meth:`TreeSequence.f3`
+- :meth:`TreeSequence.f2`
 
 ------------
 Y statistics
@@ -66,8 +67,8 @@ These are the `Y` statistics introduced by
 as a three-sample intermediate between diversity/divergence (which are
 pairwise) and Patterson's f statistics (which are four-way).
 
-- :meth:`.TreeSequence.Y3`
-- :meth:`.TreeSequence.Y2`
+- :meth:`TreeSequence.Y3`
+- :meth:`TreeSequence.Y2`
 
 ------------------
 Trait correlations
@@ -77,8 +78,8 @@ These methods compute correlations and covariances of traits (i.e., an
 arbitrary vector) with allelic state, possibly in the context of a multivariate
 regression with other covariates (as in GWAS).
 
-- :meth:`.TreeSequence.trait_covariance`
-- :meth:`.TreeSequence.trait_correlation`
+- :meth:`TreeSequence.trait_covariance`
+- :meth:`TreeSequence.trait_correlation`
 
 ------------------
 Derived statistics
@@ -89,8 +90,8 @@ The other statistics above all have the property that `mode="branch"` and
 a high neutral mutation rate. The following statistics do not have this
 property (since both are ratios of statistics that do have this property).
 
-- :meth:`.TreeSequence.Fst`
-- :meth:`.TreeSequence.Tajimas_D`
+- :meth:`TreeSequence.Fst`
+- :meth:`TreeSequence.Tajimas_D`
 
 ---------------
 General methods
@@ -101,8 +102,8 @@ using weights or sample counts, and summary functions. See the documentation
 for more details. The pre-implemented statistics above will be faster than
 using these methods directly, so they should be preferred.
 
-- :meth:`.TreeSequence.general_stat`
-- :meth:`.TreeSequence.sample_count_stat`
+- :meth:`TreeSequence.general_stat`
+- :meth:`TreeSequence.sample_count_stat`
 
 
 .. _sec_stats_interface:
@@ -222,7 +223,7 @@ that operate on single sample sets and multiple sample sets.
 One-way methods
 ---------------
 
-One-way statistics such as :meth:`.TreeSequence.diversity` are defined over a single
+One-way statistics such as :meth:`TreeSequence.diversity` are defined over a single
 sample set. For these methods, ``sample_sets`` is interpreted in the following way:
 
 - If it is a single list of node IDs (e.g., ``sample_sets=[0, 1 ,2]``), this is
@@ -244,7 +245,7 @@ sample set. For these methods, ``sample_sets`` is interpreted in the following w
 Multi-way methods
 -----------------
 
-Multi-way statistics such as :meth:`.TreeSequence.divergence` are defined over a
+Multi-way statistics such as :meth:`TreeSequence.divergence` are defined over a
 ``k`` sample sets.
 
 In this case, ``sample_sets`` must be a list of lists of sample IDs, and there
@@ -448,7 +449,7 @@ various output dimension options.
 General API
 ***********
 
-The methods :meth:`.TreeSequence.general_stat` and :meth:`.TreeSequence.sample_count_stat`
+The methods :meth:`TreeSequence.general_stat` and :meth:`TreeSequence.sample_count_stat`
 provide access to the general-purpose algorithm for computing statistics.
 Here is a bit more discussion of how to use these.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: tskit
 .. _sec_tutorial:
 
 ========
@@ -14,17 +15,17 @@ Tutorial
 Trees
 *****
 
-A :class:`.Tree` represents a single tree in a :class:`.TreeSequence`.
+A :class:`Tree` represents a single tree in a :class:`TreeSequence`.
 The ``tskit`` Tree implementation differs from most tree libraries by
 using **integer IDs** to refer to nodes rather than objects. Thus, when we wish to
 find the parent of the node with ID '0', we use ``tree.parent(0)``, which
 returns another integer. If '0' does not have a parent in the current tree
-(e.g., if it is a root), then the special value :data:`.NULL`
+(e.g., if it is a root), then the special value :data:`tskit.NULL`
 (:math:`-1`) is returned. The children of a node are found using the
-:meth:`.Tree.children` method. To obtain information about a particular node,
+:meth:`Tree.children` method. To obtain information about a particular node,
 one may either use ``tree.tree_sequence.node(u)`` to which returns the
-corresponding :class:`.Node` instance, or use the :meth:`.Tree.time` or
-:meth:`.Tree.population` shorthands.
+corresponding :class:`Node` instance, or use the :meth:`Tree.time` or
+:meth:`Tree.population` shorthands.
 
 .. _sec_tutorial_trees_traversals:
 
@@ -32,7 +33,7 @@ corresponding :class:`.Node` instance, or use the :meth:`.Tree.time` or
 Traversals
 ++++++++++
 
-Tree traversals in various orders are possible using the :meth:`.Tree.nodes` iterator.
+Tree traversals in various orders are possible using the :meth:`Tree.nodes` iterator.
 For example, in the following tree we can visit the nodes in different orders:
 
 .. image:: _static/tree_structure1.svg
@@ -64,7 +65,7 @@ Traversing upwards
 ++++++++++++++++++
 
 For many applications it is useful to be able to traverse upwards from the
-leaves. We can do this using the :meth:`.Tree.parent` method, which
+leaves. We can do this using the :meth:`Tree.parent` method, which
 returns the parent of a node. For example, we can traverse upwards from
 each of the samples in the tree::
 
@@ -118,7 +119,7 @@ Moving along a tree sequence
 
 Most of the time we will want to iterate over all the trees in a tree sequence
 sequentially as efficiently as possible. The simplest way to do this is to
-use the :meth:`.TreeSequence.trees` method:
+use the :meth:`TreeSequence.trees` method:
 
 .. code-block:: python
 
@@ -146,7 +147,7 @@ Running the code, we get::
 
 Here we run a small simulation using `msprime <https://msprime.readthedocs.io>`_
 which results in 7 distinct trees along a genome of length 1. We then iterate
-over these trees sequentially using the :meth:`.TreeSequence.trees` method,
+over these trees sequentially using the :meth:`TreeSequence.trees` method,
 and print out each tree's index, the interval over which the tree applies
 and the time of the most recent common ancestor of all the samples. This
 method is very efficient, and allows us to quickly iterate over very large
@@ -196,13 +197,13 @@ list, we will get unexpected results:
     Tree -1 covers [0.00, 0.00): id=7f290becb3c8
     Tree -1 covers [0.00, 0.00): id=7f290becb3c8
 
-We have stored seven copies of the same :class:`.Tree` instance in the
+We have stored seven copies of the same :class:`Tree` instance in the
 list. Because iteration has ended, this tree is in the "null" state (see
 below for more details) which means that it doesn't represent any of the
 trees in the tree sequence.
 
 If we do wish to obtain a list of the trees, we can do so by using the
-:meth:`.TreeSequence.aslist` method:
+:meth:`TreeSequence.aslist` method:
 
 .. code-block:: python
 
@@ -222,14 +223,14 @@ If we do wish to obtain a list of the trees, we can do so by using the
 
 Note that we now have a different object for each tree in the list. Please
 note that this is **much** less efficient than iterating over the trees
-using the :meth:`.TreeSequence.trees` method (and uses far more memory!),
+using the :meth:`TreeSequence.trees` method (and uses far more memory!),
 and should only be used as a convenience when working with small trees.
 
 We can also obtain specific trees along the sequence, using the
-:meth:`.TreeSequence.first`,
-:meth:`.TreeSequence.last`
-:meth:`.TreeSequence.at` and
-:meth:`.TreeSequence.at_index` methods. The ``first()`` and ``last()``
+:meth:`TreeSequence.first`,
+:meth:`TreeSequence.last`
+:meth:`TreeSequence.at` and
+:meth:`TreeSequence.at_index` methods. The ``first()`` and ``last()``
 methods return the first and last trees in the sequence, as might be
 imagined. The ``at()`` method returns the tree that covers a
 given genomic location, and the ``at_index()`` method returns the
@@ -253,9 +254,9 @@ tree at a given index along the sequence:
     Tree 0 covers [0.00, 0.08): id=7f9fdb46d160
     Tree 6 covers [0.75, 1.00): id=7f9fdb469630
 
-Note that each call to these methods returns a different :class:`.Tree` instance
+Note that each call to these methods returns a different :class:`Tree` instance
 and so it is much, much less efficient to sequentially access trees
-by their index values than it is to use the :meth:`.TreeSequence.trees`
+by their index values than it is to use the :meth:`TreeSequence.trees`
 iterator.
 
 
@@ -295,11 +296,11 @@ to remove all singleton sites from a given tree sequence.
 This function takes a tree sequence containing some infinite sites mutations as
 input, and returns a copy in which all singleton sites have been removed.
 The approach is very simple: we get a copy of the underlying
-table data in a :class:`.TableCollection` object, and first clear the
+table data in a :class:`TableCollection` object, and first clear the
 site and mutation tables. We then consider each site in turn,
 and if the number of samples with
 the mutation is greater than one, we add the site and mutation to our
-output tables using :meth:`.SiteTable.add_row` and :meth:`.MutationTable.add_row`.
+output tables using :meth:`SiteTable.add_row` and :meth:`MutationTable.add_row`.
 (In this case we consider only simple infinite sites mutations,
 where we cannot have back or recurrent mutations. These would require a slightly
 more involved approach where we keep a map of mutation IDs so that
@@ -307,7 +308,7 @@ mutation ``parent`` values could be computed. We have also omitted the
 site and mutation metadata in the interest of simplicity.)
 
 After considering each site, we then create a new tree sequence using
-the :meth:`.TableCollection.tree_sequence` method on our updated tables.
+the :meth:`TableCollection.tree_sequence` method on our updated tables.
 Using this function then, we get::
 
     >>> ts = msprime.simulate(10, mutation_rate=10)
@@ -335,7 +336,7 @@ Tables provide a convenient method for viewing, importing and exporting tree
 sequences, and are closely tied to the underlying data structures.
 There are eight tables that together define a tree sequence,
 although some may be empty,
-and together they form a :class:`.TableCollection`.
+and together they form a :class:`TableCollection`.
 The tables are defined in :ref:`Table Definitions <sec_table_definitions>`,
 and the :ref:`Tables API <sec_tables_api>` section describes how to work with them.
 Here we make some general remarks about what you can and cannot do with them.
@@ -435,7 +436,7 @@ along the chromosome of length 1.0.
 
 Each node in each of the above trees represents a particular ancestral genome
 (a *haploid* genome; diploid individuals would be represented by two nodes).
-We record when each of nodes lived in a :class:`.NodeTable`::
+We record when each of nodes lived in a :class:`NodeTable`::
 
     NodeTable:
 
@@ -457,7 +458,7 @@ on the middle portion of the genome, but not on the ends.)
 
 We next need to record each tree's edges. Since some edges are present
 in more than one tree (e.g., node 1 inherits from node 4 across
-the entire sequence), we record in the :class:`.EdgeTable` each edge
+the entire sequence), we record in the :class:`EdgeTable` each edge
 and the genomic region for which it appears in the trees::
 
 
@@ -492,7 +493,7 @@ second tree both occurred at the same position, at 0.5 (with a back mutation).
 To record the inheritance patterns of these, we need only record
 the positions on the genome at which they occurred,
 and on which edge (equivalently, above which node) they occurred.
-The positions are recorded in the :class:`.SiteTable`::
+The positions are recorded in the :class:`SiteTable`::
 
     SiteTable:
 
@@ -522,8 +523,8 @@ samples::
 
 
 To create these tables, and the corresponding tree sequence, we would
-create a :class:`.TableCollection`, and then use its
-:meth:`.TableCollection.tree_sequence` method::
+create a :class:`TableCollection`, and then use its
+:meth:`TableCollection.tree_sequence` method::
 
     tables = tskit.TableCollection(sequence_length=1.0)
 
@@ -584,10 +585,10 @@ Calculating LD
 **************
 
 The ``tskit`` API provides methods to efficiently calculate
-population genetics statistics. For example, the :class:`.LdCalculator`
+population genetics statistics. For example, the :class:`LdCalculator`
 class allows us to compute pairwise `linkage disequilibrium
 <https://en.wikipedia.org/wiki/Linkage_disequilibrium>`_ coefficients.
-Here we use the :meth:`.LdCalculator.r2_matrix` method to easily make an
+Here we use the :meth:`LdCalculator.r2_matrix` method to easily make an
 LD plot using `matplotlib <http://matplotlib.org/>`_. (Thanks to
 the excellent `scikit-allel
 <http://scikit-allel.readthedocs.io/en/latest/index.html>`_
@@ -655,7 +656,7 @@ CPU intensive tasks are being undertaken.
 In the following example we wish to find all mutations that are in approximate
 LD (:math:`r^2 \geq 0.5`) with a given set of mutations. We parallelise this
 by splitting the input array between a number of threads, and use the
-:meth:`.LdCalculator.r2_array` method to compute the :math:`r^2` value
+:meth:`LdCalculator.r2_array` method to compute the :math:`r^2` value
 both up and downstream of each focal mutation, filter out those that
 exceed our threshold, and store the results in a dictionary. We also
 use the very cool `tqdm <https://pypi.python.org/pypi/tqdm>`_ module to give us a
@@ -727,8 +728,8 @@ of these doubletons and have an :math:`r^2` statistic of greater than 0.5.
 The ``find_ld_sites()`` function performs these calculations in parallel using
 8 threads. The real work is done in the nested ``thread_worker()`` function,
 which is called once by each thread. In the thread worker, we first allocate an
-instance of the :class:`.LdCalculator` class. (It is **critically important**
-that each thread has its own instance of :class:`.LdCalculator`, as the threads
+instance of the :class:`LdCalculator` class. (It is **critically important**
+that each thread has its own instance of :class:`LdCalculator`, as the threads
 will not work efficiently otherwise.) After this, each thread works out the
 slice of the input array that it is responsible for, and then iterates over
 each focal mutation in turn. After the :math:`r^2` values have been calculated,
@@ -751,7 +752,7 @@ Running this example we get::
 Parsimony
 *********
 
-The :meth:`.Tree.map_mutations` method finds a parsimonious explanation for a
+The :meth:`Tree.map_mutations` method finds a parsimonious explanation for a
 set of discrete character observations on the samples in a tree using classical phylogenetic
 algorithms.
 
@@ -783,7 +784,7 @@ a mutation to blue and green over nodes 4 and 5.
 Building tables
 +++++++++++++++
 
-One of the main uses of :meth:`.Tree.map_mutations` is to position mutations on a tree
+One of the main uses of :meth:`Tree.map_mutations` is to position mutations on a tree
 to encode observed data. In the following example we show how a set
 of tables can be updated using the :ref:`Tables API<sec_tables_api>`; here we
 infer the location of mutations in an simulated tree sequence, and recompute
@@ -842,7 +843,7 @@ The output is::
 Missing data
 ++++++++++++
 
-The Fitch parsimony algorithm in :meth:`.Tree.map_mutations` can also take missing data
+The Fitch parsimony algorithm in :meth:`Tree.map_mutations` can also take missing data
 into account when finding a set of parsimonious state transitions. We do this by
 specifying the special value ``-1`` as the state, which is treated by the algorithm as
 "could be anything".
@@ -927,7 +928,7 @@ One-way statistics
 
 We refer to statistics that are defined with respect to a single set of
 samples as "one-way". An example of such a statistic is diversity, which
-is computed using the :meth:`.TreeSequence.diversity` method::
+is computed using the :meth:`TreeSequence.diversity` method::
 
     x = ts.diversity()
     print("Average diversity per unit sequence length = {:.3G}".format(x))
@@ -1016,7 +1017,7 @@ Multi-way statistics
 ++++++++++++++++++++
 
 Many population genetic statistics compare multiple sets of samples to
-each other. For example, the :meth:`.TreeSequence.divergence` method computes
+each other. For example, the :meth:`TreeSequence.divergence` method computes
 the divergence between two subsets of samples::
 
     A = ts.samples()[:100]
@@ -1197,7 +1198,7 @@ and not present in the other sample set.
 Branch length spectra
 +++++++++++++++++++++
 
-Up to now we've used the :meth:`.TreeSequence.allele_frequency_spectrum` method
+Up to now we've used the :meth:`TreeSequence.allele_frequency_spectrum` method
 to summarise the number of sites that occur at different frequencies. We can also
 use this approach to compute the total branch lengths subtending a given
 number of samples by setting ``mode="branch"``::

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -35,11 +35,11 @@ class LdCalculator(object):
     """
     Class for calculating `linkage disequilibrium
     <https://en.wikipedia.org/wiki/Linkage_disequilibrium>`_ coefficients
-    between pairs of mutations in a :class:`.TreeSequence`. This class requires
+    between pairs of mutations in a :class:`TreeSequence`. This class requires
     the `numpy <http://www.numpy.org/>`_ library.
 
     This class supports multithreaded access using the Python :mod:`threading`
-    module. Separate instances of :class:`.LdCalculator` referencing the
+    module. Separate instances of :class:`LdCalculator` referencing the
     same tree sequence can operate in parallel in multiple threads.
 
     .. note:: This class does not currently support sites that have more than one

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -199,7 +199,7 @@ class BaseTable(object):
 
     def set_columns(self, **kwargs):
         """
-        Sets the values for each column in this :class:`.Table` using
+        Sets the values for each column in this :class:`Table` using
         values provided in numpy arrays. Overwrites any data currently stored in
         the table.
         """
@@ -294,7 +294,7 @@ class IndividualTable(BaseTable, MetadataMixin):
             self, flags=None, location=None, location_offset=None,
             metadata=None, metadata_offset=None):
         """
-        Sets the values for each column in this :class:`.IndividualTable` using the
+        Sets the values for each column in this :class:`IndividualTable` using the
         values in the specified arrays. Overwrites any data currently stored in
         the table.
 
@@ -435,9 +435,9 @@ class NodeTable(BaseTable, MetadataMixin):
         :param int flags: The bitwise flags for the new node.
         :param float time: The birth time for the new node.
         :param int population: The ID of the population in which the new node was born.
-            Defaults to :data:`.NULL`.
+            Defaults to :data:`tskit.NULL`.
         :param int individual: The ID of the individual in which the new node was born.
-            Defaults to :data:`.NULL`.
+            Defaults to :data:`tskit.NULL`.
         :param bytes metadata: The binary-encoded metadata for the new node. If not
             specified or None, a zero-length byte string is stored.
         :return: The ID of the newly added node.
@@ -449,7 +449,7 @@ class NodeTable(BaseTable, MetadataMixin):
             self, flags=None, time=None, population=None, individual=None, metadata=None,
             metadata_offset=None):
         """
-        Sets the values for each column in this :class:`.NodeTable` using the values in
+        Sets the values for each column in this :class:`NodeTable` using the values in
         the specified arrays. Overwrites any data currently stored in the table.
 
         The ``flags``, ``time`` and ``population`` arrays must all be of the same length,
@@ -463,10 +463,10 @@ class NodeTable(BaseTable, MetadataMixin):
         :param time: The time values for each node. Required.
         :type time: numpy.ndarray, dtype=np.float64
         :param population: The population values for each node. If not specified
-            or None, the :data:`.NULL` value is stored for each node.
+            or None, the :data:`tskit.NULL` value is stored for each node.
         :type population: numpy.ndarray, dtype=np.int32
         :param individual: The individual values for each node. If not specified
-            or None, the :data:`.NULL` value is stored for each node.
+            or None, the :data:`tskit.NULL` value is stored for each node.
         :type individual: numpy.ndarray, dtype=np.int32
         :param metadata: The flattened metadata array. Must be specified along
             with ``metadata_offset``. If not specified or None, an empty metadata
@@ -498,10 +498,10 @@ class NodeTable(BaseTable, MetadataMixin):
         :param time: The time values for each node. Required.
         :type time: numpy.ndarray, dtype=np.float64
         :param population: The population values for each node. If not specified
-            or None, the :data:`.NULL` value is stored for each node.
+            or None, the :data:`tskit.NULL` value is stored for each node.
         :type population: numpy.ndarray, dtype=np.int32
         :param individual: The individual values for each node. If not specified
-            or None, the :data:`.NULL` value is stored for each node.
+            or None, the :data:`tskit.NULL` value is stored for each node.
         :type individual: numpy.ndarray, dtype=np.int32
         :param metadata: The flattened metadata array. Must be specified along
             with ``metadata_offset``. If not specified or None, an empty metadata
@@ -574,7 +574,7 @@ class EdgeTable(BaseTable):
 
     def set_columns(self, left=None, right=None, parent=None, child=None):
         """
-        Sets the values for each column in this :class:`.EdgeTable` using the values
+        Sets the values for each column in this :class:`EdgeTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
 
         All four parameters are mandatory, and must be numpy arrays of the
@@ -699,7 +699,7 @@ class MigrationTable(BaseTable):
     def set_columns(
             self, left=None, right=None, node=None, source=None, dest=None, time=None):
         """
-        Sets the values for each column in this :class:`.MigrationTable` using the values
+        Sets the values for each column in this :class:`MigrationTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
 
         All six parameters are mandatory, and must be numpy arrays of the
@@ -819,7 +819,7 @@ class SiteTable(BaseTable, MetadataMixin):
             self, position=None, ancestral_state=None, ancestral_state_offset=None,
             metadata=None, metadata_offset=None):
         """
-        Sets the values for each column in this :class:`.SiteTable` using the values
+        Sets the values for each column in this :class:`SiteTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
 
         The ``position``, ``ancestral_state`` and ``ancestral_state_offset``
@@ -989,7 +989,7 @@ class MutationTable(BaseTable, MetadataMixin):
             self, site=None, node=None, derived_state=None, derived_state_offset=None,
             parent=None, metadata=None, metadata_offset=None):
         """
-        Sets the values for each column in this :class:`.MutationTable` using the values
+        Sets the values for each column in this :class:`MutationTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
 
         The ``site``, ``node``, ``derived_state`` and ``derived_state_offset``
@@ -1141,7 +1141,7 @@ class PopulationTable(BaseTable, MetadataMixin):
 
     def set_columns(self, metadata=None, metadata_offset=None):
         """
-        Sets the values for each column in this :class:`.PopulationTable` using the
+        Sets the values for each column in this :class:`PopulationTable` using the
         values in the specified arrays. Overwrites any data currently stored in the
         table.
 
@@ -1235,7 +1235,7 @@ class ProvenanceTable(BaseTable):
             self, timestamp=None, timestamp_offset=None,
             record=None, record_offset=None):
         """
-        Sets the values for each column in this :class:`.ProvenanceTable` using the
+        Sets the values for each column in this :class:`ProvenanceTable` using the
         values in the specified arrays. Overwrites any data currently stored in the
         table.
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -78,7 +78,7 @@ class Individual(SimpleContainer):
     underlying tree sequence data.
 
     :ivar id: The integer ID of this individual. Varies from 0 to
-        :attr:`.TreeSequence.num_individuals` - 1.
+        :attr:`TreeSequence.num_individuals` - 1.
     :vartype id: int
     :ivar flags: The bitwise flags for this individual.
     :vartype flags: int
@@ -119,7 +119,7 @@ class Node(SimpleContainer):
     underlying tree sequence data.
 
     :ivar id: The integer ID of this node. Varies from 0 to
-        :attr:`.TreeSequence.num_nodes` - 1.
+        :attr:`TreeSequence.num_nodes` - 1.
     :vartype id: int
     :ivar flags: The bitwise flags for this node.
     :vartype flags: int
@@ -165,14 +165,14 @@ class Edge(SimpleContainer):
     :vartype right: float
     :ivar parent: The integer ID of the parent node for this edge.
         To obtain further information about a node with a given ID, use
-        :meth:`.TreeSequence.node`.
+        :meth:`TreeSequence.node`.
     :vartype parent: int
     :ivar child: The integer ID of the child node for this edge.
         To obtain further information about a node with a given ID, use
-        :meth:`.TreeSequence.node`.
+        :meth:`TreeSequence.node`.
     :vartype child: int
     :ivar id: The integer ID of this edge. Varies from 0 to
-        :attr:`.TreeSequence.num_edges` - 1.
+        :attr:`TreeSequence.num_edges` - 1.
     :vartype id: int
     """
     def __init__(self, left, right, parent, child, id_=None):
@@ -195,10 +195,10 @@ class Site(SimpleContainer):
     underlying tree sequence data.
 
     :ivar id: The integer ID of this site. Varies from 0 to
-        :attr:`.TreeSequence.num_sites` - 1.
+        :attr:`TreeSequence.num_sites` - 1.
     :vartype id: int
     :ivar position: The floating point location of this site in genome coordinates.
-        Ranges from 0 (inclusive) to :attr:`.TreeSequence.sequence_length`
+        Ranges from 0 (inclusive) to :attr:`TreeSequence.sequence_length`
         (exclusive).
     :vartype position: float
     :ivar ancestral_state: The ancestral state at this site (i.e., the state
@@ -208,8 +208,8 @@ class Site(SimpleContainer):
     :vartype metadata: bytes
     :ivar mutations: The list of mutations at this site. Mutations
         within a site are returned in the order they are specified in the
-        underlying :class:`.MutationTable`.
-    :vartype mutations: list[:class:`.Mutation`]
+        underlying :class:`MutationTable`.
+    :vartype mutations: list[:class:`Mutation`]
     """
     def __init__(self, id_, position, ancestral_state, mutations, metadata):
         self.id = id_
@@ -227,15 +227,15 @@ class Mutation(SimpleContainer):
     underlying tree sequence data.
 
     :ivar id: The integer ID of this mutation. Varies from 0 to
-        :attr:`.TreeSequence.num_mutations` - 1.
+        :attr:`TreeSequence.num_mutations` - 1.
     :vartype id: int
     :ivar site: The integer ID of the site that this mutation occurs at. To obtain
         further information about a site with a given ID use
-        :meth:`.TreeSequence.site`.
+        :meth:`TreeSequence.site`.
     :vartype site: int
     :ivar node: The integer ID of the first node that inherits this mutation.
         To obtain further information about a node with a given ID, use
-        :meth:`.TreeSequence.node`.
+        :meth:`TreeSequence.node`.
     :vartype node: int
     :ivar derived_state: The derived state for this mutation. This is the state
         inherited by nodes in the subtree rooted at this mutation's node, unless
@@ -246,7 +246,7 @@ class Mutation(SimpleContainer):
         record the mutation that is immediately above them. If the mutation does
         not have a parent, this is equal to the :data:`NULL` (-1).
         To obtain further information about a mutation with a given ID, use
-        :meth:`.TreeSequence.mutation`.
+        :meth:`TreeSequence.mutation`.
     :vartype parent: int
     :ivar metadata: The :ref:`metadata <sec_metadata_definition>` for this site.
     :vartype metadata: bytes
@@ -277,7 +277,7 @@ class Migration(SimpleContainer):
     :vartype right: float
     :ivar node: The integer ID of the node involved in this migration event.
         To obtain further information about a node with a given ID, use
-        :meth:`.TreeSequence.node`.
+        :meth:`TreeSequence.node`.
     :vartype node: int
     :ivar source: The source population ID.
     :vartype source: int
@@ -303,7 +303,7 @@ class Population(SimpleContainer):
     underlying tree sequence data.
 
     :ivar id: The integer ID of this population. Varies from 0 to
-        :attr:`.TreeSequence.num_populations` - 1.
+        :attr:`TreeSequence.num_populations` - 1.
     :vartype id: int
     :ivar metadata: The :ref:`metadata <sec_metadata_definition>` for this population.
     :vartype metadata: bytes
@@ -317,7 +317,7 @@ class Variant(SimpleContainer):
     """
     A variant represents the observed variation among samples
     for a given site. A variant consists (a) of a reference to the
-    :class:`.Site` instance in question; (b) the **alleles** that may be
+    :class:`Site` instance in question; (b) the **alleles** that may be
     observed at the samples for this site; and (c) the **genotypes**
     mapping sample IDs to the observed alleles.
 
@@ -355,7 +355,7 @@ class Variant(SimpleContainer):
     underlying tree sequence data.
 
     :ivar site: The site object for this variant.
-    :vartype site: :class:`.Site`
+    :vartype site: :class:`Site`
     :ivar alleles: A tuple of the allelic values that may be observed at the
         samples at the current site. The first element of this tuple is always
         the site's ancestral state.
@@ -420,7 +420,7 @@ def add_deprecated_mutation_attrs(site, mutation):
 
 class Tree(object):
     """
-    A single tree in a :class:`.TreeSequence`. Please see the
+    A single tree in a :class:`TreeSequence`. Please see the
     :ref:`sec_tutorial_moving_along_a_tree_sequence` section for information
     on how efficiently access trees sequentially or obtain a list
     of individual trees in a tree sequence.
@@ -428,41 +428,41 @@ class Tree(object):
     The ``sample_counts`` and ``sample_lists`` parameters control the
     features that are enabled for this tree. If ``sample_counts``
     is True, then it is possible to count the number of samples underneath
-    a particular node in constant time using the :meth:`.num_samples`
+    a particular node in constant time using the :meth:`num_samples`
     method. If ``sample_lists`` is True a more efficient algorithm is
-    used in the :meth:`.Tree.samples` method.
+    used in the :meth:`Tree.samples` method.
 
     The ``tracked_samples`` parameter can be used to efficiently count the
     number of samples in a given set that exist in a particular subtree
-    using the :meth:`.Tree.num_tracked_samples` method. It is an
+    using the :meth:`Tree.num_tracked_samples` method. It is an
     error to use the ``tracked_samples`` parameter when the ``sample_counts``
     flag is False.
 
-    The :class:`.Tree` class is a state-machine which has a state
+    The :class:`Tree` class is a state-machine which has a state
     corresponding to each of the trees in the parent tree sequence. We
     transition between these states by using the seek functions like
-    :meth:`.Tree.first`, :meth:`.Tree.last`, :meth:`.Tree.seek` and
-    :meth:`.Tree.seek_index`. There is one more state, the so-called "null"
-    or "cleared" state. This is the state that a :class:`.Tree` is in
+    :meth:`Tree.first`, :meth:`Tree.last`, :meth:`Tree.seek` and
+    :meth:`Tree.seek_index`. There is one more state, the so-called "null"
+    or "cleared" state. This is the state that a :class:`Tree` is in
     immediately after initialisation;  it has an index of -1, and no edges. We
-    can also enter the null state by calling :meth:`.Tree.next` on the last
-    tree in a sequence, calling :meth:`.Tree.prev` on the first tree in a
-    sequence or calling calling the :meth:`.Tree.clear` method at any time.
+    can also enter the null state by calling :meth:`Tree.next` on the last
+    tree in a sequence, calling :meth:`Tree.prev` on the first tree in a
+    sequence or calling calling the :meth:`Tree.clear` method at any time.
 
     The high-level TreeSequence seeking and iterations methods (e.g,
-    :meth:`.TreeSequence.trees`) are built on these low-level state-machine
+    :meth:`TreeSequence.trees`) are built on these low-level state-machine
     seek operations. We recommend these higher level operations for most
     users.
 
     :param TreeSequence tree_sequence: The parent tree sequence.
     :param list tracked_samples: The list of samples to be tracked and
-        counted using the :meth:`.Tree.num_tracked_samples` method.
+        counted using the :meth:`Tree.num_tracked_samples` method.
     :param bool sample_counts: If True, support constant time sample counts
-        via the :meth:`.Tree.num_samples` and
-        :meth:`.Tree.num_tracked_samples` methods.
+        via the :meth:`Tree.num_samples` and
+        :meth:`Tree.num_tracked_samples` methods.
     :param bool sample_lists: If True, provide more efficient access
         to the samples beneath a give node using the
-        :meth:`.Tree.samples` method.
+        :meth:`Tree.samples` method.
     """
     def __init__(
             self, tree_sequence,
@@ -501,7 +501,7 @@ class Tree(object):
         Returns the tree sequence that this tree is from.
 
         :return: The parent tree sequence for this tree.
-        :rtype: :class:`.TreeSequence`
+        :rtype: :class:`TreeSequence`
         """
         return self._tree_sequence
 
@@ -613,7 +613,7 @@ class Tree(object):
         :param float position: The position along the sequence length to
             seek to.
         :raises ValueError: If 0 < position or position >=
-            :attr:`.TreeSequence.sequence_length`.
+            :attr:`TreeSequence.sequence_length`.
         """
         if position < 0 or position >= self.tree_sequence.sequence_length:
             raise ValueError("Position out of bounds")
@@ -639,7 +639,7 @@ class Tree(object):
         defined as zero.
 
         Note that this is not related to the property `.length` which
-        is a deprecated alias for the genomic :attr:`.span` covered by a tree.
+        is a deprecated alias for the genomic :attr:`~Tree.span` covered by a tree.
 
         :param int u: The node of interest.
         :return: The branch length from u to its parent.
@@ -717,7 +717,7 @@ class Tree(object):
     def parent(self, u):
         """
         Returns the parent of the specified node. Returns
-        :data:`.NULL` if u is a root or is not a node in
+        :data:`tskit.NULL` if u is a root or is not a node in
         the current tree.
 
         :param int u: The node of interest.
@@ -731,7 +731,7 @@ class Tree(object):
     def left_child(self, u):
         """
         Returns the leftmost child of the specified node. Returns
-        :data:`.NULL` if u is a leaf or is not a node in
+        :data:`tskit.NULL` if u is a leaf or is not a node in
         the current tree. The left-to-right ordering of children
         is arbitrary and should not be depended on; see the
         :ref:`data model <sec_data_model_tree_structure>` section
@@ -750,7 +750,7 @@ class Tree(object):
     def right_child(self, u):
         """
         Returns the rightmost child of the specified node. Returns
-        :data:`.NULL` if u is a leaf or is not a node in
+        :data:`tskit.NULL` if u is a leaf or is not a node in
         the current tree. The left-to-right ordering of children
         is arbitrary and should not be depended on; see the
         :ref:`data model <sec_data_model_tree_structure>` section
@@ -768,7 +768,7 @@ class Tree(object):
 
     def left_sib(self, u):
         """
-        Returns the sibling node to the left of u, or :data:`.NULL`
+        Returns the sibling node to the left of u, or :data:`tskit.NULL`
         if u does not have a left sibling.
         The left-to-right ordering of children
         is arbitrary and should not be depended on; see the
@@ -783,7 +783,7 @@ class Tree(object):
 
     def right_sib(self, u):
         """
-        Returns the sibling node to the right of u, or :data:`.NULL`
+        Returns the sibling node to the right of u, or :data:`tskit.NULL`
         if u does not have a right sibling.
         The left-to-right ordering of children
         is arbitrary and should not be depended on; see the
@@ -828,14 +828,14 @@ class Tree(object):
         section for details.
 
         This is a low-level method giving access to the quintuply linked
-        tree structure in memory; the :attr:`.roots` attribute is a more
+        tree structure in memory; the :attr:`~Tree.roots` attribute is a more
         convenient way to obtain the roots of a tree. If you are assuming
         that there is a single root in the tree you should use the
-        :attr:`.root` property.
+        :attr:`~Tree.root` property.
 
         .. warning:: Do not use this property if you are assuming that there
             is a single root in trees that are being processed. The
-            :attr:`.root` property should be used in this case, as it will
+            :attr:`~Tree.root` property should be used in this case, as it will
             raise an error when multiple roots exists.
 
         :rtype: int
@@ -942,7 +942,7 @@ class Tree(object):
     @property
     def num_nodes(self):
         """
-        Returns the number of nodes in the :class:`.TreeSequence` this tree is in.
+        Returns the number of nodes in the :class:`TreeSequence` this tree is in.
         Equivalent to ``tree.tree_sequence.num_nodes``. To find the number of
         nodes that are reachable from all roots use ``len(list(tree.nodes()))``.
 
@@ -953,7 +953,8 @@ class Tree(object):
     @property
     def num_roots(self):
         """
-        The number of roots in this tree, as defined in the :attr:`.roots` attribute.
+        The number of roots in this tree, as defined in the :attr:`~Tree.roots`
+        attribute.
 
         Requires O(number of roots) time.
 
@@ -999,7 +1000,7 @@ class Tree(object):
     def root(self):
         """
         The root of this tree. If the tree contains multiple roots, a ValueError is
-        raised indicating that the :attr:`.roots` attribute should be used instead.
+        raised indicating that the :attr:`~Tree.roots` attribute should be used instead.
 
         :return: The root node.
         :rtype: int
@@ -1060,7 +1061,7 @@ class Tree(object):
         """
         Returns the genomic distance that this tree spans.
         This is defined as :math:`r - l`, where :math:`(l, r)` is the genomic
-        interval returned by :attr:`.interval`.
+        interval returned by :attr:`~Tree.interval`.
 
         :return: The genomic distance covered by this tree.
         :rtype: float
@@ -1268,8 +1269,8 @@ class Tree(object):
             >>>     for mutation in site.mutations:
             >>>         yield mutation
 
-        :return: An iterator over all :class:`.Mutation` objects in this tree.
-        :rtype: iter(:class:`.Mutation`)
+        :return: An iterator over all :class:`Mutation` objects in this tree.
+        :rtype: iter(:class:`Mutation`)
         """
         for site in self.sites():
             for mutation in site.mutations:
@@ -1324,7 +1325,7 @@ class Tree(object):
         underneath the specified node. If u is a sample, it is included in the
         returned iterator. If u is not specified, return all samples in the tree.
 
-        If the :meth:`.TreeSequence.trees` method is called with
+        If the :meth:`TreeSequence.trees` method is called with
         ``sample_lists=True``, this method uses an efficient algorithm to find
         the samples. If not, a simple traversal based method is used.
 
@@ -1362,7 +1363,7 @@ class Tree(object):
         node (including the node itself). If u is not specified return
         the total number of samples in the tree.
 
-        If the :meth:`.TreeSequence.trees` method is called with
+        If the :meth:`TreeSequence.trees` method is called with
         ``sample_counts=True`` this method is a constant time operation. If not,
         a slower traversal based algorithm is used to count the samples.
 
@@ -1388,7 +1389,7 @@ class Tree(object):
     def num_tracked_samples(self, u=None):
         """
         Returns the number of samples in the set specified in the
-        ``tracked_samples`` parameter of the :meth:`.TreeSequence.trees` method
+        ``tracked_samples`` parameter of the :meth:`TreeSequence.trees` method
         underneath the specified node. If the input node is not specified,
         return the total number of tracked samples in the tree.
 
@@ -1398,7 +1399,7 @@ class Tree(object):
         :return: The number of samples within the set of tracked samples in
             the subtree rooted at u.
         :rtype: int
-        :raises RuntimeError: if the :meth:`.TreeSequence.trees`
+        :raises RuntimeError: if the :meth:`TreeSequence.trees`
             method is not called with ``sample_counts=True``.
         """
         roots = [u]
@@ -1583,7 +1584,7 @@ class Tree(object):
         set of genotypes and alleles, return a parsimonious set of state transitions
         explaining these observations. The genotypes array is interpreted as indexes
         into the alleles list in the same manner as described in the
-        :meth:`.TreeSequence.variants` method. Thus, if sample ``j`` carries the
+        :meth:`TreeSequence.variants` method. Thus, if sample ``j`` carries the
         allele at index ``k``, then we have ``genotypes[j] = k``.
         Missing data can be specified for a sample using the value
         ``tskit.MISSING_DATA`` (-1). At least one non-missing observation must be
@@ -1599,13 +1600,13 @@ class Tree(object):
 
         The state reconstruction is returned as two-tuple, ``(ancestral_state,
         mutations)``, where ``ancestral_state`` is the allele assigned to the
-        tree root(s) and ``mutations`` is a list of :class:`.Mutation` objects.
+        tree root(s) and ``mutations`` is a list of :class:`Mutation` objects.
         For each mutation, ``node`` is the tree node at the bottom of the branch
         on which the transition occurred, and ``derived_state`` is the new state
         after this mutation. When multiple mutations are returned the ``parent``
         property contains the index of the previous mutation on the path to root
         (see the :ref:`sec_mutation_table_definition` for more information on the
-        concept of mutation parents). All other attributes of the :class:`.Mutation`
+        concept of mutation parents). All other attributes of the :class:`Mutation`
         object are undefined and should not be used.
 
         See the :ref:`sec_tutorial_parsimony` section in the tutorial for examples
@@ -1632,7 +1633,7 @@ def load(path):
     """
     Loads a tree sequence from the specified file path. This file must be in the
     :ref:`tree sequence file format <sec_tree_sequence_file_format>` produced by the
-    :meth:`.TreeSequence.dump` method.
+    :meth:`TreeSequence.dump` method.
 
     :param str path: The file path of the ``.trees`` file containing the
         tree sequence we wish to load.
@@ -1657,7 +1658,7 @@ def parse_individuals(
     <sec_individual_table_definition>` section for the required properties of
     the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict``
+    See :func:`tskit.load_text` for a detailed explanation of the ``strict``
     parameter.
 
     :param io.TextIOBase source: The file-like object containing the text.
@@ -1667,7 +1668,7 @@ def parse_individuals(
     :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     :param IndividualTable table: If specified write into this table. If not,
-        create a new :class:`.IndividualTable` instance.
+        create a new :class:`IndividualTable` instance.
     """
     sep = None
     if strict:
@@ -1716,7 +1717,7 @@ def parse_nodes(
     :ref:`node table definition <sec_node_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict``
+    See :func:`tskit.load_text` for a detailed explanation of the ``strict``
     parameter.
 
     :param io.TextIOBase source: The file-like object containing the text.
@@ -1726,7 +1727,7 @@ def parse_nodes(
     :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     :param NodeTable table: If specified write into this table. If not,
-        create a new :class:`.NodeTable` instance.
+        create a new :class:`NodeTable` instance.
     """
     sep = None
     if strict:
@@ -1786,13 +1787,13 @@ def parse_edges(source, strict=True, table=None):
     :ref:`edge table definition <sec_edge_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict`` parameter.
+    See :func:`tskit.load_text` for a detailed explanation of the ``strict`` parameter.
 
     :param io.TextIOBase source: The file-like object containing the text.
     :param bool strict: If True, require strict tab delimiting (default). If
         False, a relaxed whitespace splitting algorithm is used.
     :param EdgeTable table: If specified, write the edges into this table. If
-        not, create a new :class:`.EdgeTable` instance and return.
+        not, create a new :class:`EdgeTable` instance and return.
     """
     sep = None
     if strict:
@@ -1826,7 +1827,7 @@ def parse_sites(
     :ref:`site table definition <sec_site_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict``
+    See :func:`tskit.load_text` for a detailed explanation of the ``strict``
     parameter.
 
     :param io.TextIOBase source: The file-like object containing the text.
@@ -1836,7 +1837,7 @@ def parse_sites(
     :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     :param SiteTable table: If specified write site into this table. If not,
-        create a new :class:`.SiteTable` instance.
+        create a new :class:`SiteTable` instance.
     """
     sep = None
     if strict:
@@ -1876,7 +1877,7 @@ def parse_mutations(
     :ref:`mutation table definition <sec_mutation_table_definition>` section for the
     required properties of the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict``
+    See :func:`tskit.load_text` for a detailed explanation of the ``strict``
     parameter.
 
     :param io.TextIOBase source: The file-like object containing the text.
@@ -1886,7 +1887,7 @@ def parse_mutations(
     :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     :param MutationTable table: If specified, write mutations into this table.
-        If not, create a new :class:`.MutationTable` instance.
+        If not, create a new :class:`MutationTable` instance.
     """
     sep = None
     if strict:
@@ -1938,7 +1939,7 @@ def parse_populations(
     <sec_population_table_definition>` section for the required properties of
     the contents.
 
-    See :func:`.load_text` for a detailed explanation of the ``strict``
+    See :func:`tskit.load_text` for a detailed explanation of the ``strict``
     parameter.
 
     :param io.TextIOBase source: The file-like object containing the text.
@@ -1948,7 +1949,7 @@ def parse_populations(
     :param bool base64_metadata: If True, metadata is encoded using Base64
         encoding; otherwise, as plain text.
     :param PopulationTable table: If specified write into this table. If not,
-        create a new :class:`.PopulationTable` instance.
+        create a new :class:`PopulationTable` instance.
     """
     sep = None
     if strict:
@@ -1973,9 +1974,9 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
               encoding='utf8', base64_metadata=True):
     """
     Parses the tree sequence data from the specified file-like objects, and
-    returns the resulting :class:`.TreeSequence` object. The format
+    returns the resulting :class:`TreeSequence` object. The format
     for these files is documented in the :ref:`sec_text_file_format` section,
-    and is produced by the :meth:`.TreeSequence.dump_text` method. Further
+    and is produced by the :meth:`TreeSequence.dump_text` method. Further
     properties required for an input tree sequence are described in the
     :ref:`sec_valid_tree_sequence_requirements` section. This method is intended as a
     convenient interface for importing external data into tskit; the binary
@@ -1994,7 +1995,7 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
     be loaded. This will be fixed: https://github.com/tskit-dev/msprime/issues/498
 
     The ``sequence_length`` parameter determines the
-    :attr:`.TreeSequence.sequence_length` of the returned tree sequence. If it
+    :attr:`TreeSequence.sequence_length` of the returned tree sequence. If it
     is 0 or not specified, the value is taken to be the maximum right
     coordinate of the input edges. This parameter is useful in degenerate
     situations (such as when there are zero edges), but can usually be ignored.
@@ -2014,11 +2015,11 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
     IDs of various entities changing from their positions in the input file.
 
     :param io.TextIOBase nodes: The file-like object containing text describing a
-        :class:`.NodeTable`.
+        :class:`NodeTable`.
     :param io.TextIOBase edges: The file-like object containing text
-        describing an :class:`.EdgeTable`.
+        describing an :class:`EdgeTable`.
     :param io.TextIOBase sites: The file-like object containing text describing a
-        :class:`.SiteTable`.
+        :class:`SiteTable`.
     :param io.TextIOBase mutations: The file-like object containing text
         describing a :class:`MutationTable`.
     :param io.TextIOBase individuals: The file-like object containing text
@@ -2106,15 +2107,15 @@ class TreeSequence(object):
     A single tree sequence, as defined by the :ref:`data model <sec_data_model>`.
     A TreeSequence instance can be created from a set of
     :ref:`tables <sec_table_definitions>` using
-    :meth:`.TableCollection.tree_sequence`; or loaded from a set of text files
-    using :func:`.load_text`; or, loaded from a native binary file using
-    :func:`load`.
+    :meth:`TableCollection.tree_sequence`, or loaded from a set of text files
+    using :func:`tskit.load_text`, or loaded from a native binary file using
+    :func:`tskit.load`.
 
     TreeSequences are immutable. To change the data held in a particular
-    tree sequence, first get the table information as a :class:`.TableCollection`
+    tree sequence, first get the table information as a :class:`TableCollection`
     instance (using :meth:`.dump_tables`), edit those tables using the
     :ref:`tables api <sec_tables_api>`, and create a new tree sequence using
-    :meth:`.TableCollection.tree_sequence`.
+    :meth:`TableCollection.tree_sequence`.
 
     The :meth:`.trees` method iterates over all trees in a tree sequence, and
     the :meth:`.variants` method iterates over all sites and their genotypes.
@@ -2133,7 +2134,7 @@ class TreeSequence(object):
     def aslist(self):
         """
         Returns the trees in this tree sequence as a list. Each tree is
-        represented by a different instance of :class:`.Tree`. As such, this
+        represented by a different instance of :class:`Tree`. As such, this
         method is inefficient and may use a large amount of memory, and should
         not be used when performance is a consideration. The :meth:`.trees`
         method is the recommended way to efficiently iterate over the trees
@@ -2182,7 +2183,7 @@ class TreeSequence(object):
             updated, please use the :meth:`.dump_tables` method instead as
             this will always return a new copy of the TableCollection.
 
-        :return: A :class:`.TableCollection` containing all a copy of the
+        :return: A :class:`TableCollection` containing all a copy of the
             tables underlying this tree sequence.
         :rtype: TableCollection
         """
@@ -2192,7 +2193,7 @@ class TreeSequence(object):
         """
         A copy of the tables defining this tree sequence.
 
-        :return: A :class:`.TableCollection` containing all tables underlying
+        :return: A :class:`TableCollection` containing all tables underlying
             the tree sequence.
         :rtype: TableCollection
         """
@@ -2532,7 +2533,7 @@ class TreeSequence(object):
         Migrations are returned in nondecreasing order of the ``time`` value.
 
         :return: An iterator over all migrations.
-        :rtype: :class:`collections.abc.Iterable`, :class:`.Migration`
+        :rtype: :class:`collections.abc.Iterable`, :class:`Migration`
         """
         for j in range(self._ll_tree_sequence.get_num_migrations()):
             yield Migration(*self._ll_tree_sequence.get_migration(j))
@@ -2543,7 +2544,7 @@ class TreeSequence(object):
         :ref:`individuals <sec_individual_table_definition>` in this tree sequence.
 
         :return: An iterator over all individuals.
-        :rtype: :class:`collections.abc.Iterable`, :class:`.Individual`
+        :rtype: :class:`collections.abc.Iterable`, :class:`Individual`
         """
         for j in range(self.num_individuals):
             yield self.individual(j)
@@ -2554,7 +2555,7 @@ class TreeSequence(object):
         in this tree sequence.
 
         :return: An iterator over all nodes.
-        :rtype: :class:`collections.abc.Iterable`, :class:`.Node`
+        :rtype: :class:`collections.abc.Iterable`, :class:`Node`
         """
         for j in range(self.num_nodes):
             yield self.node(j)
@@ -2570,7 +2571,7 @@ class TreeSequence(object):
         are sorted first by child ID and then by left coordinate.
 
         :return: An iterator over all edges.
-        :rtype: :class:`collections.abc.Iterable`, :class:`.Edge`
+        :rtype: :class:`collections.abc.Iterable`, :class:`Edge`
         """
         for j in range(self.num_edges):
             yield self.edge(j)
@@ -2639,7 +2640,7 @@ class TreeSequence(object):
         the available fields for each site.
 
         :return: An iterator over all sites.
-        :rtype: iter(:class:`.Site`)
+        :rtype: iter(:class:`Site`)
         """
         for j in range(self.num_sites):
             yield self.site(j)
@@ -2660,7 +2661,7 @@ class TreeSequence(object):
             >>>         yield mutation
 
         :return: An iterator over all mutations in this tree sequence.
-        :rtype: iter(:class:`.Mutation`)
+        :rtype: iter(:class:`Mutation`)
         """
         for site in self.sites():
             for mutation in site.mutations:
@@ -2672,7 +2673,7 @@ class TreeSequence(object):
         :ref:`populations <sec_population_table_definition>` in this tree sequence.
 
         :return: An iterator over all populations.
-        :rtype: iter(:class:`.Population`)
+        :rtype: iter(:class:`Population`)
         """
         for j in range(self.num_populations):
             yield self.population(j)
@@ -2683,7 +2684,7 @@ class TreeSequence(object):
         :ref:`provenances <sec_provenance_table_definition>` in this tree sequence.
 
         :return: An iterator over all provenances.
-        :rtype: iter(:class:`.Provenance`)
+        :rtype: iter(:class:`Provenance`)
         """
         for j in range(self.num_provenances):
             yield self.provenance(j)
@@ -2716,9 +2717,9 @@ class TreeSequence(object):
         """
         Returns the tree covering the specified genomic location. The returned tree
         will have ``tree.interval[0]`` <= ``position`` < ``tree.interval[1]``.
-        See also :meth:`.Tree.seek`.
+        See also :meth:`Tree.seek`.
 
-        :return: A new instance of :class:`.Tree` positioned to cover the specified
+        :return: A new instance of :class:`Tree` positioned to cover the specified
             position.
         :rtype: Tree
         """
@@ -2728,9 +2729,9 @@ class TreeSequence(object):
 
     def at_index(self, index):
         """
-        Returns the tree at the specified index. See also :meth:`.Tree.seek_index`.
+        Returns the tree at the specified index. See also :meth:`Tree.seek_index`.
 
-        :return: A new instance of :class:`.Tree` positioned at the specified index.
+        :return: A new instance of :class:`Tree` positioned at the specified index.
         :rtype: Tree
         """
         tree = Tree(self)
@@ -2739,11 +2740,11 @@ class TreeSequence(object):
 
     def first(self):
         """
-        Returns the first tree in this :class:`.TreeSequence`. To iterate over all
+        Returns the first tree in this :class:`TreeSequence`. To iterate over all
         trees in the sequence, use the :meth:`.trees` method.
 
         :return: The first tree in this tree sequence.
-        :rtype: :class:`.Tree`.
+        :rtype: :class:`Tree`.
         """
         tree = Tree(self)
         tree.first()
@@ -2751,11 +2752,11 @@ class TreeSequence(object):
 
     def last(self):
         """
-        Returns the last tree in this :class:`.TreeSequence`. To iterate over all
+        Returns the last tree in this :class:`TreeSequence`. To iterate over all
         trees in the sequence, use the :meth:`.trees` method.
 
         :return: The last tree in this tree sequence.
-        :rtype: :class:`.Tree`.
+        :rtype: :class:`Tree`.
         """
         tree = Tree(self)
         tree.last()
@@ -2766,12 +2767,12 @@ class TreeSequence(object):
             tracked_leaves=None, leaf_counts=None, leaf_lists=None):
         """
         Returns an iterator over the trees in this tree sequence. Each value
-        returned in this iterator is an instance of :class:`.Tree`. Upon
+        returned in this iterator is an instance of :class:`Tree`. Upon
         successful termination of the iterator, the tree will be in the
         "cleared" null state.
 
         The ``sample_counts``, ``sample_lists`` and ``tracked_samples``
-        parameters are passed to the :class:`.Tree` constructor, and control
+        parameters are passed to the :class:`Tree` constructor, and control
         the options that are set in the returned tree instance.
 
         :warning: Do not store the results of this iterator in a list!
@@ -2781,13 +2782,13 @@ class TreeSequence(object):
            please use ``ts.aslist()`` instead.
 
         :param list tracked_samples: The list of samples to be tracked and
-            counted using the :meth:`.Tree.num_tracked_samples` method.
+            counted using the :meth:`Tree.num_tracked_samples` method.
         :param bool sample_counts: If True, support constant time sample counts
-            via the :meth:`.Tree.num_samples` and
-            :meth:`.Tree.num_tracked_samples` methods.
+            via the :meth:`Tree.num_samples` and
+            :meth:`Tree.num_tracked_samples` methods.
         :param bool sample_lists: If True, provide more efficient access
             to the samples beneath a give node using the
-            :meth:`.Tree.samples` method.
+            :meth:`Tree.samples` method.
         :return: An iterator over the sparse trees in this tree sequence.
         :rtype: collections.abc.Iterable
         """
@@ -2867,7 +2868,7 @@ class TreeSequence(object):
         If :ref:`missing data<sec_data_model_missing_data>` is present
         at a given site, the genotypes array will contain a special value
         ``tskit.MISSING_DATA`` (-1) to identify these missing samples.
-        See the :class:`.Variant` class for more details on how missing
+        See the :class:`Variant` class for more details on how missing
         data is reported.
 
         Missing data is reported by default, but if ``impute_missing_data``
@@ -2948,7 +2949,7 @@ class TreeSequence(object):
         Returns the :ref:`individual <sec_individual_table_definition>`
         in this tree sequence with the specified ID.
 
-        :rtype: :class:`.Individual`
+        :rtype: :class:`Individual`
         """
         flags, location, metadata, nodes = self._ll_tree_sequence.get_individual(id_)
         return Individual(
@@ -2959,7 +2960,7 @@ class TreeSequence(object):
         Returns the :ref:`node <sec_node_table_definition>` in this tree sequence
         with the specified ID.
 
-        :rtype: :class:`.Node`
+        :rtype: :class:`Node`
         """
         (flags, time, population, individual,
          metadata) = self._ll_tree_sequence.get_node(id_)
@@ -2972,7 +2973,7 @@ class TreeSequence(object):
         Returns the :ref:`edge <sec_edge_table_definition>` in this tree sequence
         with the specified ID.
 
-        :rtype: :class:`.Edge`
+        :rtype: :class:`Edge`
         """
         (left, right, parent, child) = self._ll_tree_sequence.get_edge(id_)
         return Edge(id_=id_, left=left, right=right, parent=parent, child=child)
@@ -2982,7 +2983,7 @@ class TreeSequence(object):
         Returns the :ref:`mutation <sec_mutation_table_definition>` in this tree sequence
         with the specified ID.
 
-        :rtype: :class:`.Mutation`
+        :rtype: :class:`Mutation`
         """
         ll_mut = self._ll_tree_sequence.get_mutation(id_)
         return Mutation(
@@ -2994,7 +2995,7 @@ class TreeSequence(object):
         Returns the :ref:`site <sec_site_table_definition>` in this tree sequence
         with the specified ID.
 
-        :rtype: :class:`.Site`
+        :rtype: :class:`Site`
         """
         ll_site = self._ll_tree_sequence.get_site(id_)
         pos, ancestral_state, ll_mutations, _, metadata = ll_site
@@ -3008,7 +3009,7 @@ class TreeSequence(object):
         Returns the :ref:`population <sec_population_table_definition>`
         in this tree sequence with the specified ID.
 
-        :rtype: :class:`.Population`
+        :rtype: :class:`Population`
         """
         metadata, = self._ll_tree_sequence.get_population(id_)
         return Population(id_=id_, metadata=metadata)


### PR DESCRIPTION
Some weird undocumented behaviour in sphinx means that `:attr:` doesn't work the same as `:meth:`, so while we can refer to

```:meth:`.TreeSequence.simplify` ```

we can't simply do ```:attr:`.TreeSequence.num_sites` ```

instead, we have to fully cite the path, e.g. 

```:attr:`tskit.TreeSequence.num_sites` ```

This leads to a load of sphinx warnings like `BDI/tskit/python/tskit/trees.py:docstring of tskit.Tree.seek:8: WARNING: py:attr reference target not found: TreeSequence.sequence_length`, and means that in the current docs, some links aren't working, e.g. see the broken link at https://tskit.readthedocs.io/en/latest/python-api.html#tskit.Tree.seek .

My suggestion to correct this is to use `.. currentmodule:: tskit` at the top of all relevant .rst files, which means we can then switch, and (optionally) drop the leading `.` from both method and attribute names. 

A further implication of the undocumented behaviour is that *within* a class such as `Tree`, we can't simply refer to attributes as ```:attr:`.num_roots` ```, but still have to qualify it as ```:attr:`tskit.Tree.num_roots` ```, or, with the `currentmodule` addition, simply ```:attr:`Tree.num_roots` ```. Since this is documentation *within* the Tree class, it looks weird to refer to **`Tree.num_roots`** written out in full in the docs for that class, and so I've used the sphinx tilde shortcut to remove the `Tree` prefix in these cases (i.e. ```:attr:`~Tree.num_roots` ```)

This PR implements the above changes in the files that cause the warnings, and means that we no longer get any warning output. For consistency, I've removed the (now optional) `.` that prefixes the class names too. However, I haven't done this for all the .py files, as it would be rather a large change - it's only been done in trees.py. If the approach is deemed correct, I suggest that I add the `currentmodule` directive to all the `.rst` files and remove the `.` prefix from the remaining python docstrings in tskit.