### PR TITLE
Multi letter alleles (e.g. indels) in haplotypes()

### DIFF
--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -554,7 +554,14 @@ class TestHaplotypeGenerator(unittest.TestCase):
         tables = ts.tables
         tables.sites.add_row(0, "ACTG")
         tsp = tables.tree_sequence()
-        self.assertRaises(exceptions.LibraryError, list, tsp.haplotypes())
+        self.assertRaises(TypeError, list, tsp.haplotypes())
+
+    def test_nonascii_mutations(self):
+        ts = msprime.simulate(10, random_seed=2)
+        tables = ts.tables
+        tables.sites.add_row(0, chr(169))  # Copyright symbol
+        tsp = tables.tree_sequence()
+        self.assertRaises(TypeError, list, tsp.haplotypes())
 
     def test_recurrent_mutations_over_samples(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -591,12 +598,15 @@ class TestHaplotypeGenerator(unittest.TestCase):
             ts = tsutil.insert_branch_mutations(base_ts, mutations_per_branch=j)
             self.verify_tree_sequence(ts)
 
-    def test_fails_missing_data(self):
+    def test_missing_data(self):
         tables = tskit.TableCollection(1.0)
         tables.nodes.add_row(tskit.NODE_IS_SAMPLE, 0)
         tables.nodes.add_row(tskit.NODE_IS_SAMPLE, 0)
         tables.sites.add_row(0.5, "A")
         ts = tables.tree_sequence()
-        self.assertRaises(exceptions.LibraryError, list, ts.haplotypes())
+        self.assertRaises(ValueError, list, ts.haplotypes(missing_data_character="A"))
+        for c in ("-", ".", "a"):
+            h = list(ts.haplotypes(missing_data_character=c))
+            self.assertEqual(h, [c, c])
         h = list(ts.haplotypes(impute_missing_data=True))
         self.assertEqual(h, ["A", "A"])


### PR DESCRIPTION
There was discussion of this in the following PR: https://github.com/tskit-dev/tskit/pull/426. @jeromekelleher is keen not to open the multi-letter-allele can of worms, unless there is demand from users. @hyanwong thinks that (in the case of haplotype output) the semantics are reasonably clear, and being able to output haplotype strings containing indels will be needed by users quite soon.

Some of this is probably only relevant once [finite site tree sequences](https://github.com/tskit-dev/tskit/issues/146#issuecomment-559154270) have been implemented. But (IMO) if we think it is reasonable to concatenate widely spaced SNPs into a string of letters, it is also reasonable to concatenate multi-letter haplotypes from an infinite-sites TS, as long as each allele takes the same number of characters. This is what this PR does.

Also from that PR, a quick summary - do we think it useful to be able to output small indels as aligned haplotypes, e.g.

```
Sample1: .A.T.---.G.T
Sample2: .A.C.---.G.A
Sample3: .A.T.ATT.G.A
```

Note that the current code does not output the `.` between sites (an optional convention to represents non-variable regions between variants) - I put them there for clarity, and also because I think it might be a useful addition to address https://github.com/tskit-dev/tskit/issues/353#issuecomment-555930529