### PR TITLE
Remove more nitpick exclusions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,22 +290,12 @@ nitpick_ignore = [
     ("c:type", "bool"),
     # TODO these have been triaged here to make the docs compile, but we should
     # sort them out properly. https://github.com/tskit-dev/tskit/issues/336
-    ("py:class", "ndarray"),
-    ("py:class", "numpy array"),
-    ("py:class", "numpy.ndarray"),
-    ("py:class", "numpy.array"),
+    ("py:class", "array_like"),
     ("py:class", "array-like"),
-    ("py:class", "np.uint32"),
-    ("py:class", "np.float64"),
-    ("py:class", "np.int32"),
-    ("py:class", "np.int8"),
     ("py:class", "dtype=np.uint32"),
     ("py:class", "dtype=np.uint32."),
     ("py:class", "dtype=np.int32"),
     ("py:class", "dtype=np.int8"),
     ("py:class", "dtype=np.float64"),
     ("py:class", "dtype=np.int64"),
-    ("py:class", "array"),
-    ("py:class", "array_like"),
-    ("py:class", ""),
 ]

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1588,7 +1588,7 @@ class TableCollection(object):
             in the output. (Default: False)
         :return: A numpy array mapping node IDs in the input tables to their
             corresponding node IDs in the output tables.
-        :rtype: numpy array (dtype=np.int32).
+        :rtype: numpy.ndarray (dtype=np.int32)
         """
         if filter_zero_mutation_sites is not None:
             # Deprecated in 0.6.1.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2705,7 +2705,7 @@ class TreeSequence(object):
 
         :param bool as_array: If True, return the breakpoints as a numpy array.
         :return: The breakpoints defined by the tree intervals along the sequence.
-        :rtype: collections.abc.Iterable or array
+        :rtype: collections.abc.Iterable or numpy.ndarray
         """
         breakpoints = self.ll_tree_sequence.get_breakpoints()
         if not as_array:
@@ -3304,7 +3304,7 @@ class TreeSequence(object):
             a tuple consisting of the simplified tree sequence and a numpy array
             mapping source node IDs to their corresponding IDs in the new tree
             sequence.
-        :rtype: .TreeSequence or (.TreeSequence, numpy.array)
+        :rtype: .TreeSequence or (.TreeSequence, numpy.ndarray)
         """
         tables = self.dump_tables()
         if samples is None:
@@ -3511,8 +3511,8 @@ class TreeSequence(object):
             unaffected by parts of the tree sequence ancestral to none or all
             of the samples, respectively.
 
-        :param ndarray W: An array of values with one row for each sample and one column
-            for each weight.
+        :param numpy.ndarray W: An array of values with one row for each sample and one
+            column for each weight.
         :param f: A function that takes a one-dimensional array of length
             equal to the number of columns of ``W`` and returns a one-dimensional
             array.
@@ -3901,8 +3901,8 @@ class TreeSequence(object):
             For each node, the squared covariance between the property of
             inheriting from this node and phenotypes, computed as in "branch".
 
-        :param ndarray W: An array of values with one row for each sample and one column
-            for each "phenotype".
+        :param numpy.ndarray W: An array of values with one row for each sample and one
+            column for each "phenotype".
         :param list windows: An increasing list of breakpoints between the windows
             to compute the statistic in.
         :param str mode: A string giving the "type" of the statistic to be computed
@@ -3959,8 +3959,9 @@ class TreeSequence(object):
         Note that above we divide by the **sample** variance, which for a
         vector x of length n is ``np.var(x) * n / (n-1)``.
 
-        :param ndarray W: An array of values with one row for each sample and one column
-            for each "phenotype". Each column must have positive standard deviation.
+        :param numpy.ndarray W: An array of values with one row for each sample and one
+            column for each "phenotype". Each column must have positive standard
+            deviation.
         :param list windows: An increasing list of breakpoints between the windows
             to compute the statistic in.
         :param str mode: A string giving the "type" of the statistic to be computed
@@ -4022,10 +4023,11 @@ class TreeSequence(object):
             For each node, the squared coefficient `b_1^2`, computed for the property of
             inheriting from this node, as in "branch".
 
-        :param ndarray W: An array of values with one row for each sample and one column
-            for each "phenotype".
-        :param ndarray Z: An array of values with one row for each sample and one column
-            for each "covariate", or `None`. Columns of `Z` must be linearly independent.
+        :param numpy.ndarray W: An array of values with one row for each sample and one
+            column for each "phenotype".
+        :param numpy.ndarray Z: An array of values with one row for each sample and one
+            column for each "covariate", or `None`. Columns of `Z` must be linearly
+            independent.
         :param list windows: An increasing list of breakpoints between the windows
             to compute the statistic in.
         :param str mode: A string giving the "type" of the statistic to be computed

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -75,7 +75,7 @@ def pack_bytes(data):
     :param list[bytes] data: The list of bytes values to encode.
     :return: The tuple (packed, offset) of numpy arrays representing the flattened
         input data and offsets.
-    :rtype: numpy.array (dtype=np.int8), numpy.array (dtype=np.uint32).
+    :rtype: numpy.ndarray (dtype=np.int8), numpy.ndarray (dtype=np.uint32)
     """
     n = len(data)
     offsets = np.zeros(n + 1, dtype=np.uint32)
@@ -119,7 +119,7 @@ def pack_strings(strings, encoding="utf8"):
         string encodings.
     :return: The tuple (packed, offset) of numpy arrays representing the flattened
         input data and offsets.
-    :rtype: numpy.array (dtype=np.int8), numpy.array (dtype=np.uint32).
+    :rtype: numpy.ndarray (dtype=np.int8), numpy.ndarray (dtype=np.uint32)
     """
     return pack_bytes([bytearray(s.encode(encoding)) for s in strings])
 
@@ -152,7 +152,7 @@ def pack_arrays(list_of_lists):
     :param list[list] list_of_lists: The list of numeric lists to encode.
     :return: The tuple (packed, offset) of numpy arrays representing the flattened
         input data and offsets.
-    :rtype: numpy.array (dtype=np.float64), numpy.array (dtype=np.uint32).
+    :rtype: numpy.array (dtype=np.float64), numpy.array (dtype=np.uint32)
     """
     # TODO must be possible to do this more efficiently with numpy
     n = len(list_of_lists)


### PR DESCRIPTION
By tidying up the documentation to always refer to numpy.ndarray, and never ending the :rtype: doc line with a period