### PR TITLE
User specified alleles

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -16,6 +16,9 @@ In development.
   of distinct alleles supported by 8 bit genotypes has therefore dropped
   from 255 to 127, with a similar reduction for 16 bit genotypes.
 
+- Change the ``tsk_vargen_init`` method to take an extra parameter ``alleles``.
+  To keep the current behaviour, set this parameter to NULL.
+
 **New features**
 
 - Add the ``TSK_KEEP_UNARY`` option to simplify (:user:`gtsambos`). See :issue:`1`

--- a/c/dev-tools/dev-cli.c
+++ b/c/dev-tools/dev-cli.c
@@ -62,7 +62,7 @@ print_variants(tsk_treeseq_t *ts)
     tsk_variant_t* var;
 
     printf("variants (%d) \n", (int) tsk_treeseq_get_num_sites(ts));
-    ret = tsk_vargen_init(&vg, ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vg, ts, NULL, 0, NULL, 0);
     if (ret != 0) {
         fatal_library_error(ret, "tsk_vargen_alloc");
     }

--- a/c/tests/test_genotypes.c
+++ b/c/tests/test_genotypes.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 
 static void
-test_simplest_vargen_missing_data(void)
+test_simplest_missing_data(void)
 {
     const char *nodes =
         "1  0   0\n"
@@ -45,7 +45,7 @@ test_simplest_vargen_missing_data(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 1);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_vargen_next(&vargen, &var);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -57,7 +57,7 @@ test_simplest_vargen_missing_data(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_free(&vargen);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, TSK_16_BIT_GENOTYPES);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_16_BIT_GENOTYPES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_vargen_next(&vargen, &var);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -69,7 +69,7 @@ test_simplest_vargen_missing_data(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_free(&vargen);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, TSK_IMPUTE_MISSING_DATA);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_IMPUTE_MISSING_DATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_vargen_next(&vargen, &var);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -85,7 +85,172 @@ test_simplest_vargen_missing_data(void)
 }
 
 static void
-test_single_tree_vargen_char_alphabet(void)
+test_simplest_missing_data_user_alleles(void)
+{
+    const char *nodes =
+        "1  0   0\n"
+        "1  0   0\n";
+    const char *sites =
+        "0.0    A\n";
+    tsk_treeseq_t ts;
+    tsk_vargen_t vargen;
+    tsk_variant_t *var;
+    const char *alleles[] = {"A", NULL};
+    int ret;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, "", NULL, sites, NULL, NULL, NULL);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 1);
+
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, alleles, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.0);
+    CU_ASSERT_TRUE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i8[0], TSK_MISSING_DATA);
+    CU_ASSERT_EQUAL(var->genotypes.i8[1], TSK_MISSING_DATA);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tsk_vargen_free(&vargen);
+
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_16_BIT_GENOTYPES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.0);
+    CU_ASSERT_TRUE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i16[0], TSK_MISSING_DATA);
+    CU_ASSERT_EQUAL(var->genotypes.i16[1], TSK_MISSING_DATA);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tsk_vargen_free(&vargen);
+
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_IMPUTE_MISSING_DATA);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.0);
+    CU_ASSERT_FALSE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i8[0], 0);
+    CU_ASSERT_EQUAL(var->genotypes.i8[1], 0);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tsk_vargen_free(&vargen);
+
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_single_tree_user_alleles(void)
+{
+    int ret = 0;
+    const char *sites =
+        "0.0    G\n"
+        "0.125  A\n"
+        "0.25   C\n"
+        "0.5    A\n";
+    const char *mutations =
+        "0    0     T   -1\n"
+        "1    1     C   -1\n"
+        "2    0     G   -1\n"
+        "2    1     A   -1\n"
+        "2    2     T   -1\n"  // A bunch of different sample mutations
+        "3    4     T   -1\n"
+        "3    0     A   5\n"; // A back mutation from T -> A
+    tsk_treeseq_t ts;
+    tsk_vargen_t vargen;
+    tsk_variant_t *var;
+    const char *alleles[] = {"A", "C", "G", "T", NULL};
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+            sites, mutations, NULL, NULL);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, alleles, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    tsk_vargen_print_state(&vargen, _devnull);
+
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.0);
+    CU_ASSERT_EQUAL_FATAL(var->num_alleles, 4);
+    CU_ASSERT_EQUAL(var->allele_lengths[0], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[1], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[2], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[3], 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[0], "A", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[1], "C", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[2], "G", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[3], "T", 1);
+    CU_ASSERT_FALSE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i8[0], 3);
+    CU_ASSERT_EQUAL(var->genotypes.i8[1], 2);
+    CU_ASSERT_EQUAL(var->genotypes.i8[2], 2);
+    CU_ASSERT_EQUAL(var->genotypes.i8[3], 2);
+
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.125);
+    CU_ASSERT_EQUAL(var->num_alleles, 4);
+    CU_ASSERT_EQUAL(var->allele_lengths[0], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[1], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[2], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[3], 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[0], "A", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[1], "C", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[2], "G", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[3], "T", 1);
+    CU_ASSERT_FALSE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i8[0], 0);
+    CU_ASSERT_EQUAL(var->genotypes.i8[1], 1);
+    CU_ASSERT_EQUAL(var->genotypes.i8[2], 0);
+    CU_ASSERT_EQUAL(var->genotypes.i8[3], 0);
+
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.25);
+    CU_ASSERT_EQUAL(var->num_alleles, 4);
+    CU_ASSERT_EQUAL(var->allele_lengths[0], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[1], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[2], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[3], 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[0], "A", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[1], "C", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[2], "G", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[3], "T", 1);
+    CU_ASSERT_FALSE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i8[0], 2);
+    CU_ASSERT_EQUAL(var->genotypes.i8[1], 0);
+    CU_ASSERT_EQUAL(var->genotypes.i8[2], 3);
+    CU_ASSERT_EQUAL(var->genotypes.i8[3], 1);
+
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL(var->site->position, 0.5);
+    CU_ASSERT_EQUAL(var->num_alleles, 4);
+    CU_ASSERT_EQUAL(var->allele_lengths[0], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[1], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[2], 1);
+    CU_ASSERT_EQUAL(var->allele_lengths[3], 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[0], "A", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[1], "C", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[2], "G", 1);
+    CU_ASSERT_NSTRING_EQUAL(var->alleles[3], "T", 1);
+    CU_ASSERT_FALSE(var->has_missing_data);
+    CU_ASSERT_EQUAL(var->genotypes.i8[0], 0);
+    CU_ASSERT_EQUAL(var->genotypes.i8[1], 3);
+    CU_ASSERT_EQUAL(var->genotypes.i8[2], 0);
+    CU_ASSERT_EQUAL(var->genotypes.i8[3], 0);
+
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    tsk_vargen_free(&vargen);
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_single_tree_char_alphabet(void)
 {
     int ret = 0;
     const char *sites =
@@ -107,7 +272,7 @@ test_single_tree_vargen_char_alphabet(void)
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             sites, mutations, NULL, NULL);
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_vargen_next(&vargen, &var);
@@ -178,7 +343,7 @@ test_single_tree_vargen_char_alphabet(void)
 }
 
 static void
-test_single_tree_vargen_binary_alphabet(void)
+test_single_tree_binary_alphabet(void)
 {
     int ret = 0;
     tsk_treeseq_t ts;
@@ -187,7 +352,7 @@ test_single_tree_vargen_binary_alphabet(void)
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
 
@@ -236,7 +401,7 @@ test_single_tree_vargen_binary_alphabet(void)
 }
 
 static void
-test_single_tree_vargen_non_samples(void)
+test_single_tree_non_samples(void)
 {
     int ret = 0;
     tsk_treeseq_t ts;
@@ -248,11 +413,11 @@ test_single_tree_vargen_non_samples(void)
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
     /* It's an error to hand in non-samples without imputation turned on */
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUST_IMPUTE_NON_SAMPLES);
     tsk_vargen_free(&vargen);
 
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, TSK_IMPUTE_MISSING_DATA);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, TSK_IMPUTE_MISSING_DATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
 
@@ -294,10 +459,8 @@ test_single_tree_vargen_non_samples(void)
     tsk_treeseq_free(&ts);
 }
 
-
-
 static void
-test_single_tree_vargen_errors(void)
+test_single_tree_errors(void)
 {
     int ret;
     tsk_treeseq_t ts;
@@ -306,22 +469,22 @@ test_single_tree_vargen_errors(void)
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_free(&vargen);
 
     samples[0] = -1;
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_OUT_OF_BOUNDS);
     tsk_vargen_free(&vargen);
 
     samples[0] = 7;
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_OUT_OF_BOUNDS);
     tsk_vargen_free(&vargen);
 
     samples[0] = 3;
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
     tsk_vargen_free(&vargen);
 
@@ -329,7 +492,57 @@ test_single_tree_vargen_errors(void)
 }
 
 static void
-test_single_tree_vargen_subsample(void)
+test_single_tree_user_alleles_errors(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_vargen_t vargen;
+    tsk_variant_t *var;
+    int j;
+    /* The maximium number of alleles is 127. We need space for one more plus the
+     * sentinel */
+    const int max_alleles = 129;
+    const char * acct_alleles[] = {"A", "C", "G", "T", NULL};
+    const char * zero_allele[] = {"0", NULL};
+    const char * no_alleles[] = {NULL};
+    const char * many_alleles[max_alleles];
+    tsk_id_t samples[] = {0, 3};
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
+            single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+
+    /* these are 0/1 alleles */
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, acct_alleles, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_ALLELE_NOT_FOUND);
+    tsk_vargen_free(&vargen);
+
+    /* pass just the 0 allele alleles at all */
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, zero_allele, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_vargen_next(&vargen, &var);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_ALLELE_NOT_FOUND);
+    tsk_vargen_free(&vargen);
+
+    /* Empty allele list is an error */
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, no_alleles, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_ZERO_ALLELES);
+    tsk_vargen_free(&vargen);
+
+    for (j = 0; j < max_alleles; j++) {
+        many_alleles[j] = "0";
+    }
+    many_alleles[128] = NULL;
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, many_alleles, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TOO_MANY_ALLELES);
+    tsk_vargen_free(&vargen);
+
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_single_tree_subsample(void)
 {
     int ret = 0;
     tsk_treeseq_t ts;
@@ -339,7 +552,7 @@ test_single_tree_vargen_subsample(void)
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
             single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
 
@@ -380,7 +593,7 @@ test_single_tree_vargen_subsample(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Zero samples */
-    ret = tsk_vargen_init(&vargen, &ts, samples, 0, 0);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
 
@@ -418,7 +631,7 @@ test_single_tree_vargen_subsample(void)
 }
 
 static void
-test_single_tree_vargen_many_alleles(void)
+test_single_tree_many_alleles(void)
 {
     int ret = 0;
     tsk_treeseq_t ts;
@@ -452,7 +665,7 @@ test_single_tree_vargen_many_alleles(void)
             if (l == 1) {
                 options = TSK_16_BIT_GENOTYPES;
             }
-            ret = tsk_vargen_init(&vargen, &ts, NULL, 0, options);
+            ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, options);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             tsk_vargen_print_state(&vargen, _devnull);
             ret = tsk_vargen_next(&vargen, &var);
@@ -504,7 +717,7 @@ test_single_tree_inconsistent_mutations(void)
 
     for (s = 0; s < 2; s++) {
         for (f = 0; f < sizeof(options) / sizeof(*options); f++) {
-            ret = tsk_vargen_init(&vargen, &ts, samples[s], num_samples, options[f]);
+            ret = tsk_vargen_init(&vargen, &ts, samples[s], num_samples, NULL, options[f]);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             ret = tsk_vargen_next(&vargen, &var);
             CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -523,13 +736,16 @@ int
 main(int argc, char **argv)
 {
     CU_TestInfo tests[] = {
-        {"test_simplest_vargen_missing_data", test_simplest_vargen_missing_data},
-        {"test_single_tree_vargen_char_alphabet", test_single_tree_vargen_char_alphabet},
-        {"test_single_tree_vargen_binary_alphabet", test_single_tree_vargen_binary_alphabet},
-        {"test_single_tree_vargen_non_samples", test_single_tree_vargen_non_samples},
-        {"test_single_tree_vargen_errors", test_single_tree_vargen_errors},
-        {"test_single_tree_vargen_subsample", test_single_tree_vargen_subsample},
-        {"test_single_tree_vargen_many_alleles", test_single_tree_vargen_many_alleles},
+        {"test_simplest_missing_data", test_simplest_missing_data},
+        {"test_simplest_missing_data_user_alleles", test_simplest_missing_data_user_alleles},
+        {"test_single_tree_user_alleles", test_single_tree_user_alleles},
+        {"test_single_tree_char_alphabet", test_single_tree_char_alphabet},
+        {"test_single_tree_binary_alphabet", test_single_tree_binary_alphabet},
+        {"test_single_tree_non_samples", test_single_tree_non_samples},
+        {"test_single_tree_errors", test_single_tree_errors},
+        {"test_single_tree_user_alleles_errors", test_single_tree_user_alleles_errors},
+        {"test_single_tree_subsample", test_single_tree_subsample},
+        {"test_single_tree_many_alleles", test_single_tree_many_alleles},
         {"test_single_tree_inconsistent_mutations", test_single_tree_inconsistent_mutations},
         {NULL, NULL},
     };

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -432,9 +432,9 @@ verify_simplify_genotypes(tsk_treeseq_t *ts, tsk_treeseq_t *subset,
     /* tsk_treeseq_print_state(ts, stdout); */
     /* tsk_treeseq_print_state(subset, stdout); */
 
-    ret = tsk_vargen_init(&vargen, ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vargen, ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_vargen_init(&subset_vargen, subset, NULL, 0, TSK_IMPUTE_MISSING_DATA);
+    ret = tsk_vargen_init(&subset_vargen, subset, NULL, 0, NULL, TSK_IMPUTE_MISSING_DATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(m, tsk_treeseq_get_num_sites(subset));
 
@@ -1004,7 +1004,7 @@ test_simplest_non_sample_leaf_records(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 1);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     tsk_vargen_print_state(&vargen, _devnull);
     ret = tsk_vargen_next(&vargen, &var);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -1250,7 +1250,7 @@ test_simplest_back_mutations(void)
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 1);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, 0);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_vargen_next(&vargen, &var);

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -268,14 +268,8 @@ tsk_strerror_internal(int err)
         case TSK_ERR_MUTATION_PARENT_AFTER_CHILD:
             ret = "Parent mutation ID must be < current ID";
             break;
-        case TSK_ERR_TOO_MANY_ALLELES:
-            ret = "Cannot have more than 127 alleles";
-            break;
         case TSK_ERR_INCONSISTENT_MUTATIONS:
             ret = "Inconsistent mutations: state already equal to derived state";
-            break;
-        case TSK_ERR_NON_SINGLE_CHAR_MUTATION:
-            ret = "Only single char mutations supported";
             break;
         case TSK_ERR_UNSORTED_MUTATIONS:
             ret = "Mutations must be provided in non-decreasing site order";
@@ -363,10 +357,19 @@ tsk_strerror_internal(int err)
             ret = "Bad genotype value provided";
             break;
 
-        /* Missing data errors */
+        /* Genotype decoding errors */
+        case TSK_ERR_TOO_MANY_ALLELES:
+            ret = "Cannot have more than 127 alleles";
+            break;
+        case TSK_ERR_ZERO_ALLELES:
+            ret = "Must have at least one allele when specifying an allele map";
+            break;
         case TSK_ERR_MUST_IMPUTE_NON_SAMPLES:
             ret = "Cannot generate genotypes for non-samples unless missing data "
                     "imputation is enabled";
+            break;
+        case TSK_ERR_ALLELE_NOT_FOUND:
+            ret = "An allele was not found in the user-specified allele map";
             break;
 
         /* Distance metric errors */

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -180,10 +180,8 @@ of tskit.
 #define TSK_ERR_MUTATION_PARENT_DIFFERENT_SITE                      -500
 #define TSK_ERR_MUTATION_PARENT_EQUAL                               -501
 #define TSK_ERR_MUTATION_PARENT_AFTER_CHILD                         -502
-#define TSK_ERR_TOO_MANY_ALLELES                                    -503
-#define TSK_ERR_INCONSISTENT_MUTATIONS                              -504
-#define TSK_ERR_NON_SINGLE_CHAR_MUTATION                            -505
-#define TSK_ERR_UNSORTED_MUTATIONS                                  -506
+#define TSK_ERR_INCONSISTENT_MUTATIONS                              -503
+#define TSK_ERR_UNSORTED_MUTATIONS                                  -505
 
 /* Sample errors */
 #define TSK_ERR_DUPLICATE_SAMPLE                                    -600
@@ -219,8 +217,11 @@ of tskit.
 #define TSK_ERR_GENOTYPES_ALL_MISSING                              -1000
 #define TSK_ERR_BAD_GENOTYPE                                       -1001
 
-/* Missing data errors */
+/* Genotype decoding errors */
 #define TSK_ERR_MUST_IMPUTE_NON_SAMPLES                            -1100
+#define TSK_ERR_ALLELE_NOT_FOUND                                   -1101
+#define TSK_ERR_TOO_MANY_ALLELES                                   -1102
+#define TSK_ERR_ZERO_ALLELES                                       -1103
 
 /* Distance metric errors */
 #define TSK_ERR_SAMPLE_SIZE_MISMATCH                               -1200

--- a/c/tskit/genotypes.h
+++ b/c/tskit/genotypes.h
@@ -55,6 +55,8 @@ typedef struct {
     tsk_id_t *samples;
     tsk_id_t *sample_index_map;
     bool sample_index_map_allocated;
+    bool user_alleles;
+    char *user_alleles_mem;
     size_t tree_site_index;
     int finished;
     tsk_tree_t tree;
@@ -63,7 +65,8 @@ typedef struct {
 } tsk_vargen_t;
 
 int tsk_vargen_init(tsk_vargen_t *self, tsk_treeseq_t *tree_sequence,
-        tsk_id_t *samples, size_t num_samples, tsk_flags_t options);
+        tsk_id_t *samples, size_t num_samples, const char **alleles,
+        tsk_flags_t options);
 int tsk_vargen_next(tsk_vargen_t *self, tsk_variant_t **variant);
 int tsk_vargen_free(tsk_vargen_t *self);
 void tsk_vargen_print_state(tsk_vargen_t *self, FILE *out);

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -64,6 +64,8 @@ Constants
 .. autodata:: tskit.REVERSE
     :annotation: = -1
 
+.. autodata:: tskit.ALLELES_ACGT
+
 
 ++++++++++++++++++++++++
 Simple container classes

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -16,6 +16,9 @@ In development
 - Access the number of children of a node in a tree directly using
   ``tree.num_children(u)`` (:user:`hyanwong`, :pr:`436`).
 
+- User specified allele mapping for genotypes in ``variants`` and
+  ``genotype_matrix`` (:user:`jeromekelleher`, :pr:`430`).
+
 **Bugfixes**
 
 --------------------

--- a/python/tskit/__init__.py
+++ b/python/tskit/__init__.py
@@ -39,6 +39,14 @@ FORWARD = _tskit.FORWARD
 #: decreasing genomic coordinate values).
 REVERSE = _tskit.REVERSE
 
+#: The allele mapping where the strings "0" and "1" map to genotype
+#: values 0 and 1.
+ALLELES_01 = ("0", "1")
+
+#: The allele mapping where the four nucleotides A, C, G and T map to
+#: the genotype integers 0, 1, 2, and 3, respectively.
+ALLELES_ACGT = ("A", "C", "G", "T")
+
 from tskit.provenance import __version__  # NOQA
 from tskit.provenance import validate_provenance  # NOQA
 from tskit.formats import *  # NOQA


### PR DESCRIPTION
This adds the ability to specify a fixed mapping for allelic values to genotypes. The motivation for this is that it can be quite annoying to have a different allele mapping for every site (especially when doing downstream things like haplotype matching). Allowing the user to specify a fixed mapping for this doesn't cover every possible situation, but it does make a very common one (fixed alphabet of ACGT) much simpler.