### PR TITLE
First pass at basic cli docs

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,11 @@
+.. currentmodule:: tskit
+.. _sec_cli:
+
+======================
+Command line interface
+======================
+
+.. argparse::
+    :module: tskit.cli
+    :func: get_tskit_parser
+    :prog: python3 -m tskit

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'breathe',
+    'sphinxarg.ext',
     'sphinx_issues',
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to tskit's documentation!
    python-api
    stats
    c-api
+   cli
    data-model
    provenance
    development

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -234,6 +234,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.human, True)
 
+    @unittest.skip("fasta output temporarily disabled")
     def test_fasta_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
@@ -242,6 +243,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.wrap, 60)
 
+    @unittest.skip("fasta output temporarily disabled")
     def test_fasta_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
@@ -251,6 +253,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.wrap, 100)
 
+    @unittest.skip("fasta output temporarily disabled")
     def test_fasta_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
@@ -471,6 +474,7 @@ class TestTskitConversionOutput(unittest.TestCase):
             fasta = f.read()
         self.assertEqual(output_fasta, fasta)
 
+    @unittest.skip("fasta output temporarily disabled")
     def test_fasta(self):
         cmd = "fasta"
         stdout, stderr = capture_output(cli.tskit_main, [cmd, self._tree_sequence_file])

--- a/python/tskit/cli.py
+++ b/python/tskit/cli.py
@@ -152,6 +152,7 @@ def add_precision_argument(parser):
 
 def get_tskit_parser():
     top_parser = argparse.ArgumentParser(
+        prog="python3 -m tskit",
         description="Command line interface for tskit.")
     top_parser.add_argument(
         "-V", "--version", action='version',
@@ -186,18 +187,15 @@ def get_tskit_parser():
         "--remove-duplicate-positions", "-d", action="store_true", default=False,
         help="Remove any duplicated mutation positions in the source file. ")
     parser.set_defaults(runner=run_upgrade)
-
-    parser = subparsers.add_parser(
-        "fasta",
-        # help="Convert the tree sequence haplotypes to fasta format")
-        # suppress fasta visibility pending https://github.com/tskit-dev/tskit/issues/353
-        help=argparse.SUPPRESS)
-    add_tree_sequence_argument(parser)
-    parser.add_argument(
-        "--wrap", "-w", type=int, default=60,
-        help=("line-wrapping width for printed sequences"))
-    parser.set_defaults(runner=run_fasta)
-
+    # suppress fasta visibility pending https://github.com/tskit-dev/tskit/issues/353
+    # parser = subparsers.add_parser(
+    #    "fasta",
+    #     help="Convert the tree sequence haplotypes to fasta format")
+    # add_tree_sequence_argument(parser)
+    # parser.add_argument(
+    #     "--wrap", "-w", type=int, default=60,
+    #     help=("line-wrapping width for printed sequences"))
+    # parser.set_defaults(runner=run_fasta)
     parser = subparsers.add_parser(
         "vcf",
         help="Convert the tree sequence genotypes to VCF format.")


### PR DESCRIPTION
This is not at all hand-crafted, and therefore a bit confusing, but at least it's something. (Partially) fixes #160

Note that due to a bug in sphinx-argparse (which I've submitted a PR to), we have to comment out the entire cli subparser for FASTA output if we want to remove it from the CLI documentation. I've done this on the assumption that no-one is currently using FASTA output via the CLI anyway.