### PR TITLE
More flexible definition of a tree root

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -19,10 +19,25 @@ In development.
 - Change the ``tsk_vargen_init`` method to take an extra parameter ``alleles``.
   To keep the current behaviour, set this parameter to NULL.
 
+
 **New features**
 
 - Add the ``TSK_KEEP_UNARY`` option to simplify (:user:`gtsambos`). See :issue:`1`
   and :pr:`143`.
+
+- Add a ``set_root_threshold`` option to tsk_tree_t which allows us to set the
+  number of samples a node must be an ancestor of to be considered a root
+  (:pr:`462`).
+
+- Change the semantics of tsk_tree_t so that sample counts are always
+  computed, and add a new ``TSK_NO_SAMPLE_COUNTS`` option to turn this
+  off (:pr:`462`).
+
+
+**Deprecated**
+
+- The ``TSK_SAMPLE_COUNTS`` options is now ignored and  will print out a warning
+  if used (:pr:`462`).
 
 ---------------------
 [0.99.2] - 2019-03-27

--- a/c/dev-tools/dev-cli.c
+++ b/c/dev-tools/dev-cli.c
@@ -178,7 +178,7 @@ print_tree_sequence(tsk_treeseq_t *ts, int verbose)
         printf("========================\n");
         printf("trees\n");
         printf("========================\n");
-        ret = tsk_tree_init(&tree, ts, TSK_SAMPLE_COUNTS|TSK_SAMPLE_LISTS);
+        ret = tsk_tree_init(&tree, ts, TSK_SAMPLE_LISTS);
         if (ret != 0) {
             fatal_error("ERROR: %d: %s\n", ret, tsk_strerror(ret));
         }

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -683,7 +683,7 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
             sigma, TSK_STAT_BRANCH|TSK_STAT_POLARISED|TSK_STAT_SPAN_NORMALISE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_tree_init(&tree, ts, TSK_SAMPLE_COUNTS);
+    ret = tsk_tree_init(&tree, ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
     for (ret = tsk_tree_first(&tree); ret == 1; ret = tsk_tree_next(&tree)) {

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -5237,6 +5237,33 @@ test_zero_edges(void)
     tsk_treeseq_free(&tss);
 }
 
+static void
+test_sample_counts_deprecated(void)
+{
+    tsk_treeseq_t ts;
+    tsk_tree_t tree;
+    int ret;
+    FILE *f = fopen(_tmp_file_name, "w");
+    FILE *tmp = stderr;
+
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges,
+            NULL, NULL, NULL, NULL, NULL);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
+
+    stderr = f;
+    ret = tsk_tree_init(&tree, &ts, TSK_SAMPLE_COUNTS);
+    stderr = tmp;
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    CU_ASSERT_FATAL(ftell(f) > 0);
+
+    fclose(f);
+    tsk_tree_free(&tree);
+    tsk_treeseq_free(&ts);
+}
+
+
 int
 main(int argc, char **argv)
 {
@@ -5357,6 +5384,7 @@ main(int argc, char **argv)
         {"test_deduplicate_sites_multichar", test_deduplicate_sites_multichar},
         {"test_empty_tree_sequence", test_empty_tree_sequence},
         {"test_zero_edges", test_zero_edges},
+        {"test_sample_counts_deprecated", test_sample_counts_deprecated},
 
         {NULL, NULL},
     };

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -1228,6 +1228,7 @@ test_simplest_multi_root_tree(void)
     CU_ASSERT_EQUAL(tsk_tree_set_root_threshold(&t, 0), TSK_ERR_BAD_PARAM_VALUE);
     ret = tsk_tree_set_root_threshold(&t, 2);
     CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(tsk_tree_get_root_threshold(&t), 2);
 
     ret = tsk_tree_next(&t);
     CU_ASSERT_EQUAL(ret, 1);

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -80,7 +80,7 @@ to the API or ABI are introduced, i.e., the addition of a new function.
 The library patch version. Incremented when any changes not relevant to the
 to the API or ABI are introduced, i.e., internal refactors of bugfixes.
 */
-#define TSK_VERSION_PATCH   2
+#define TSK_VERSION_PATCH   3
 /** @} */
 
 /* Node flags */

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -176,7 +176,7 @@ tsk_ls_hmm_init(tsk_ls_hmm_t *self, tsk_treeseq_t *tree_sequence,
             self->alleles[l] = _zero_one_alleles;
         }
     }
-    ret = tsk_tree_init(&self->tree, self->tree_sequence, TSK_SAMPLE_COUNTS);
+    ret = tsk_tree_init(&self->tree, self->tree_sequence, 0);
     if (ret != 0) {
         goto out;
     }

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -78,13 +78,11 @@ tsk_ld_calc_init(tsk_ld_calc_t *self, tsk_treeseq_t *tree_sequence)
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
-    ret = tsk_tree_init(self->outer_tree, self->tree_sequence,
-            TSK_SAMPLE_COUNTS|TSK_SAMPLE_LISTS);
+    ret = tsk_tree_init(self->outer_tree, self->tree_sequence, TSK_SAMPLE_LISTS);
     if (ret != 0) {
         goto out;
     }
-    ret = tsk_tree_init(self->inner_tree, self->tree_sequence,
-            TSK_SAMPLE_COUNTS);
+    ret = tsk_tree_init(self->inner_tree, self->tree_sequence, 0);
     if (ret != 0) {
         goto out;
     }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3126,6 +3126,12 @@ tsk_tree_init(tsk_tree_t *self, tsk_treeseq_t *tree_sequence, tsk_flags_t option
         ret = TSK_ERR_BAD_PARAM_VALUE;
         goto out;
     }
+    if (options & TSK_SAMPLE_COUNTS) {
+        fprintf(stderr,
+            "TSK_SAMPLE_COUNTS is no longer supported. "
+            "Sample counts are tracked by default since 0.99.3, "
+            "Please use TSK_NO_SAMPLE_COUNTS to turn off sample counts.");
+    }
     num_nodes = tree_sequence->tables->nodes.num_rows;
     num_samples = tree_sequence->num_samples;
     self->num_nodes = num_nodes;

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3196,6 +3196,12 @@ out:
     return ret;
 }
 
+tsk_size_t
+tsk_tree_get_root_threshold(tsk_tree_t *self)
+{
+    return self->root_threshold;
+}
+
 int
 tsk_tree_free(tsk_tree_t *self)
 {
@@ -3348,6 +3354,7 @@ tsk_tree_copy(tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
     dest->index = self->index;
     dest->sites = self->sites;
     dest->sites_length = self->sites_length;
+    dest->root_threshold = self->root_threshold;
 
     memcpy(dest->parent, self->parent, N * sizeof(tsk_id_t));
     memcpy(dest->left_child, self->left_child, N * sizeof(tsk_id_t));

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -43,8 +43,12 @@ extern "C" {
  * Perhaps TSK_NO_SAMPLE_COUNTS, and document that this gets rid 
  * of root tracking also?
  */
-#define TSK_SAMPLE_COUNTS  (1 << 0)
-#define TSK_SAMPLE_LISTS   (1 << 1)
+/* TODO put this back in before merging, and mark it for removal at 
+ * some point. There's no harm in specifying it, since we do this by
+ * default now */
+/* #define TSK_SAMPLE_COUNTS           (1 << 0) */
+#define TSK_SAMPLE_LISTS            (1 << 1)
+#define TSK_NO_SAMPLE_COUNTS        (1 << 2)
 
 #define TSK_STAT_SITE               (1 << 0)
 #define TSK_STAT_BRANCH             (1 << 1)
@@ -150,28 +154,23 @@ typedef struct {
 
     tsk_size_t num_nodes;
     tsk_flags_t options;
+    tsk_size_t root_threshold;
     tsk_id_t *samples;
     /* TODO before documenting this should be change to interval. */
     /* Left and right physical coordinates of the tree */
     double left;
     double right;
-
-    /* FIXME The root tracking code changed after 0.99.2 to use a definition
-     * based on a number of samples threshold. This means that we are 
-     * computing the number of samples twice in most cases, which is dumb.
-     * However, it's not obvious how we should update the API to minimise
-     * code breakage, so this is a temporary workaround to give the 
-     * useful root tracking functionality.
-     */
-    tsk_id_t *root_num_samples;
-    tsk_size_t root_threshold;
-
     tsk_id_t index;
     /* These are involved in the optional sample tracking; num_samples counts
      * all samples below a give node, and num_tracked_samples counts those
-     * from a specific subset. */
+     * from a specific subset. By default sample counts are tracked and roots
+     * maintained. If TSK_NO_SAMPLE_COUNTS is specified, then neither sample
+     * counts or roots are available. */
     tsk_id_t *num_samples;
     tsk_id_t *num_tracked_samples;
+    /* TODO the only place this feature seems to be used is in the ld_calculator.
+     * when this is being replaced we should come up with a better way of doing
+     * whatever this is being used for. */
     /* All nodes that are marked during a particular transition are marked
      * with a given value. */
     uint8_t *marked;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -36,6 +36,13 @@ extern "C" {
 
 #include <tskit/tables.h>
 
+/* TODO we need to get rid of this option somehow because the root 
+ * computation is now based on computing sample counts. However,
+ * we also want to give the option of stripping away this so that 
+ * we don't compute anything other than the quintuply linked tree.
+ * Perhaps TSK_NO_SAMPLE_COUNTS, and document that this gets rid 
+ * of root tracking also?
+ */
 #define TSK_SAMPLE_COUNTS  (1 << 0)
 #define TSK_SAMPLE_LISTS   (1 << 1)
 
@@ -148,7 +155,17 @@ typedef struct {
     /* Left and right physical coordinates of the tree */
     double left;
     double right;
-    bool *above_sample;
+
+    /* FIXME The root tracking code changed after 0.99.2 to use a definition
+     * based on a number of samples threshold. This means that we are 
+     * computing the number of samples twice in most cases, which is dumb.
+     * However, it's not obvious how we should update the API to minimise
+     * code breakage, so this is a temporary workaround to give the 
+     * useful root tracking functionality.
+     */
+    tsk_id_t *root_num_samples;
+    tsk_size_t root_threshold;
+
     tsk_id_t index;
     /* These are involved in the optional sample tracking; num_samples counts
      * all samples below a give node, and num_tracked_samples counts those
@@ -351,6 +368,8 @@ int tsk_tree_clear(tsk_tree_t *self);
 
 void tsk_tree_print_state(tsk_tree_t *self, FILE *out);
 /** @} */
+
+int tsk_tree_set_root_threshold(tsk_tree_t *self, tsk_size_t root_threshold);
 
 bool tsk_tree_has_sample_lists(tsk_tree_t *self);
 bool tsk_tree_has_sample_counts(tsk_tree_t *self);

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -36,17 +36,12 @@ extern "C" {
 
 #include <tskit/tables.h>
 
-/* TODO we need to get rid of this option somehow because the root 
- * computation is now based on computing sample counts. However,
- * we also want to give the option of stripping away this so that 
- * we don't compute anything other than the quintuply linked tree.
- * Perhaps TSK_NO_SAMPLE_COUNTS, and document that this gets rid 
- * of root tracking also?
- */
-/* TODO put this back in before merging, and mark it for removal at 
- * some point. There's no harm in specifying it, since we do this by
- * default now */
-/* #define TSK_SAMPLE_COUNTS           (1 << 0) */
+/* The TSK_SAMPLE_COUNTS was removed in version 0.99.3, where 
+ * the default is now to always count samples except when 
+ * TSK_NO_SAMPLE_COUNTS is specified. This macro can be undefined
+ * at some point in the future and the option reused for something
+ * else. */
+#define TSK_SAMPLE_COUNTS           (1 << 0)
 #define TSK_SAMPLE_LISTS            (1 << 1)
 #define TSK_NO_SAMPLE_COUNTS        (1 << 2)
 

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -370,6 +370,7 @@ void tsk_tree_print_state(tsk_tree_t *self, FILE *out);
 /** @} */
 
 int tsk_tree_set_root_threshold(tsk_tree_t *self, tsk_size_t root_threshold);
+tsk_size_t tsk_tree_get_root_threshold(tsk_tree_t *self);
 
 bool tsk_tree_has_sample_lists(tsk_tree_t *self);
 bool tsk_tree_has_sample_counts(tsk_tree_t *self);

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -19,7 +19,17 @@ In development
 - User specified allele mapping for genotypes in ``variants`` and
   ``genotype_matrix`` (:user:`jeromekelleher`, :pr:`430`).
 
+- New ``root_threshold`` option for the Tree class, which allows
+  us to efficiently iterate over 'real' roots when we have
+  missing data (:user:`jeromekelleher`, :pr:`462`).
+
 **Bugfixes**
+
+**Deprecated**
+
+- The ``sample_counts`` feature has been deprecated and is now
+  ignored. Sample counts are now always computed.
+
 
 --------------------
 [0.2.3] - 2019-11-22

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -8534,6 +8534,37 @@ out:
     return ret;
 }
 
+static PyObject *
+Tree_get_root_threshold(Tree *self)
+{
+    PyObject *ret = NULL;
+
+    ret = Py_BuildValue("I",
+        (unsigned int) tsk_tree_get_root_threshold(self->tree));
+    return ret;
+}
+
+static PyObject *
+Tree_set_root_threshold(Tree *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    int err;
+    unsigned int threshold = 0;
+
+    if (!PyArg_ParseTuple(args, "I", &threshold)) {
+        goto out;
+    }
+
+    err = tsk_tree_set_root_threshold(self->tree, threshold);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
 static PyMemberDef Tree_members[] = {
     {NULL}  /* Sentinel */
 };
@@ -8617,6 +8648,12 @@ static PyMethodDef Tree_methods[] = {
     {"get_kc_distance", (PyCFunction) Tree_get_kc_distance,
             METH_VARARGS|METH_KEYWORDS,
             "Returns the KC distance between this tree and another." },
+    {"set_root_threshold", (PyCFunction) Tree_set_root_threshold,
+            METH_VARARGS,
+            "Sets the root threshold to the specified value." },
+    {"get_root_threshold", (PyCFunction) Tree_get_root_threshold,
+            METH_NOARGS,
+            "Returns the root threshold for this tree." },
 
     {NULL}  /* Sentinel */
 };

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7715,7 +7715,7 @@ Tree_init(Tree *self, PyObject *args, PyObject *kwds)
     num_nodes = tsk_treeseq_get_num_nodes(tree_sequence->tree_sequence);
     num_tracked_samples = 0;
     if (py_tracked_samples != NULL) {
-        if (!(options & TSK_SAMPLE_COUNTS)) {
+        if ((options & TSK_NO_SAMPLE_COUNTS)) {
             PyErr_SetString(PyExc_ValueError,
                 "Cannot specified tracked_samples without count_samples flag");
             goto out;
@@ -7749,7 +7749,7 @@ Tree_init(Tree *self, PyObject *args, PyObject *kwds)
         handle_library_error(err);
         goto out;
     }
-    if (!!(options & TSK_SAMPLE_COUNTS)) {
+    if (!(options & TSK_NO_SAMPLE_COUNTS)) {
         err = tsk_tree_set_tracked_samples(self->tree, num_tracked_samples,
                 tracked_samples);
         if (err != 0) {
@@ -10102,7 +10102,7 @@ PyInit__tskit(void)
     /* Node flags */
     PyModule_AddIntConstant(module, "NODE_IS_SAMPLE", TSK_NODE_IS_SAMPLE);
     /* Tree flags */
-    PyModule_AddIntConstant(module, "SAMPLE_COUNTS", TSK_SAMPLE_COUNTS);
+    PyModule_AddIntConstant(module, "NO_SAMPLE_COUNTS", TSK_NO_SAMPLE_COUNTS);
     PyModule_AddIntConstant(module, "SAMPLE_LISTS", TSK_SAMPLE_LISTS);
     /* Directions */
     PyModule_AddIntConstant(module, "FORWARD", TSK_DIR_FORWARD);

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -274,9 +274,7 @@ class PythonTreeSequence(object):
             st.left_root = samples[0]
 
         u = st.left_root
-        roots = []
         while u != -1:
-            roots.append(u)
             v = st.right_sib[u]
             if v != -1:
                 assert st.left_sib[v] == u

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2019 Tskit Developers
+# Copyright (c) 2018-2020 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@ import base64
 # TODO remove this code and refactor elsewhere.
 
 from .simplify import *  # NOQA
+from . import tsutil
 
 import tskit
 
@@ -42,11 +43,8 @@ class PythonTree(object):
         self.right_child = [tskit.NULL for _ in range(num_nodes)]
         self.left_sib = [tskit.NULL for _ in range(num_nodes)]
         self.right_sib = [tskit.NULL for _ in range(num_nodes)]
-        self.above_sample = [False for _ in range(num_nodes)]
-        self.is_sample = [False for _ in range(num_nodes)]
         self.left = 0
         self.right = 0
-        self.root = 0
         self.index = -1
         self.left_root = -1
         # We need a sites function, so this name is taken.
@@ -191,30 +189,37 @@ class PythonTree(object):
 class PythonTreeSequence(object):
     """
     A python implementation of the TreeSequence object.
+
+    TODO this class is of limited use now and should be factored out as
+    part of a drive towards more modular versions of the tests currently
+    in tests_highlevel.py.
     """
     def __init__(self, tree_sequence, breakpoints=None):
         self._tree_sequence = tree_sequence
-        self._num_samples = tree_sequence.get_num_samples()
-        self._breakpoints = breakpoints
         self._sites = []
+        # TODO this code here is expressed in terms of the low-level
+        # tree sequence for legacy reasons. It probably makes more sense
+        # to describe it in terms of the tables now if we want to have an
+        # independent implementation.
+        ll_ts = self._tree_sequence._ll_tree_sequence
 
         def make_mutation(id_):
-            site, node, derived_state, parent, metadata = tree_sequence.get_mutation(id_)
+            site, node, derived_state, parent, metadata = ll_ts.get_mutation(id_)
             return tskit.Mutation(
                 id_=id_, site=site, node=node, derived_state=derived_state,
                 parent=parent, metadata=metadata)
-        for j in range(tree_sequence.get_num_sites()):
-            pos, ancestral_state, ll_mutations, id_, metadata = tree_sequence.get_site(j)
+        for j in range(tree_sequence.num_sites):
+            pos, ancestral_state, ll_mutations, id_, metadata = ll_ts.get_site(j)
             self._sites.append(tskit.Site(
                 id_=id_, position=pos, ancestral_state=ancestral_state,
                 mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
                 metadata=metadata))
 
     def edge_diffs(self):
-        M = self._tree_sequence.get_num_edges()
-        sequence_length = self._tree_sequence.get_sequence_length()
-        edges = [tskit.Edge(*self._tree_sequence.get_edge(j), j) for j in range(M)]
-        time = [self._tree_sequence.get_node(edge.parent)[1] for edge in edges]
+        M = self._tree_sequence.num_edges
+        sequence_length = self._tree_sequence.sequence_length
+        edges = list(self._tree_sequence.edges())
+        time = [self._tree_sequence.node(edge.parent).time for edge in edges]
         in_order = sorted(range(M), key=lambda j: (
             edges[j].left, time[j], edges[j].parent, edges[j].child))
         out_order = sorted(range(M), key=lambda j: (
@@ -242,172 +247,24 @@ class PythonTreeSequence(object):
             left = right
 
     def trees(self):
-        M = self._tree_sequence.get_num_edges()
-        sequence_length = self._tree_sequence.get_sequence_length()
-        edges = [
-            tskit.Edge(*self._tree_sequence.get_edge(j), j) for j in range(M)]
-        t = [
-            self._tree_sequence.get_node(j)[1]
-            for j in range(self._tree_sequence.get_num_nodes())]
-        in_order = sorted(
-            range(M), key=lambda j: (
-                edges[j].left, t[edges[j].parent], edges[j].parent, edges[j].child))
-        out_order = sorted(
-            range(M), key=lambda j: (
-                edges[j].right, -t[edges[j].parent], -edges[j].parent, -edges[j].child))
-        j = 0
-        k = 0
-        N = self._tree_sequence.get_num_nodes()
-        st = PythonTree(N)
-
-        samples = list(self._tree_sequence.get_samples())
-        for l in range(len(samples)):
-            if l < len(samples) - 1:
-                st.right_sib[samples[l]] = samples[l + 1]
-            if l > 0:
-                st.left_sib[samples[l]] = samples[l - 1]
-            st.above_sample[samples[l]] = True
-            st.is_sample[samples[l]] = True
-
-        st.left_root = tskit.NULL
-        if len(samples) > 0:
-            st.left_root = samples[0]
-
-        u = st.left_root
-        while u != -1:
-            v = st.right_sib[u]
-            if v != -1:
-                assert st.left_sib[v] == u
-            u = v
-
-        st.left = 0
-        while j < M or st.left < sequence_length:
-            while k < M and edges[out_order[k]].right == st.left:
-                p = edges[out_order[k]].parent
-                c = edges[out_order[k]].child
-                k += 1
-
-                lsib = st.left_sib[c]
-                rsib = st.right_sib[c]
-                if lsib == tskit.NULL:
-                    st.left_child[p] = rsib
-                else:
-                    st.right_sib[lsib] = rsib
-                if rsib == tskit.NULL:
-                    st.right_child[p] = lsib
-                else:
-                    st.left_sib[rsib] = lsib
-                st.parent[c] = tskit.NULL
-                st.left_sib[c] = tskit.NULL
-                st.right_sib[c] = tskit.NULL
-
-                # If c is not above a sample then we have nothing to do as we
-                # cannot affect the status of any roots.
-                if st.above_sample[c]:
-                    # Compute the new above sample status for the nodes from
-                    # p up to root.
-                    v = p
-                    above_sample = False
-                    while v != tskit.NULL and not above_sample:
-                        above_sample = st.is_sample[v]
-                        u = st.left_child[v]
-                        while u != tskit.NULL:
-                            above_sample = above_sample or st.above_sample[u]
-                            u = st.right_sib[u]
-                        st.above_sample[v] = above_sample
-                        root = v
-                        v = st.parent[v]
-
-                    if not above_sample:
-                        # root is no longer above samples. Remove it from the root list.
-                        lroot = st.left_sib[root]
-                        rroot = st.right_sib[root]
-                        st.left_root = tskit.NULL
-                        if lroot != tskit.NULL:
-                            st.right_sib[lroot] = rroot
-                            st.left_root = lroot
-                        if rroot != tskit.NULL:
-                            st.left_sib[rroot] = lroot
-                            st.left_root = rroot
-                        st.left_sib[root] = tskit.NULL
-                        st.right_sib[root] = tskit.NULL
-
-                    # Add c to the root list.
-                    # print("Insert ", c, "into root list")
-                    if st.left_root != tskit.NULL:
-                        lroot = st.left_sib[st.left_root]
-                        if lroot != tskit.NULL:
-                            st.right_sib[lroot] = c
-                        st.left_sib[c] = lroot
-                        st.left_sib[st.left_root] = c
-                    st.right_sib[c] = st.left_root
-                    st.left_root = c
-
-            while j < M and edges[in_order[j]].left == st.left:
-                p = edges[in_order[j]].parent
-                c = edges[in_order[j]].child
-                j += 1
-
-                # print("insert ", c, "->", p)
-                st.parent[c] = p
-                u = st.right_child[p]
-                lsib = st.left_sib[c]
-                rsib = st.right_sib[c]
-                if u == tskit.NULL:
-                    st.left_child[p] = c
-                    st.left_sib[c] = tskit.NULL
-                    st.right_sib[c] = tskit.NULL
-                else:
-                    st.right_sib[u] = c
-                    st.left_sib[c] = u
-                    st.right_sib[c] = tskit.NULL
-                st.right_child[p] = c
-
-                if st.above_sample[c]:
-                    v = p
-                    above_sample = False
-                    while v != tskit.NULL and not above_sample:
-                        above_sample = st.above_sample[v]
-                        st.above_sample[v] = st.above_sample[v] or st.above_sample[c]
-                        root = v
-                        v = st.parent[v]
-                    # print("root = ", root, st.above_sample[root])
-
-                    if not above_sample:
-                        # Replace c with root in root list.
-                        # print("replacing", root, "with ", c ," in root list")
-                        if lsib != tskit.NULL:
-                            st.right_sib[lsib] = root
-                        if rsib != tskit.NULL:
-                            st.left_sib[rsib] = root
-                        st.left_sib[root] = lsib
-                        st.right_sib[root] = rsib
-                        st.left_root = root
-                    else:
-                        # Remove c from root list.
-                        # print("remove ", c ," from root list")
-                        st.left_root = tskit.NULL
-                        if lsib != tskit.NULL:
-                            st.right_sib[lsib] = rsib
-                            st.left_root = lsib
-                        if rsib != tskit.NULL:
-                            st.left_sib[rsib] = lsib
-                            st.left_root = rsib
-
-            st.right = sequence_length
-            if j < M:
-                st.right = min(st.right, edges[in_order[j]].left)
-            if k < M:
-                st.right = min(st.right, edges[out_order[k]].right)
-            assert st.left_root != tskit.NULL
-            while st.left_sib[st.left_root] != tskit.NULL:
-                st.left_root = st.left_sib[st.left_root]
-            st.index += 1
+        rtt = tsutil.RootThresholdTree(self._tree_sequence)
+        pt = PythonTree(self._tree_sequence.get_num_nodes())
+        pt.index = 0
+        for left, right in rtt.iterate():
+            pt.parent[:] = rtt.parent
+            pt.left_child[:] = rtt.left_child
+            pt.right_child[:] = rtt.right_child
+            pt.left_sib[:] = rtt.left_sib
+            pt.right_sib[:] = rtt.right_sib
+            pt.left_root = rtt.left_root
+            pt.left = left
+            pt.right = right
             # Add in all the sites
-            st.site_list = [
-                site for site in self._sites if st.left <= site.position < st.right]
-            yield st
-            st.left = st.right
+            pt.site_list = [
+                site for site in self._sites if left <= site.position < right]
+            yield pt
+            pt.index += 1
+        pt.index = -1
 
 
 class MRCACalculator(object):

--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -918,6 +918,17 @@ class LiStephensBase(object):
         ts = tsutil.jukes_cantor(ts, num_sites=10, mu=0.1, seed=10)
         self.verify(ts, tskit.ALLELES_ACGT)
 
+    @unittest.skip("Not supporting internal samples yet")
+    def test_ancestors_n_3(self):
+        ts = msprime.simulate(3, recombination_rate=2, mutation_rate=7, random_seed=2)
+        self.assertGreater(ts.num_sites, 5)
+        tables = ts.dump_tables()
+        print(tables.nodes)
+        tables.nodes.flags = np.ones_like(tables.nodes.flags)
+        print(tables.nodes)
+        ts = tables.tree_sequence()
+        self.verify(ts)
+
 
 class ForwardAlgorithmBase(LiStephensBase):
     """
@@ -949,6 +960,7 @@ class TestExactMatchViterbi(ViterbiAlgorithmBase, unittest.TestCase):
     def verify(self, ts, alleles=tskit.ALLELES_01):
         G = ts.genotype_matrix(alleles=alleles)
         H = G.T
+        # print(H)
         rho = np.zeros(ts.num_sites) + 0.1
         mu = np.zeros(ts.num_sites)
         rho[0] = 0

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -816,11 +816,13 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(t.get_num_samples(0), 1)
             self.assertRaises(RuntimeError, t.get_num_tracked_samples, 0)
             self.assertEqual(list(t.samples(0)), [0])
+            self.assertEqual(t.left_root, tskit.NULL)
 
         for t in ts.trees(sample_counts=True):
             self.assertEqual(t.get_num_samples(0), 1)
             self.assertEqual(t.get_num_tracked_samples(0), 0)
             self.assertEqual(list(t.samples(0)), [0])
+            self.assertNotEqual(t.left_root, tskit.NULL)
 
         for t in ts.trees(sample_counts=True, tracked_samples=[0]):
             self.assertEqual(t.get_num_samples(0), 1)
@@ -836,6 +838,7 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(t.get_num_samples(0), 1)
             self.assertRaises(RuntimeError, t.get_num_tracked_samples, 0)
             self.assertEqual(list(t.samples(0)), [0])
+            self.assertEqual(t.left_root, tskit.NULL)
 
         self.assertRaises(
             ValueError, ts.trees, sample_counts=False, tracked_samples=[0])

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1863,4 +1863,4 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test_tskit_version(self):
         version = _tskit.get_tskit_version()
-        self.assertEqual(version, (0, 99, 2))
+        self.assertEqual(version, (0, 99, 3))

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -1371,7 +1371,7 @@ class TestTsinferExamples(TopologyTestCase):
         28      0.00000000      200000.00000000 0       4
         """)
         ts = tskit.load_text(nodes, edges, sequence_length=200000, strict=False)
-        pts = tests.PythonTreeSequence(ts.get_ll_tree_sequence())
+        pts = tests.PythonTreeSequence(ts)
         num_trees = 0
         for t in pts.trees():
             num_trees += 1
@@ -4745,7 +4745,7 @@ class TestOneSampleRoot(unittest.TestCase, ExampleTopologyMixin):
         tree2.first()
         for interval in tree1.iterate():
             self.assertEqual(interval, tree2.interval)
-            self.assertEqual(sorted(tree1.roots()), sorted(tree2.roots))
+            self.assertEqual(tree1.roots(), tree2.roots)
             # Definition here is the set unique path ends from samples
             roots = set()
             for u in ts.samples():
@@ -4765,7 +4765,7 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
     def verify(self, ts):
         for k in range(1, 5):
             tree1 = tsutil.RootThresholdTree(ts, root_threshold=k)
-            tree2 = tskit.Tree(ts)
+            tree2 = tskit.Tree(ts, root_threshold=k)
             tree2.first()
             for interval in tree1.iterate():
                 self.assertEqual(interval, tree2.interval)
@@ -4779,6 +4779,7 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
                     if tree2.num_samples(path_end) >= k:
                         roots.add(path_end)
                 self.assertEqual(set(tree1.roots()), roots)
+                self.assertEqual(tree1.roots(), tree2.roots)
                 tree2.next()
             self.assertEqual(tree2.index, -1)
 

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -4618,48 +4618,10 @@ class TestSimpleTreeAlgorithm(unittest.TestCase):
         self.assertRaises(StopIteration, next, new_trees)
 
 
-class TestSampleLists(unittest.TestCase):
+class ExampleTopologyMixin(object):
     """
-    Tests for the sample lists algorithm.
+    Some example topologies for tests cases.
     """
-    def verify(self, ts):
-        tree1 = tsutil.LinkedTree(ts)
-        s = str(tree1)
-        self.assertIsNotNone(s)
-        trees = ts.trees(sample_lists=True)
-        for left, right in tree1.sample_lists():
-            tree2 = next(trees)
-            assert (left, right) == tree2.interval
-            for u in tree2.nodes():
-                self.assertEqual(tree1.left_sample[u], tree2.left_sample(u))
-                self.assertEqual(tree1.right_sample[u], tree2.right_sample(u))
-            for j in range(ts.num_samples):
-                self.assertEqual(tree1.next_sample[j], tree2.next_sample(j))
-        assert right == ts.sequence_length
-
-        tree1 = tsutil.LinkedTree(ts)
-        trees = ts.trees(sample_lists=False)
-        sample_index_map = ts.samples()
-        for left, right in tree1.sample_lists():
-            tree2 = next(trees)
-            for u in range(ts.num_nodes):
-                samples2 = list(tree2.samples(u))
-                samples1 = []
-                index = tree1.left_sample[u]
-                if index != tskit.NULL:
-                    self.assertEqual(
-                        sample_index_map[tree1.left_sample[u]], samples2[0])
-                    self.assertEqual(
-                        sample_index_map[tree1.right_sample[u]], samples2[-1])
-                    stop = tree1.right_sample[u]
-                    while True:
-                        assert index != -1
-                        samples1.append(sample_index_map[index])
-                        if index == stop:
-                            break
-                        index = tree1.next_sample[index]
-                self.assertEqual(samples1, samples2)
-        assert right == ts.sequence_length
 
     def test_single_coalescent_tree(self):
         ts = msprime.simulate(10, random_seed=1, length=10)
@@ -4721,6 +4683,104 @@ class TestSampleLists(unittest.TestCase):
         self.assertGreater(ts.num_trees, 3)
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         self.verify(ts)
+
+    def test_multiroot_tree(self):
+        ts = msprime.simulate(15, random_seed=10)
+        ts = tsutil.decapitate(ts, ts.num_edges // 2)
+        self.verify(ts)
+
+
+class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
+    """
+    Tests for the sample lists algorithm.
+    """
+    def verify(self, ts):
+        tree1 = tsutil.SampleListTree(ts)
+        s = str(tree1)
+        self.assertIsNotNone(s)
+        trees = ts.trees(sample_lists=True)
+        for left, right in tree1.sample_lists():
+            tree2 = next(trees)
+            assert (left, right) == tree2.interval
+            for u in tree2.nodes():
+                self.assertEqual(tree1.left_sample[u], tree2.left_sample(u))
+                self.assertEqual(tree1.right_sample[u], tree2.right_sample(u))
+            for j in range(ts.num_samples):
+                self.assertEqual(tree1.next_sample[j], tree2.next_sample(j))
+        assert right == ts.sequence_length
+
+        tree1 = tsutil.SampleListTree(ts)
+        trees = ts.trees(sample_lists=False)
+        sample_index_map = ts.samples()
+        for left, right in tree1.sample_lists():
+            tree2 = next(trees)
+            for u in range(ts.num_nodes):
+                samples2 = list(tree2.samples(u))
+                samples1 = []
+                index = tree1.left_sample[u]
+                if index != tskit.NULL:
+                    self.assertEqual(
+                        sample_index_map[tree1.left_sample[u]], samples2[0])
+                    self.assertEqual(
+                        sample_index_map[tree1.right_sample[u]], samples2[-1])
+                    stop = tree1.right_sample[u]
+                    while True:
+                        assert index != -1
+                        samples1.append(sample_index_map[index])
+                        if index == stop:
+                            break
+                        index = tree1.next_sample[index]
+                self.assertEqual(samples1, samples2)
+        assert right == ts.sequence_length
+
+
+class TestOneSampleRoot(unittest.TestCase, ExampleTopologyMixin):
+    """
+    Tests for the standard root threshold of subtending at least
+    one sample.
+    """
+    def verify(self, ts):
+        tree1 = tsutil.RootThresholdTree(ts, root_threshold=1)
+        tree2 = tskit.Tree(ts)
+        tree2.first()
+        for interval in tree1.iterate():
+            self.assertEqual(interval, tree2.interval)
+            self.assertEqual(sorted(tree1.roots()), sorted(tree2.roots))
+            # Definition here is the set unique path ends from samples
+            roots = set()
+            for u in ts.samples():
+                while u != tskit.NULL:
+                    path_end = u
+                    u = tree2.parent(u)
+                roots.add(path_end)
+            self.assertEqual(set(tree1.roots()), roots)
+            tree2.next()
+        self.assertEqual(tree2.index, -1)
+
+
+class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
+    """
+    Tests for the root criteria of subtending at least k samples.
+    """
+    def verify(self, ts):
+        for k in range(1, 5):
+            tree1 = tsutil.RootThresholdTree(ts, root_threshold=k)
+            tree2 = tskit.Tree(ts)
+            tree2.first()
+            for interval in tree1.iterate():
+                self.assertEqual(interval, tree2.interval)
+                # Definition here is the set unique path ends from samples
+                # that subtend at least k samples
+                roots = set()
+                for u in ts.samples():
+                    while u != tskit.NULL:
+                        path_end = u
+                        u = tree2.parent(u)
+                    if tree2.num_samples(path_end) >= k:
+                        roots.add(path_end)
+                self.assertEqual(set(tree1.roots()), roots)
+                tree2.next()
+            self.assertEqual(tree2.index, -1)
 
 
 class TestSquashEdges(unittest.TestCase):

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -931,7 +931,7 @@ class TopologyTestCase(unittest.TestCase):
         `(tree number, parent, number of samples)`.
         """
         k = 0
-        tss = ts.trees(sample_counts=True)
+        tss = ts.trees()
         t = next(tss)
         for j, node, nl in x:
             while k < j:
@@ -941,7 +941,7 @@ class TopologyTestCase(unittest.TestCase):
 
     def check_num_tracked_samples(self, ts, tracked_samples, x):
         k = 0
-        tss = ts.trees(sample_counts=True, tracked_samples=tracked_samples)
+        tss = ts.trees(tracked_samples=tracked_samples)
         t = next(tss)
         for j, node, nl in x:
             while k < j:
@@ -4782,22 +4782,6 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
                 self.assertEqual(tree1.roots(), tree2.roots)
                 tree2.next()
             self.assertEqual(tree2.index, -1)
-
-
-class TestNoCountSamplesRoots(unittest.TestCase, ExampleTopologyMixin):
-    """
-    If count_samples is turned off, we should always get zero roots.
-    """
-    def verify(self, ts):
-        for tree in ts.trees(sample_counts=False):
-            self.assertEqual(tree.num_roots, 0)
-            self.assertEqual(tree.roots, [])
-            self.assertEqual(tree.left_root, tskit.NULL)
-            self.assertEqual(tree.root, tskit.NULL)
-        for tree in ts.trees(sample_counts=True):
-            self.assertGreater(tree.num_roots, 0)
-            self.assertNotEqual(tree.roots, [])
-            self.assertNotEqual(tree.left_root, tskit.NULL)
 
 
 class TestSquashEdges(unittest.TestCase):

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -4784,6 +4784,22 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
             self.assertEqual(tree2.index, -1)
 
 
+class TestNoCountSamplesRoots(unittest.TestCase, ExampleTopologyMixin):
+    """
+    If count_samples is turned off, we should always get zero roots.
+    """
+    def verify(self, ts):
+        for tree in ts.trees(sample_counts=False):
+            self.assertEqual(tree.num_roots, 0)
+            self.assertEqual(tree.roots, [])
+            self.assertEqual(tree.left_root, tskit.NULL)
+            self.assertEqual(tree.root, tskit.NULL)
+        for tree in ts.trees(sample_counts=True):
+            self.assertGreater(tree.num_roots, 0)
+            self.assertNotEqual(tree.roots, [])
+            self.assertNotEqual(tree.left_root, tskit.NULL)
+
+
 class TestSquashEdges(unittest.TestCase):
     """
     Tests of the squash_edges function.

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -2752,7 +2752,7 @@ def naive_branch_allele_frequency_spectrum(
         for set_index, sample_set in enumerate(sample_sets):
             S = np.zeros(out_dim)
             trees = [
-                next(ts.trees(tracked_samples=sample_set, sample_counts=True))
+                next(ts.trees(tracked_samples=sample_set))
                 for sample_set in sample_sets]
             t = trees[0]
             while True:

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -709,7 +709,7 @@ class RootThresholdTree(object):
         self.right_child = [-1 for _ in range(num_nodes)]
         self.num_samples = [0 for _ in range(num_nodes)]
         self.left_root = -1
-        for u in tree_sequence.samples():
+        for u in tree_sequence.samples()[::-1]:
             self.num_samples[u] = 1
             if self.root_threshold == 1:
                 self.add_root(u)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -445,18 +445,13 @@ class Tree(object):
     on how efficiently access trees sequentially or obtain a list
     of individual trees in a tree sequence.
 
-    The ``sample_counts`` and ``sample_lists`` parameters control the
-    features that are enabled for this tree. If ``sample_counts``
-    is True, then it is possible to count the number of samples underneath
-    a particular node in constant time using the :meth:`num_samples`
-    method. If ``sample_lists`` is True a more efficient algorithm is
+    The ``sample_lists`` parameter controls the features that are enabled
+    for this tree. If ``sample_lists`` is True a more efficient algorithm is
     used in the :meth:`Tree.samples` method.
 
     The ``tracked_samples`` parameter can be used to efficiently count the
     number of samples in a given set that exist in a particular subtree
-    using the :meth:`Tree.num_tracked_samples` method. It is an
-    error to use the ``tracked_samples`` parameter when the ``sample_counts``
-    flag is False.
+    using the :meth:`Tree.num_tracked_samples` method.
 
     The :class:`Tree` class is a state-machine which has a state
     corresponding to each of the trees in the parent tree sequence. We
@@ -477,9 +472,7 @@ class Tree(object):
     :param TreeSequence tree_sequence: The parent tree sequence.
     :param list tracked_samples: The list of samples to be tracked and
         counted using the :meth:`Tree.num_tracked_samples` method.
-    :param bool sample_counts: If True, support constant time sample counts
-        via the :meth:`Tree.num_samples` and
-        :meth:`Tree.num_tracked_samples` methods.
+    :param bool sample_counts: Deprecated since 0.2.4.
     :param bool sample_lists: If True, provide more efficient access
         to the samples beneath a give node using the
         :meth:`Tree.samples` method.
@@ -492,13 +485,13 @@ class Tree(object):
     """
     def __init__(
             self, tree_sequence,
-            tracked_samples=None, sample_counts=True, sample_lists=False,
+            tracked_samples=None, sample_counts=None, sample_lists=False,
             root_threshold=1):
         options = 0
-        if not sample_counts:
-            options |= _tskit.NO_SAMPLE_COUNTS
-            if tracked_samples is not None:
-                raise ValueError("Cannot set tracked_samples without sample_counts")
+        if sample_counts is not None:
+            warnings.warn(
+                "The sample_counts option is not supported since 0.2.4 "
+                "and is ignored", RuntimeWarning)
         if sample_lists:
             options |= _tskit.SAMPLE_LISTS
         kwargs = {"options": options}
@@ -1413,9 +1406,7 @@ class Tree(object):
         node (including the node itself). If u is not specified return
         the total number of samples in the tree.
 
-        If the :meth:`TreeSequence.trees` method is called with
-        ``sample_counts=True`` this method is a constant time operation. If not,
-        a slower traversal based algorithm is used to count the samples.
+        This is a constant time operation.
 
         :param int u: The node of interest.
         :return: The number of samples in the subtree rooted at u.
@@ -1449,16 +1440,10 @@ class Tree(object):
         :return: The number of samples within the set of tracked samples in
             the subtree rooted at u.
         :rtype: int
-        :raises RuntimeError: if the :meth:`TreeSequence.trees`
-            method is not called with ``sample_counts=True``.
         """
         roots = [u]
         if u is None:
             roots = self.roots
-        if (self._ll_tree.get_options() & _tskit.NO_SAMPLE_COUNTS) != 0:
-            raise RuntimeError(
-                "The get_num_tracked_samples method is only supported "
-                "when sample_counts=True.")
         return sum(self._ll_tree.get_num_tracked_samples(root) for root in roots)
 
     def _preorder_traversal(self, u):
@@ -2894,7 +2879,7 @@ class TreeSequence(object):
         return tree
 
     def trees(
-            self, tracked_samples=None, sample_counts=True, sample_lists=False,
+            self, tracked_samples=None, sample_counts=None, sample_lists=False,
             tracked_leaves=None, leaf_counts=None, leaf_lists=None):
         """
         Returns an iterator over the trees in this tree sequence. Each value
@@ -2902,16 +2887,9 @@ class TreeSequence(object):
         successful termination of the iterator, the tree will be in the
         "cleared" null state.
 
-        The ``sample_counts``, ``sample_lists`` and ``tracked_samples``
-        parameters are passed to the :class:`Tree` constructor, and control
+        The ``sample_lists`` and ``tracked_samples`` parameters are passed
+        to the :class:`Tree` constructor, and control
         the options that are set in the returned tree instance.
-
-        :warning: Since version 0.3.0, if ``sample_counts`` is set to False the
-            roots of the returned trees are **not** tracked. Therefore, the list
-            returned by :meth:`Tree.roots` will always be empty and
-            :data:`Tree.root` will return :data:`tskit.NULL` (-1). It is
-            particularly important to note that the :meth:`Tree.nodes` method
-            will not return any nodes.
 
         :warning: Do not store the results of this iterator in a list!
            For performance reasons, the same underlying object is used
@@ -2921,9 +2899,7 @@ class TreeSequence(object):
 
         :param list tracked_samples: The list of samples to be tracked and
             counted using the :meth:`Tree.num_tracked_samples` method.
-        :param bool sample_counts: If True, support root tracking and
-            constant time sample counts via the :meth:`Tree.num_samples` and
-            :meth:`Tree.num_tracked_samples` methods.
+        :param bool sample_counts: Deprecated since 0.2.4.
         :param bool sample_lists: If True, provide more efficient access
             to the samples beneath a give node using the
             :meth:`Tree.samples` method.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -483,10 +483,17 @@ class Tree(object):
     :param bool sample_lists: If True, provide more efficient access
         to the samples beneath a give node using the
         :meth:`Tree.samples` method.
+    :param int root_threshold: The minimum number of samples that a node
+        must be ancestral to for it to be in the list of roots. By default
+        this is 1, so that isolated samples (representing missing data)
+        are roots. To efficiently restrict the roots of the tree to
+        those subtending meaningful topology, set this to 2. This value
+        is only relevant when trees have multiple roots.
     """
     def __init__(
             self, tree_sequence,
-            tracked_samples=None, sample_counts=True, sample_lists=False):
+            tracked_samples=None, sample_counts=True, sample_lists=False,
+            root_threshold=1):
         options = 0
         if sample_counts:
             options |= _tskit.SAMPLE_COUNTS
@@ -501,6 +508,7 @@ class Tree(object):
 
         self._tree_sequence = tree_sequence
         self._ll_tree = _tskit.Tree(tree_sequence.ll_tree_sequence, **kwargs)
+        self._ll_tree.set_root_threshold(root_threshold)
 
     def copy(self):
         """
@@ -524,6 +532,17 @@ class Tree(object):
         :rtype: :class:`TreeSequence`
         """
         return self._tree_sequence
+
+    @property
+    def root_threshold(self):
+        """
+        Returns the minimum number of samples that a node must be an ancestor
+        of to be considered a potential root.
+
+        :return: The root threshold.
+        :rtype: :class:`TreeSequence`
+        """
+        return self._ll_tree.get_root_threshold()
 
     def __eq__(self, other):
         ret = False


### PR DESCRIPTION
The roots of a tree are currently defined as the set of unique path ends starting from samples. This is unhelpful in some cases with lots of missing data and we want to get the "real" roots, which actually subtend some topology.

This makes the concept of a root more flexible, and changes it to "the set of unique path ends starting from samples, **that subtend at least k samples**". 

Still a WIP, I'll document more when the plumbing is in place.