### PR TITLE
Add __len__ to the tree iterator

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1217,6 +1217,11 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(migration.right, 1)
             self.assertTrue(0 <= migration.node < ts.num_nodes)
 
+    def test_len_trees(self):
+        for ts in get_example_tree_sequences():
+            tree_iter = ts.trees()
+            self.assertEqual(len(tree_iter), ts.num_trees)
+
     def test_list(self):
         for ts in get_example_tree_sequences():
             tree_list = ts.aslist()

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2146,6 +2146,9 @@ class TreeIterator(object):
             raise StopIteration()
         return self.tree
 
+    def __len__(self):
+        return self.tree.tree_sequence.num_trees
+
 
 class TreeSequence(object):
     """


### PR DESCRIPTION
Trivial, but this allows me to use tqdm when iterating over trees without explictly having to specify the total, so probably worth it, unless there's good reason not to.