### PR TITLE
Add table.copy_row() function

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -510,6 +510,22 @@ class CommonTestsMixin(object):
                 self.assertEqual(copy, table)
                 table = copy
 
+    def test_copy_row(self):
+        for num_rows in [0, 10]:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
+                value = list_col.get_input(num_rows)
+                input_data[list_col.name] = value
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            table = self.table_class()
+            table.set_columns(**input_data)
+            copy = self.table_class()
+            for table_row in table:
+                copy.copy_row(table_row)
+            self.assertNotEqual(id(copy), id(table))
+            self.assertIsInstance(copy, self.table_class)
+            self.assertEqual(copy, table)
+
     def test_pickle(self):
         for num_rows in [0, 10, 100]:
             input_data = {col.name: col.get_input(num_rows) for col in self.columns}

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -1567,22 +1567,21 @@ class TestUnaryNodes(TopologyTestCase):
         tables = ts.dump_tables()
         next_node = ts.num_nodes
         node_times = {j: node.time for j, node in enumerate(ts.nodes())}
-        edges = []
+        edge_rows = []
         for e in ts.edges():
             node = ts.node(e.parent)
             t = node.time - 1e-14  # Arbitrary small value.
             next_node = len(tables.nodes)
             tables.nodes.add_row(time=t, population=node.population)
-            edges.append(tskit.Edge(
+            edge_rows.append(tskit.EdgeTableRow(
                 left=e.left, right=e.right, parent=next_node, child=e.child))
             node_times[next_node] = t
-            edges.append(tskit.Edge(
+            edge_rows.append(tskit.EdgeTableRow(
                 left=e.left, right=e.right, parent=e.parent, child=next_node))
-        edges.sort(key=lambda e: node_times[e.parent])
+        edge_rows.sort(key=lambda e: node_times[e.parent])
         tables.edges.reset()
-        for e in edges:
-            tables.edges.add_row(
-                left=e.left, right=e.right, child=e.child, parent=e.parent)
+        for edge_row in edge_rows:
+            tables.edges.copy_row(edge_row)
         ts_new = tables.tree_sequence()
         self.assertGreater(ts_new.num_edges, ts.num_edges)
         self.assert_haplotypes_equal(ts, ts_new)

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -205,6 +205,20 @@ class BaseTable(object):
         """
         raise NotImplementedError()
 
+    def copy_row(self, table_row):
+        """
+        Add a new row to this table by copying from the row object of another
+        table of the same type
+
+        :param table_row: An object of class NodeTableRow, EdgeTableRow, etc,
+            corresponding to the type of table
+        """
+        # By default we assume the order in the TableRow is the same as the
+        # parameter order in add_row, which should nearly always be the case.
+        # Using this in the base class means exceptions should be caught, if not
+        # explictly overridden e.g. with self.add_row(**table_row._asdict())
+        self.add_row(*table_row)
+
 
 class MetadataMixin(object):
     """
@@ -1329,6 +1343,11 @@ class ProvenanceTable(BaseTable):
         d["timestamp"] = packed
         d["timestamp_offset"] = offset
         self.set_columns(**d)
+
+    def copy_row(self, table_row):
+        # The ProvenanceTable stores columns in a different order to parameter
+        # order in its `add_row` method, so needs overriding here
+        self.add_row(**table_row._asdict())
 
 
 class TableCollection(object):


### PR DESCRIPTION
Perhaps slightly more convoluted than it needs to be, but the advantage is that now we check that the order of columns in any table is the same as in its `add_row` function, and have to override explicitly (and hopefully comment) if not - i.e. for the ProvenanceTable.

See e.g. comments around https://github.com/tskit-dev/tskit/pull/446#issuecomment-565308833