### PR TITLE
Simple test additions

### DIFF
--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -217,14 +217,13 @@ def naive_mean_descendants(ts, reference_sets):
     tree_iters = [ts.trees(tracked_samples=sample_set) for sample_set in reference_sets]
     for _ in range(ts.num_trees):
         trees = [next(tree_iter) for tree_iter in tree_iters]
-        left, right = trees[0].interval
-        length = right - left
+        span = trees[0].span
         for node in trees[0].nodes():
             num_samples = trees[0].num_samples(node)
             if num_samples > 0:
                 for j, tree in enumerate(trees):
-                    C[node, j] += length * tree.num_tracked_samples(node)
-                T[node] += length
+                    C[node, j] += span * tree.num_tracked_samples(node)
+                T[node] += span
     for node in range(ts.num_nodes):
         if T[node] > 0:
             C[node] /= T[node]

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -30,6 +30,7 @@ import random
 import unittest
 import warnings
 import itertools
+import inspect
 
 import numpy as np
 
@@ -2034,3 +2035,15 @@ class TestBaseTable(unittest.TestCase):
         t = tskit.BaseTable(None, None)
         with self.assertRaises(NotImplementedError):
             t.set_columns()
+
+
+class TestTableRowClasses(unittest.TestCase):
+    """
+    Test classes such as IndividualTableRow, NodeTableRow, etc
+    """
+    def test_same_order_as_add_row(self):
+        # to allow tuple unpacking, e.g. tables.edges.add_row(*edge_row)
+        ts = msprime.simulate(2)
+        for name, table in ts.tables:
+            parameter_names = tuple(inspect.signature(table.add_row).parameters)
+            self.assertEqual(parameter_names, table.row_class._fields)

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -678,7 +678,7 @@ def mean_descendants(ts, reference_sets):
     # The -1th element of ref_count is for all nodes in the reference set.
     ref_count = np.zeros((ts.num_nodes, K + 1), dtype=int)
     last_update = np.zeros(ts.num_nodes)
-    total_length = np.zeros(ts.num_nodes)
+    total_span = np.zeros(ts.num_nodes)
 
     def update_counts(edge, sign):
         # Update the counts and statistics for a given node. Before we change the
@@ -689,9 +689,9 @@ def mean_descendants(ts, reference_sets):
         while v != -1:
             if last_update[v] != left:
                 if ref_count[v, K] > 0:
-                    length = left - last_update[v]
-                    C[v] += length * ref_count[v, :K]
-                    total_length[v] += length
+                    span = left - last_update[v]
+                    C[v] += span * ref_count[v, :K]
+                    total_span[v] += span
                 last_update[v] = left
             ref_count[v] += sign * ref_count[edge.child]
             v = parent[v]
@@ -710,14 +710,14 @@ def mean_descendants(ts, reference_sets):
             update_counts(edge, +1)
 
     # Finally, add the stats for the last tree and divide by the total
-    # length that each node was an ancestor to > 0 samples.
+    # span that each node was an ancestor to > 0 samples.
     for v in range(ts.num_nodes):
         if ref_count[v, K] > 0:
-            length = ts.sequence_length - last_update[v]
-            total_length[v] += length
-            C[v] += length * ref_count[v, :K]
-        if total_length[v] != 0:
-            C[v] /= total_length[v]
+            span = ts.sequence_length - last_update[v]
+            total_span[v] += span
+            C[v] += span * ref_count[v, :K]
+        if total_span[v] != 0:
+            C[v] /= total_span[v]
     return C
 
 
@@ -765,9 +765,9 @@ def genealogical_nearest_neighbours(ts, focal, reference_sets):
                     break
                 p = parent[p]
             if p != tskit.NULL:
-                length = right - left
-                L[j] += length
-                scale = length / (total - delta)
+                span = right - left
+                L[j] += span
+                scale = span / (total - delta)
                 for k, reference_set in enumerate(reference_sets):
                     n = sample_count[p, k] - int(focal_reference_set == k)
                     A[j, k] += n * scale

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -78,7 +78,7 @@ PopulationTableRow = collections.namedtuple(
 
 ProvenanceTableRow = collections.namedtuple(
     "ProvenanceTableRow",
-    ["timestamp", "record"])
+    ["record", "timestamp"])
 
 
 def keep_with_offset(keep, data, offset):


### PR DESCRIPTION
A few things I noticed when looking through some tests. In particular, it seems neat to use tuple unpacking when messing with table rows, so that you can do e.g.

```
for edge_row in ts.tables.edges:
    new_tables.edges.add_row(*edge_row)
```

without having to remember all the add_row parameters or their order, which I always found tedious. I didn't realise you could unpack namedtuples like this. So I added it to one of the tests, as a demo to remind myself, and to keep the tests checking that this method will keep on working (it also saves a line).

I've kept the three commits separate here, as they are all different sorts of thing, but I can squash them if needed.