### PR TITLE
Format Python code with black.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ jobs:
       - run:
           name: Checkout submodules
           command: |
-            git submodule update --init --recursive 
+            git submodule update --init --recursive
       - run:
           name: Install dependencies and set path
           command: |
             sudo apt-get install ninja-build libcunit1-dev valgrind clang doxygen libgsl-dev
             # Install meson to the system packages so we can run it as root
-            sudo pip install meson 
+            sudo pip install meson
             pip install --user -r python/requirements/development.txt
             pip install twine --user
             # Remove tskit installed by msprime
@@ -38,10 +38,11 @@ jobs:
           name: Lint Python
           command: |
             cd python
-            flake8 --max-line-length 89 tskit setup.py tests
+            flake8 *.py tskit/ tests/
+            black --check *.py tskit/ tests/
 
       - run:
-          name: Run Python tests 
+          name: Run Python tests
           command: |
             PYTHONPATH=python nosetests -v --with-coverage --cover-package tskit \
               --cover-branches --cover-erase --cover-xml \
@@ -50,7 +51,7 @@ jobs:
       - run:
           name: Upload Python coverage
           command: |
-            codecov -X gcov -F python_tests 
+            codecov -X gcov -F python_tests
             # Clean up reports so we don't upload them twice.
             rm -f coverage.xml
 
@@ -58,7 +59,7 @@ jobs:
             cd python
             gcov -pb -o ./build/temp.linux*/*.gcno _tskitmodule.c
             cd ..
-            codecov -X gcov -F python_c_tests 
+            codecov -X gcov -F python_c_tests
             # Clean up reports so we don't upload them twice.
             rm -f python/*.gcov
 
@@ -71,12 +72,12 @@ jobs:
             python setup.py check
             python -m twine check dist/*.tar.gz
             python -m venv venv
-            source venv/bin/activate 
+            source venv/bin/activate
             pip install --upgrade setuptools pip wheel
             python setup.py build_ext
             python setup.py egg_info
             python setup.py bdist_wheel
-            pip install dist/*.tar.gz 
+            pip install dist/*.tar.gz
             tskit --help
 
       - run:
@@ -88,8 +89,8 @@ jobs:
       - run:
           name: Compile C with clang
           command: |
-            CC=clang CXX=clang++ meson build-clang c 
-            ninja -C build-clang 
+            CC=clang CXX=clang++ meson build-clang c
+            ninja -C build-clang
 
       - run:
           name: Run C tests

--- a/python/.flake8
+++ b/python/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# Based directly on Black's recommendations:
+# https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203, E501, W503

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -1,6 +1,7 @@
 codecov
 coverage
 flake8
+black
 h5py
 newick
 nose

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,9 +14,11 @@ class local_build_ext(build_ext):
     def finalize_options(self):
         build_ext.finalize_options(self)
         import builtins
+
         # Prevent numpy from thinking it is still in its setup process:
         builtins.__NUMPY_SETUP__ = False
         import numpy
+
         self.include_dirs.append(numpy.get_include())
 
 
@@ -31,9 +33,11 @@ tsk_source_files = [
     "convert.c",
     "haplotype_matching.c",
 ]
-sources = ["_tskitmodule.c"] + [
-    os.path.join(libdir, "tskit", f) for f in tsk_source_files] + [
-    os.path.join(kastore_dir, "kastore.c")]
+sources = (
+    ["_tskitmodule.c"]
+    + [os.path.join(libdir, "tskit", f) for f in tsk_source_files]
+    + [os.path.join(kastore_dir, "kastore.c")]
+)
 
 defines = []
 libraries = []
@@ -43,7 +47,7 @@ if IS_WINDOWS:
     defines.append(("WIN32", None))
 
 _tskit_module = Extension(
-    '_tskit',
+    "_tskit",
     sources=sources,
     extra_compile_args=["-std=c99"],
     libraries=libraries,
@@ -54,7 +58,7 @@ _tskit_module = Extension(
 )
 
 here = os.path.abspath(os.path.dirname(__file__))
-with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+with codecs.open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 # After exec'ing this file we have tskit_version defined.
@@ -66,44 +70,38 @@ with open(version_file) as f:
 numpy_ver = "numpy>=1.7"
 
 setup(
-    name='tskit',
-    description='The tree sequence toolkit.',
+    name="tskit",
+    description="The tree sequence toolkit.",
     long_description=long_description,
-    url='https://github.com/tskit-dev/tskit',
-    author='tskit developers',
+    url="https://github.com/tskit-dev/tskit",
+    author="tskit developers",
     version=tskit_version,
     # TODO setup a tskit developers email address.
-    author_email='jerome.kelleher@well.ox.ac.uk',
-    python_requires='>=3.4',
+    author_email="jerome.kelleher@well.ox.ac.uk",
+    python_requires=">=3.4",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Topic :: Scientific/Engineering :: Bio-Informatics',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3 :: Only',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3 :: Only",
     ],
-    keywords='tree sequence',
-    packages=['tskit'],
+    keywords="tree sequence",
+    packages=["tskit"],
     include_package_data=True,
     ext_modules=[_tskit_module],
     install_requires=[numpy_ver, "h5py", "svgwrite", "jsonschema"],
-    entry_points={
-        'console_scripts': [
-            'tskit=tskit.cli:tskit_main',
-        ],
-    },
+    entry_points={"console_scripts": ["tskit=tskit.cli:tskit_main",],},
     project_urls={
-        'Bug Reports': 'https://github.com/tskit-dev/tskit/issues',
-        'Source': 'https://github.com/tskit-dev/tskit',
+        "Bug Reports": "https://github.com/tskit-dev/tskit/issues",
+        "Source": "https://github.com/tskit-dev/tskit",
     },
     setup_requires=[numpy_ver],
-    cmdclass={
-        'build_ext': local_build_ext
-    },
+    cmdclass={"build_ext": local_build_ext},
     license="MIT",
     platforms=["POSIX", "Windows", "MacOS X"],
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,7 +95,7 @@ setup(
     include_package_data=True,
     ext_modules=[_tskit_module],
     install_requires=[numpy_ver, "h5py", "svgwrite", "jsonschema"],
-    entry_points={"console_scripts": ["tskit=tskit.cli:tskit_main",],},
+    entry_points={"console_scripts": ["tskit=tskit.cli:tskit_main"]},
     project_urls={
         "Bug Reports": "https://github.com/tskit-dev/tskit/issues",
         "Source": "https://github.com/tskit-dev/tskit",

--- a/python/stress_lowlevel.py
+++ b/python/stress_lowlevel.py
@@ -39,10 +39,14 @@ def main():
         "haplotype_matching": test_haplotype_matching,
     }
     parser = argparse.ArgumentParser(
-        description="Run tests in a loop to stress low-level interface")
+        description="Run tests in a loop to stress low-level interface"
+    )
     parser.add_argument(
-        "-m", "--module", help="Run tests only on this module",
-        choices=list(modules.keys()))
+        "-m",
+        "--module",
+        help="Run tests only on this module",
+        choices=list(modules.keys()),
+    )
     args = parser.parse_args()
     test_modules = list(modules.values())
     if args.module is not None:
@@ -57,7 +61,7 @@ def main():
     min_rss = 1e100
     iteration = 0
     last_print = time.time()
-    devnull = open(os.devnull, 'w')
+    devnull = open(os.devnull, "w")
     while True:
         # We don't want any random variation in the amount of memory
         # used from test-to-test.
@@ -78,10 +82,18 @@ def main():
         # We don't want to flood stdout, so we rate-limit to 1 per second.
         if time.time() - last_print > 1:
             print(
-                iteration, result.testsRun, len(result.failures),
-                len(result.errors), len(result.skipped),
-                rusage.ru_maxrss, min_rss,  max_rss, max_rss_iter,
-                sep="\t", end="\r")
+                iteration,
+                result.testsRun,
+                len(result.failures),
+                len(result.errors),
+                len(result.skipped),
+                rusage.ru_maxrss,
+                min_rss,
+                max_rss,
+                max_rss_iter,
+                sep="\t",
+                end="\r",
+            )
             last_print = time.time()
             sys.stdout.flush()
 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -36,6 +36,7 @@ class PythonTree(object):
     is tightly coupled with the PythonTreeSequence object below which updates
     the internal structures during iteration.
     """
+
     def __init__(self, num_nodes):
         self.num_nodes = num_nodes
         self.parent = [tskit.NULL for _ in range(num_nodes)]
@@ -147,8 +148,10 @@ class PythonTree(object):
 
     def get_parent_dict(self):
         d = {
-            u: self.parent[u] for u in range(self.num_nodes)
-            if self.parent[u] != tskit.NULL}
+            u: self.parent[u]
+            for u in range(self.num_nodes)
+            if self.parent[u] != tskit.NULL
+        }
         return d
 
     def sites(self):
@@ -156,11 +159,12 @@ class PythonTree(object):
 
     def __eq__(self, other):
         return (
-            self.get_parent_dict() == other.get_parent_dict() and
-            self.get_interval() == other.get_interval() and
-            self.roots == other.roots and
-            self.get_index() == other.get_index() and
-            list(self.sites()) == list(other.sites()))
+            self.get_parent_dict() == other.get_parent_dict()
+            and self.get_interval() == other.get_interval()
+            and self.roots == other.roots
+            and self.get_index() == other.get_index()
+            and list(self.sites()) == list(other.sites())
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -194,6 +198,7 @@ class PythonTreeSequence(object):
     part of a drive towards more modular versions of the tests currently
     in tests_highlevel.py.
     """
+
     def __init__(self, tree_sequence, breakpoints=None):
         self._tree_sequence = tree_sequence
         self._sites = []
@@ -206,24 +211,39 @@ class PythonTreeSequence(object):
         def make_mutation(id_):
             site, node, derived_state, parent, metadata = ll_ts.get_mutation(id_)
             return tskit.Mutation(
-                id_=id_, site=site, node=node, derived_state=derived_state,
-                parent=parent, metadata=metadata)
+                id_=id_,
+                site=site,
+                node=node,
+                derived_state=derived_state,
+                parent=parent,
+                metadata=metadata,
+            )
+
         for j in range(tree_sequence.num_sites):
             pos, ancestral_state, ll_mutations, id_, metadata = ll_ts.get_site(j)
-            self._sites.append(tskit.Site(
-                id_=id_, position=pos, ancestral_state=ancestral_state,
-                mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
-                metadata=metadata))
+            self._sites.append(
+                tskit.Site(
+                    id_=id_,
+                    position=pos,
+                    ancestral_state=ancestral_state,
+                    mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
+                    metadata=metadata,
+                )
+            )
 
     def edge_diffs(self):
         M = self._tree_sequence.num_edges
         sequence_length = self._tree_sequence.sequence_length
         edges = list(self._tree_sequence.edges())
         time = [self._tree_sequence.node(edge.parent).time for edge in edges]
-        in_order = sorted(range(M), key=lambda j: (
-            edges[j].left, time[j], edges[j].parent, edges[j].child))
-        out_order = sorted(range(M), key=lambda j: (
-            edges[j].right, -time[j], -edges[j].parent, -edges[j].child))
+        in_order = sorted(
+            range(M),
+            key=lambda j: (edges[j].left, time[j], edges[j].parent, edges[j].child),
+        )
+        out_order = sorted(
+            range(M),
+            key=lambda j: (edges[j].right, -time[j], -edges[j].parent, -edges[j].child),
+        )
         j = 0
         k = 0
         left = 0.0
@@ -261,7 +281,8 @@ class PythonTreeSequence(object):
             pt.right = right
             # Add in all the sites
             pt.site_list = [
-                site for site in self._sites if left <= site.position < right]
+                site for site in self._sites if left <= site.position < right
+            ]
             yield pt
             pt.index += 1
         pt.index = -1
@@ -280,6 +301,7 @@ class MRCACalculator(object):
     :param oriented_forest: the input oriented forest
     :type oriented_forest: list of integers
     """
+
     LAMBDA = 0
 
     def __init__(self, oriented_forest):
@@ -344,10 +366,7 @@ class MRCACalculator(object):
         while p != self.LAMBDA:
             notDone = True
             while notDone:
-                a = (
-                    self.__alpha[parent[p]] |
-                    (self.__beta[p] & -self.__beta[p])
-                )
+                a = self.__alpha[parent[p]] | (self.__beta[p] & -self.__beta[p])
                 self.__alpha[p] = a
                 if child[p] != self.LAMBDA:
                     p = child[p]
@@ -404,4 +423,4 @@ def base64_encode(metadata):
     Returns the specified metadata bytes object encoded as an ASCII-safe
     string.
     """
-    return base64.b64encode(metadata).decode('utf8')
+    return base64.b64encode(metadata).decode("utf8")

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -73,6 +73,7 @@ class Segment(object):
 
     The node it records is the *output* node ID.
     """
+
     def __init__(self, left=None, right=None, node=None, next=None):
         self.left = left
         self.right = right
@@ -81,7 +82,8 @@ class Segment(object):
 
     def __str__(self):
         s = "({}-{}->{}:next={})".format(
-            self.left, self.right, self.node, repr(self.next))
+            self.left, self.right, self.node, repr(self.next)
+        )
         return s
 
     def __repr__(self):
@@ -96,9 +98,17 @@ class Simplifier(object):
     Simplifies a tree sequence to its minimal representation given a subset
     of the leaves.
     """
+
     def __init__(
-            self, ts, sample, reduce_to_site_topology=False, filter_sites=True,
-            filter_populations=True, filter_individuals=True, keep_unary=False):
+        self,
+        ts,
+        sample,
+        reduce_to_site_topology=False,
+        filter_sites=True,
+        filter_populations=True,
+        filter_individuals=True,
+        keep_unary=False,
+    ):
         self.ts = ts
         self.n = len(sample)
         self.reduce_to_site_topology = reduce_to_site_topology
@@ -143,8 +153,12 @@ class Simplifier(object):
         if is_sample:
             flags |= tskit.NODE_IS_SAMPLE
         output_id = self.tables.nodes.add_row(
-            flags=flags, time=node.time, population=node.population,
-            metadata=node.metadata, individual=node.individual)
+            flags=flags,
+            time=node.time,
+            population=node.population,
+            metadata=node.metadata,
+            individual=node.individual,
+        )
         self.node_id_map[input_id] = output_id
         return output_id
 
@@ -166,7 +180,9 @@ class Simplifier(object):
         num_edges = 0
         for child in sorted(self.edge_buffer.keys()):
             for edge in self.edge_buffer[child]:
-                self.tables.edges.add_row(edge.left, edge.right, edge.parent, edge.child)
+                self.tables.edges.add_row(
+                    edge.left, edge.right, edge.parent, edge.child
+                )
                 num_edges += 1
         self.edge_buffer.clear()
         return num_edges
@@ -298,7 +314,9 @@ class Simplifier(object):
             x = self.A_head[edge.child]
             while x is not None:
                 if x.right > edge.left and edge.right > x.left:
-                    y = Segment(max(x.left, edge.left), min(x.right, edge.right), x.node)
+                    y = Segment(
+                        max(x.left, edge.left), min(x.right, edge.right), x.node
+                    )
                     S.append(y)
                 x = x.next
         self.merge_labeled_ancestors(S, parent)
@@ -337,10 +355,13 @@ class Simplifier(object):
                             node=self.mutation_node_map[mut.id],
                             parent=mapped_parent,
                             derived_state=mut.derived_state,
-                            metadata=mut.metadata)
+                            metadata=mut.metadata,
+                        )
                 self.tables.sites.add_row(
-                    position=site.position, ancestral_state=site.ancestral_state,
-                    metadata=site.metadata)
+                    position=site.position,
+                    ancestral_state=site.ancestral_state,
+                    metadata=site.metadata,
+                )
 
     def map_mutation_nodes(self):
         for input_node in range(len(self.mutation_map)):
@@ -392,7 +413,8 @@ class Simplifier(object):
             if count > 0:
                 row = input_individuals[input_id]
                 output_id = self.tables.individuals.add_row(
-                    flags=row.flags, location=row.location, metadata=row.metadata)
+                    flags=row.flags, location=row.location, metadata=row.metadata
+                )
                 individual_id_map[input_id] = output_id
 
         # Remap the population ID references for nodes.
@@ -403,7 +425,8 @@ class Simplifier(object):
             metadata=nodes.metadata,
             metadata_offset=nodes.metadata_offset,
             individual=individual_id_map[nodes.individual],
-            population=population_id_map[nodes.population])
+            population=population_id_map[nodes.population],
+        )
 
         # We don't support migrations for now. We'll need to remap these as well.
         assert self.ts.num_migrations == 0
@@ -492,7 +515,9 @@ class AncestorMap(object):
             x = self.A_head[edge.child]
             while x is not None:
                 if x.right > edge.left and edge.right > x.left:
-                    y = Segment(max(x.left, edge.left), min(x.right, edge.right), x.node)
+                    y = Segment(
+                        max(x.left, edge.left), min(x.right, edge.right), x.node
+                    )
                     S.append(y)
                 x = x.next
         self.merge_labeled_ancestors(S, parent)
@@ -619,15 +644,15 @@ class AncestorMap(object):
 if __name__ == "__main__":
     # Simple CLI for running simplifier/ancestor mapping above.
     class_to_implement = sys.argv[1]
-    assert class_to_implement == 'Simplifier' or class_to_implement == 'AncestorMap'
+    assert class_to_implement == "Simplifier" or class_to_implement == "AncestorMap"
     ts = tskit.load(sys.argv[2])
 
-    if class_to_implement == 'Simplifier':
+    if class_to_implement == "Simplifier":
 
         samples = list(map(int, sys.argv[3:]))
 
         # When keep_unary = True
-        print('When keep_unary = True:')
+        print("When keep_unary = True:")
         s = Simplifier(ts, samples, keep_unary=True)
         # s.print_state()
         tss, _ = s.simplify()
@@ -638,7 +663,7 @@ if __name__ == "__main__":
         print(tables.mutations)
 
         # When keep_unary = False
-        print('\nWhen keep_unary = False:')
+        print("\nWhen keep_unary = False:")
         s = Simplifier(ts, samples, keep_unary=False)
         # s.print_state()
         tss, _ = s.simplify()
@@ -648,7 +673,7 @@ if __name__ == "__main__":
         print(tables.sites)
         print(tables.mutations)
 
-    elif class_to_implement == 'AncestorMap':
+    elif class_to_implement == "AncestorMap":
 
         samples = sys.argv[3]
         samples = samples.split(",")

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -73,6 +73,7 @@ class TestCli(unittest.TestCase):
     """
     Superclass of tests for the CLI needing temp files.
     """
+
     def setUp(self):
         fd, self.temp_file = tempfile.mkstemp(prefix="tsk_cli_testcase_")
         os.close(fd)
@@ -106,8 +107,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "individuals"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--precision", "5"])
+        args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.precision, 5)
 
@@ -131,8 +131,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "nodes"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--precision", "5"])
+        args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.precision, 5)
 
@@ -156,8 +155,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "edges"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--precision", "5"])
+        args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.precision, 5)
 
@@ -181,8 +179,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "sites"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--precision", "5"])
+        args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.precision, 5)
 
@@ -248,8 +245,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "-w", "100"])
+        args = parser.parse_args([cmd, tree_sequence, "-w", "100"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.wrap, 100)
 
@@ -258,8 +254,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--wrap", "50"])
+        args = parser.parse_args([cmd, tree_sequence, "--wrap", "50"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.wrap, 50)
 
@@ -275,8 +270,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "vcf"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "-P", "2"])
+        args = parser.parse_args([cmd, tree_sequence, "-P", "2"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.ploidy, 2)
 
@@ -284,8 +278,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "vcf"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--ploidy", "5"])
+        args = parser.parse_args([cmd, tree_sequence, "--ploidy", "5"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.ploidy, 5)
 
@@ -335,8 +328,7 @@ class TestTskitArgumentParser(unittest.TestCase):
         parser = cli.get_tskit_parser()
         cmd = "trees"
         tree_sequence = "test.trees"
-        args = parser.parse_args([
-            cmd, tree_sequence, "--precision", "5", "--draw"])
+        args = parser.parse_args([cmd, tree_sequence, "--precision", "5", "--draw"])
         self.assertEqual(args.tree_sequence, tree_sequence)
         self.assertEqual(args.precision, 5)
         self.assertEqual(args.draw, True)
@@ -346,17 +338,25 @@ class TestTskitConversionOutput(unittest.TestCase):
     """
     Tests the output of msp to ensure it's correct.
     """
+
     @classmethod
     def setUpClass(cls):
         ts = msprime.simulate(
-            length=1, recombination_rate=2, mutation_rate=2, random_seed=1,
+            length=1,
+            recombination_rate=2,
+            mutation_rate=2,
+            random_seed=1,
             migration_matrix=[[0, 1], [1, 0]],
             population_configurations=[
-                msprime.PopulationConfiguration(5) for _ in range(2)],
-            record_migrations=True)
+                msprime.PopulationConfiguration(5) for _ in range(2)
+            ],
+            record_migrations=True,
+        )
         assert ts.num_migrations > 0
         cls._tree_sequence = tsutil.insert_random_ploidy_individuals(ts)
-        fd, cls._tree_sequence_file = tempfile.mkstemp(prefix="tsk_cli", suffix=".trees")
+        fd, cls._tree_sequence_file = tempfile.mkstemp(
+            prefix="tsk_cli", suffix=".trees"
+        )
         os.close(fd)
         cls._tree_sequence.dump(cls._tree_sequence_file)
 
@@ -374,8 +374,9 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_individuals(self):
         cmd = "individuals"
         precision = 8
-        stdout, stderr = capture_output(cli.tskit_main, [
-            cmd, self._tree_sequence_file, "-p", str(precision)])
+        stdout, stderr = capture_output(
+            cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
+        )
         self.assertEqual(len(stderr), 0)
         output_individuals = stdout.splitlines()
         self.verify_individuals(output_individuals, precision)
@@ -390,8 +391,9 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_nodes(self):
         cmd = "nodes"
         precision = 8
-        stdout, stderr = capture_output(cli.tskit_main, [
-            cmd, self._tree_sequence_file, "-p", str(precision)])
+        stdout, stderr = capture_output(
+            cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
+        )
         self.assertEqual(len(stderr), 0)
         output_nodes = stdout.splitlines()
         self.verify_nodes(output_nodes, precision)
@@ -406,8 +408,9 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_edges(self):
         cmd = "edges"
         precision = 8
-        stdout, stderr = capture_output(cli.tskit_main, [
-            cmd, self._tree_sequence_file, "-p", str(precision)])
+        stdout, stderr = capture_output(
+            cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
+        )
         self.assertEqual(len(stderr), 0)
         output_edges = stdout.splitlines()
         self.verify_edges(output_edges, precision)
@@ -422,8 +425,9 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_sites(self):
         cmd = "sites"
         precision = 8
-        stdout, stderr = capture_output(cli.tskit_main, [
-            cmd, self._tree_sequence_file, "-p", str(precision)])
+        stdout, stderr = capture_output(
+            cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
+        )
         self.assertEqual(len(stderr), 0)
         output_sites = stdout.splitlines()
         self.verify_sites(output_sites, precision)
@@ -438,8 +442,9 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_mutations(self):
         cmd = "mutations"
         precision = 8
-        stdout, stderr = capture_output(cli.tskit_main, [
-            cmd, self._tree_sequence_file, "-p", str(precision)])
+        stdout, stderr = capture_output(
+            cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
+        )
         self.assertEqual(len(stderr), 0)
         output_mutations = stdout.splitlines()
         self.verify_mutations(output_mutations, precision)
@@ -461,7 +466,8 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_provenances_human(self):
         cmd = "provenances"
         stdout, stderr = capture_output(
-            cli.tskit_main, [cmd, "-H", self._tree_sequence_file])
+            cli.tskit_main, [cmd, "-H", self._tree_sequence_file]
+        )
         self.assertEqual(len(stderr), 0)
         output_provenances = stdout.splitlines()
         # TODO Check the actual output here.
@@ -531,7 +537,8 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_trees_draw(self):
         cmd = "trees"
         stdout, stderr = capture_output(
-            cli.tskit_main, [cmd, "-d", self._tree_sequence_file])
+            cli.tskit_main, [cmd, "-d", self._tree_sequence_file]
+        )
         self.assertEqual(len(stderr), 0)
         ts = tskit.load(self._tree_sequence_file)
         self.assertGreater(len(stdout.splitlines()), 3 * ts.num_trees)
@@ -541,6 +548,7 @@ class TestBadFile(unittest.TestCase):
     """
     Tests that we deal with IO errors appropriately.
     """
+
     def verify(self, command):
         with mock.patch("sys.exit", side_effect=TestException) as mocked_exit:
             with self.assertRaises(TestException):
@@ -577,6 +585,7 @@ class TestUpgrade(TestCli):
     Tests the results of the upgrade operation to ensure they are
     correct.
     """
+
     def setUp(self):
         fd, self.legacy_file_name = tempfile.mkstemp(prefix="msp_cli", suffix=".trees")
         os.close(fd)
@@ -592,8 +601,9 @@ class TestUpgrade(TestCli):
         for version in [2, 3]:
             tskit.dump_legacy(ts1, self.legacy_file_name, version=version)
             stdout, stderr = capture_output(
-                cli.tskit_main, [
-                    "upgrade", self.legacy_file_name, self.current_file_name])
+                cli.tskit_main,
+                ["upgrade", self.legacy_file_name, self.current_file_name],
+            )
             ts2 = tskit.load(self.current_file_name)
             self.assertEqual(stdout, "")
             self.assertEqual(stderr, "")
@@ -608,11 +618,12 @@ class TestUpgrade(TestCli):
         for version in [2, 3]:
             tskit.dump_legacy(ts, self.legacy_file_name, version=version)
             root = h5py.File(self.legacy_file_name, "r+")
-            root['mutations/position'][:] = 0
+            root["mutations/position"][:] = 0
             root.close()
             stdout, stderr = capture_output(
                 cli.tskit_main,
-                ["upgrade", "-d", self.legacy_file_name, self.current_file_name])
+                ["upgrade", "-d", self.legacy_file_name, self.current_file_name],
+            )
             self.assertEqual(stdout, "")
             tsp = tskit.load(self.current_file_name)
             self.assertEqual(tsp.sample_size, ts.sample_size)
@@ -623,11 +634,12 @@ class TestUpgrade(TestCli):
         for version in [2, 3]:
             tskit.dump_legacy(ts, self.legacy_file_name, version=version)
             root = h5py.File(self.legacy_file_name, "r+")
-            root['mutations/position'][:] = 0
+            root["mutations/position"][:] = 0
             root.close()
             with mock.patch("sys.exit", side_effect=TestException) as mocked_exit:
                 with self.assertRaises(TestException):
                     capture_output(
                         cli.tskit_main,
-                        ["upgrade",  self.legacy_file_name, self.current_file_name])
+                        ["upgrade", self.legacy_file_name, self.current_file_name],
+                    )
                 self.assertEqual(mocked_exit.call_count, 1)

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -39,16 +39,22 @@ class TestTreeDraw(unittest.TestCase):
     """
     Tests for the tree drawing functionality.
     """
+
     def get_binary_tree(self):
         ts = msprime.simulate(10, random_seed=1, mutation_rate=1)
         return next(ts.trees())
 
     def get_nonbinary_tree(self):
         demographic_events = [
-            msprime.SimpleBottleneck(time=0.1, population=0, proportion=0.5)]
+            msprime.SimpleBottleneck(time=0.1, population=0, proportion=0.5)
+        ]
         ts = msprime.simulate(
-            10, recombination_rate=5, mutation_rate=10,
-            demographic_events=demographic_events, random_seed=1)
+            10,
+            recombination_rate=5,
+            mutation_rate=10,
+            demographic_events=demographic_events,
+            random_seed=1,
+        )
         for t in ts.trees():
             for u in t.nodes():
                 if len(t.children(u)) > 2:
@@ -84,8 +90,11 @@ class TestTreeDraw(unittest.TestCase):
         edges = tables.edges
         n = len(edges) - len(edges) // 4
         edges.set_columns(
-            left=edges.left[:n], right=edges.right[:n],
-            parent=edges.parent[:n], child=edges.child[:n])
+            left=edges.left[:n],
+            right=edges.right[:n],
+            parent=edges.parent[:n],
+            child=edges.child[:n],
+        )
         ts = tables.tree_sequence()
         for t in ts.trees():
             if t.num_roots > 1:
@@ -104,9 +113,7 @@ class TestTreeDraw(unittest.TestCase):
             tables.mutations.add_row(site_id, node=node, derived_state="1")
         ts = tables.tree_sequence()
         tree = ts.first()
-        assert any(
-            tree.parent(mut.node) == tskit.NULL
-            for mut in tree.mutations())
+        assert any(tree.parent(mut.node) == tskit.NULL for mut in tree.mutations())
         return tree
 
     def get_unary_node_tree(self):
@@ -116,8 +123,11 @@ class TestTreeDraw(unittest.TestCase):
         # Take out all the edges except 1
         n = 1
         edges.set_columns(
-            left=edges.left[:n], right=edges.right[:n],
-            parent=edges.parent[:n], child=edges.child[:n])
+            left=edges.left[:n],
+            right=edges.right[:n],
+            parent=edges.parent[:n],
+            child=edges.child[:n],
+        )
         ts = tables.tree_sequence()
         for t in ts.trees():
             for u in t.nodes():
@@ -135,6 +145,7 @@ class TestFormats(TestTreeDraw):
     """
     Tests that formats are recognised correctly.
     """
+
     def test_svg_variants(self):
         t = self.get_binary_tree()
         for svg in ["svg", "SVG", "sVg"]:
@@ -157,16 +168,20 @@ class TestFormats(TestTreeDraw):
         for fmt in ["ascii", "ASCII", "AScii"]:
             output = t.draw(format=fmt)
             self.assertRaises(
-                xml.etree.ElementTree.ParseError, xml.etree.ElementTree.fromstring,
-                output)
+                xml.etree.ElementTree.ParseError,
+                xml.etree.ElementTree.fromstring,
+                output,
+            )
 
     def test_unicode_variants(self):
         t = self.get_binary_tree()
         for fmt in ["unicode", "UNICODE", "uniCODE"]:
             output = t.draw(format=fmt)
             self.assertRaises(
-                xml.etree.ElementTree.ParseError, xml.etree.ElementTree.fromstring,
-                output)
+                xml.etree.ElementTree.ParseError,
+                xml.etree.ElementTree.fromstring,
+                output,
+            )
 
     def test_bad_formats(self):
         t = self.get_binary_tree()
@@ -178,6 +193,7 @@ class TestDrawText(TestTreeDraw):
     """
     Tests the ASCII tree drawing method.
     """
+
     drawing_format = "ascii"
     example_label = "XXX"
 
@@ -224,7 +240,8 @@ class TestDrawText(TestTreeDraw):
         self.verify_basic_text(text)
 
     def test_even_num_children_tree(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           1
@@ -233,8 +250,10 @@ class TestDrawText(TestTreeDraw):
         4   1           4
         5   1           5
         6   1           7
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       6       0
         0       1       6       1
@@ -242,14 +261,16 @@ class TestDrawText(TestTreeDraw):
         0       1       6       3
         0       1       6       4
         0       1       6       5
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         text = t.draw(format=self.drawing_format)
         self.verify_basic_text(text)
 
     def test_odd_num_children_tree(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           1
@@ -257,15 +278,18 @@ class TestDrawText(TestTreeDraw):
         3   1           1
         4   1           4
         5   1           5
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       5       0
         0       1       5       1
         0       1       5       2
         0       1       5       3
         0       1       5       4
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         text = t.draw(format=self.drawing_format)
@@ -300,23 +324,30 @@ class TestDrawText(TestTreeDraw):
         self.assertRaises(ValueError, t.draw, format=self.drawing_format, width=300)
         self.assertRaises(ValueError, t.draw, format=self.drawing_format, height=300)
         self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, mutation_labels={})
+            ValueError, t.draw, format=self.drawing_format, mutation_labels={}
+        )
         self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, mutation_colours={})
+            ValueError, t.draw, format=self.drawing_format, mutation_colours={}
+        )
         self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, edge_colours={})
+            ValueError, t.draw, format=self.drawing_format, edge_colours={}
+        )
         self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, node_colours={})
+            ValueError, t.draw, format=self.drawing_format, node_colours={}
+        )
         self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, max_tree_height=1234)
+            ValueError, t.draw, format=self.drawing_format, max_tree_height=1234
+        )
         self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, tree_height_scale="time")
+            ValueError, t.draw, format=self.drawing_format, tree_height_scale="time"
+        )
 
 
 class TestDrawUnicode(TestDrawText):
     """
     Tests the Unicode tree drawing method
     """
+
     drawing_format = "unicode"
     example_label = "\u20ac" * 10  # euro symbol
 
@@ -325,6 +356,7 @@ class TestDrawTextErrors(unittest.TestCase):
     """
     Tests for errors occuring in tree drawing code.
     """
+
     def test_bad_orientation(self):
         t = msprime.simulate(5, mutation_rate=0.1, random_seed=2).first()
         for bad_orientation in ["", "leftright", "sdf"]:
@@ -336,6 +368,7 @@ class TestDrawTextExamples(unittest.TestCase):
     """
     Verify that we get the correct rendering for some examples.
     """
+
     def verify_text_rendering(self, drawn, drawn_tree, debug=False):
         if debug:
             print("Drawn:")
@@ -350,17 +383,21 @@ class TestDrawTextExamples(unittest.TestCase):
             self.assertEqual(l1.rstrip(), l2.rstrip())
 
     def test_simple_tree(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   1           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       2       0
         0       1       2       1
-        """)
+        """
+        )
         tree = (
             # fmt: off
             " 2 \n"
@@ -405,17 +442,21 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(drawn, tree)
 
     def test_simple_tree_long_label(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   1           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       2       0
         0       1       2       1
-        """)
+        """
+        )
         tree = (
             # fmt: off
             "ABCDEF\n"
@@ -436,11 +477,13 @@ class TestDrawTextExamples(unittest.TestCase):
             # fmt: on
         )
         drawn = t.draw_text(
-            node_labels={0: "0", 1: "1", 2: "ABCDEF"}, orientation="right")
+            node_labels={0: "0", 1: "1", 2: "ABCDEF"}, orientation="right"
+        )
         self.verify_text_rendering(drawn, tree)
 
         drawn = t.draw_text(
-            node_labels={0: "ABCDEF", 1: "1", 2: "2"}, orientation="right")
+            node_labels={0: "ABCDEF", 1: "1", 2: "2"}, orientation="right"
+        )
         tree = (
             # fmt: off
             "ABCDEF┓ \n"
@@ -458,11 +501,13 @@ class TestDrawTextExamples(unittest.TestCase):
             # fmt: on
         )
         drawn = t.draw_text(
-            node_labels={0: "0", 1: "1", 2: "ABCDEF"}, orientation="left")
+            node_labels={0: "0", 1: "1", 2: "ABCDEF"}, orientation="left"
+        )
         self.verify_text_rendering(drawn, tree)
 
     def test_four_leaves(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      individual      time    metadata
         0       1       0       -1      0.00000000000000
         1       1       0       -1      0.00000000000000
@@ -471,8 +516,10 @@ class TestDrawTextExamples(unittest.TestCase):
         4       0       0       -1      0.26676079696421
         5       0       0       -1      1.48826948286480
         6       0       0       -1      2.91835007758007
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left            right           parent  child
         0.00000000      1.00000000      4       0
         0.00000000      1.00000000      4       3
@@ -480,7 +527,8 @@ class TestDrawTextExamples(unittest.TestCase):
         0.00000000      1.00000000      5       4
         0.00000000      1.00000000      6       1
         0.00000000      1.00000000      6       5
-        """)
+        """
+        )
         tree = (
             "  6     \n"
             "┏━┻━┓   \n"
@@ -488,7 +536,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "┃ ┏━┻┓  \n"
             "┃ ┃  4  \n"
             "┃ ┃ ┏┻┓ \n"
-            "1 2 0 3 \n")
+            "1 2 0 3 \n"
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = ts.first()
         drawn = t.draw(format="unicode")
@@ -503,7 +552,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "┃ ┗━┳┛ \n"
             "┃   5  \n"
             "┗━┳━┛  \n"
-            "  6    \n")
+            "  6    \n"
+        )
         self.verify_text_rendering(drawn, tree)
 
         tree = (
@@ -513,7 +563,8 @@ class TestDrawTextExamples(unittest.TestCase):
             " ┃ ┃   \n"
             " ┗5┫ ┏0\n"
             "   ┗4┫  \n"
-            "     ┗3\n")
+            "     ┗3\n"
+        )
         self.verify_text_rendering(t.draw_text(orientation="left"), tree)
 
         tree = (
@@ -524,7 +575,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "0.27┊ ┃ ┃  4  ┊\n"
             "    ┊ ┃ ┃ ┏┻┓ ┊\n"
             "0.00┊ 1 2 0 3 ┊\n"
-            "  0.00      1.00\n")
+            "  0.00      1.00\n"
+        )
         self.verify_text_rendering(ts.draw_text(), tree)
 
         tree = (
@@ -534,7 +586,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "| +-++ \n"
             "| |  4 \n"
             "| | +++\n"
-            "1 2 0 3\n")
+            "1 2 0 3\n"
+        )
         drawn = t.draw(format="ascii")
         self.verify_text_rendering(drawn, tree)
 
@@ -545,7 +598,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "┃ ┏━┻┓  \n"
             "┃ ┃  4  \n"
             "┃ ┃ ┏┻┓ \n"
-            "1 2 0 3 \n")
+            "1 2 0 3 \n"
+        )
         labels = {u: str(u) for u in t.nodes()}
         labels[5] = "xxxxxxxxxx"
         drawn = t.draw_text(node_labels=labels)
@@ -558,7 +612,8 @@ class TestDrawTextExamples(unittest.TestCase):
             " ┃          ┃   \n"
             " ┗xxxxxxxxxx┫ ┏0\n"
             "            ┗4┫ \n"
-            "              ┗3\n")
+            "              ┗3\n"
+        )
         drawn = t.draw_text(node_labels=labels, orientation="left")
         self.verify_text_rendering(drawn, tree)
 
@@ -570,24 +625,29 @@ class TestDrawTextExamples(unittest.TestCase):
             "0.27┊ ┃ ┃  4      ┊\n"
             "    ┊ ┃ ┃ ┏┻┓     ┊\n"
             "0.00┊ 1 2 0 3     ┊\n"
-            "  0.00          1.00\n")
+            "  0.00          1.00\n"
+        )
         drawn = ts.draw_text(node_labels=labels)
         self.verify_text_rendering(drawn, tree)
 
     def test_trident_tree(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   1           0
         3   1           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       3       0
         0       1       3       1
         0       1       3       2
-        """)
+        """
+        )
         tree = (
             # fmt: off
             "  3  \n"
@@ -626,21 +686,25 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(drawn, tree)
 
     def test_pitchfork_tree(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   1           0
         3   1           0
         4   1           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       4       0
         0       1       4       1
         0       1       4       2
         0       1       4       3
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         tree = (
@@ -707,17 +771,21 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(drawn, tree)
 
     def test_stick_tree(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           1
         2   1           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       1       0
         0       1       2       1
-        """)
+        """
+        )
         tree = (
             # fmt: off
             "2\n"
@@ -755,19 +823,21 @@ class TestDrawTextExamples(unittest.TestCase):
 
     def test_draw_forky_tree(self):
         tree = (
-           "      14            \n"
-           "  ┏━━━━┻━━━━┓       \n"
-           "  ┃        13       \n"
-           "  ┃   ┏━┳━┳━╋━┳━━┓  \n"
-           "  ┃   ┃ ┃ ┃ ┃ ┃ 12  \n"
-           "  ┃   ┃ ┃ ┃ ┃ ┃ ┏┻┓ \n"
-           " 11   ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
-           "┏━┻┓  ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
-           "┃ 10  ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
-           "┃ ┏┻┓ ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
-           "8 0 3 2 4 5 6 9 1 7 \n")
+            "      14            \n"
+            "  ┏━━━━┻━━━━┓       \n"
+            "  ┃        13       \n"
+            "  ┃   ┏━┳━┳━╋━┳━━┓  \n"
+            "  ┃   ┃ ┃ ┃ ┃ ┃ 12  \n"
+            "  ┃   ┃ ┃ ┃ ┃ ┃ ┏┻┓ \n"
+            " 11   ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
+            "┏━┻┓  ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
+            "┃ 10  ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
+            "┃ ┏┻┓ ┃ ┃ ┃ ┃ ┃ ┃ ┃ \n"
+            "8 0 3 2 4 5 6 9 1 7 \n"
+        )
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
             id      is_sample   population      individual      time    metadata
             0       1       0       -1      0.00000000000000
             1       1       0       -1      0.00000000000000
@@ -784,8 +854,10 @@ class TestDrawTextExamples(unittest.TestCase):
             12      0       0       -1      0.19950200178411
             13      0       0       -1      0.20000000000000
             14      0       0       -1      5.68339203134457
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
             left            right           parent  child
             0.00000000      1.00000000      10      0
             0.00000000      1.00000000      10      3
@@ -801,7 +873,8 @@ class TestDrawTextExamples(unittest.TestCase):
             0.00000000      1.00000000      13      12
             0.00000000      1.00000000      14      11
             0.00000000      1.00000000      14      13
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         drawn = t.draw(format="unicode")
@@ -809,33 +882,36 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(t.draw_text(), tree)
 
         tree = (
-           "        14              \n"
-           "  ┏━━━━━━┻━━━━━━┓       \n"
-           "  ┃            13       \n"
-           "  ┃        ┏━┳━┳┻┳━┳━━┓ \n"
-           "  ┃        ┃ ┃ ┃ ┃ ┃ 12 \n"
-           "  ┃        ┃ ┃ ┃ ┃ ┃ ┏┻┓\n"
-           "x11xxxxxxx ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
-           "┏━┻┓       ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
-           "┃ 10       ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
-           "┃ ┏┻┓      ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
-           "8 0 3      2 4 5 6 9 1 7\n")
+            "        14              \n"
+            "  ┏━━━━━━┻━━━━━━┓       \n"
+            "  ┃            13       \n"
+            "  ┃        ┏━┳━┳┻┳━┳━━┓ \n"
+            "  ┃        ┃ ┃ ┃ ┃ ┃ 12 \n"
+            "  ┃        ┃ ┃ ┃ ┃ ┃ ┏┻┓\n"
+            "x11xxxxxxx ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
+            "┏━┻┓       ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
+            "┃ 10       ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
+            "┃ ┏┻┓      ┃ ┃ ┃ ┃ ┃ ┃ ┃\n"
+            "8 0 3      2 4 5 6 9 1 7\n"
+        )
         labels = {u: str(u) for u in t.nodes()}
         labels[11] = "x11xxxxxxx"
         self.verify_text_rendering(t.draw_text(node_labels=labels), tree)
 
     def test_draw_multiroot_forky_tree(self):
         tree = (
-           "     13              \n"
-           "┏━┳━┳━╋━┳━━┓         \n"
-           "┃ ┃ ┃ ┃ ┃ 12         \n"
-           "┃ ┃ ┃ ┃ ┃ ┏┻┓        \n"
-           "┃ ┃ ┃ ┃ ┃ ┃ ┃  11    \n"
-           "┃ ┃ ┃ ┃ ┃ ┃ ┃  ┏┻━┓  \n"
-           "┃ ┃ ┃ ┃ ┃ ┃ ┃  ┃ 10  \n"
-           "┃ ┃ ┃ ┃ ┃ ┃ ┃  ┃ ┏┻┓ \n"
-           "2 4 5 6 9 1 7  8 0 3 \n")
-        nodes = io.StringIO("""\
+            "     13              \n"
+            "┏━┳━┳━╋━┳━━┓         \n"
+            "┃ ┃ ┃ ┃ ┃ 12         \n"
+            "┃ ┃ ┃ ┃ ┃ ┏┻┓        \n"
+            "┃ ┃ ┃ ┃ ┃ ┃ ┃  11    \n"
+            "┃ ┃ ┃ ┃ ┃ ┃ ┃  ┏┻━┓  \n"
+            "┃ ┃ ┃ ┃ ┃ ┃ ┃  ┃ 10  \n"
+            "┃ ┃ ┃ ┃ ┃ ┃ ┃  ┃ ┏┻┓ \n"
+            "2 4 5 6 9 1 7  8 0 3 \n"
+        )
+        nodes = io.StringIO(
+            """\
             id      is_sample   population      individual      time    metadata
             0       1       0       -1      0.00000000000000
             1       1       0       -1      0.00000000000000
@@ -852,8 +928,10 @@ class TestDrawTextExamples(unittest.TestCase):
             12      0       0       -1      0.19950200178411
             13      0       0       -1      0.20000000000000
             14      0       0       -1      5.68339203134457
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
             left            right           parent  child
             0.00000000      1.00000000      10      0
             0.00000000      1.00000000      10      3
@@ -867,7 +945,8 @@ class TestDrawTextExamples(unittest.TestCase):
             0.00000000      1.00000000      13      6
             0.00000000      1.00000000      13      9
             0.00000000      1.00000000      13      12
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         drawn = t.draw(format="unicode")
@@ -875,7 +954,8 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(t.draw_text(), tree)
 
     def test_simple_tree_sequence(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
             id      is_sample   population      individual      time    metadata
             0       1       0       -1      0.00000000000000
             1       1       0       -1      0.00000000000000
@@ -887,8 +967,10 @@ class TestDrawTextExamples(unittest.TestCase):
             7       0       0       -1      2.31067154311640
             8       0       0       -1      3.57331354884652
             9       0       0       -1      9.08308317451295
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
             id      left            right           parent  child
             0       0.00000000      1.00000000      4       0
             1       0.00000000      1.00000000      4       1
@@ -904,7 +986,8 @@ class TestDrawTextExamples(unittest.TestCase):
             11      0.91029435      1.00000000      8       5
             12      0.00000000      0.05975243      9       4
             13      0.00000000      0.05975243      9       5
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
 
         ts_drawing = (
@@ -921,7 +1004,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "0.02┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊\n"
             "    ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊\n"
             "0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊\n"
-            "  0.00      0.06      0.79      0.91      0.91      1.00\n")
+            "  0.00      0.06      0.79      0.91      0.91      1.00\n"
+        )
         self.verify_text_rendering(ts.draw_text(), ts_drawing)
 
         ts_drawing = (
@@ -938,7 +1022,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "0.02|  4  | | |  4  | | |  4  | | |  4  | | |  4  | | |\n"
             "    | +++ | | | +++ | | | +++ | | | +++ | | | +++ | | |\n"
             "0.00| 0 1 2 3 | 0 1 2 3 | 0 1 2 3 | 0 1 2 3 | 0 1 2 3 |\n"
-            "  0.00      0.06      0.79      0.91      0.91      1.00\n")
+            "  0.00      0.06      0.79      0.91      0.91      1.00\n"
+        )
         self.verify_text_rendering(ts.draw_text(use_ascii=True), ts_drawing)
 
         ts_drawing = (
@@ -955,7 +1040,8 @@ class TestDrawTextExamples(unittest.TestCase):
             "┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊\n"
             "┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊\n"
             "┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊\n"
-            "0.00    0.06      0.79      0.91      0.91      1.00\n")
+            "0.00    0.06      0.79      0.91      0.91      1.00\n"
+        )
         self.verify_text_rendering(ts.draw_text(time_label_format=""), ts_drawing)
 
         ts_drawing = (
@@ -972,12 +1058,15 @@ class TestDrawTextExamples(unittest.TestCase):
             "┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊  4  ┃ ┃ ┊\n"
             "┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊ ┏┻┓ ┃ ┃ ┊\n"
             "┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0 1 2 3 ┊\n"
-            "┊         ┊         ┊         ┊         ┊         ┊\n")
+            "┊         ┊         ┊         ┊         ┊         ┊\n"
+        )
         self.verify_text_rendering(
-            ts.draw_text(time_label_format="", position_label_format=""), ts_drawing)
+            ts.draw_text(time_label_format="", position_label_format=""), ts_drawing
+        )
 
     def test_max_tree_height(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
             id      is_sample   population      individual      time    metadata
             0       1       0       -1      0.00000000000000
             1       1       0       -1      0.00000000000000
@@ -989,8 +1078,10 @@ class TestDrawTextExamples(unittest.TestCase):
             7       0       0       -1      2.31067154311640
             8       0       0       -1      3.57331354884652
             9       0       0       -1      9.08308317451295
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
             id      left            right           parent  child
             0       0.00000000      1.00000000      4       0
             1       0.00000000      1.00000000      4       1
@@ -1006,33 +1097,36 @@ class TestDrawTextExamples(unittest.TestCase):
             11      0.91029435      1.00000000      8       5
             12      0.00000000      0.05975243      9       4
             13      0.00000000      0.05975243      9       5
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         tree = (
-           "   9   \n"
-           " ┏━┻━┓ \n"
-           " ┃   ┃ \n"
-           " ┃   ┃ \n"
-           " ┃   ┃ \n"
-           " ┃   ┃ \n"
-           " ┃   ┃ \n"
-           " ┃   ┃ \n"
-           " ┃   5 \n"
-           " ┃  ┏┻┓\n"
-           " 4  ┃ ┃\n"
-           "┏┻┓ ┃ ┃\n"
-           "0 1 2 3\n")
+            "   9   \n"
+            " ┏━┻━┓ \n"
+            " ┃   ┃ \n"
+            " ┃   ┃ \n"
+            " ┃   ┃ \n"
+            " ┃   ┃ \n"
+            " ┃   ┃ \n"
+            " ┃   ┃ \n"
+            " ┃   5 \n"
+            " ┃  ┏┻┓\n"
+            " 4  ┃ ┃\n"
+            "┏┻┓ ┃ ┃\n"
+            "0 1 2 3\n"
+        )
         t = ts.first()
         self.verify_text_rendering(t.draw_text(max_tree_height="ts"), tree)
 
         tree = (
-           "   9   \n"
-           " ┏━┻━┓ \n"
-           " ┃   5 \n"
-           " ┃  ┏┻┓\n"
-           " 4  ┃ ┃\n"
-           "┏┻┓ ┃ ┃\n"
-           "0 1 2 3\n")
+            "   9   \n"
+            " ┏━┻━┓ \n"
+            " ┃   5 \n"
+            " ┃  ┏┻┓\n"
+            " 4  ┃ ┃\n"
+            "┏┻┓ ┃ ┃\n"
+            "0 1 2 3\n"
+        )
         t = ts.first()
         self.verify_text_rendering(t.draw_text(max_tree_height="tree"), tree)
         for bad_max_tree_height in [1, "sdfr", ""]:
@@ -1044,6 +1138,7 @@ class TestDrawSvg(TestTreeDraw):
     """
     Tests the SVG tree drawing.
     """
+
     def verify_basic_svg(self, svg, width=200, height=200):
         root = xml.etree.ElementTree.fromstring(svg)
         self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
@@ -1174,7 +1269,7 @@ class TestDrawSvg(TestTreeDraw):
         svg = t.draw(format="svg", node_colours=colours)
         self.verify_basic_svg(svg)
         self.assertEqual(svg.count('fill="{}"'.format(colour)), 1)
-        svg = t.draw_svg(node_attrs={0: {'fill': colour}})
+        svg = t.draw_svg(node_attrs={0: {"fill": colour}})
         self.verify_basic_svg(svg)
         self.assertEqual(svg.count('fill="{}"'.format(colour)), 1)
 
@@ -1186,7 +1281,7 @@ class TestDrawSvg(TestTreeDraw):
         for colour in colours.values():
             self.assertEqual(svg.count('fill="{}"'.format(colour)), 1)
 
-        svg = t.draw_svg(node_attrs={u: {'fill': colours[u]} for u in t.nodes()})
+        svg = t.draw_svg(node_attrs={u: {"fill": colours[u]} for u in t.nodes()})
         self.verify_basic_svg(svg)
         self.assertEqual(svg.count('fill="{}"'.format(colour)), 1)
         for colour in colours.values():
@@ -1219,13 +1314,13 @@ class TestDrawSvg(TestTreeDraw):
 
     def test_bad_tree_height_scale(self):
         t = self.get_binary_tree()
-        for bad_scale in ["te", "asdf", "", [], b'23']:
+        for bad_scale in ["te", "asdf", "", [], b"23"]:
             with self.assertRaises(ValueError):
                 t.draw_svg(tree_height_scale=bad_scale)
 
     def test_bad_max_tree_height(self):
         t = self.get_binary_tree()
-        for bad_height in ["te", "asdf", "", [], b'23']:
+        for bad_height in ["te", "asdf", "", [], b"23"]:
             with self.assertRaises(ValueError):
                 t.draw_svg(max_tree_height=bad_height)
 
@@ -1310,7 +1405,8 @@ class TestDrawSvg(TestTreeDraw):
         t = self.get_binary_tree()
         colours = {
             mut.id: "rgb({}, {}, {})".format(mut.id, mut.id, mut.id)
-            for mut in t.mutations()}
+            for mut in t.mutations()
+        }
         svg = t.draw(format="svg", mutation_colours=colours)
         self.verify_basic_svg(svg)
         for colour in colours.values():
@@ -1325,7 +1421,8 @@ class TestDrawSvg(TestTreeDraw):
         self.assertEqual(svg.count('opacity="0"'), 1)
 
     def test_max_tree_height(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
@@ -1333,8 +1430,10 @@ class TestDrawSvg(TestTreeDraw):
         3   0           1
         4   0           2
         5   0           3
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       5       2
         0       1       5       3
@@ -1342,7 +1441,8 @@ class TestDrawSvg(TestTreeDraw):
         1       2       4       3
         0       2       3       0
         0       2       3       1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
 
         svg1 = ts.at_index(0).draw()
@@ -1350,10 +1450,10 @@ class TestDrawSvg(TestTreeDraw):
         # if not scaled to ts, node 3 is at a different height in both trees, because the
         # root is at a different height. We expect a label looking something like
         # <text x="10.0" y="XXXX">3</text> where XXXX is different
-        str_pos = svg1.find('>3<')
-        snippet1 = svg1[svg1.rfind("<", 0, str_pos):str_pos]
-        str_pos = svg2.find('>3<')
-        snippet2 = svg2[svg2.rfind("<", 0, str_pos):str_pos]
+        str_pos = svg1.find(">3<")
+        snippet1 = svg1[svg1.rfind("<", 0, str_pos) : str_pos]
+        str_pos = svg2.find(">3<")
+        snippet2 = svg2[svg2.rfind("<", 0, str_pos) : str_pos]
         self.assertNotEqual(snippet1, snippet2)
 
         svg1 = ts.at_index(0).draw(max_tree_height="ts")
@@ -1362,10 +1462,10 @@ class TestDrawSvg(TestTreeDraw):
         # should be the same
         self.verify_basic_svg(svg1)
         self.verify_basic_svg(svg2)
-        str_pos = svg1.find('>3<')
-        snippet1 = svg1[svg1.rfind("<", 0, str_pos):str_pos]
-        str_pos = svg2.find('>3<')
-        snippet2 = svg2[svg2.rfind("<", 0, str_pos):str_pos]
+        str_pos = svg1.find(">3<")
+        snippet1 = svg1[svg1.rfind("<", 0, str_pos) : str_pos]
+        str_pos = svg2.find(">3<")
+        snippet2 = svg2[svg2.rfind("<", 0, str_pos) : str_pos]
         self.assertEqual(snippet1, snippet2)
 
     def test_draw_simple_ts(self):

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -362,9 +362,12 @@ class TestDrawTextExamples(unittest.TestCase):
         0       1       2       1
         """)
         tree = (
+            # fmt: off
             " 2 \n"
             "┏┻┓\n"
-            "0 1")
+            "0 1"
+            # fmt: on
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         drawn = t.draw(format="unicode")
@@ -373,22 +376,31 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(drawn, tree)
 
         tree = (
+            # fmt: off
             " 2 \n"
             "+++\n"
-            "0 1\n")
+            "0 1\n"
+            # fmt: on
+        )
         drawn = t.draw_text(use_ascii=True)
         self.verify_text_rendering(drawn, tree)
 
         tree = (
+            # fmt: off
             " ┏0\n"
             "2┫  \n"
-            " ┗1\n")
+            " ┗1\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="left")
         self.verify_text_rendering(drawn, tree)
         tree = (
+            # fmt: off
             " +0\n"
             "2+  \n"
-            " +1\n")
+            " +1\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="left", use_ascii=True)
         self.verify_text_rendering(drawn, tree)
 
@@ -405,18 +417,24 @@ class TestDrawTextExamples(unittest.TestCase):
         0       1       2       1
         """)
         tree = (
+            # fmt: off
             "ABCDEF\n"
             "┏┻┓   \n"
-            "0 1   \n")
+            "0 1   \n"
+            # fmt: on
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         drawn = t.draw_text(node_labels={0: "0", 1: "1", 2: "ABCDEF"})
         self.verify_text_rendering(drawn, tree)
 
         tree = (
+            # fmt: off
             "0┓      \n"
             " ┣ABCDEF\n"
-            "1┛      \n")
+            "1┛      \n"
+            # fmt: on
+        )
         drawn = t.draw_text(
             node_labels={0: "0", 1: "1", 2: "ABCDEF"}, orientation="right")
         self.verify_text_rendering(drawn, tree)
@@ -424,15 +442,21 @@ class TestDrawTextExamples(unittest.TestCase):
         drawn = t.draw_text(
             node_labels={0: "ABCDEF", 1: "1", 2: "2"}, orientation="right")
         tree = (
+            # fmt: off
             "ABCDEF┓ \n"
             "      ┣2\n"
-            "1━━━━━┛ \n")
+            "1━━━━━┛ \n"
+            # fmt: on
+        )
         self.verify_text_rendering(drawn, tree)
 
         tree = (
+            # fmt: off
             "      ┏0\n"
             "ABCDEF┫ \n"
-            "      ┗1\n")
+            "      ┗1\n"
+            # fmt: on
+        )
         drawn = t.draw_text(
             node_labels={0: "0", 1: "1", 2: "ABCDEF"}, orientation="left")
         self.verify_text_rendering(drawn, tree)
@@ -565,9 +589,12 @@ class TestDrawTextExamples(unittest.TestCase):
         0       1       3       2
         """)
         tree = (
+            # fmt: off
             "  3  \n"
             "┏━╋━┓\n"
-            "0 1 2\n")
+            "0 1 2\n"
+            # fmt: on
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         drawn = t.draw(format="unicode")
@@ -575,20 +602,26 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(t.draw_text(), tree)
 
         tree = (
+            # fmt: off
             " ┏0\n"
             " ┃\n"
             "3╋1\n"
             " ┃\n"
-            " ┗2\n")
+            " ┗2\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="left")
         self.verify_text_rendering(drawn, tree)
 
         tree = (
+            # fmt: off
             "0┓\n"
             " ┃\n"
             "1╋3\n"
             " ┃\n"
-            "2┛\n")
+            "2┛\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="right")
         self.verify_text_rendering(drawn, tree)
 
@@ -611,50 +644,65 @@ class TestDrawTextExamples(unittest.TestCase):
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         tree = (
+            # fmt: off
             "   4   \n"
             "┏━┳┻┳━┓\n"
-            "0 1 2 3\n")
+            "0 1 2 3\n"
+            # fmt: on
+        )
         drawn = t.draw(format="unicode")
         self.verify_text_rendering(drawn, tree)
         self.verify_text_rendering(t.draw_text(), tree)
 
         # No labels
         tree = (
+            # fmt: off
             "   ┃   \n"
             "┏━┳┻┳━┓\n"
-            "┃ ┃ ┃ ┃\n")
+            "┃ ┃ ┃ ┃\n"
+            # fmt: on
+        )
         drawn = t.draw(format="unicode", node_labels={})
         self.verify_text_rendering(drawn, tree)
         self.verify_text_rendering(t.draw_text(node_labels={}), tree)
         # Some labels
         tree = (
+            # fmt: off
             "   ┃   \n"
             "┏━┳┻┳━┓\n"
-            "0 ┃ ┃ 3\n")
+            "0 ┃ ┃ 3\n"
+            # fmt: on
+        )
         labels = {0: "0", 3: "3"}
         drawn = t.draw(format="unicode", node_labels=labels)
         self.verify_text_rendering(drawn, tree)
         self.verify_text_rendering(t.draw_text(node_labels=labels), tree)
 
         tree = (
+            # fmt: off
             " ┏0\n"
             " ┃\n"
             " ┣1\n"
             "4┫\n"
             " ┣2\n"
             " ┃\n"
-            " ┗3\n")
+            " ┗3\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="left")
         self.verify_text_rendering(drawn, tree)
 
         tree = (
+            # fmt: off
             "0┓\n"
             " ┃\n"
             "1┫\n"
             " ┣4\n"
             "2┫\n"
             " ┃\n"
-            "3┛\n")
+            "3┛\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="right")
         self.verify_text_rendering(drawn, tree)
 
@@ -671,11 +719,14 @@ class TestDrawTextExamples(unittest.TestCase):
         0       1       2       1
         """)
         tree = (
+            # fmt: off
             "2\n"
             "┃\n"
             "1\n"
             "┃\n"
-            "0\n")
+            "0\n"
+            # fmt: on
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         t = next(ts.trees())
         drawn = t.draw(format="unicode")
@@ -683,11 +734,14 @@ class TestDrawTextExamples(unittest.TestCase):
         self.verify_text_rendering(t.draw_text(), tree)
 
         tree = (
+            # fmt: off
             "0\n"
             "┃\n"
             "1\n"
             "┃\n"
-            "2\n")
+            "2\n"
+            # fmt: on
+        )
         drawn = t.draw_text(orientation="bottom")
         self.verify_text_rendering(drawn, tree)
 

--- a/python/tests/test_fasta.py
+++ b/python/tests/test_fasta.py
@@ -37,8 +37,9 @@ from tests import tsutil
 
 # setting up some basic haplotype data for tests
 def create_data(length):
-    ts = msprime.simulate(sample_size=10, length=length, mutation_rate=1e-2,
-                          random_seed=123)
+    ts = msprime.simulate(
+        sample_size=10, length=length, mutation_rate=1e-2, random_seed=123
+    )
     ts = tsutil.jukes_cantor(ts, length, 1.0, seed=123)
     assert ts.num_sites == length
     return ts
@@ -49,6 +50,7 @@ class TestLineLength(unittest.TestCase):
     Tests if the fasta file produced has the correct line lengths for
     default, custom, and no-wrapping options.
     """
+
     def verify_line_length(self, length, wrap_width=60):
         # set up data
         length = length
@@ -66,9 +68,9 @@ class TestLineLength(unittest.TestCase):
             # full length, ok as called write already
             wrap_width = length
         elif length % wrap_width == 0:
-            lines_expect = length//wrap_width
+            lines_expect = length // wrap_width
         else:
-            lines_expect = length//wrap_width + 1
+            lines_expect = length // wrap_width + 1
             extra_line_length = length % wrap_width
             no_hanging_line = False
 
@@ -78,7 +80,7 @@ class TestLineLength(unittest.TestCase):
             # testing correct characters per sequence line
             if line[0] != ">":
                 seq_line_counter += 1
-                line_chars = len(line.strip('\n'))
+                line_chars = len(line.strip("\n"))
                 # test full default width lines
                 if seq_line_counter < lines_expect:
                     self.assertEqual(wrap_width, line_chars)
@@ -126,6 +128,7 @@ class TestSequenceIds(unittest.TestCase):
     Tests that sequence IDs are output correctly, whether default or custom
     and that the length of IDs supplied must equal number of sequences
     """
+
     def verify_ids(self, ts, seq_ids_in=None):
         seq_ids_read = []
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -159,10 +162,10 @@ class TestSequenceIds(unittest.TestCase):
     def test_bad_length_ids(self):
         ts = create_data(100)
         with self.assertRaises(ValueError):
-            seq_ids_in = ["x_{}".format(_) for _ in range(ts.num_samples-1)]
+            seq_ids_in = ["x_{}".format(_) for _ in range(ts.num_samples - 1)]
             ts.write_fasta(io.StringIO(), sequence_ids=seq_ids_in)
         with self.assertRaises(ValueError):
-            seq_ids_in = ["x_{}".format(_) for _ in range(ts.num_samples+1)]
+            seq_ids_in = ["x_{}".format(_) for _ in range(ts.num_samples + 1)]
             ts.write_fasta(io.StringIO(), sequence_ids=seq_ids_in)
         with self.assertRaises(ValueError):
             seq_ids_in = []
@@ -174,6 +177,7 @@ class TestRoundTrip(unittest.TestCase):
     Tests that output from our code is read in by available software packages
     Here test for compatability with biopython processing - Bio.SeqIO
     """
+
     def verify(self, ts, wrap_width=60):
         biopython_fasta_read = []
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -83,7 +83,8 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
 
     def test_many_trees(self):
         ts = msprime.simulate(
-            8, recombination_rate=10, mutation_rate=10, random_seed=234)
+            8, recombination_rate=10, mutation_rate=10, random_seed=234
+        )
         self.assertGreater(ts.num_trees, 1)
         self.assertGreater(ts.num_sites, 1)
         self.verify(ts)
@@ -106,8 +107,8 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
 
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
-            6, 5, seed=3, deep_history=True, initial_generation_samples=True,
-            num_loci=2)
+            6, 5, seed=3, deep_history=True, initial_generation_samples=True, num_loci=2
+        )
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
@@ -116,8 +117,13 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            9, 10, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            9,
+            10,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
@@ -156,9 +162,11 @@ class TestVariantGenerator(unittest.TestCase):
     """
     Tests the variants() method to ensure the output is consistent.
     """
+
     def get_tree_sequence(self):
         ts = msprime.simulate(
-            10, length=10, recombination_rate=1, mutation_rate=10, random_seed=3)
+            10, length=10, recombination_rate=1, mutation_rate=10, random_seed=3
+        )
         self.assertGreater(ts.get_num_mutations(), 10)
         return ts
 
@@ -166,18 +174,18 @@ class TestVariantGenerator(unittest.TestCase):
         ts = self.get_tree_sequence()
         n = ts.get_sample_size()
         m = ts.get_num_mutations()
-        A = np.zeros((m, n), dtype='u1')
-        B = np.zeros((m, n), dtype='u1')
+        A = np.zeros((m, n), dtype="u1")
+        B = np.zeros((m, n), dtype="u1")
         for variant in ts.variants():
             A[variant.index] = variant.genotypes
         for variant in ts.variants(as_bytes=True):
             self.assertIsInstance(variant.genotypes, bytes)
-            B[variant.index] = np.fromstring(variant.genotypes, np.uint8) - ord('0')
+            B[variant.index] = np.fromstring(variant.genotypes, np.uint8) - ord("0")
         self.assertTrue(np.all(A == B))
         bytes_variants = list(ts.variants(as_bytes=True))
         for j, variant in enumerate(bytes_variants):
             self.assertEqual(j, variant.index)
-            row = np.fromstring(variant.genotypes, np.uint8) - ord('0')
+            row = np.fromstring(variant.genotypes, np.uint8) - ord("0")
             self.assertTrue(np.all(A[j] == row))
 
     def test_as_bytes_fails(self):
@@ -200,7 +208,8 @@ class TestVariantGenerator(unittest.TestCase):
             self.assertTrue(np.all(G[var.index] == var.genotypes))
             self.assertEqual(
                 [var.alleles[g] for g in var.genotypes],
-                [var.alleles[g] for g in G[var.index]])
+                [var.alleles[g] for g in G[var.index]],
+            )
             G[var.index, :] = var.genotypes
             self.assertTrue(np.array_equal(G[var.index], var.genotypes))
 
@@ -219,7 +228,7 @@ class TestVariantGenerator(unittest.TestCase):
         tables.sites.clear()
         tables.mutations.clear()
         # This gives us a total of 360 permutations.
-        alleles = list(map("".join, itertools.permutations('ABCDEF', 4)))
+        alleles = list(map("".join, itertools.permutations("ABCDEF", 4)))
         self.assertGreater(len(alleles), 127)
         tables.sites.add_row(0, alleles[0])
         parent = -1
@@ -234,7 +243,9 @@ class TestVariantGenerator(unittest.TestCase):
                 self.assertEqual(var.num_alleles, num_alleles)
                 self.assertEqual(len(var.alleles), num_alleles)
                 self.assertEqual(list(var.alleles), alleles[:num_alleles])
-                self.assertEqual(var.alleles[var.genotypes[0]], alleles[num_alleles - 1])
+                self.assertEqual(
+                    var.alleles[var.genotypes[0]], alleles[num_alleles - 1]
+                )
                 for u in ts.samples():
                     if u != 0:
                         self.assertEqual(var.alleles[var.genotypes[u]], alleles[0])
@@ -250,7 +261,7 @@ class TestVariantGenerator(unittest.TestCase):
         # Add an isolated sample
         tables.nodes.add_row(flags=1, time=0)
         # This gives us a total of 360 permutations.
-        alleles = list(map("".join, itertools.permutations('ABCDEF', 4)))
+        alleles = list(map("".join, itertools.permutations("ABCDEF", 4)))
         self.assertGreater(len(alleles), 127)
         tables.sites.add_row(0, alleles[0])
         parent = -1
@@ -266,7 +277,9 @@ class TestVariantGenerator(unittest.TestCase):
                 self.assertEqual(len(var.alleles), num_alleles + 1)
                 self.assertEqual(list(var.alleles)[:-1], alleles[:num_alleles])
                 self.assertIsNone(var.alleles[-1])
-                self.assertEqual(var.alleles[var.genotypes[0]], alleles[num_alleles - 1])
+                self.assertEqual(
+                    var.alleles[var.genotypes[0]], alleles[num_alleles - 1]
+                )
                 self.assertEqual(var.genotypes[-1], -1)
                 samples = ts.samples()
                 for u in samples[:-1]:
@@ -305,8 +318,8 @@ class TestVariantGenerator(unittest.TestCase):
         num_sites = 5
         for j in range(num_sites):
             tables.sites.add_row(
-                position=j * ts.sequence_length / num_sites,
-                ancestral_state="0")
+                position=j * ts.sequence_length / num_sites, ancestral_state="0"
+            )
             for u in range(ts.sample_size):
                 tables.mutations.add_row(site=j, node=u, derived_state="1")
         ts = tables.tree_sequence()
@@ -344,7 +357,8 @@ class TestVariantGenerator(unittest.TestCase):
     def test_samples(self):
         n = 4
         ts = msprime.simulate(
-            n, length=5, recombination_rate=1, mutation_rate=5, random_seed=2)
+            n, length=5, recombination_rate=1, mutation_rate=5, random_seed=2
+        )
         self.assertGreater(ts.num_sites, 1)
         samples = list(range(n))
         # Generate all possible sample lists.
@@ -364,19 +378,22 @@ class TestVariantGenerator(unittest.TestCase):
         # We don't have to use sample nodes. This does make the terminology confusing
         # but it's probably still the best option.
         ts = msprime.simulate(
-            10, length=5, recombination_rate=1, mutation_rate=5, random_seed=2)
+            10, length=5, recombination_rate=1, mutation_rate=5, random_seed=2
+        )
         tables = ts.dump_tables()
         tables.nodes.set_columns(
             flags=np.zeros_like(tables.nodes.flags) + tskit.NODE_IS_SAMPLE,
-            time=tables.nodes.time)
+            time=tables.nodes.time,
+        )
         all_samples_ts = tables.tree_sequence()
         self.assertEqual(all_samples_ts.num_samples, ts.num_nodes)
 
         count = 0
         samples = range(ts.num_nodes)
         for var1, var2 in zip(
-                all_samples_ts.variants(impute_missing_data=True),
-                ts.variants(samples=samples, impute_missing_data=True)):
+            all_samples_ts.variants(impute_missing_data=True),
+            ts.variants(samples=samples, impute_missing_data=True),
+        ):
             self.assertEqual(var1.site, var2.site)
             self.assertEqual(var1.alleles, var2.alleles)
             self.assertEqual(var2.genotypes.shape, (len(samples),))
@@ -391,7 +408,8 @@ class TestVariantGenerator(unittest.TestCase):
             self.assertFalse(variant.has_missing_data)
             mutations = {
                 mutation.node: mutation.derived_state
-                for mutation in variant.site.mutations}
+                for mutation in variant.site.mutations
+            }
             for sample_index, u in enumerate(ts.samples()):
                 while u not in mutations and u != tskit.NULL:
                     u = tree.parent(u)
@@ -484,8 +502,8 @@ class TestHaplotypeGenerator(unittest.TestCase):
             col = ""
             for j in range(n):
                 b = haplotypes[j][k]
-                zeros += b == '0'
-                ones += b == '1'
+                zeros += b == "0"
+                ones += b == "1"
                 col += b
             self.assertEqual(zeros + ones, n)
 
@@ -493,11 +511,11 @@ class TestHaplotypeGenerator(unittest.TestCase):
         n = tree_sequence.sample_size
         m = tree_sequence.num_sites
         haplotypes = list(tree_sequence.haplotypes())
-        A = np.zeros((n, m), dtype='u1')
-        B = np.zeros((n, m), dtype='u1')
+        A = np.zeros((n, m), dtype="u1")
+        B = np.zeros((n, m), dtype="u1")
         for j, h in enumerate(haplotypes):
             self.assertEqual(len(h), m)
-            A[j] = np.fromstring(h, np.uint8) - ord('0')
+            A[j] = np.fromstring(h, np.uint8) - ord("0")
         for variant in tree_sequence.variants():
             B[:, variant.index] = variant.genotypes
         self.assertTrue(np.all(A == B))
@@ -509,7 +527,8 @@ class TestHaplotypeGenerator(unittest.TestCase):
         """
         recomb_map = msprime.RecombinationMap.uniform_map(m, r, m)
         tree_sequence = msprime.simulate(
-            n, recombination_map=recomb_map, mutation_rate=theta)
+            n, recombination_map=recomb_map, mutation_rate=theta
+        )
         self.verify_tree_sequence(tree_sequence)
 
     def test_random_parameters(self):
@@ -525,10 +544,15 @@ class TestHaplotypeGenerator(unittest.TestCase):
         bottlenecks = [
             msprime.SimpleBottleneck(0.01, 0, proportion=0.05),
             msprime.SimpleBottleneck(0.02, 0, proportion=0.25),
-            msprime.SimpleBottleneck(0.03, 0, proportion=1)]
+            msprime.SimpleBottleneck(0.03, 0, proportion=1),
+        ]
         ts = msprime.simulate(
-            10, length=100, recombination_rate=1,
-            demographic_events=bottlenecks, random_seed=1)
+            10,
+            length=100,
+            recombination_rate=1,
+            demographic_events=bottlenecks,
+            random_seed=1,
+        )
         self.verify_tree_sequence(ts)
 
     def test_acgt_mutations(self):
@@ -540,12 +564,14 @@ class TestHaplotypeGenerator(unittest.TestCase):
         sites.set_columns(
             position=sites.position,
             ancestral_state=np.zeros(ts.num_sites, dtype=np.int8) + ord("A"),
-            ancestral_state_offset=np.arange(ts.num_sites + 1, dtype=np.uint32))
+            ancestral_state_offset=np.arange(ts.num_sites + 1, dtype=np.uint32),
+        )
         mutations.set_columns(
             site=mutations.site,
             node=mutations.node,
             derived_state=np.zeros(ts.num_sites, dtype=np.int8) + ord("T"),
-            derived_state_offset=np.arange(ts.num_sites + 1, dtype=np.uint32))
+            derived_state_offset=np.arange(ts.num_sites + 1, dtype=np.uint32),
+        )
         tsp = tables.tree_sequence()
         H = [h.replace("0", "A").replace("1", "T") for h in ts.haplotypes()]
         self.assertEqual(H, list(tsp.haplotypes()))
@@ -577,8 +603,8 @@ class TestHaplotypeGenerator(unittest.TestCase):
         tables = ts.dump_tables()
         for j in range(num_sites):
             tables.sites.add_row(
-                position=j * ts.sequence_length / num_sites,
-                ancestral_state="0")
+                position=j * ts.sequence_length / num_sites, ancestral_state="0"
+            )
             for u in range(ts.sample_size):
                 tables.mutations.add_row(site=j, node=u, derived_state="1")
         ts_new = tables.tree_sequence()
@@ -632,7 +658,8 @@ class TestUserAlleles(unittest.TestCase):
         G2 = ts.genotype_matrix(alleles=("0", "1"))
         self.assertTrue(np.array_equal(G1, G2))
         for v1, v2 in itertools.zip_longest(
-                ts.variants(), ts.variants(alleles=("0", "1"))):
+            ts.variants(), ts.variants(alleles=("0", "1"))
+        ):
             self.assertEqual(v1.alleles, v2.alleles)
             self.assertEqual(v1.site, v2.site)
             self.assertTrue(np.array_equal(v1.genotypes, v2.genotypes))
@@ -645,7 +672,8 @@ class TestUserAlleles(unittest.TestCase):
         G2 = ts.genotype_matrix(alleles=alleles)
         self.assertTrue(np.array_equal(G1, G2))
         for v1, v2 in itertools.zip_longest(
-                ts.variants(), ts.variants(alleles=alleles)):
+            ts.variants(), ts.variants(alleles=alleles)
+        ):
             self.assertEqual(v2.alleles, alleles)
             self.assertEqual(v1.site, v2.site)
             self.assertTrue(np.array_equal(v1.genotypes, v2.genotypes))
@@ -658,7 +686,8 @@ class TestUserAlleles(unittest.TestCase):
         G2 = ts.genotype_matrix(alleles=alleles)
         self.assertTrue(np.array_equal(G1 + 3, G2))
         for v1, v2 in itertools.zip_longest(
-                ts.variants(), ts.variants(alleles=alleles)):
+            ts.variants(), ts.variants(alleles=alleles)
+        ):
             self.assertEqual(v2.alleles, alleles)
             self.assertEqual(v1.site, v2.site)
             self.assertTrue(np.array_equal(v1.genotypes + 3, v2.genotypes))
@@ -673,7 +702,8 @@ class TestUserAlleles(unittest.TestCase):
         G1[index] = 2
         self.assertTrue(np.array_equal(G1, G2))
         for v1, v2 in itertools.zip_longest(
-                ts.variants(), ts.variants(alleles=alleles)):
+            ts.variants(), ts.variants(alleles=alleles)
+        ):
             self.assertEqual(v2.alleles, alleles)
             self.assertEqual(v1.site, v2.site)
             g = v1.genotypes
@@ -684,11 +714,14 @@ class TestUserAlleles(unittest.TestCase):
     def test_simple_acgt(self):
         ts = msprime.simulate(10, random_seed=2)
         ts = msprime.mutate(
-            ts, rate=4, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES))
+            ts, rate=4, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES)
+        )
         self.assertGreater(ts.num_sites, 2)
         alleles = tskit.ALLELES_ACGT
         G = ts.genotype_matrix(alleles=alleles)
-        for v1, v2 in itertools.zip_longest(ts.variants(), ts.variants(alleles=alleles)):
+        for v1, v2 in itertools.zip_longest(
+            ts.variants(), ts.variants(alleles=alleles)
+        ):
             self.assertEqual(v2.alleles, alleles)
             self.assertEqual(v1.site, v2.site)
             h1 = "".join(v1.alleles[g] for g in v1.genotypes)
@@ -699,11 +732,16 @@ class TestUserAlleles(unittest.TestCase):
     def test_missing_alleles(self):
         ts = msprime.simulate(10, random_seed=2)
         ts = msprime.mutate(
-            ts, rate=4, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES))
+            ts, rate=4, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES)
+        )
         self.assertGreater(ts.num_sites, 2)
         bad_allele_examples = [
-                tskit.ALLELES_01, tuple(["A"]), ("C", "T", "G"), ("AA", "C", "T", "G"),
-                tuple(["ACTG"])]
+            tskit.ALLELES_01,
+            tuple(["A"]),
+            ("C", "T", "G"),
+            ("AA", "C", "T", "G"),
+            tuple(["ACTG"]),
+        ]
         for bad_alleles in bad_allele_examples:
             with self.assertRaises(exceptions.LibraryError):
                 ts.genotype_matrix(alleles=bad_alleles)
@@ -737,7 +775,8 @@ class TestUserAlleles(unittest.TestCase):
         for impute in [True, False]:
             G1 = ts.genotype_matrix(impute_missing_data=impute)
             G2 = ts.genotype_matrix(
-                impute_missing_data=impute, alleles=tskit.ALLELES_01)
+                impute_missing_data=impute, alleles=tskit.ALLELES_01
+            )
             self.assertTrue(np.array_equal(G1, G2))
             vars1 = ts.variants(impute_missing_data=impute)
             vars2 = ts.variants(impute_missing_data=impute, alleles=tskit.ALLELES_01)
@@ -752,8 +791,11 @@ class TestUserAllelesRoundTrip(unittest.TestCase):
     Tests that we correctly produce haplotypes in a variety of situations for
     the user specified allele map encoding.
     """
+
     def verify(self, ts, alleles):
-        for v1, v2 in itertools.zip_longest(ts.variants(), ts.variants(alleles=alleles)):
+        for v1, v2 in itertools.zip_longest(
+            ts.variants(), ts.variants(alleles=alleles)
+        ):
             h1 = [v1.alleles[g] for g in v1.genotypes]
             h2 = [v2.alleles[g] for g in v2.genotypes]
             self.assertEqual(h1, h2)
@@ -774,7 +816,8 @@ class TestUserAllelesRoundTrip(unittest.TestCase):
     def test_simple_acgt(self):
         ts = msprime.simulate(5, random_seed=3)
         ts = msprime.mutate(
-            ts, rate=4, random_seed=3, model=msprime.InfiniteSites(msprime.NUCLEOTIDES))
+            ts, rate=4, random_seed=3, model=msprime.InfiniteSites(msprime.NUCLEOTIDES)
+        )
         self.assertGreater(ts.num_sites, 3)
         valid_alleles = [
             tskit.ALLELES_ACGT,

--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -1099,20 +1099,26 @@ class TestAllPaths(unittest.TestCase):
 
     def test_n3_m4(self):
         G = np.array([
-            [1, 0, 0],
-            [0, 0, 1],
-            [1, 0, 1],
-            [0, 1, 1]])
+                # fmt: off
+                [1, 0, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0, 1, 1],
+                # fmt: on
+        ])
         self.verify(G, [0, 0, 0, 0])
         self.verify(G, [1, 1, 1, 1])
         self.verify(G, [1, 1, 0, 0])
 
     def test_n4_m5(self):
         G = np.array([
-            [1, 0, 0, 0],
-            [0, 0, 1, 1],
-            [1, 0, 1, 1],
-            [0, 1, 1, 0]])
+                # fmt: off
+                [1, 0, 0, 0],
+                [0, 0, 1, 1],
+                [1, 0, 1, 1],
+                [0, 1, 1, 0],
+                # fmt: on
+            ])
         self.verify(G, [0, 0, 0, 0, 0])
         self.verify(G, [1, 1, 1, 1, 1])
         self.verify(G, [1, 1, 0, 0, 0])
@@ -1142,12 +1148,15 @@ class TestBasicViterbi(unittest.TestCase):
 
     def test_n2_m6_exact(self):
         G = np.array([
-            [1, 0],
-            [1, 0],
-            [1, 0],
-            [0, 1],
-            [0, 1],
-            [0, 1]])
+                # fmt: off
+                [1, 0],
+                [1, 0],
+                [1, 0],
+                [0, 1],
+                [0, 1],
+                [0, 1],
+                # fmt: on
+        ])
         self.verify_exact_match(G, [1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1])
         self.verify_exact_match(G, [0, 0, 0, 0, 0, 0], [1, 1, 1, 0, 0, 0])
         self.verify_exact_match(G, [0, 0, 0, 1, 1, 1], [1, 1, 1, 1, 1, 1])
@@ -1156,12 +1165,15 @@ class TestBasicViterbi(unittest.TestCase):
 
     def test_n3_m6_exact(self):
         G = np.array([
-            [1, 0, 1],
-            [1, 0, 0],
-            [1, 0, 1],
-            [0, 1, 0],
-            [0, 1, 1],
-            [0, 1, 0]])
+                # fmt: off
+                [1, 0, 1],
+                [1, 0, 0],
+                [1, 0, 1],
+                [0, 1, 0],
+                [0, 1, 1],
+                [0, 1, 0],
+                # fmt: on
+        ])
         self.verify_exact_match(G, [1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1])
         self.verify_exact_match(G, [0, 0, 0, 0, 0, 0], [1, 1, 1, 0, 0, 0])
         self.verify_exact_match(G, [0, 0, 0, 1, 1, 1], [1, 1, 1, 1, 1, 1])
@@ -1169,12 +1181,15 @@ class TestBasicViterbi(unittest.TestCase):
 
     def test_n3_m6(self):
         G = np.array([
-            [1, 0, 1],
-            [1, 0, 0],
-            [1, 0, 1],
-            [0, 1, 0],
-            [0, 1, 1],
-            [0, 1, 0]])
+                # fmt: off
+                [1, 0, 1],
+                [1, 0, 0],
+                [1, 0, 1],
+                [0, 1, 0],
+                [0, 1, 1],
+                [0, 1, 0],
+                # fmt: on
+            ])
 
         m, n = G.shape
         rho = np.zeros(m) + 1e-2

--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -110,7 +110,8 @@ def ls_viterbi_naive(h, alleles, G, rho, mu):
         if L[j] == 0:
             assert mu[l] == 0
             raise ValueError(
-                "Trying to match non-existent allele with zero mutation rate")
+                "Trying to match non-existent allele with zero mutation rate"
+            )
         L /= L[j]
 
     P = np.zeros(m, dtype=int)
@@ -152,7 +153,8 @@ def ls_viterbi_vectorised(h, alleles, G, rho, mu):
         if V[max_index[site]] == 0:
             assert mu[site] == 0
             raise ValueError(
-                "Trying to match non-existent allele with zero mutation rate")
+                "Trying to match non-existent allele with zero mutation rate"
+            )
         V /= V[max_index[site]]
 
     # Traceback
@@ -300,8 +302,12 @@ def ls_forward_tree(h, alleles, ts, rho, mu, precision=30, use_lib=True):
     if use_lib:
         acgt_alleles = tuple(alleles) == tskit.ALLELES_ACGT
         ls_hmm = _tskit.LsHmm(
-            ts.ll_tree_sequence, recombination_rate=rho, mutation_rate=mu,
-            precision=precision, acgt_alleles=acgt_alleles)
+            ts.ll_tree_sequence,
+            recombination_rate=rho,
+            mutation_rate=mu,
+            precision=precision,
+            acgt_alleles=acgt_alleles,
+        )
         cm = _tskit.CompressedMatrix(ts.ll_tree_sequence)
         ls_hmm.forward_matrix(h, cm)
         return cm
@@ -317,8 +323,12 @@ def ls_viterbi_tree(h, alleles, ts, rho, mu, precision=30, use_lib=True):
     if use_lib:
         acgt_alleles = tuple(alleles) == tskit.ALLELES_ACGT
         ls_hmm = _tskit.LsHmm(
-            ts.ll_tree_sequence, recombination_rate=rho, mutation_rate=mu,
-            precision=precision, acgt_alleles=acgt_alleles)
+            ts.ll_tree_sequence,
+            recombination_rate=rho,
+            mutation_rate=mu,
+            precision=precision,
+            acgt_alleles=acgt_alleles,
+        )
         vm = _tskit.ViterbiMatrix(ts.ll_tree_sequence)
         ls_hmm.viterbi_matrix(h, vm)
         return vm
@@ -331,6 +341,7 @@ class ValueTransition(object):
     """
     Simple struct holding value transition values.
     """
+
     def __init__(self, tree_node=-1, value=-1, value_index=-1):
         self.tree_node = tree_node
         self.value = value
@@ -350,6 +361,7 @@ class LsHmmAlgorithm(object):
     """
     Abstract superclass of Li and Stephens HMM algorithm.
     """
+
     def __init__(self, ts, rho, mu, alleles, precision=10):
         self.ts = ts
         self.mu = mu
@@ -411,7 +423,9 @@ class LsHmmAlgorithm(object):
                 A[u] = union
 
         A = np.zeros((tree.tree_sequence.num_nodes, len(values)), dtype=int)
-        t_node_time = [-1 if st.tree_node == -1 else tree.time(st.tree_node) for st in T]
+        t_node_time = [
+            -1 if st.tree_node == -1 else tree.time(st.tree_node) for st in T
+        ]
         order = np.argsort(t_node_time)
         for j in order:
             st = T[j]
@@ -456,14 +470,16 @@ class LsHmmAlgorithm(object):
                         new_child_state = np.where(A[v] == 1)[0][0]
                         child_t_parent = len(T)
                         T_parent.append(t_parent)
-                        T.append(ValueTransition(
-                            tree_node=v, value=values[new_child_state]))
+                        T.append(
+                            ValueTransition(tree_node=v, value=values[new_child_state])
+                        )
                     stack.append((v, old_child_state, new_child_state, child_t_parent))
                 else:
                     if old_child_state != new_state:
                         T_parent.append(t_parent)
-                        T.append(ValueTransition(
-                            tree_node=v, value=values[old_child_state]))
+                        T.append(
+                            ValueTransition(tree_node=v, value=values[old_child_state])
+                        )
 
         for st in T_old:
             if st.tree_node != -1:
@@ -492,8 +508,9 @@ class LsHmmAlgorithm(object):
                     u = parent[u]
                     assert u != -1
                 T_index[edge.child] = len(T)
-                T.append(ValueTransition(
-                    tree_node=edge.child, value=T[T_index[u]].value))
+                T.append(
+                    ValueTransition(tree_node=edge.child, value=T[T_index[u]].value)
+                )
             parent[edge.child] = -1
 
         for edge in edges_in:
@@ -503,8 +520,11 @@ class LsHmmAlgorithm(object):
                 # Grafting onto a new root.
                 if T_index[edge.parent] == -1:
                     T_index[edge.parent] = len(T)
-                    T.append(ValueTransition(
-                        tree_node=edge.parent, value=T[T_index[edge.child]].value))
+                    T.append(
+                        ValueTransition(
+                            tree_node=edge.parent, value=T[T_index[edge.child]].value
+                        )
+                    )
             else:
                 # Grafting into an existing subtree.
                 while T_index[u] == -1:
@@ -546,8 +566,9 @@ class LsHmmAlgorithm(object):
                 while T_index[u] == tskit.NULL:
                     u = tree.parent(u)
                 T_index[mutation.node] = len(T)
-                T.append(ValueTransition(
-                    tree_node=mutation.node, value=T[T_index[u]].value))
+                T.append(
+                    ValueTransition(tree_node=mutation.node, value=T[T_index[u]].value)
+                )
 
         for st in T:
             u = st.tree_node
@@ -559,7 +580,8 @@ class LsHmmAlgorithm(object):
                     v = tree.parent(v)
                     assert v != -1
                 x = self.compute_next_probability(
-                    site.id, st.value, haplotype_state == allelic_state[v], u)
+                    site.id, st.value, haplotype_state == allelic_state[v], u
+                )
                 st.value = round(x, self.precision)
 
         # Unset the states
@@ -596,6 +618,7 @@ class CompressedMatrix(object):
     from a particular node will inherit that value (unless any other
     values are on the path).
     """
+
     def __init__(self, ts):
         self.ts = ts
         self.num_sites = ts.num_sites
@@ -643,6 +666,7 @@ class ForwardAlgorithm(LsHmmAlgorithm):
     """
     Runs the Li and Stephens forward algorithm.
     """
+
     def __init__(self, ts, rho, mu, alleles, precision=10):
         super().__init__(ts, rho, mu, alleles, precision)
         self.output = ForwardMatrix(ts)
@@ -671,6 +695,7 @@ class ViterbiMatrix(CompressedMatrix):
     """
     Class representing the compressed Viterbi matrix.
     """
+
     def __init__(self, ts):
         super().__init__(ts)
         self.recombination_required = [(-1, 0, False)]
@@ -748,6 +773,7 @@ class ViterbiAlgorithm(LsHmmAlgorithm):
     """
     Runs the Li and Stephens Viterbi algorithm.
     """
+
     def __init__(self, ts, rho, mu, alleles, precision=10):
         super().__init__(ts, rho, mu, alleles, precision)
         self.output = ViterbiMatrix(ts)
@@ -760,12 +786,15 @@ class ViterbiAlgorithm(LsHmmAlgorithm):
         if max_st.value == 0:
             assert self.mu[l] == 0
             raise ValueError(
-                "Trying to match non-existent allele with zero mutation rate")
+                "Trying to match non-existent allele with zero mutation rate"
+            )
 
         max_value = max_st.value
         for st in self.T:
             st.value /= max_value
-        self.output.store_site(l, max_value, [(st.tree_node, st.value) for st in self.T])
+        self.output.store_site(
+            l, max_value, [(st.tree_node, st.value) for st in self.T]
+        )
 
     def compute_next_probability(self, site_id, p_last, is_match, node):
         rho = self.rho[site_id]
@@ -797,6 +826,7 @@ class LiStephensBase(object):
     """
     Superclass of Li and Stephens tests.
     """
+
     def assertCompressedMatricesEqual(self, cm1, cm2):
         """
         Checks that the specified compressed matrices contain the same data.
@@ -864,12 +894,14 @@ class LiStephensBase(object):
         rhos = [
             np.zeros(ts.num_sites) + 0.999,
             np.zeros(ts.num_sites) + 1e-6,
-            rng.uniform(0, 1, ts.num_sites)]
+            rng.uniform(0, 1, ts.num_sites),
+        ]
         # mu can't be more than 1 / 3 if we have 4 alleles
         mus = [
             np.zeros(ts.num_sites) + 0.33,
             np.zeros(ts.num_sites) + 1e-6,
-            rng.uniform(0, 0.33, ts.num_sites)]
+            rng.uniform(0, 0.33, ts.num_sites),
+        ]
         for h, rho, mu in itertools.product(haplotypes, rhos, mus):
             rho[0] = 0
             yield h, rho, mu
@@ -941,6 +973,7 @@ class TestNumpyMatrixMethod(ForwardAlgorithmBase, unittest.TestCase):
     Tests that we compute the same values from the numpy matrix method as
     the naive algorithm.
     """
+
     def verify(self, ts, alleles=tskit.ALLELES_01):
         G = ts.genotype_matrix(alleles=alleles)
         for h, rho, mu in self.example_parameters(ts, alleles):
@@ -988,7 +1021,6 @@ class TestExactMatchViterbi(ViterbiAlgorithmBase, unittest.TestCase):
 
 
 class TestGeneralViterbi(ViterbiAlgorithmBase, unittest.TestCase):
-
     def verify(self, ts, alleles=tskit.ALLELES_01):
         np.set_printoptions(linewidth=20000)
         np.set_printoptions(threshold=20000000)
@@ -1041,6 +1073,7 @@ class TestForwardMatrixScaling(ForwardAlgorithmBase, unittest.TestCase):
     Tests that we get the correct values from scaling version of the matrix
     algorithm works correctly.
     """
+
     def verify(self, ts, alleles=tskit.ALLELES_01):
         G = ts.genotype_matrix(alleles=alleles)
         computed_log_proba = False
@@ -1066,6 +1099,7 @@ class TestForwardTree(ForwardAlgorithmBase, unittest.TestCase):
     Tests that the tree algorithm computes the same forward matrix as the
     simple method.
     """
+
     def verify(self, ts, alleles=tskit.ALLELES_01):
         G = ts.genotype_matrix(alleles=alleles)
         for h, rho, mu in self.example_parameters(ts, alleles):
@@ -1083,6 +1117,7 @@ class TestAllPaths(unittest.TestCase):
     Tests that we compute the correct forward probablities if we sum over all
     possible paths through the genotype matrix.
     """
+
     def verify(self, G, h):
         m, n = G.shape
         rho = np.zeros(m) + 0.1
@@ -1098,27 +1133,31 @@ class TestAllPaths(unittest.TestCase):
         self.assertAlmostEqual(proba, forward_proba)
 
     def test_n3_m4(self):
-        G = np.array([
+        G = np.array(
+            [
                 # fmt: off
                 [1, 0, 0],
                 [0, 0, 1],
                 [1, 0, 1],
                 [0, 1, 1],
                 # fmt: on
-        ])
+            ]
+        )
         self.verify(G, [0, 0, 0, 0])
         self.verify(G, [1, 1, 1, 1])
         self.verify(G, [1, 1, 0, 0])
 
     def test_n4_m5(self):
-        G = np.array([
+        G = np.array(
+            [
                 # fmt: off
                 [1, 0, 0, 0],
                 [0, 0, 1, 1],
                 [1, 0, 1, 1],
                 [0, 1, 1, 0],
                 # fmt: on
-            ])
+            ]
+        )
         self.verify(G, [0, 0, 0, 0, 0])
         self.verify(G, [1, 1, 1, 1, 1])
         self.verify(G, [1, 1, 0, 0, 0])
@@ -1135,6 +1174,7 @@ class TestBasicViterbi(unittest.TestCase):
     """
     Very simple tests of the Viterbi algorithm.
     """
+
     def verify_exact_match(self, G, h, path):
         m, n = G.shape
         rho = np.zeros(m) + 1e-9
@@ -1147,7 +1187,8 @@ class TestBasicViterbi(unittest.TestCase):
         self.assertEqual(list(path2), path)
 
     def test_n2_m6_exact(self):
-        G = np.array([
+        G = np.array(
+            [
                 # fmt: off
                 [1, 0],
                 [1, 0],
@@ -1156,7 +1197,8 @@ class TestBasicViterbi(unittest.TestCase):
                 [0, 1],
                 [0, 1],
                 # fmt: on
-        ])
+            ]
+        )
         self.verify_exact_match(G, [1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1])
         self.verify_exact_match(G, [0, 0, 0, 0, 0, 0], [1, 1, 1, 0, 0, 0])
         self.verify_exact_match(G, [0, 0, 0, 1, 1, 1], [1, 1, 1, 1, 1, 1])
@@ -1164,7 +1206,8 @@ class TestBasicViterbi(unittest.TestCase):
         self.verify_exact_match(G, [0, 0, 0, 0, 1, 0], [1, 1, 1, 0, 1, 0])
 
     def test_n3_m6_exact(self):
-        G = np.array([
+        G = np.array(
+            [
                 # fmt: off
                 [1, 0, 1],
                 [1, 0, 0],
@@ -1173,14 +1216,16 @@ class TestBasicViterbi(unittest.TestCase):
                 [0, 1, 1],
                 [0, 1, 0],
                 # fmt: on
-        ])
+            ]
+        )
         self.verify_exact_match(G, [1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1])
         self.verify_exact_match(G, [0, 0, 0, 0, 0, 0], [1, 1, 1, 0, 0, 0])
         self.verify_exact_match(G, [0, 0, 0, 1, 1, 1], [1, 1, 1, 1, 1, 1])
         self.verify_exact_match(G, [1, 0, 1, 0, 1, 0], [2, 2, 2, 2, 2, 2])
 
     def test_n3_m6(self):
-        G = np.array([
+        G = np.array(
+            [
                 # fmt: off
                 [1, 0, 1],
                 [1, 0, 0],
@@ -1189,7 +1234,8 @@ class TestBasicViterbi(unittest.TestCase):
                 [0, 1, 1],
                 [0, 1, 0],
                 # fmt: on
-            ])
+            ]
+        )
 
         m, n = G.shape
         rho = np.zeros(m) + 1e-2

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -54,11 +54,16 @@ def insert_uniform_mutations(tables, num_mutations, nodes):
     """
     for j in range(num_mutations):
         tables.sites.add_row(
-            position=j * (tables.sequence_length / num_mutations), ancestral_state='0',
-            metadata=json.dumps({"index": j}).encode())
+            position=j * (tables.sequence_length / num_mutations),
+            ancestral_state="0",
+            metadata=json.dumps({"index": j}).encode(),
+        )
         tables.mutations.add_row(
-            site=j, derived_state='1', node=nodes[j % len(nodes)],
-            metadata=json.dumps({"index": j}).encode())
+            site=j,
+            derived_state="1",
+            node=nodes[j % len(nodes)],
+            metadata=json.dumps({"index": j}).encode(),
+        )
 
 
 def get_table_collection_copy(tables, sequence_length):
@@ -160,7 +165,7 @@ def get_internal_samples_examples():
 
     # Set a mixture of internal and leaf samples.
     flags[:] = 0
-    flags[n // 2: n + n // 2] = tskit.NODE_IS_SAMPLE
+    flags[n // 2 : n + n // 2] = tskit.NODE_IS_SAMPLE
     nodes.flags = flags
     yield tables.tree_sequence()
 
@@ -192,19 +197,25 @@ def get_example_tree_sequences(back_mutations=True, gaps=True, internal_samples=
             for rho in [0, 0.1, 0.5]:
                 recomb_map = msprime.RecombinationMap.uniform_map(m, rho, num_loci=m)
                 ts = msprime.simulate(
-                    recombination_map=recomb_map, mutation_rate=0.1,
+                    recombination_map=recomb_map,
+                    mutation_rate=0.1,
                     random_seed=seed,
                     population_configurations=[
                         msprime.PopulationConfiguration(n),
-                        msprime.PopulationConfiguration(0)],
-                    migration_matrix=[[0, 1], [1, 0]])
+                        msprime.PopulationConfiguration(0),
+                    ],
+                    migration_matrix=[[0, 1], [1, 0]],
+                )
                 ts = tsutil.insert_random_ploidy_individuals(ts, 4, seed=seed)
                 yield tsutil.add_random_metadata(ts, seed=seed)
                 seed += 1
     for ts in get_bottleneck_examples():
         yield msprime.mutate(
-            ts, rate=0.1, random_seed=seed,
-            model=msprime.InfiniteSites(msprime.NUCLEOTIDES))
+            ts,
+            rate=0.1,
+            random_seed=seed,
+            model=msprime.InfiniteSites(msprime.NUCLEOTIDES),
+        )
     ts = msprime.simulate(15, length=4, recombination_rate=1)
     assert ts.num_trees > 1
     if back_mutations:
@@ -221,12 +232,16 @@ def get_bottleneck_examples():
     bottlenecks = [
         msprime.SimpleBottleneck(0.01, 0, proportion=0.05),
         msprime.SimpleBottleneck(0.02, 0, proportion=0.25),
-        msprime.SimpleBottleneck(0.03, 0, proportion=1)]
+        msprime.SimpleBottleneck(0.03, 0, proportion=1),
+    ]
     for n in [3, 10, 100]:
         ts = msprime.simulate(
-            n, length=100, recombination_rate=1,
+            n,
+            length=100,
+            recombination_rate=1,
             demographic_events=bottlenecks,
-            random_seed=n)
+            random_seed=n,
+        )
         yield ts
 
 
@@ -259,8 +274,7 @@ def simplify_tree_sequence(ts, samples, filter_sites=True):
     """
     Simple tree-by-tree algorithm to get a simplify of a tree sequence.
     """
-    s = simplify.Simplifier(
-        ts, samples, filter_sites=filter_sites)
+    s = simplify.Simplifier(ts, samples, filter_sites=filter_sites)
     return s.simplify()
 
 
@@ -325,6 +339,7 @@ class TestMRCACalculator(unittest.TestCase):
     These tests are included here as we use the MRCA calculator below in
     our tests.
     """
+
     def test_all_oriented_forests(self):
         # Runs through all possible oriented forests and checks all possible
         # node pairs using an inferior algorithm.
@@ -341,6 +356,7 @@ class HighLevelTestCase(unittest.TestCase):
     """
     Superclass of tests on the high level interface.
     """
+
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp(prefix="tsk_hl_testcase_")
         self.temp_file = os.path.join(self.temp_dir, "generic")
@@ -471,23 +487,29 @@ class TestNumpySamples(unittest.TestCase):
     Tests that we correctly handle samples as numpy arrays when passed to
     various methods.
     """
+
     def get_tree_sequence(self, num_demes=4):
         n = 40
         return msprime.simulate(
             samples=[
-                msprime.Sample(time=0, population=j % num_demes) for j in range(n)],
+                msprime.Sample(time=0, population=j % num_demes) for j in range(n)
+            ],
             population_configurations=[
-                msprime.PopulationConfiguration() for _ in range(num_demes)],
+                msprime.PopulationConfiguration() for _ in range(num_demes)
+            ],
             migration_matrix=[
-                [int(j != k) for j in range(num_demes)] for k in range(num_demes)],
+                [int(j != k) for j in range(num_demes)] for k in range(num_demes)
+            ],
             random_seed=1,
-            mutation_rate=10)
+            mutation_rate=10,
+        )
 
     def test_samples(self):
         d = 4
         ts = self.get_tree_sequence(d)
-        self.assertTrue(np.array_equal(
-            ts.samples(), np.arange(ts.num_samples, dtype=np.int32)))
+        self.assertTrue(
+            np.array_equal(ts.samples(), np.arange(ts.num_samples, dtype=np.int32))
+        )
         total = 0
         for pop in range(d):
             subsample = ts.samples(pop)
@@ -495,8 +517,12 @@ class TestNumpySamples(unittest.TestCase):
             self.assertTrue(np.array_equal(subsample, ts.samples(population=pop)))
             self.assertEqual(
                 list(subsample),
-                [node.id for node in ts.nodes()
-                    if node.population == pop and node.is_sample()])
+                [
+                    node.id
+                    for node in ts.nodes()
+                    if node.population == pop and node.is_sample()
+                ],
+            )
         self.assertEqual(total, ts.num_samples)
 
     def test_genotype_matrix_indexing(self):
@@ -627,8 +653,9 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(edgeset.children, sorted(edgeset.children))
             self.assertGreater(len(edgeset.children), 0)
             for child in edgeset.children:
-                new_edges.append(tskit.Edge(
-                    edgeset.left, edgeset.right, edgeset.parent, child))
+                new_edges.append(
+                    tskit.Edge(edgeset.left, edgeset.right, edgeset.parent, child)
+                )
         # squash the edges.
         t = ts.dump_tables().nodes.time
         new_edges.sort(key=lambda e: (t[e.parent], e.parent, e.child, e.left))
@@ -637,9 +664,10 @@ class TestTreeSequence(HighLevelTestCase):
         last_e = new_edges[0]
         for e in new_edges[1:]:
             condition = (
-                e.parent != last_e.parent or
-                e.child != last_e.child or
-                e.left != last_e.right)
+                e.parent != last_e.parent
+                or e.child != last_e.child
+                or e.left != last_e.right
+            )
             if condition:
                 squashed.append(last_e)
                 last_e = e
@@ -745,14 +773,14 @@ class TestTreeSequence(HighLevelTestCase):
             for t_new, t_old in zip(trees_new, trees_old):
                 for u in t_new.nodes():
                     self.assertEqual(
-                        t_new.num_tracked_samples(u), t_old.get_num_tracked_leaves(u))
+                        t_new.num_tracked_samples(u), t_old.get_num_tracked_leaves(u)
+                    )
             trees_new = ts.trees()
             trees_old = ts.trees()
             for t_new, t_old in zip(trees_new, trees_old):
                 for u in t_new.nodes():
                     self.assertEqual(t_new.num_samples(u), t_old.get_num_leaves(u))
-                    self.assertEqual(
-                        list(t_new.samples(u)), list(t_old.get_leaves(u)))
+                    self.assertEqual(list(t_new.samples(u)), list(t_old.get_leaves(u)))
             for on in [True, False]:
                 trees_new = ts.trees(sample_lists=on)
                 trees_old = ts.trees(leaf_lists=on)
@@ -760,7 +788,8 @@ class TestTreeSequence(HighLevelTestCase):
                     for u in t_new.nodes():
                         self.assertEqual(t_new.num_samples(u), t_old.get_num_leaves(u))
                         self.assertEqual(
-                            list(t_new.samples(u)), list(t_old.get_leaves(u)))
+                            list(t_new.samples(u)), list(t_old.get_leaves(u))
+                        )
 
     def verify_samples(self, ts):
         # We should get the same list of samples if we use the low-level
@@ -780,11 +809,17 @@ class TestTreeSequence(HighLevelTestCase):
             for pop in pops:
                 subsample = ts.samples(pop)
                 self.assertTrue(np.array_equal(subsample, ts.samples(population=pop)))
-                self.assertTrue(np.array_equal(subsample, ts.samples(population_id=pop)))
+                self.assertTrue(
+                    np.array_equal(subsample, ts.samples(population_id=pop))
+                )
                 self.assertEqual(
                     list(subsample),
-                    [node.id for node in ts.nodes()
-                        if node.population == pop and node.is_sample()])
+                    [
+                        node.id
+                        for node in ts.nodes()
+                        if node.population == pop and node.is_sample()
+                    ],
+                )
             self.assertRaises(ValueError, ts.samples, population=0, population_id=0)
 
     def test_first_last(self):
@@ -824,11 +859,12 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertRaises(ValueError, ts.get_pairwise_diversity, [])
             samples = list(ts.samples())
             self.assertEqual(
-                ts.get_pairwise_diversity(),
-                ts.get_pairwise_diversity(samples))
+                ts.get_pairwise_diversity(), ts.get_pairwise_diversity(samples)
+            )
             self.assertEqual(
                 ts.get_pairwise_diversity(samples[:2]),
-                ts.get_pairwise_diversity(list(reversed(samples[:2]))))
+                ts.get_pairwise_diversity(list(reversed(samples[:2]))),
+            )
 
     def test_populations(self):
         more_than_zero = False
@@ -893,7 +929,8 @@ class TestTreeSequence(HighLevelTestCase):
     def test_max_root_time(self):
         for ts in get_example_tree_sequences():
             oldest = max(
-                max(tree.time(root) for root in tree.roots) for tree in ts.trees())
+                max(tree.time(root) for root in tree.roots) for tree in ts.trees()
+            )
             self.assertEqual(oldest, ts.max_root_time)
 
     def test_max_root_time_corner_cases(self):
@@ -973,17 +1010,21 @@ class TestTreeSequence(HighLevelTestCase):
                     self.assertEqual(mrca2, node_map[mrca1])
                     self.assertEqual(old_tree.get_time(mrca1), new_tree.get_time(mrca2))
                     self.assertEqual(
-                        old_tree.get_population(mrca1), new_tree.get_population(mrca2))
+                        old_tree.get_population(mrca1), new_tree.get_population(mrca2)
+                    )
 
     def verify_simplify_equality(self, ts, sample):
         for filter_sites in [False, True]:
             s1, node_map1 = ts.simplify(
-                sample, map_nodes=True, filter_sites=filter_sites)
+                sample, map_nodes=True, filter_sites=filter_sites
+            )
             t1 = s1.dump_tables()
-            s2, node_map2 = simplify_tree_sequence(ts, sample, filter_sites=filter_sites)
+            s2, node_map2 = simplify_tree_sequence(
+                ts, sample, filter_sites=filter_sites
+            )
             t2 = s2.dump_tables()
-            self.assertEqual(s1.num_samples,  len(sample))
-            self.assertEqual(s2.num_samples,  len(sample))
+            self.assertEqual(s1.num_samples, len(sample))
+            self.assertEqual(s2.num_samples, len(sample))
             self.assertTrue(all(node_map1 == node_map2))
             self.assertEqual(t1.individuals, t2.individuals)
             self.assertEqual(t1.nodes, t2.nodes)
@@ -1026,8 +1067,7 @@ class TestTreeSequence(HighLevelTestCase):
         self.assertGreater(num_mutations, 0)
 
     def test_simplify_bugs(self):
-        prefix = os.path.join(
-            os.path.dirname(__file__), "data", "simplify-bugs")
+        prefix = os.path.join(os.path.dirname(__file__), "data", "simplify-bugs")
         j = 1
         while True:
             nodes_file = os.path.join(prefix, "{:02d}-nodes.txt".format(j))
@@ -1036,13 +1076,16 @@ class TestTreeSequence(HighLevelTestCase):
             edges_file = os.path.join(prefix, "{:02d}-edges.txt".format(j))
             sites_file = os.path.join(prefix, "{:02d}-sites.txt".format(j))
             mutations_file = os.path.join(prefix, "{:02d}-mutations.txt".format(j))
-            with open(nodes_file) as nodes, \
-                    open(edges_file) as edges,\
-                    open(sites_file) as sites,\
-                    open(mutations_file) as mutations:
+            with open(nodes_file) as nodes, open(edges_file) as edges, open(
+                sites_file
+            ) as sites, open(mutations_file) as mutations:
                 ts = tskit.load_text(
-                    nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-                    strict=False)
+                    nodes=nodes,
+                    edges=edges,
+                    sites=sites,
+                    mutations=mutations,
+                    strict=False,
+                )
             samples = list(ts.samples())
             self.verify_simplify_equality(ts, samples)
             j += 1
@@ -1052,10 +1095,12 @@ class TestTreeSequence(HighLevelTestCase):
         ts = msprime.simulate(
             population_configurations=[
                 msprime.PopulationConfiguration(10),
-                msprime.PopulationConfiguration(10)],
+                msprime.PopulationConfiguration(10),
+            ],
             migration_matrix=[[0, 1], [1, 0]],
             random_seed=2,
-            record_migrations=True)
+            record_migrations=True,
+        )
         self.assertGreater(ts.num_migrations, 0)
         # We don't support simplify with migrations, so should fail.
         with self.assertRaises(_tskit.LibraryError):
@@ -1073,7 +1118,8 @@ class TestTreeSequence(HighLevelTestCase):
         self.assertEqual(ts.get_pairwise_diversity(), ts.pairwise_diversity())
         samples = ts.samples()
         self.assertEqual(
-            ts.get_pairwise_diversity(samples), ts.pairwise_diversity(samples))
+            ts.get_pairwise_diversity(samples), ts.pairwise_diversity(samples)
+        )
         self.assertTrue(np.array_equal(ts.get_samples(), ts.samples()))
 
     def test_sites(self):
@@ -1087,9 +1133,11 @@ class TestTreeSequence(HighLevelTestCase):
             previous_pos = -1
             mutation_index = 0
             ancestral_state = tskit.unpack_strings(
-                sites.ancestral_state, sites.ancestral_state_offset)
+                sites.ancestral_state, sites.ancestral_state_offset
+            )
             derived_state = tskit.unpack_strings(
-                mutations.derived_state, mutations.derived_state_offset)
+                mutations.derived_state, mutations.derived_state_offset
+            )
 
             for index, site in enumerate(ts.sites()):
                 s2 = ts.site(site.id)
@@ -1108,7 +1156,8 @@ class TestTreeSequence(HighLevelTestCase):
                     self.assertEqual(mutation.parent, mutations.parent[mutation_index])
                     self.assertEqual(mutation.id, mutation_index)
                     self.assertEqual(
-                        derived_state[mutation_index], mutation.derived_state)
+                        derived_state[mutation_index], mutation.derived_state
+                    )
                     mutation_index += 1
                 some_sites = True
             total_sites = 0
@@ -1183,10 +1232,12 @@ class TestTreeSequence(HighLevelTestCase):
         ts = msprime.simulate(
             population_configurations=[
                 msprime.PopulationConfiguration(10),
-                msprime.PopulationConfiguration(10)],
+                msprime.PopulationConfiguration(10),
+            ],
             migration_matrix=[[0, 1], [1, 0]],
             random_seed=2,
-            record_migrations=True)
+            record_migrations=True,
+        )
         self.assertGreater(ts.num_migrations, 0)
         migrations = list(ts.migrations())
         self.assertEqual(len(migrations), ts.num_migrations)
@@ -1262,7 +1313,7 @@ class TestTreeSequence(HighLevelTestCase):
                 for i, n in enumerate(sequence):
                     self.assertEqual(i, n.id)
                 self.assertEqual(n.id, length - 1 if length else 0)
-                if table_name == 'mutations':
+                if table_name == "mutations":
                     # Mutations are not currently sequences, so have no len or idx access
                     self.assertRaises(TypeError, len, sequence)
                     if length != 0:
@@ -1274,7 +1325,7 @@ class TestTreeSequence(HighLevelTestCase):
                     # Test __getitem__ on the last item in the sequence
                     if length != 0:
                         self.assertEqual(sequence[length - 1], n)  # +ive indexing
-                        self.assertEqual(sequence[-1], n)          # -ive indexing
+                        self.assertEqual(sequence[-1], n)  # -ive indexing
                     with self.assertRaises(IndexError):
                         sequence[length]
                     # Test reverse
@@ -1287,6 +1338,7 @@ class TestFileUuid(HighLevelTestCase):
     """
     Tests that the file UUID attribute is handled correctly.
     """
+
     def validate(self, ts):
         self.assertIsNone(ts.file_uuid)
         ts.dump(self.temp_file)
@@ -1343,13 +1395,16 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         """
         Verifies that the nodes we output have the correct form.
         """
+
         def convert(v):
             return "{:.{}f}".format(v, precision)
+
         output_nodes = nodes_file.read().splitlines()
         self.assertEqual(len(output_nodes) - 1, ts.num_nodes)
         self.assertEqual(
             list(output_nodes[0].split()),
-            ["id", "is_sample", "time", "population", "individual", "metadata"])
+            ["id", "is_sample", "time", "population", "individual", "metadata"],
+        )
         for node, line in zip(ts.nodes(), output_nodes[1:]):
             splits = line.split("\t")
             self.assertEqual(str(node.id), splits[0])
@@ -1363,13 +1418,15 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         """
         Verifies that the edges we output have the correct form.
         """
+
         def convert(v):
             return "{:.{}f}".format(v, precision)
+
         output_edges = edges_file.read().splitlines()
         self.assertEqual(len(output_edges) - 1, ts.num_edges)
         self.assertEqual(
-            list(output_edges[0].split()),
-            ["left", "right", "parent", "child"])
+            list(output_edges[0].split()), ["left", "right", "parent", "child"]
+        )
         for edge, line in zip(ts.edges(), output_edges[1:]):
             splits = line.split("\t")
             self.assertEqual(convert(edge.left), splits[0])
@@ -1381,13 +1438,15 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         """
         Verifies that the sites we output have the correct form.
         """
+
         def convert(v):
             return "{:.{}f}".format(v, precision)
+
         output_sites = sites_file.read().splitlines()
         self.assertEqual(len(output_sites) - 1, ts.num_sites)
         self.assertEqual(
-            list(output_sites[0].split()),
-            ["position", "ancestral_state", "metadata"])
+            list(output_sites[0].split()), ["position", "ancestral_state", "metadata"]
+        )
         for site, line in zip(ts.sites(), output_sites[1:]):
             splits = line.split("\t")
             self.assertEqual(convert(site.position), splits[0])
@@ -1398,13 +1457,16 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         """
         Verifies that the mutations we output have the correct form.
         """
+
         def convert(v):
             return "{:.{}f}".format(v, precision)
+
         output_mutations = mutations_file.read().splitlines()
         self.assertEqual(len(output_mutations) - 1, ts.num_mutations)
         self.assertEqual(
             list(output_mutations[0].split()),
-            ["site", "node", "derived_state", "parent", "metadata"])
+            ["site", "node", "derived_state", "parent", "metadata"],
+        )
         mutations = [mut for site in ts.sites() for mut in site.mutations]
         for mutation, line in zip(mutations, output_mutations[1:]):
             splits = line.split("\t")
@@ -1422,8 +1484,12 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
                 sites_file = io.StringIO()
                 mutations_file = io.StringIO()
                 ts.dump_text(
-                    nodes=nodes_file, edges=edges_file, sites=sites_file,
-                    mutations=mutations_file, precision=precision)
+                    nodes=nodes_file,
+                    edges=edges_file,
+                    sites=sites_file,
+                    mutations=mutations_file,
+                    precision=precision,
+                )
                 nodes_file.seek(0)
                 edges_file.seek(0)
                 sites_file.seek(0)
@@ -1487,9 +1553,14 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             individuals_file = io.StringIO()
             populations_file = io.StringIO()
             ts1.dump_text(
-                nodes=nodes_file, edges=edges_file, sites=sites_file,
-                mutations=mutations_file, individuals=individuals_file,
-                populations=populations_file, precision=16)
+                nodes=nodes_file,
+                edges=edges_file,
+                sites=sites_file,
+                mutations=mutations_file,
+                individuals=individuals_file,
+                populations=populations_file,
+                precision=16,
+            )
             nodes_file.seek(0)
             edges_file.seek(0)
             sites_file.seek(0)
@@ -1497,11 +1568,15 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
             individuals_file.seek(0)
             populations_file.seek(0)
             ts2 = tskit.load_text(
-                nodes=nodes_file, edges=edges_file, sites=sites_file,
-                mutations=mutations_file, individuals=individuals_file,
+                nodes=nodes_file,
+                edges=edges_file,
+                sites=sites_file,
+                mutations=mutations_file,
+                individuals=individuals_file,
                 populations=populations_file,
                 sequence_length=ts1.sequence_length,
-                strict=True)
+                strict=True,
+            )
             self.verify_approximate_equality(ts1, ts2)
 
     def test_empty_files(self):
@@ -1510,9 +1585,13 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         sites_file = io.StringIO("position\tancestral_state\n")
         mutations_file = io.StringIO("site\tnode\tderived_state\n")
         self.assertRaises(
-            _tskit.LibraryError, tskit.load_text,
-            nodes=nodes_file, edges=edges_file, sites=sites_file,
-            mutations=mutations_file)
+            _tskit.LibraryError,
+            tskit.load_text,
+            nodes=nodes_file,
+            edges=edges_file,
+            sites=sites_file,
+            mutations=mutations_file,
+        )
 
     def test_empty_files_sequence_length(self):
         nodes_file = io.StringIO("is_sample\ttime\n")
@@ -1520,8 +1599,12 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         sites_file = io.StringIO("position\tancestral_state\n")
         mutations_file = io.StringIO("site\tnode\tderived_state\n")
         ts = tskit.load_text(
-            nodes=nodes_file, edges=edges_file, sites=sites_file,
-            mutations=mutations_file, sequence_length=100)
+            nodes=nodes_file,
+            edges=edges_file,
+            sites=sites_file,
+            mutations=mutations_file,
+            sequence_length=100,
+        )
         self.assertEqual(ts.sequence_length, 100)
         self.assertEqual(ts.num_nodes, 0)
         self.assertEqual(ts.num_edges, 0)
@@ -1533,6 +1616,7 @@ class TestTree(HighLevelTestCase):
     """
     Some simple tests on the tree API.
     """
+
     def get_tree(self, sample_lists=False):
         ts = msprime.simulate(10, random_seed=1, mutation_rate=1, record_full_arg=True)
         return next(ts.trees(sample_lists=sample_lists))
@@ -1593,6 +1677,7 @@ class TestTree(HighLevelTestCase):
                     if t.is_internal(v):
                         for c in reversed(t.get_children(v)):
                             stack.append(c)
+
             for u in t.nodes():
                 l1 = list(t.samples(u))
                 l2 = list(test_func(t, u))
@@ -1656,13 +1741,11 @@ class TestTree(HighLevelTestCase):
         self.assertSetEqual(set(tree.nodes()), set(g.nodes))
 
         self.assertSetEqual(
-            set(tree.roots),
-            {n for n in g.nodes if g.in_degree(n) == 0}
+            set(tree.roots), {n for n in g.nodes if g.in_degree(n) == 0}
         )
 
         self.assertSetEqual(
-            set(tree.leaves()),
-            {n for n in g.nodes if g.out_degree(n) == 0}
+            set(tree.leaves()), {n for n in g.nodes if g.out_degree(n) == 0}
         )
 
         # test if tree has no in-degrees > 1
@@ -1675,7 +1758,7 @@ class TestTree(HighLevelTestCase):
             # test descendants
             self.assertSetEqual(
                 set(u for u in tree.nodes() if tree.is_descendant(u, root)),
-                set(nx.descendants(g, root)) | {root}
+                set(nx.descendants(g, root)) | {root},
             )
 
             # test MRCA
@@ -1689,11 +1772,11 @@ class TestTree(HighLevelTestCase):
             # test node traversal modes
             self.assertEqual(
                 list(tree.nodes(root=root, order="breadthfirst")),
-                [root] + [v for u, v in nx.bfs_edges(g, root)]
+                [root] + [v for u, v in nx.bfs_edges(g, root)],
             )
             self.assertEqual(
                 list(tree.nodes(root=root, order="preorder")),
-                list(nx.dfs_preorder_nodes(g, root))
+                list(nx.dfs_preorder_nodes(g, root)),
             )
 
     def verify_nx_for_tutorial_algorithms(self, tree, g):
@@ -1708,8 +1791,7 @@ class TestTree(HighLevelTestCase):
             self.assertSetEqual(set(path), {u} | nx.ancestors(g, u))
             self.assertEqual(
                 path,
-                [u] +
-                [n1 for n1, n2, _ in nx.edge_dfs(g, u, orientation="reverse")]
+                [u] + [n1 for n1, n2, _ in nx.edge_dfs(g, u, orientation="reverse")],
             )
 
         # traversals with information
@@ -1724,7 +1806,7 @@ class TestTree(HighLevelTestCase):
         for root in tree.roots:
             self.assertDictEqual(
                 {k: v for k, v in preorder_dist(tree, root)},
-                nx.shortest_path_length(g, source=root)
+                nx.shortest_path_length(g, source=root),
             )
 
         for root in tree.roots:
@@ -1735,11 +1817,8 @@ class TestTree(HighLevelTestCase):
                 self.assertAlmostEqual(
                     tree.time(root) - tmrca,
                     nx.shortest_path_length(
-                        g,
-                        source=root,
-                        target=mrca,
-                        weight='branch_length'
-                    )
+                        g, source=root, target=mrca, weight="branch_length"
+                    ),
                 )
 
     def verify_nx_nearest_neighbor_search(self):
@@ -1765,13 +1844,11 @@ class TestTree(HighLevelTestCase):
         dist_dod = collections.defaultdict(dict)
         for source, target in itertools.combinations(tree.samples(), 2):
             dist_dod[source][target] = nx.shortest_path_length(
-                g, source=source, target=target, weight='branch_length'
+                g, source=source, target=target, weight="branch_length"
             )
             dist_dod[target][source] = dist_dod[source][target]
 
-        nearest_neighbor_of = [
-            min(dist_dod[u], key=dist_dod[u].get) for u in range(3)
-        ]
+        nearest_neighbor_of = [min(dist_dod[u], key=dist_dod[u].get) for u in range(3)]
         self.assertEqual([2, 2, 1], [nearest_neighbor_of[u] for u in range(3)])
 
     def test_traversals(self):
@@ -1805,34 +1882,37 @@ class TestTree(HighLevelTestCase):
             self.assertRaises(ValueError, list, t1.nodes(order="bad order"))
             self.assertEqual(list(t1.nodes()), list(t1.nodes(t1.get_root())))
             self.assertEqual(
-                list(t1.nodes()),
-                list(t1.nodes(t1.get_root(), "preorder")))
+                list(t1.nodes()), list(t1.nodes(t1.get_root(), "preorder"))
+            )
             for u in t1.nodes():
                 self.assertEqual(list(t1.nodes(u)), list(t2.nodes(u)))
             for test_order in orders:
                 self.assertEqual(
-                    sorted(list(t1.nodes())),
-                    sorted(list(t1.nodes(order=test_order))))
+                    sorted(list(t1.nodes())), sorted(list(t1.nodes(order=test_order)))
+                )
                 self.assertEqual(
                     list(t1.nodes(order=test_order)),
-                    list(t1.nodes(t1.get_root(), order=test_order)))
+                    list(t1.nodes(t1.get_root(), order=test_order)),
+                )
                 self.assertEqual(
                     list(t1.nodes(order=test_order)),
-                    list(t1.nodes(t1.get_root(), test_order)))
+                    list(t1.nodes(t1.get_root(), test_order)),
+                )
                 self.assertEqual(
-                    list(t1.nodes(order=test_order)),
-                    list(t2.nodes(order=test_order)))
+                    list(t1.nodes(order=test_order)), list(t2.nodes(order=test_order))
+                )
                 for u in t1.nodes():
                     self.assertEqual(
-                        list(t1.nodes(u, test_order)),
-                        list(t2.nodes(u, test_order)))
+                        list(t1.nodes(u, test_order)), list(t2.nodes(u, test_order))
+                    )
         else:
             for test_order in orders:
                 all_nodes = []
                 for root in t1.roots:
                     self.assertEqual(
                         list(t1.nodes(root, order=test_order)),
-                        list(t2.nodes(root, order=test_order)))
+                        list(t2.nodes(root, order=test_order)),
+                    )
                     all_nodes.extend(t1.nodes(root, order=test_order))
                 self.assertEqual(all_nodes, list(t1.nodes(order=test_order)))
 
@@ -1859,7 +1939,6 @@ class TestTree(HighLevelTestCase):
         self.assertEqual(tree.total_branch_length, 0)
 
     def test_is_descendant(self):
-
         def is_descendant(tree, u, v):
             path = []
             while u != tskit.NULL:
@@ -1895,10 +1974,10 @@ class TestTree(HighLevelTestCase):
                 self.assertEqual(t1.get_children(node), t1.children(node))
                 self.assertEqual(t1.get_population(node), t1.population(node))
                 self.assertEqual(t1.get_num_samples(node), t1.num_samples(node))
-                self.assertEqual(t1.get_branch_length(node),
-                                 t1.branch_length(node))
-                self.assertEqual(t1.get_num_tracked_samples(node),
-                                 t1.num_tracked_samples(node))
+                self.assertEqual(t1.get_branch_length(node), t1.branch_length(node))
+                self.assertEqual(
+                    t1.get_num_tracked_samples(node), t1.num_tracked_samples(node)
+                )
 
         pairs = itertools.islice(itertools.combinations(t1.nodes(), 2), 50)
         for pair in pairs:
@@ -1924,7 +2003,7 @@ class TestTree(HighLevelTestCase):
             self.assertEqual(tree.index, index)
 
         tree = tskit.Tree(ts)
-        for index in [-1,  -2, -N + 2, -N + 1, -N]:
+        for index in [-1, -2, -N + 2, -N + 1, -N]:
             fresh_tree = tskit.Tree(ts)
             self.assertEqual(fresh_tree.index, -1)
             fresh_tree.seek_index(index)
@@ -2056,19 +2135,24 @@ class TestTree(HighLevelTestCase):
         self.assertIs(t1.num_nodes, t2.num_nodes)
         self.assertEqual(
             [t1.parent(u) for u in range(t1.num_nodes)],
-            [t2.parent(u) for u in range(t2.num_nodes)])
+            [t2.parent(u) for u in range(t2.num_nodes)],
+        )
         self.assertEqual(
             [t1.left_child(u) for u in range(t1.num_nodes)],
-            [t2.left_child(u) for u in range(t2.num_nodes)])
+            [t2.left_child(u) for u in range(t2.num_nodes)],
+        )
         self.assertEqual(
             [t1.right_child(u) for u in range(t1.num_nodes)],
-            [t2.right_child(u) for u in range(t2.num_nodes)])
+            [t2.right_child(u) for u in range(t2.num_nodes)],
+        )
         self.assertEqual(
             [t1.left_sib(u) for u in range(t1.num_nodes)],
-            [t2.left_sib(u) for u in range(t2.num_nodes)])
+            [t2.left_sib(u) for u in range(t2.num_nodes)],
+        )
         self.assertEqual(
             [t1.right_sib(u) for u in range(t1.num_nodes)],
-            [t2.right_sib(u) for u in range(t2.num_nodes)])
+            [t2.right_sib(u) for u in range(t2.num_nodes)],
+        )
         self.assertEqual(list(t1.sites()), list(t2.sites()))
 
     def test_copy_seek(self):
@@ -2113,13 +2197,15 @@ class TestTree(HighLevelTestCase):
             copy = tree.copy()
             for j in range(ts.num_nodes):
                 self.assertEqual(
-                    tree.num_tracked_samples(j), copy.num_tracked_samples(j))
+                    tree.num_tracked_samples(j), copy.num_tracked_samples(j)
+                )
         copy = tree.copy()
         while tree.next():
             copy.next()
             for j in range(ts.num_nodes):
                 self.assertEqual(
-                    tree.num_tracked_samples(j), copy.num_tracked_samples(j))
+                    tree.num_tracked_samples(j), copy.num_tracked_samples(j)
+                )
 
     def test_copy_multiple_roots(self):
         ts = msprime.simulate(20, recombination_rate=2, length=3, random_seed=42)
@@ -2175,6 +2261,7 @@ class TestNodeOrdering(HighLevelTestCase):
     Verify that we can use any node ordering for internal nodes
     and get the same topologies.
     """
+
     num_random_permutations = 10
 
     def verify_tree_sequences_equal(self, ts1, ts2, approx=False):
@@ -2219,11 +2306,15 @@ class TestNodeOrdering(HighLevelTestCase):
         for j in range(ts.num_nodes):
             node = ts.node(inv_node_map[j])
             other_tables.nodes.add_row(
-                flags=node.flags, time=node.time, population=node.population)
+                flags=node.flags, time=node.time, population=node.population
+            )
         for e in ts.edges():
             other_tables.edges.add_row(
-                left=e.left, right=e.right, parent=node_map[e.parent],
-                child=node_map[e.child])
+                left=e.left,
+                right=e.right,
+                parent=node_map[e.parent],
+                child=node_map[e.child],
+            )
         for _ in range(ts.num_populations):
             other_tables.populations.add_row()
         other_tables.sort()
@@ -2242,9 +2333,7 @@ class TestNodeOrdering(HighLevelTestCase):
                 v_map = u
                 while v_orig != tskit.NULL:
                     self.assertEqual(node_map[v_orig], v_map)
-                    self.assertEqual(
-                        t1.get_time(v_orig),
-                        t2.get_time(v_map))
+                    self.assertEqual(t1.get_time(v_orig), t2.get_time(v_map))
                     v_orig = t1.get_parent(v_orig)
                     v_map = t2.get_parent(v_map)
                 self.assertEqual(v_orig, tskit.NULL)
@@ -2276,9 +2365,12 @@ class TestNodeOrdering(HighLevelTestCase):
 
     def test_nonbinary(self):
         ts = msprime.simulate(
-            sample_size=20, recombination_rate=10,
+            sample_size=20,
+            recombination_rate=10,
             demographic_events=[
-                msprime.SimpleBottleneck(time=0.5, population=0, proportion=1)])
+                msprime.SimpleBottleneck(time=0.5, population=0, proportion=1)
+            ],
+        )
         # Make sure this really has some non-binary nodes
         found = False
         for t in ts.trees():
@@ -2297,18 +2389,19 @@ class SimpleContainersMixin(object):
     """
     Tests for the SimpleContainer classes.
     """
+
     def test_equality(self):
         c1, c2 = self.get_instances(2)
         self.assertTrue(c1 == c1)
         self.assertFalse(c1 == c2)
         self.assertFalse(c1 != c1)
         self.assertTrue(c1 != c2)
-        c3, = self.get_instances(1)
+        (c3,) = self.get_instances(1)
         self.assertTrue(c1 == c3)
         self.assertFalse(c1 != c3)
 
     def test_repr(self):
-        c, = self.get_instances(1)
+        (c,) = self.get_instances(1)
         self.assertGreater(len(repr(c)), 0)
 
 
@@ -2316,47 +2409,60 @@ class TestIndividualContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
         return [
             tskit.Individual(id_=j, flags=j, location=[j], nodes=[j], metadata=b"x" * j)
-            for j in range(n)]
+            for j in range(n)
+        ]
 
 
 class TestNodeContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
         return [
             tskit.Node(
-                id_=j, flags=j, time=j, population=j, individual=j, metadata=b"x" * j)
-            for j in range(n)]
+                id_=j, flags=j, time=j, population=j, individual=j, metadata=b"x" * j
+            )
+            for j in range(n)
+        ]
 
 
 class TestEdgeContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
-        return [
-            tskit.Edge(left=j, right=j, parent=j, child=j, id_=j) for j in range(n)]
+        return [tskit.Edge(left=j, right=j, parent=j, child=j, id_=j) for j in range(n)]
 
 
 class TestSiteContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
         return [
             tskit.Site(
-                id_=j, position=j, ancestral_state="A" * j,
+                id_=j,
+                position=j,
+                ancestral_state="A" * j,
                 mutations=TestMutationContainer().get_instances(j),
-                metadata=b"x" * j)
-            for j in range(n)]
+                metadata=b"x" * j,
+            )
+            for j in range(n)
+        ]
 
 
 class TestMutationContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
         return [
             tskit.Mutation(
-                id_=j, site=j, node=j, derived_state="A" * j, parent=j,
-                metadata=b"x" * j)
-            for j in range(n)]
+                id_=j,
+                site=j,
+                node=j,
+                derived_state="A" * j,
+                parent=j,
+                metadata=b"x" * j,
+            )
+            for j in range(n)
+        ]
 
 
 class TestMigrationContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
         return [
             tskit.Migration(left=j, right=j, node=j, source=j, dest=j, time=j)
-            for j in range(n)]
+            for j in range(n)
+        ]
 
 
 class TestPopulationContainer(unittest.TestCase, SimpleContainersMixin):
@@ -2367,13 +2473,13 @@ class TestPopulationContainer(unittest.TestCase, SimpleContainersMixin):
 class TestProvenanceContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
         return [
-            tskit.Provenance(id_=j, timestamp="x" * j, record="y" * j) for j in range(n)]
+            tskit.Provenance(id_=j, timestamp="x" * j, record="y" * j) for j in range(n)
+        ]
 
 
 class TestEdgesetContainer(unittest.TestCase, SimpleContainersMixin):
     def get_instances(self, n):
-        return [
-            tskit.Edgeset(left=j, right=j, parent=j, children=j) for j in range(n)]
+        return [tskit.Edgeset(left=j, right=j, parent=j, children=j) for j in range(n)]
 
 
 class TestVariantContainer(unittest.TestCase, SimpleContainersMixin):
@@ -2381,5 +2487,8 @@ class TestVariantContainer(unittest.TestCase, SimpleContainersMixin):
         return [
             tskit.Variant(
                 site=TestSiteContainer().get_instances(1)[0],
-                alleles=["A" * j, "T"], genotypes=np.zeros(j, dtype=np.int8))
-            for j in range(n)]
+                alleles=["A" * j, "T"],
+                genotypes=np.zeros(j, dtype=np.int8),
+            )
+            for j in range(n)
+        ]

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -72,6 +72,7 @@ class LowLevelTestCase(unittest.TestCase):
     """
     Superclass of tests for the low-level interface.
     """
+
     def verify_tree_dict(self, n, pi):
         """
         Verifies that the specified tree in dict format is a
@@ -105,10 +106,15 @@ class LowLevelTestCase(unittest.TestCase):
                 self.assertGreaterEqual(num_children[j], 2)
 
     def get_example_tree_sequence(
-            self, sample_size=10, length=1, mutation_rate=1, random_seed=1):
+        self, sample_size=10, length=1, mutation_rate=1, random_seed=1
+    ):
         ts = msprime.simulate(
-            sample_size, recombination_rate=0.1, mutation_rate=mutation_rate,
-            random_seed=random_seed, length=length)
+            sample_size,
+            recombination_rate=0.1,
+            mutation_rate=mutation_rate,
+            random_seed=random_seed,
+            length=length,
+        )
         return ts.ll_tree_sequence
 
     def get_example_tree_sequences(self):
@@ -125,7 +131,8 @@ class LowLevelTestCase(unittest.TestCase):
             migration_matrix=migration_matrix,
             mutation_rate=1,
             record_migrations=True,
-            random_seed=1)
+            random_seed=1,
+        )
         return ts.ll_tree_sequence
 
     def verify_iterator(self, iterator):
@@ -149,8 +156,15 @@ class TestTableCollection(LowLevelTestCase):
         tc = ts.tables.ll_tables
         # Get references to all the tables
         tables = [
-            tc.individuals, tc.nodes, tc.edges, tc.migrations, tc.sites, tc.mutations,
-            tc.populations, tc.provenances]
+            tc.individuals,
+            tc.nodes,
+            tc.edges,
+            tc.migrations,
+            tc.sites,
+            tc.mutations,
+            tc.populations,
+            tc.provenances,
+        ]
         del tc
         for _ in range(10):
             for table in tables:
@@ -167,7 +181,7 @@ class TestTableCollection(LowLevelTestCase):
     def test_set_sequence_length(self):
         tables = _tskit.TableCollection(1)
         self.assertEqual(tables.sequence_length, 1)
-        for value in [-1, 1e6, 1e-22, 1000, 2**32, -10000]:
+        for value in [-1, 1e6, 1e-22, 1000, 2 ** 32, -10000]:
             tables.sequence_length = value
             self.assertEqual(tables.sequence_length, value)
 
@@ -212,6 +226,7 @@ class TestTreeSequence(LowLevelTestCase):
     """
     Tests for the low-level interface for the TreeSequence.
     """
+
     def setUp(self):
         fd, self.temp_file = tempfile.mkstemp(prefix="msp_ll_ts_")
         os.close(fd)
@@ -320,7 +335,7 @@ class TestTreeSequence(LowLevelTestCase):
             num_edges = ts.get_num_edges()
             # We don't accept Python negative indexes here.
             self.assertRaises(IndexError, ts.get_edge, -1)
-            for j in [0, 10, 10**6]:
+            for j in [0, 10, 10 ** 6]:
                 self.assertRaises(IndexError, ts.get_edge, num_edges + j)
             for x in [None, "", {}, []]:
                 self.assertRaises(TypeError, ts.get_edge, x)
@@ -330,7 +345,7 @@ class TestTreeSequence(LowLevelTestCase):
             num_nodes = ts.get_num_nodes()
             # We don't accept Python negative indexes here.
             self.assertRaises(IndexError, ts.get_node, -1)
-            for j in [0, 10, 10**6]:
+            for j in [0, 10, 10 ** 6]:
                 self.assertRaises(IndexError, ts.get_node, num_nodes + j)
             for x in [None, "", {}, []]:
                 self.assertRaises(TypeError, ts.get_node, x)
@@ -342,11 +357,10 @@ class TestTreeSequence(LowLevelTestCase):
             G = ts.get_genotype_matrix()
             self.assertEqual(G.shape, (num_sites, num_samples))
             self.assertRaises(
-                TypeError, ts.get_genotype_matrix, impute_missing_data=None)
-            self.assertRaises(
-                TypeError, ts.get_genotype_matrix, alleles="XYZ")
-            self.assertRaises(
-                ValueError, ts.get_genotype_matrix, alleles=tuple())
+                TypeError, ts.get_genotype_matrix, impute_missing_data=None
+            )
+            self.assertRaises(TypeError, ts.get_genotype_matrix, alleles="XYZ")
+            self.assertRaises(ValueError, ts.get_genotype_matrix, alleles=tuple())
             G = ts.get_genotype_matrix(impute_missing_data=True)
             self.assertEqual(G.shape, (num_sites, num_samples))
 
@@ -357,39 +371,56 @@ class TestTreeSequence(LowLevelTestCase):
         num_records = ts.get_num_migrations()
         # We don't accept Python negative indexes here.
         self.assertRaises(IndexError, ts.get_migration, -1)
-        for j in [0, 10, 10**6]:
+        for j in [0, 10, 10 ** 6]:
             self.assertRaises(IndexError, ts.get_migration, num_records + j)
 
     def test_get_samples(self):
         for ts in self.get_example_tree_sequences():
             # get_samples takes no arguments.
             self.assertRaises(TypeError, ts.get_samples, 0)
-            self.assertTrue(np.array_equal(
-                np.arange(ts.get_num_samples(), dtype=np.int32), ts.get_samples()))
+            self.assertTrue(
+                np.array_equal(
+                    np.arange(ts.get_num_samples(), dtype=np.int32), ts.get_samples()
+                )
+            )
 
     def test_genealogical_nearest_neighbours(self):
         for ts in self.get_example_tree_sequences():
             self.assertRaises(TypeError, ts.genealogical_nearest_neighbours)
+            self.assertRaises(TypeError, ts.genealogical_nearest_neighbours, focal=None)
             self.assertRaises(
-                TypeError, ts.genealogical_nearest_neighbours, focal=None)
+                TypeError,
+                ts.genealogical_nearest_neighbours,
+                focal=ts.get_samples(),
+                reference_sets={},
+            )
             self.assertRaises(
-                TypeError, ts.genealogical_nearest_neighbours, focal=ts.get_samples(),
-                reference_sets={})
-            self.assertRaises(
-                ValueError, ts.genealogical_nearest_neighbours, focal=ts.get_samples(),
-                reference_sets=[])
+                ValueError,
+                ts.genealogical_nearest_neighbours,
+                focal=ts.get_samples(),
+                reference_sets=[],
+            )
 
             bad_array_values = ["", {}, "x", [[[0], [1, 2]]]]
             for bad_array_value in bad_array_values:
                 self.assertRaises(
-                    ValueError, ts.genealogical_nearest_neighbours,
-                    focal=bad_array_value, reference_sets=[[0], [1]])
+                    ValueError,
+                    ts.genealogical_nearest_neighbours,
+                    focal=bad_array_value,
+                    reference_sets=[[0], [1]],
+                )
                 self.assertRaises(
-                    ValueError, ts.genealogical_nearest_neighbours,
-                    focal=ts.get_samples(), reference_sets=[[0], bad_array_value])
+                    ValueError,
+                    ts.genealogical_nearest_neighbours,
+                    focal=ts.get_samples(),
+                    reference_sets=[[0], bad_array_value],
+                )
                 self.assertRaises(
-                    ValueError, ts.genealogical_nearest_neighbours,
-                    focal=ts.get_samples(), reference_sets=[bad_array_value])
+                    ValueError,
+                    ts.genealogical_nearest_neighbours,
+                    focal=ts.get_samples(),
+                    reference_sets=[bad_array_value],
+                )
             focal = ts.get_samples()
             A = ts.genealogical_nearest_neighbours(focal, [focal[2:], focal[:2]])
             self.assertEqual(A.shape, (len(focal), 2))
@@ -403,10 +434,13 @@ class TestTreeSequence(LowLevelTestCase):
             bad_array_values = ["", {}, "x", [[[0], [1, 2]]]]
             for bad_array_value in bad_array_values:
                 self.assertRaises(
-                    ValueError, ts.mean_descendants,
-                    reference_sets=[[0], bad_array_value])
+                    ValueError,
+                    ts.mean_descendants,
+                    reference_sets=[[0], bad_array_value],
+                )
                 self.assertRaises(
-                    ValueError, ts.mean_descendants, reference_sets=[bad_array_value])
+                    ValueError, ts.mean_descendants, reference_sets=[bad_array_value]
+                )
             focal = ts.get_samples()
             A = ts.mean_descendants([focal[2:], focal[:2]])
             self.assertEqual(A.shape, (ts.get_num_nodes(), 2))
@@ -439,8 +473,14 @@ class StatsInterfaceMixin(object):
                 f(windows=bad_windows, **params)
         L = ts.get_sequence_length()
         bad_windows = [
-            [L, 0], [0.1, L], [-1, L], [0, L + 0.1], [0, 0.1, 0.1, L],
-            [0, -1, L], [0, 0.1, 0.05, 0.2, L]]
+            [L, 0],
+            [0.1, L],
+            [-1, L],
+            [0, L + 0.1],
+            [0, 0.1, 0.1, L],
+            [0, -1, L],
+            [0, 0.1, 0.05, 0.2, L],
+        ]
         for bad_window in bad_windows:
             with self.assertRaises(_tskit.LibraryError):
                 f(windows=bad_window, **params)
@@ -456,12 +496,12 @@ class StatsInterfaceMixin(object):
 
 
 class WeightMixin(StatsInterfaceMixin):
-
     def get_example(self):
         ts, method = self.get_method()
         params = {
             "weights": np.ones((ts.get_num_samples(), 2)),
-            "windows": [0, ts.get_sequence_length()]}
+            "windows": [0, ts.get_sequence_length()],
+        }
         return ts, method, params
 
     def test_bad_weights(self):
@@ -472,13 +512,13 @@ class WeightMixin(StatsInterfaceMixin):
         with self.assertRaises(_tskit.LibraryError):
             f(weights=np.ones((n, 0)), **params)
 
-        for bad_weight_shape in [(n-1, 1), (n+1, 1), (0, 3)]:
+        for bad_weight_shape in [(n - 1, 1), (n + 1, 1), (0, 3)]:
             with self.assertRaises(ValueError):
                 f(weights=np.ones(bad_weight_shape), **params)
 
     def test_output_dims(self):
         ts, method, params = self.get_example()
-        weights = params['weights']
+        weights = params["weights"]
         nw = weights.shape[1]
         windows = [0, ts.get_sequence_length()]
 
@@ -500,22 +540,23 @@ class WeightMixin(StatsInterfaceMixin):
 
 
 class WeightCovariateMixin(StatsInterfaceMixin):
-
     def get_example(self):
         ts, method = self.get_method()
         params = {
             "weights": np.ones((ts.get_num_samples(), 2)),
-            "covariates": np.array([np.arange(ts.get_num_samples()),
-                                    np.arange(ts.get_num_samples())**2]).T,
-            "windows": [0, ts.get_sequence_length()]}
+            "covariates": np.array(
+                [np.arange(ts.get_num_samples()), np.arange(ts.get_num_samples()) ** 2]
+            ).T,
+            "windows": [0, ts.get_sequence_length()],
+        }
         return ts, method, params
 
     def test_output_dims(self):
         ts, method, params = self.get_example()
-        weights = params['weights']
+        weights = params["weights"]
         nw = weights.shape[1]
         windows = [0, ts.get_sequence_length()]
-        for covariates in (params['covariates'], params['covariates'][:, :0]):
+        for covariates in (params["covariates"], params["covariates"][:, :0]):
             for mode in ["site", "branch"]:
                 out = method(weights[:, [0]], covariates, windows, mode=mode)
                 self.assertEqual(out.shape, (1, 1))
@@ -534,7 +575,6 @@ class WeightCovariateMixin(StatsInterfaceMixin):
 
 
 class SampleSetMixin(StatsInterfaceMixin):
-
     def test_bad_sample_sets(self):
         ts, f, params = self.get_example()
         del params["sample_set_sizes"]
@@ -569,21 +609,26 @@ class OneWaySampleStatsMixin(SampleSetMixin):
         params = {
             "sample_set_sizes": [ts.get_num_samples()],
             "sample_sets": ts.get_samples(),
-            "windows": [0, ts.get_sequence_length()]}
+            "windows": [0, ts.get_sequence_length()],
+        }
         return ts, method, params
 
     def test_basic_example(self):
         ts, method = self.get_method()
         result = method(
-            [ts.get_num_samples()], ts.get_samples(), [0, ts.get_sequence_length()])
+            [ts.get_num_samples()], ts.get_samples(), [0, ts.get_sequence_length()]
+        )
         self.assertEqual(result.shape, (1, 1))
         result = method(
-            [ts.get_num_samples()], ts.get_samples(), [0, ts.get_sequence_length()],
-            mode="node")
+            [ts.get_num_samples()],
+            ts.get_samples(),
+            [0, ts.get_sequence_length()],
+            mode="node",
+        )
         self.assertEqual(result.shape, (1, ts.get_num_nodes(), 1))
         result = method(
-            [ts.get_num_samples()], ts.get_samples(), ts.get_breakpoints(),
-            mode="node")
+            [ts.get_num_samples()], ts.get_samples(), ts.get_breakpoints(), mode="node"
+        )
         self.assertEqual(result.shape, (ts.get_num_trees(), ts.get_num_nodes(), 1))
 
     def test_output_dims(self):
@@ -626,6 +671,7 @@ class TestDiversity(LowLevelTestCase, OneWaySampleStatsMixin):
     """
     Tests for the diversity method.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.diversity
@@ -635,6 +681,7 @@ class TestTraitCovariance(LowLevelTestCase, WeightMixin):
     """
     Tests for trait covariance.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.trait_covariance
@@ -644,6 +691,7 @@ class TestTraitCorrelation(LowLevelTestCase, WeightMixin):
     """
     Tests for trait correlation.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.trait_correlation
@@ -653,6 +701,7 @@ class TestTraitRegression(LowLevelTestCase, WeightCovariateMixin):
     """
     Tests for trait correlation.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.trait_regression
@@ -662,6 +711,7 @@ class TestSegregatingSites(LowLevelTestCase, OneWaySampleStatsMixin):
     """
     Tests for the diversity method.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.segregating_sites
@@ -671,6 +721,7 @@ class TestY1(LowLevelTestCase, OneWaySampleStatsMixin):
     """
     Tests for the diversity method.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.Y1
@@ -680,6 +731,7 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
     """
     Tests for the diversity method.
     """
+
     def get_method(self):
         ts = self.get_example_tree_sequence()
         return ts, ts.allele_frequency_spectrum
@@ -688,10 +740,12 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
         ts = self.get_example_tree_sequence()
         n = ts.get_num_samples()
         result = ts.allele_frequency_spectrum(
-            [n], ts.get_samples(), [0, ts.get_sequence_length()])
+            [n], ts.get_samples(), [0, ts.get_sequence_length()]
+        )
         self.assertEqual(result.shape, (1, n + 1))
         result = ts.allele_frequency_spectrum(
-            [n], ts.get_samples(), [0, ts.get_sequence_length()], polarised=True)
+            [n], ts.get_samples(), [0, ts.get_sequence_length()], polarised=True
+        )
         self.assertEqual(result.shape, (1, n + 1))
 
     def test_output_dims(self):
@@ -706,18 +760,27 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
                 windows = [0, L]
                 for windows in [[0, L], [0, L / 2, L], np.linspace(0, L, num=10)]:
                     jafs = ts.allele_frequency_spectrum(
-                        s, samples, windows, mode=mode, polarised=True)
-                    self.assertEqual(jafs.shape, tuple([len(windows) - 1] + list(s + 1)))
+                        s, samples, windows, mode=mode, polarised=True
+                    )
+                    self.assertEqual(
+                        jafs.shape, tuple([len(windows) - 1] + list(s + 1))
+                    )
                     jafs = ts.allele_frequency_spectrum(
-                        s, samples, windows, mode=mode, polarised=False)
-                    self.assertEqual(jafs.shape, tuple([len(windows) - 1] + list(s + 1)))
+                        s, samples, windows, mode=mode, polarised=False
+                    )
+                    self.assertEqual(
+                        jafs.shape, tuple([len(windows) - 1] + list(s + 1))
+                    )
 
     def test_node_mode_not_supported(self):
         ts = self.get_example_tree_sequence()
         with self.assertRaises(_tskit.LibraryError):
             ts.allele_frequency_spectrum(
-                [ts.get_num_samples()], ts.get_samples(), [0, ts.get_sequence_length()],
-                mode="node")
+                [ts.get_num_samples()],
+                ts.get_samples(),
+                [0, ts.get_sequence_length()],
+                mode="node",
+            )
 
 
 class TwoWaySampleStatsMixin(SampleSetMixin):
@@ -731,7 +794,8 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
             "sample_set_sizes": [2, ts.get_num_samples() - 2],
             "sample_sets": ts.get_samples(),
             "indexes": [[0, 1]],
-            "windows": [0, ts.get_sequence_length()]}
+            "windows": [0, ts.get_sequence_length()],
+        }
         return ts, method, params
 
     def test_basic_example(self):
@@ -740,7 +804,8 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
             [2, ts.get_num_samples() - 2],
             ts.get_samples(),
             [[0, 1]],
-            windows=[0, ts.get_sequence_length()])
+            windows=[0, ts.get_sequence_length()],
+        )
         self.assertEqual(div.shape, (1, 1))
 
     def test_output_dims(self):
@@ -751,11 +816,11 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
         for mode in ["site", "branch"]:
             div = method([2, 2, n - 4], samples, [[0, 1]], windows, mode=mode)
             self.assertEqual(div.shape, (1, 1))
-            div = method(
-                [2, 2, n - 4], samples, [[0, 1], [1, 2]], windows, mode=mode)
+            div = method([2, 2, n - 4], samples, [[0, 1], [1, 2]], windows, mode=mode)
             self.assertEqual(div.shape, (1, 2))
             div = method(
-                [2, 2, n - 4], samples, [[0, 1], [1, 2], [0, 1]], windows, mode=mode)
+                [2, 2, n - 4], samples, [[0, 1], [1, 2], [0, 1]], windows, mode=mode
+            )
             self.assertEqual(div.shape, (1, 3))
 
         N = ts.get_num_nodes()
@@ -765,7 +830,8 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
         div = method([2, 2, n - 4], samples, [[0, 1], [1, 2]], windows, mode=mode)
         self.assertEqual(div.shape, (1, N, 2))
         div = method(
-            [2, 2, n - 4], samples, [[0, 1], [1, 2], [0, 1]], windows, mode=mode)
+            [2, 2, n - 4], samples, [[0, 1], [1, 2], [0, 1]], windows, mode=mode
+        )
         self.assertEqual(div.shape, (1, N, 3))
 
     def test_set_index_errors(self):
@@ -796,7 +862,8 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
             "sample_set_sizes": [1, 1, ts.get_num_samples() - 2],
             "sample_sets": ts.get_samples(),
             "indexes": [[0, 1, 2]],
-            "windows": [0, ts.get_sequence_length()]}
+            "windows": [0, ts.get_sequence_length()],
+        }
         return ts, method, params
 
     def test_basic_example(self):
@@ -805,7 +872,8 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
             [1, 1, ts.get_num_samples() - 2],
             ts.get_samples(),
             [[0, 1, 2]],
-            windows=[0, ts.get_sequence_length()])
+            windows=[0, ts.get_sequence_length()],
+        )
         self.assertEqual(div.shape, (1, 1))
 
     def test_output_dims(self):
@@ -817,11 +885,16 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
             div = method([2, 2, n - 4], samples, [[0, 1, 2]], windows, mode=mode)
             self.assertEqual(div.shape, (1, 1))
             div = method(
-                [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3]], windows, mode=mode)
+                [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3]], windows, mode=mode
+            )
             self.assertEqual(div.shape, (1, 2))
             div = method(
-                [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3], [0, 1, 2]],
-                windows, mode=mode)
+                [1, 1, 2, n - 4],
+                samples,
+                [[0, 1, 2], [1, 2, 3], [0, 1, 2]],
+                windows,
+                mode=mode,
+            )
             self.assertEqual(div.shape, (1, 3))
 
         N = ts.get_num_nodes()
@@ -829,11 +902,16 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
         div = method([2, 2, n - 4], samples, [[0, 1, 2]], windows, mode=mode)
         self.assertEqual(div.shape, (1, N, 1))
         div = method(
-            [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3]], windows, mode=mode)
+            [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3]], windows, mode=mode
+        )
         self.assertEqual(div.shape, (1, N, 2))
         div = method(
-            [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3], [0, 1, 2]],
-            windows, mode=mode)
+            [1, 1, 2, n - 4],
+            samples,
+            [[0, 1, 2], [1, 2, 3], [0, 1, 2]],
+            windows,
+            mode=mode,
+        )
         self.assertEqual(div.shape, (1, N, 3))
 
     def test_set_index_errors(self):
@@ -864,7 +942,8 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             "sample_set_sizes": [1, 1, 1, ts.get_num_samples() - 3],
             "sample_sets": ts.get_samples(),
             "indexes": [[0, 1, 2, 3]],
-            "windows": [0, ts.get_sequence_length()]}
+            "windows": [0, ts.get_sequence_length()],
+        }
         return ts, method, params
 
     def test_basic_example(self):
@@ -873,7 +952,8 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             [1, 1, 1, ts.get_num_samples() - 3],
             ts.get_samples(),
             [[0, 1, 2, 3]],
-            windows=[0, ts.get_sequence_length()])
+            windows=[0, ts.get_sequence_length()],
+        )
         self.assertEqual(div.shape, (1, 1))
 
     def test_output_dims(self):
@@ -885,12 +965,20 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             div = method([2, 1, 1, n - 4], samples, [[0, 1, 2, 3]], windows, mode=mode)
             self.assertEqual(div.shape, (1, 1))
             div = method(
-                [1, 1, 1, 1, n - 4], samples, [[0, 1, 2, 3], [1, 2, 3, 4]],
-                windows, mode=mode)
+                [1, 1, 1, 1, n - 4],
+                samples,
+                [[0, 1, 2, 3], [1, 2, 3, 4]],
+                windows,
+                mode=mode,
+            )
             self.assertEqual(div.shape, (1, 2))
             div = method(
-                [1, 1, 1, 1, n - 4], samples, [[0, 1, 2, 3], [1, 2, 3, 4], [0, 1, 2, 4]],
-                windows, mode=mode)
+                [1, 1, 1, 1, n - 4],
+                samples,
+                [[0, 1, 2, 3], [1, 2, 3, 4], [0, 1, 2, 4]],
+                windows,
+                mode=mode,
+            )
             self.assertEqual(div.shape, (1, 3))
 
         N = ts.get_num_nodes()
@@ -898,12 +986,20 @@ class FourWaySampleStatsMixin(SampleSetMixin):
         div = method([2, 1, 1, n - 4], samples, [[0, 1, 2, 3]], windows, mode=mode)
         self.assertEqual(div.shape, (1, N, 1))
         div = method(
-            [1, 1, 1, 1, n - 4], samples, [[0, 1, 2, 3], [1, 2, 3, 4]], windows,
-            mode=mode)
+            [1, 1, 1, 1, n - 4],
+            samples,
+            [[0, 1, 2, 3], [1, 2, 3, 4]],
+            windows,
+            mode=mode,
+        )
         self.assertEqual(div.shape, (1, N, 2))
         div = method(
-            [1, 1, 1, 1, n - 4], samples, [[0, 1, 2, 3], [1, 2, 3, 4], [0, 1, 2, 4]],
-            windows, mode=mode)
+            [1, 1, 1, 1, n - 4],
+            samples,
+            [[0, 1, 2, 3], [1, 2, 3, 4], [0, 1, 2, 4]],
+            windows,
+            mode=mode,
+        )
         self.assertEqual(div.shape, (1, N, 3))
 
     def test_set_index_errors(self):
@@ -963,6 +1059,7 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
     """
     Tests for the general stats interface.
     """
+
     def get_example(self):
         ts = self.get_example_tree_sequence()
         W = np.zeros((ts.get_num_samples(), 1))
@@ -970,7 +1067,7 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
             "weights": W,
             "summary_func": lambda x: np.cumsum(x),
             "output_dim": 1,
-            "windows": ts.get_breakpoints()
+            "windows": ts.get_breakpoints(),
         }
         return ts, ts.general_stat, params
 
@@ -978,17 +1075,20 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
         ts = self.get_example_tree_sequence()
         W = np.zeros((ts.get_num_samples(), 1))
         sigma = ts.general_stat(
-            W, lambda x: np.cumsum(x), 1, ts.get_breakpoints(), mode="branch")
+            W, lambda x: np.cumsum(x), 1, ts.get_breakpoints(), mode="branch"
+        )
         self.assertEqual(sigma.shape, (ts.get_num_trees(), 1))
 
     def test_non_numpy_return(self):
         ts = self.get_example_tree_sequence()
         W = np.ones((ts.get_num_samples(), 3))
         sigma = ts.general_stat(
-            W, lambda x: [sum(x)], 1, ts.get_breakpoints(), mode="branch")
+            W, lambda x: [sum(x)], 1, ts.get_breakpoints(), mode="branch"
+        )
         self.assertEqual(sigma.shape, (ts.get_num_trees(), 1))
         sigma = ts.general_stat(
-            W, lambda x: [2, 2], 2, ts.get_breakpoints(), mode="branch")
+            W, lambda x: [2, 2], 2, ts.get_breakpoints(), mode="branch"
+        )
         self.assertEqual(sigma.shape, (ts.get_num_trees(), 2))
 
     def test_complicated_numpy_function(self):
@@ -998,6 +1098,7 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
         def f(x):
             y = np.sum(x * x), np.prod(x + np.arange(x.shape[0]))
             return y
+
         sigma = ts.general_stat(W, f, 2, ts.get_breakpoints(), mode="branch")
         self.assertEqual(sigma.shape, (ts.get_num_trees(), 2))
 
@@ -1006,10 +1107,12 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
         for k in range(1, 20):
             W = np.zeros((ts.get_num_samples(), k))
             sigma = ts.general_stat(
-                W, lambda x: np.cumsum(x), k, ts.get_breakpoints(), mode="branch")
+                W, lambda x: np.cumsum(x), k, ts.get_breakpoints(), mode="branch"
+            )
             self.assertEqual(sigma.shape, (ts.get_num_trees(), k))
             sigma = ts.general_stat(
-                W, lambda x: [np.sum(x)], 1, ts.get_breakpoints(), mode="branch")
+                W, lambda x: [np.sum(x)], 1, ts.get_breakpoints(), mode="branch"
+            )
             self.assertEqual(sigma.shape, (ts.get_num_trees(), 1))
 
     def test_W_errors(self):
@@ -1039,8 +1142,10 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
 
         # Exceptions within f are correctly raised.
         for exception in [ValueError, TypeError]:
+
             def f(x):
                 raise exception("test")
+
             with self.assertRaises(exception):
                 ts.general_stat(W, f, 1, ts.get_breakpoints())
 
@@ -1061,6 +1166,7 @@ class TestTreeDiffIterator(LowLevelTestCase):
     """
     Tests for the low-level tree diff iterator.
     """
+
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
         self.assertRaises(ValueError, _tskit.TreeDiffIterator, ts)
@@ -1085,6 +1191,7 @@ class TestVariantGenerator(LowLevelTestCase):
     """
     Tests for the VariantGenerator class.
     """
+
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
         self.assertRaises(ValueError, _tskit.VariantGenerator, ts)
@@ -1095,11 +1202,12 @@ class TestVariantGenerator(LowLevelTestCase):
         ts = self.get_example_tree_sequence()
         self.assertRaises(ValueError, _tskit.VariantGenerator, ts, samples={})
         self.assertRaises(
-            TypeError, _tskit.VariantGenerator, ts, impute_missing_data=None)
+            TypeError, _tskit.VariantGenerator, ts, impute_missing_data=None
+        )
         self.assertRaises(
-            _tskit.LibraryError, _tskit.VariantGenerator, ts, samples=[-1, 2])
-        self.assertRaises(
-            TypeError, _tskit.VariantGenerator, ts, alleles=1234)
+            _tskit.LibraryError, _tskit.VariantGenerator, ts, samples=[-1, 2]
+        )
+        self.assertRaises(TypeError, _tskit.VariantGenerator, ts, alleles=1234)
 
     def test_alleles(self):
         ts = self.get_example_tree_sequence()
@@ -1138,6 +1246,7 @@ class TestLdCalculator(LowLevelTestCase):
     """
     Tests for the LdCalculator class.
     """
+
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
         self.assertRaises(ValueError, _tskit.LdCalculator, ts)
@@ -1177,7 +1286,7 @@ class TestLdCalculator(LowLevelTestCase):
             calc.get_r2_array(buff, 0, direction=1000)
         # TODO this API is poor, we should explicitly catch these negative
         # size errors.
-        for bad_max_mutations in [-2, -3, -2**32]:
+        for bad_max_mutations in [-2, -3, -(2 ** 32)]:
             with self.assertRaises(BufferError):
                 calc.get_r2_array(buff, 0, max_mutations=bad_max_mutations)
         for bad_start_pos in [-1, n, n + 1]:
@@ -1189,6 +1298,7 @@ class TestLsHmm(LowLevelTestCase):
     """
     Tests for the LsHmm class.
     """
+
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
         self.assertRaises(ValueError, _tskit.LsHmm, ts, None, None)
@@ -1256,8 +1366,9 @@ class TestLsHmm(LowLevelTestCase):
             fm = _tskit.CompressedMatrix(ts)
             self.assertEqual(fm.num_sites, m)
             self.assertTrue(np.array_equal(np.zeros(m), fm.normalisation_factor))
-            self.assertTrue(np.array_equal(
-                np.zeros(m, dtype=np.uint32), fm.num_transitions))
+            self.assertTrue(
+                np.array_equal(np.zeros(m, dtype=np.uint32), fm.num_transitions)
+            )
             F = fm.decode()
             self.assertTrue(np.all(F >= 0))
             for j in range(m):
@@ -1330,8 +1441,11 @@ class TestTree(LowLevelTestCase):
         st = _tskit.Tree(ts)
         self.assertEqual(st.get_options(), 0)
         all_options = [
-            0, _tskit.NO_SAMPLE_COUNTS, _tskit.SAMPLE_LISTS,
-            _tskit.NO_SAMPLE_COUNTS | _tskit.SAMPLE_LISTS]
+            0,
+            _tskit.NO_SAMPLE_COUNTS,
+            _tskit.SAMPLE_LISTS,
+            _tskit.NO_SAMPLE_COUNTS | _tskit.SAMPLE_LISTS,
+        ]
         for options in all_options:
             tree = _tskit.Tree(ts, options=options)
             copy = tree.copy()
@@ -1341,7 +1455,9 @@ class TestTree(LowLevelTestCase):
                 if options & _tskit.NO_SAMPLE_COUNTS:
                     # We should still be able to count the samples, just inefficiently.
                     self.assertEqual(st.get_num_samples(0), 1)
-                    self.assertRaises(_tskit.LibraryError, st.get_num_tracked_samples, 0)
+                    self.assertRaises(
+                        _tskit.LibraryError, st.get_num_tracked_samples, 0
+                    )
                 else:
                     self.assertEqual(st.get_num_tracked_samples(0), 0)
                 if options & _tskit.SAMPLE_LISTS:
@@ -1393,8 +1509,9 @@ class TestTree(LowLevelTestCase):
                     self.assertEqual(index, j)
                     self.assertEqual(metadata, b"")
                     for mut_id in mutations:
-                        site, node, derived_state, parent, metadata = \
-                            ts.get_mutation(mut_id)
+                        site, node, derived_state, parent, metadata = ts.get_mutation(
+                            mut_id
+                        )
                         self.assertEqual(site, index)
                         self.assertEqual(mutation_id, mut_id)
                         self.assertNotEqual(st.get_parent(node), _tskit.NULL)
@@ -1433,15 +1550,12 @@ class TestTree(LowLevelTestCase):
     def test_constructor(self):
         self.assertRaises(TypeError, _tskit.Tree)
         for bad_type in ["", {}, [], None, 0]:
-            self.assertRaises(
-                TypeError, _tskit.Tree, bad_type)
+            self.assertRaises(TypeError, _tskit.Tree, bad_type)
         ts = self.get_example_tree_sequence()
         for bad_type in ["", {}, True, 1, None]:
-            self.assertRaises(
-                TypeError, _tskit.Tree, ts, tracked_samples=bad_type)
+            self.assertRaises(TypeError, _tskit.Tree, ts, tracked_samples=bad_type)
         for bad_type in ["", {}, None, []]:
-            self.assertRaises(
-                TypeError, _tskit.Tree, ts, options=bad_type)
+            self.assertRaises(TypeError, _tskit.Tree, ts, options=bad_type)
         for ts in self.get_example_tree_sequences():
             st = _tskit.Tree(ts)
             self.assertEqual(st.get_num_nodes(), ts.get_num_nodes())
@@ -1459,21 +1573,33 @@ class TestTree(LowLevelTestCase):
         options = 0
         for bad_type in ["", {}, [], None]:
             self.assertRaises(
-                TypeError, _tskit.Tree, ts, options=options,
-                tracked_samples=[bad_type])
+                TypeError, _tskit.Tree, ts, options=options, tracked_samples=[bad_type]
+            )
             self.assertRaises(
-                TypeError, _tskit.Tree, ts, options=options,
-                tracked_samples=[1, bad_type])
-        for bad_sample in [10**6, -1e6]:
+                TypeError,
+                _tskit.Tree,
+                ts,
+                options=options,
+                tracked_samples=[1, bad_type],
+            )
+        for bad_sample in [10 ** 6, -1e6]:
             self.assertRaises(
-                ValueError, _tskit.Tree, ts, options=options,
-                tracked_samples=[bad_sample])
+                ValueError,
+                _tskit.Tree,
+                ts,
+                options=options,
+                tracked_samples=[bad_sample],
+            )
             self.assertRaises(
-                ValueError, _tskit.Tree, ts, options=options,
-                tracked_samples=[1, bad_sample])
+                ValueError,
+                _tskit.Tree,
+                ts,
+                options=options,
+                tracked_samples=[1, bad_sample],
+            )
             self.assertRaises(
-                ValueError, _tskit.Tree, ts,
-                tracked_samples=[1, bad_sample, 1])
+                ValueError, _tskit.Tree, ts, tracked_samples=[1, bad_sample, 1]
+            )
 
     def test_while_loop_semantics(self):
         for ts in self.get_example_tree_sequences():
@@ -1526,7 +1652,8 @@ class TestTree(LowLevelTestCase):
                         non_binary = True
             samples = [j for j in range(ts.get_num_samples())]
             powerset = itertools.chain.from_iterable(
-                itertools.combinations(samples, r) for r in range(len(samples) + 1))
+                itertools.combinations(samples, r) for r in range(len(samples) + 1)
+            )
             max_sets = 100
             for _, subset in zip(range(max_sets), map(list, powerset)):
                 # Ordering shouldn't make any difference.
@@ -1535,16 +1662,19 @@ class TestTree(LowLevelTestCase):
                 while st.next():
                     nu = get_tracked_sample_counts(st, subset)
                     nu_prime = [
-                        st.get_num_tracked_samples(j) for j in
-                        range(st.get_num_nodes())]
+                        st.get_num_tracked_samples(j) for j in range(st.get_num_nodes())
+                    ]
                     self.assertEqual(nu, nu_prime)
             # Passing duplicated values should raise an error
             sample = 1
             for j in range(2, 20):
                 tracked_samples = [sample for _ in range(j)]
                 self.assertRaises(
-                    _tskit.LibraryError, _tskit.Tree, ts,
-                    tracked_samples=tracked_samples)
+                    _tskit.LibraryError,
+                    _tskit.Tree,
+                    ts,
+                    tracked_samples=tracked_samples,
+                )
         self.assertTrue(non_binary)
 
     def test_bounds_checking(self):
@@ -1567,7 +1697,7 @@ class TestTree(LowLevelTestCase):
         for ts in self.get_example_tree_sequences():
             num_nodes = ts.get_num_nodes()
             st = _tskit.Tree(ts)
-            for v in [num_nodes, 10**6, _tskit.NULL]:
+            for v in [num_nodes, 10 ** 6, _tskit.NULL]:
                 self.assertRaises(ValueError, st.get_mrca, v, v)
                 self.assertRaises(ValueError, st.get_mrca, v, 1)
                 self.assertRaises(ValueError, st.get_mrca, 1, v)
@@ -1576,7 +1706,6 @@ class TestTree(LowLevelTestCase):
                 self.assertEqual(st.get_mrca(u, v), _tskit.NULL)
 
     def test_newick_precision(self):
-
         def get_times(tree):
             """
             Returns the time strings from the specified newick tree.
@@ -1601,7 +1730,8 @@ class TestTree(LowLevelTestCase):
             self.assertRaises(ValueError, st.get_newick, root=0, precision=100)
             for precision in range(17):
                 tree = st.get_newick(
-                    root=st.get_left_root(), precision=precision).decode()
+                    root=st.get_left_root(), precision=precision
+                ).decode()
                 times = get_times(tree)
                 self.assertGreater(len(times), ts.get_num_samples())
                 for t in times:
@@ -1674,16 +1804,29 @@ class TestTree(LowLevelTestCase):
                 derived_state.append("1")
                 derived_state_offset.append(derived_state_offset[-1] + 1)
                 node.append(n)
-            tables.sites.set_columns(dict(
-                position=position, ancestral_state=ancestral_state,
-                ancestral_state_offset=ancestral_state_offset,
-                metadata=None, metadata_offset=None))
-            tables.mutations.set_columns(dict(
-                site=site, node=node, derived_state=derived_state,
-                derived_state_offset=derived_state_offset,
-                parent=None, metadata=None, metadata_offset=None))
+            tables.sites.set_columns(
+                dict(
+                    position=position,
+                    ancestral_state=ancestral_state,
+                    ancestral_state_offset=ancestral_state_offset,
+                    metadata=None,
+                    metadata_offset=None,
+                )
+            )
+            tables.mutations.set_columns(
+                dict(
+                    site=site,
+                    node=node,
+                    derived_state=derived_state,
+                    derived_state_offset=derived_state_offset,
+                    parent=None,
+                    metadata=None,
+                    metadata_offset=None,
+                )
+            )
             ts2 = _tskit.TreeSequence()
             ts2.load_tables(tables)
+
         self.assertRaises(_tskit.LibraryError, f, [(0.1, -1)])
         length = ts.get_sequence_length()
         u = ts.get_num_nodes()
@@ -1705,8 +1848,10 @@ class TestTree(LowLevelTestCase):
 
                 # All non-tree nodes should have 0
                 for j in range(t.get_num_nodes()):
-                    if t.get_parent(j) == _tskit.NULL \
-                            and t.get_left_child(j) == _tskit.NULL:
+                    if (
+                        t.get_parent(j) == _tskit.NULL
+                        and t.get_left_child(j) == _tskit.NULL
+                    ):
                         self.assertEqual(t.get_left_sample(j), _tskit.NULL)
                         self.assertEqual(t.get_right_sample(j), _tskit.NULL)
                 # The roots should have all samples.
@@ -1755,8 +1900,7 @@ class TestTree(LowLevelTestCase):
         for bad_tree in [None, "tree", 0]:
             self.assertRaises(TypeError, t1.get_kc_distance, bad_tree, lambda_=0)
         for bad_value in ["tree", [], None]:
-            self.assertRaises(
-                TypeError, t1.get_kc_distance, t1, lambda_=bad_value)
+            self.assertRaises(TypeError, t1.get_kc_distance, t1, lambda_=bad_value)
 
         t2 = _tskit.Tree(ts1)
         # If we don't seek to a specific tree, it has multiple roots (i.e., it's
@@ -1840,12 +1984,14 @@ class TestTree(LowLevelTestCase):
         self.assertRaises(TypeError, tree.map_mutations)
         for bad_size in [0, 1, n - 1, n + 1]:
             self.assertRaises(
-                ValueError, tree.map_mutations, np.zeros(bad_size, dtype=np.int8))
+                ValueError, tree.map_mutations, np.zeros(bad_size, dtype=np.int8)
+            )
         for bad_type in [None, {}, set()]:
             self.assertRaises(TypeError, tree.map_mutations, [bad_type] * n)
         for bad_type in [np.uint8, np.uint64, np.float32]:
             self.assertRaises(
-                TypeError, tree.map_mutations, np.zeros(bad_size, dtype=bad_type))
+                TypeError, tree.map_mutations, np.zeros(bad_size, dtype=bad_type)
+            )
         genotypes = np.zeros(n, dtype=np.int8)
         tree.map_mutations(genotypes)
         for bad_value in [64, 65, 127, -2]:
@@ -1857,6 +2003,7 @@ class TestModuleFunctions(unittest.TestCase):
     """
     Tests for the module level functions.
     """
+
     def test_kastore_version(self):
         version = _tskit.get_kastore_version()
         self.assertEqual(version, (1, 0, 0))

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -43,6 +43,7 @@ class TestMetadataHdf5RoundTrip(unittest.TestCase):
     Tests that we can encode metadata under various formats and this will
     successfully round-trip through the HDF5 format.
     """
+
     def setUp(self):
         fd, self.temp_file = tempfile.mkstemp(prefix="msp_hdf5meta_test_")
         os.close(fd)
@@ -56,11 +57,16 @@ class TestMetadataHdf5RoundTrip(unittest.TestCase):
         nodes = tables.nodes
         # For each node, we create some Python metadata that can be JSON encoded.
         metadata = [
-            {"one": j, "two": 2 * j, "three": list(range(j))} for j in range(len(nodes))]
+            {"one": j, "two": 2 * j, "three": list(range(j))} for j in range(len(nodes))
+        ]
         encoded, offset = tskit.pack_strings(map(json.dumps, metadata))
         nodes.set_columns(
-            flags=nodes.flags, time=nodes.time, population=nodes.population,
-            metadata_offset=offset, metadata=encoded)
+            flags=nodes.flags,
+            time=nodes.time,
+            population=nodes.population,
+            metadata_offset=offset,
+            metadata=encoded,
+        )
         self.assertTrue(np.array_equal(nodes.metadata_offset, offset))
         self.assertTrue(np.array_equal(nodes.metadata, encoded))
         ts1 = tables.tree_sequence()
@@ -77,12 +83,16 @@ class TestMetadataHdf5RoundTrip(unittest.TestCase):
         # For each node, we create some Python metadata that can be pickled
         metadata = [
             {"one": j, "two": 2 * j, "three": list(range(j))}
-            for j in range(ts.num_nodes)]
+            for j in range(ts.num_nodes)
+        ]
         encoded, offset = tskit.pack_bytes(list(map(pickle.dumps, metadata)))
         tables.nodes.set_columns(
-            flags=tables.nodes.flags, time=tables.nodes.time,
+            flags=tables.nodes.flags,
+            time=tables.nodes.time,
             population=tables.nodes.population,
-            metadata_offset=offset, metadata=encoded)
+            metadata_offset=offset,
+            metadata=encoded,
+        )
         self.assertTrue(np.array_equal(tables.nodes.metadata_offset, offset))
         self.assertTrue(np.array_equal(tables.nodes.metadata, encoded))
         ts1 = tables.tree_sequence()
@@ -98,6 +108,7 @@ class ExampleMetadata(object):
     """
     Simple class that we can pickle/unpickle in metadata.
     """
+
     def __init__(self, one=None, two=None):
         self.one = one
         self.two = two
@@ -157,6 +168,7 @@ class TestJsonSchemaDecoding(unittest.TestCase):
     """
     Tests in which use json-schema to decode the metadata.
     """
+
     schema = """{
         "title": "Example Metadata",
         "type": "object",
@@ -189,75 +201,87 @@ class TestLoadTextMetadata(unittest.TestCase):
     """
 
     def test_individuals(self):
-        individuals = io.StringIO("""\
+        individuals = io.StringIO(
+            """\
         id  flags location     metadata
         0   1     0.0,1.0,0.0  abc
         1   1     1.0,2.0      XYZ+
         2   0     2.0,3.0,0.0  !@#$%^&*()
-        """)
+        """
+        )
         i = tskit.parse_individuals(
-            individuals, strict=False, encoding='utf8', base64_metadata=False)
-        expected = [(1, [0.0, 1.0, 0.0], 'abc'),
-                    (1, [1.0, 2.0], 'XYZ+'),
-                    (0, [2.0, 3.0, 0.0], '!@#$%^&*()')]
+            individuals, strict=False, encoding="utf8", base64_metadata=False
+        )
+        expected = [
+            (1, [0.0, 1.0, 0.0], "abc"),
+            (1, [1.0, 2.0], "XYZ+"),
+            (0, [2.0, 3.0, 0.0], "!@#$%^&*()"),
+        ]
         for a, b in zip(expected, i):
             self.assertEqual(a[0], b.flags)
             self.assertEqual(len(a[1]), len(b.location))
             for x, y in zip(a[1], b.location):
                 self.assertEqual(x, y)
-            self.assertEqual(a[2].encode('utf8'),
-                             b.metadata)
+            self.assertEqual(a[2].encode("utf8"), b.metadata)
 
     def test_nodes(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time    metadata
         0   1           0   abc
         1   1           0   XYZ+
         2   0           1   !@#$%^&*()
-        """)
+        """
+        )
         n = tskit.parse_nodes(
-            nodes, strict=False, encoding='utf8', base64_metadata=False)
-        expected = ['abc', 'XYZ+', '!@#$%^&*()']
+            nodes, strict=False, encoding="utf8", base64_metadata=False
+        )
+        expected = ["abc", "XYZ+", "!@#$%^&*()"]
         for a, b in zip(expected, n):
-            self.assertEqual(a.encode('utf8'),
-                             b.metadata)
+            self.assertEqual(a.encode("utf8"), b.metadata)
 
     def test_sites(self):
-        sites = io.StringIO("""\
+        sites = io.StringIO(
+            """\
         position    ancestral_state metadata
         0.1 A   abc
         0.5 C   XYZ+
         0.8 G   !@#$%^&*()
-        """)
+        """
+        )
         s = tskit.parse_sites(
-            sites, strict=False, encoding='utf8', base64_metadata=False)
-        expected = ['abc', 'XYZ+', '!@#$%^&*()']
+            sites, strict=False, encoding="utf8", base64_metadata=False
+        )
+        expected = ["abc", "XYZ+", "!@#$%^&*()"]
         for a, b in zip(expected, s):
-            self.assertEqual(a.encode('utf8'),
-                             b.metadata)
+            self.assertEqual(a.encode("utf8"), b.metadata)
 
     def test_mutations(self):
-        mutations = io.StringIO("""\
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   metadata
         0   2   C   mno
         0   3   G   )(*&^%$#@!
-        """)
+        """
+        )
         m = tskit.parse_mutations(
-            mutations, strict=False, encoding='utf8', base64_metadata=False)
-        expected = ['mno', ')(*&^%$#@!']
+            mutations, strict=False, encoding="utf8", base64_metadata=False
+        )
+        expected = ["mno", ")(*&^%$#@!"]
         for a, b in zip(expected, m):
-            self.assertEqual(a.encode('utf8'),
-                             b.metadata)
+            self.assertEqual(a.encode("utf8"), b.metadata)
 
     def test_populations(self):
-        populations = io.StringIO("""\
+        populations = io.StringIO(
+            """\
         id    metadata
         0     mno
         1     )(*&^%$#@!
-        """)
+        """
+        )
         p = tskit.parse_populations(
-            populations, strict=False, encoding='utf8', base64_metadata=False)
-        expected = ['mno', ')(*&^%$#@!']
+            populations, strict=False, encoding="utf8", base64_metadata=False
+        )
+        expected = ["mno", ")(*&^%$#@!"]
         for a, b in zip(expected, p):
-            self.assertEqual(a.encode('utf8'),
-                             b.metadata)
+            self.assertEqual(a.encode("utf8"), b.metadata)

--- a/python/tests/test_newick.py
+++ b/python/tests/test_newick.py
@@ -35,6 +35,7 @@ class TestNewick(unittest.TestCase):
     Tests that the newick output has the properties that we need using
     external Newick parser.
     """
+
     random_seed = 155
 
     def verify_newick_topology(self, tree, root=None, node_labels=None):
@@ -59,9 +60,13 @@ class TestNewick(unittest.TestCase):
 
     def get_nonbinary_example(self):
         ts = msprime.simulate(
-            sample_size=20, recombination_rate=10, random_seed=self.random_seed,
+            sample_size=20,
+            recombination_rate=10,
+            random_seed=self.random_seed,
             demographic_events=[
-                msprime.SimpleBottleneck(time=0.5, population=0, proportion=1)])
+                msprime.SimpleBottleneck(time=0.5, population=0, proportion=1)
+            ],
+        )
         # Make sure this really has some non-binary nodes
         found = False
         for e in ts.edgesets():
@@ -73,7 +78,8 @@ class TestNewick(unittest.TestCase):
 
     def get_binary_example(self):
         ts = msprime.simulate(
-            sample_size=25, recombination_rate=5, random_seed=self.random_seed)
+            sample_size=25, recombination_rate=5, random_seed=self.random_seed
+        )
         return ts
 
     def get_multiroot_example(self):
@@ -82,8 +88,11 @@ class TestNewick(unittest.TestCase):
         edges = tables.edges
         n = len(edges) // 2
         edges.set_columns(
-            left=edges.left[:n], right=edges.right[:n],
-            parent=edges.parent[:n], child=edges.child[:n])
+            left=edges.left[:n],
+            right=edges.right[:n],
+            parent=edges.parent[:n],
+            child=edges.child[:n],
+        )
         return tables.tree_sequence()
 
     def test_nonbinary_tree(self):
@@ -126,8 +135,7 @@ class TestNewick(unittest.TestCase):
         ns = tree.newick(node_labels=labels)
         root = newick.loads(ns)[0]
         self.assertEqual(root.name, labels[tree.root])
-        self.assertEqual(
-            sorted([n.name for n in root.walk()]), sorted(labels.values()))
+        self.assertEqual(sorted([n.name for n in root.walk()]), sorted(labels.values()))
 
     def test_single_node_label(self):
         tree = msprime.simulate(5, random_seed=2).first()
@@ -137,4 +145,5 @@ class TestNewick(unittest.TestCase):
         self.assertEqual(root.name, labels[tree.root])
         self.assertEqual(
             [n.name for n in root.walk()],
-            [labels[tree.root]] + [None for _ in range(len(list(tree.nodes())) - 1)])
+            [labels[tree.root]] + [None for _ in range(len(list(tree.nodes())) - 1)],
+        )

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -47,7 +47,7 @@ def get_provenance(
     """
     document = {
         "schema_version": schema_version,
-        "software": {"name": software_name, "version": software_version,},
+        "software": {"name": software_name, "version": software_version},
         "environment": {} if environment is None else environment,
         "parameters": {} if parameters is None else parameters,
     }
@@ -105,7 +105,7 @@ class TestSchema(unittest.TestCase):
     def test_minimal(self):
         minimal = {
             "schema_version": "1",
-            "software": {"name": "x", "version": "y",},
+            "software": {"name": "x", "version": "y"},
             "environment": {},
             "parameters": {},
         }
@@ -115,7 +115,7 @@ class TestSchema(unittest.TestCase):
         extra = {
             "you": "can",
             "schema_version": "1",
-            "software": {"put": "anything", "name": "x", "version": "y",},
+            "software": {"put": "anything", "name": "x", "version": "y"},
             "environment": {"extra": ["you", "want"]},
             "parameters": {"so": ["long", "its", "JSON", 0]},
         }

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -36,17 +36,18 @@ import tskit.provenance as provenance
 
 
 def get_provenance(
-        software_name="x", software_version="y", schema_version="1", environment=None,
-        parameters=None):
+    software_name="x",
+    software_version="y",
+    schema_version="1",
+    environment=None,
+    parameters=None,
+):
     """
     Utility function to return a provenance document for testing.
     """
     document = {
         "schema_version": schema_version,
-        "software": {
-            "name": software_name,
-            "version": software_version,
-        },
+        "software": {"name": software_name, "version": software_version,},
         "environment": {} if environment is None else environment,
         "parameters": {} if parameters is None else parameters,
     }
@@ -57,6 +58,7 @@ class TestSchema(unittest.TestCase):
     """
     Tests for schema validation.
     """
+
     def test_empty(self):
         with self.assertRaises(tskit.ProvenanceValidationError):
             tskit.validate_provenance({})
@@ -103,12 +105,9 @@ class TestSchema(unittest.TestCase):
     def test_minimal(self):
         minimal = {
             "schema_version": "1",
-            "software": {
-                "name": "x",
-                "version": "y",
-            },
+            "software": {"name": "x", "version": "y",},
             "environment": {},
-            "parameters": {}
+            "parameters": {},
         }
         tskit.validate_provenance(minimal)
 
@@ -116,13 +115,9 @@ class TestSchema(unittest.TestCase):
         extra = {
             "you": "can",
             "schema_version": "1",
-            "software": {
-                "put": "anything",
-                "name": "x",
-                "version": "y",
-            },
+            "software": {"put": "anything", "name": "x", "version": "y",},
             "environment": {"extra": ["you", "want"]},
-            "parameters": {"so": ["long", "its", "JSON", 0]}
+            "parameters": {"so": ["long", "its", "JSON", 0]},
         }
         tskit.validate_provenance(extra)
 
@@ -131,6 +126,7 @@ class TestOutputProvenance(unittest.TestCase):
     """
     Check that the schemas we produce in tskit are valid.
     """
+
     def test_simplify(self):
         ts = msprime.simulate(5, random_seed=1)
         ts = ts.simplify()
@@ -138,16 +134,18 @@ class TestOutputProvenance(unittest.TestCase):
         tskit.validate_provenance(prov)
         self.assertEqual(prov["parameters"]["command"], "simplify")
         self.assertEqual(
-            prov["environment"], provenance.get_environment(include_tskit=False))
+            prov["environment"], provenance.get_environment(include_tskit=False)
+        )
         self.assertEqual(
-            prov["software"],
-            {"name": "tskit", "version": tskit.__version__})
+            prov["software"], {"name": "tskit", "version": tskit.__version__}
+        )
 
 
 class TestEnvironment(unittest.TestCase):
     """
     Tests for the environment provenance.
     """
+
     def test_os(self):
         env = provenance.get_environment()
         os = {
@@ -155,7 +153,7 @@ class TestEnvironment(unittest.TestCase):
             "node": platform.node(),
             "release": platform.release(),
             "version": platform.version(),
-            "machine": platform.machine()
+            "machine": platform.machine(),
         }
         self.assertEqual(env["os"], os)
 
@@ -170,10 +168,10 @@ class TestEnvironment(unittest.TestCase):
     def test_libraries(self):
         kastore_lib = {"version": ".".join(map(str, _tskit.get_kastore_version()))}
         env = provenance.get_environment()
-        self.assertEqual({
-                "kastore": kastore_lib,
-                "tskit": {"version": tskit.__version__}},
-            env["libraries"])
+        self.assertEqual(
+            {"kastore": kastore_lib, "tskit": {"version": tskit.__version__}},
+            env["libraries"],
+        )
 
         env = provenance.get_environment(include_tskit=False)
         self.assertEqual({"kastore": kastore_lib}, env["libraries"])
@@ -189,6 +187,7 @@ class TestGetSchema(unittest.TestCase):
     """
     Ensure we return the correct JSON schema.
     """
+
     def test_file_equal(self):
         s1 = provenance.get_schema()
         base = os.path.join(os.path.dirname(__file__), "..", "tskit")
@@ -215,6 +214,7 @@ class TestTreeSeqEditMethods(unittest.TestCase):
     """
     Ensure that tree sequence 'edit' methods correctly record themselves
     """
+
     def test_keep_delete_different(self):
         ts = msprime.simulate(5, random_seed=1)
         ts_keep = ts.keep_intervals([[0.25, 0.5]])

--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -83,7 +83,7 @@ class TestLdCalculator(unittest.TestCase):
         # when we use get_r2 directly.
         for j in range(m):
             a = ldc.get_r2_array(j, direction=tskit.FORWARD)
-            b = A[j, j + 1:]
+            b = A[j, j + 1 :]
             self.assertEqual(a.shape[0], m - j - 1)
             self.assertEqual(b.shape[0], m - j - 1)
             self.assertTrue(np.allclose(a, b))
@@ -110,11 +110,11 @@ class TestLdCalculator(unittest.TestCase):
             x = mutations[j + k].position - mutations[j].position
             a = ldc.get_r2_array(j, max_distance=x)
             self.assertEqual(a.shape[0], k)
-            self.assertTrue(np.allclose(A[j, j + 1: j + 1 + k], a))
+            self.assertTrue(np.allclose(A[j, j + 1 : j + 1 + k], a))
             x = mutations[j].position - mutations[j - k].position
             a = ldc.get_r2_array(j, max_distance=x, direction=tskit.REVERSE)
             self.assertEqual(a.shape[0], k)
-            self.assertTrue(np.allclose(A[j, j - k: j], a[::-1]))
+            self.assertTrue(np.allclose(A[j, j - k : j], a[::-1]))
         L = ts.get_sequence_length()
         m = len(mutations)
         a = ldc.get_r2_array(0, max_distance=L)
@@ -135,10 +135,10 @@ class TestLdCalculator(unittest.TestCase):
         for k in range(j):
             a = ldc.get_r2_array(j, max_mutations=k)
             self.assertEqual(a.shape[0], k)
-            self.assertTrue(np.allclose(A[j, j + 1: j + 1 + k], a))
+            self.assertTrue(np.allclose(A[j, j + 1 : j + 1 + k], a))
             a = ldc.get_r2_array(j, max_mutations=k, direction=tskit.REVERSE)
             self.assertEqual(a.shape[0], k)
-            self.assertTrue(np.allclose(A[j, j - k: j], a[::-1]))
+            self.assertTrue(np.allclose(A[j, j - k : j], a[::-1]))
 
     def test_single_tree_simulated_mutations(self):
         ts = msprime.simulate(20, mutation_rate=10, random_seed=15)
@@ -167,8 +167,8 @@ class TestLdCalculator(unittest.TestCase):
 
     def test_tree_sequence_regular_mutations(self):
         ts = msprime.simulate(
-            self.num_test_sites, recombination_rate=1,
-            length=self.num_test_sites)
+            self.num_test_sites, recombination_rate=1, length=self.num_test_sites
+        )
         self.assertGreater(ts.get_num_trees(), 10)
         t = ts.dump_tables()
         t.sites.reset()
@@ -202,7 +202,7 @@ def set_partitions(collection):
         first = collection[0]
         for smaller in set_partitions(collection[1:]):
             for n, subset in enumerate(smaller):
-                yield smaller[:n] + [[first] + subset] + smaller[n + 1:]
+                yield smaller[:n] + [[first] + subset] + smaller[n + 1 :]
             yield [[first]] + smaller
 
 
@@ -234,6 +234,7 @@ class TestMeanDescendants(unittest.TestCase):
     """
     Tests the TreeSequence.mean_descendants method.
     """
+
     def verify(self, ts, reference_sets):
         C1 = naive_mean_descendants(ts, reference_sets)
         C2 = tsutil.mean_descendants(ts, reference_sets)
@@ -247,10 +248,12 @@ class TestMeanDescendants(unittest.TestCase):
         ts = msprime.simulate(
             population_configurations=[
                 msprime.PopulationConfiguration(8),
-                msprime.PopulationConfiguration(8)],
+                msprime.PopulationConfiguration(8),
+            ],
             migration_matrix=[[0, 1], [1, 0]],
             recombination_rate=3,
-            random_seed=5)
+            random_seed=5,
+        )
         self.assertGreater(ts.num_trees, 1)
         self.verify(ts, [ts.samples(0), ts.samples(1)])
 
@@ -289,8 +292,13 @@ class TestMeanDescendants(unittest.TestCase):
 
     def test_wright_fisher_unsimplified_all_sample_sets(self):
         tables = wf.wf_sim(
-            4, 5, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=10)
+            4,
+            5,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=10,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         for S in set_partitions(list(ts.samples())):
@@ -298,8 +306,13 @@ class TestMeanDescendants(unittest.TestCase):
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(
-            20, 15, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=20)
+            20,
+            15,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=20,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         samples = ts.samples()
@@ -307,8 +320,13 @@ class TestMeanDescendants(unittest.TestCase):
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            30, 10, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=5)
+            30,
+            10,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         samples = ts.samples()
@@ -320,8 +338,8 @@ def naive_genealogical_nearest_neighbours(ts, focal, reference_sets):
     # This is a limitation of the current API.
     tables = ts.dump_tables()
     tables.nodes.set_columns(
-        flags=np.ones_like(tables.nodes.flags),
-        time=tables.nodes.time)
+        flags=np.ones_like(tables.nodes.flags), time=tables.nodes.time
+    )
     ts = tables.tree_sequence()
 
     A = np.zeros((len(focal), len(reference_sets)))
@@ -331,7 +349,8 @@ def naive_genealogical_nearest_neighbours(ts, focal, reference_sets):
         for u in ref_set:
             reference_set_map[u] = k
     tree_iters = [
-        ts.trees(tracked_samples=reference_nodes) for reference_nodes in reference_sets]
+        ts.trees(tracked_samples=reference_nodes) for reference_nodes in reference_sets
+    ]
     for _ in range(ts.num_trees):
         trees = list(map(next, tree_iters))
         length = trees[0].interval[1] - trees[0].interval[0]
@@ -366,6 +385,7 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
     """
     Tests the TreeSequence.genealogical_nearest_neighbours method.
     """
+
     #
     #          8
     #         / \
@@ -416,7 +436,9 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
     def test_simple_example_all_samples(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         A = self.verify(ts, [[0, 1], [2, 3, 4]], [0])
         self.assertEqual(list(A[0]), [1, 0])
         A = self.verify(ts, [[0, 1], [2, 3, 4]], [4])
@@ -431,7 +453,9 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
     def test_simple_example_missing_samples(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         A = self.verify(ts, [[0, 1], [2, 4]], [3])
         self.assertEqual(list(A[0]), [0, 1])
         A = self.verify(ts, [[0, 1], [2, 4]], [2])
@@ -440,7 +464,9 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
     def test_simple_example_internal_focal_node(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         focal = [7]  # An internal node
         reference_sets = [[4, 0, 1], [2, 3]]
         GNN = naive_genealogical_nearest_neighbours(ts, focal, reference_sets)
@@ -461,10 +487,12 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
         ts = msprime.simulate(
             population_configurations=[
                 msprime.PopulationConfiguration(18),
-                msprime.PopulationConfiguration(18)],
+                msprime.PopulationConfiguration(18),
+            ],
             migration_matrix=[[0, 1], [1, 0]],
             recombination_rate=8,
-            random_seed=5)
+            random_seed=5,
+        )
         self.assertGreater(ts.num_trees, 1)
         self.verify(ts, [ts.samples(0), ts.samples(1)])
 
@@ -512,8 +540,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_unsimplified_all_sample_sets(self):
         tables = wf.wf_sim(
-            4, 5, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=10)
+            4,
+            5,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=10,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         for S in set_partitions(list(ts.samples())):
@@ -521,8 +554,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(
-            20, 15, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=20)
+            20,
+            15,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=20,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         samples = ts.samples()
@@ -530,8 +568,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
-            20, 15, seed=1, deep_history=True, initial_generation_samples=True,
-            num_loci=20)
+            20,
+            15,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=True,
+            num_loci=20,
+        )
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
@@ -542,8 +585,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_initial_generation_no_deep_history(self):
         tables = wf.wf_sim(
-            20, 15, seed=2, deep_history=False, initial_generation_samples=True,
-            num_loci=20)
+            20,
+            15,
+            seed=2,
+            deep_history=False,
+            initial_generation_samples=True,
+            num_loci=20,
+        )
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
@@ -554,8 +602,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
         tables = wf.wf_sim(
-            20, 15, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=20)
+            20,
+            15,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=20,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         samples = ts.samples()
@@ -563,8 +616,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            31, 10, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            31,
+            10,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         samples = ts.samples()
@@ -572,8 +630,13 @@ class TestGenealogicalNearestNeighbours(unittest.TestCase):
 
     def test_wright_fisher_simplified_multiple_roots(self):
         tables = wf.wf_sim(
-            31, 10, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=5)
+            31,
+            10,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         samples = ts.samples()
@@ -594,8 +657,8 @@ def exact_genealogical_nearest_neighbours(ts, focal, reference_sets):
     # This is a limitation of the current API.
     tables = ts.dump_tables()
     tables.nodes.set_columns(
-        flags=np.ones_like(tables.nodes.flags),
-        time=tables.nodes.time)
+        flags=np.ones_like(tables.nodes.flags), time=tables.nodes.time
+    )
     ts = tables.tree_sequence()
 
     A = np.zeros((len(reference_sets), ts.num_trees))
@@ -605,7 +668,8 @@ def exact_genealogical_nearest_neighbours(ts, focal, reference_sets):
         for u in ref_set:
             reference_set_map[u] = k
     tree_iters = [
-        ts.trees(tracked_samples=reference_nodes) for reference_nodes in reference_sets]
+        ts.trees(tracked_samples=reference_nodes) for reference_nodes in reference_sets
+    ]
     u = focal
     focal_node_set = reference_set_map[u]
     # delta(u) = 1 if u exists in any of the reference sets; 0 otherwise

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -75,9 +75,12 @@ class CommonTestsMixin(object):
     Abstract base class for common table tests. Because of the design of unittest,
     we have to make this a mixin.
     """
+
     def test_max_rows_increment(self):
-        for bad_value in [-1, -2**10]:
-            self.assertRaises(ValueError, self.table_class, max_rows_increment=bad_value)
+        for bad_value in [-1, -(2 ** 10)]:
+            self.assertRaises(
+                ValueError, self.table_class, max_rows_increment=bad_value
+            )
         for v in [1, 100, 256]:
             table = self.table_class(max_rows_increment=v)
             self.assertEqual(table.max_rows_increment, v)
@@ -115,7 +118,7 @@ class CommonTestsMixin(object):
     def test_input_parameters_errors(self):
         self.assertGreater(len(self.input_parameters), 0)
         for param, _ in self.input_parameters:
-            for bad_value in [-1, -2**10]:
+            for bad_value in [-1, -(2 ** 10)]:
                 self.assertRaises(ValueError, self.table_class, **{param: bad_value})
             for bad_type in [None, ValueError, "ser"]:
                 self.assertRaises(TypeError, self.table_class, **{param: bad_type})
@@ -260,13 +263,16 @@ class CommonTestsMixin(object):
             for list_col, offset_col in self.ragged_list_columns:
                 list_data = input_data[list_col.name]
                 self.assertTrue(
-                    np.array_equal(getattr(table, list_col.name), list_data))
+                    np.array_equal(getattr(table, list_col.name), list_data)
+                )
                 list_data += 1
                 self.assertFalse(
-                    np.array_equal(getattr(table, list_col.name), list_data))
+                    np.array_equal(getattr(table, list_col.name), list_data)
+                )
                 setattr(table, list_col.name, list_data)
                 self.assertTrue(
-                    np.array_equal(getattr(table, list_col.name), list_data))
+                    np.array_equal(getattr(table, list_col.name), list_data)
+                )
                 list_value = getattr(table[0], list_col.name)
                 self.assertEqual(len(list_value), 1)
 
@@ -414,17 +420,20 @@ class CommonTestsMixin(object):
             for list_col, offset_col in self.ragged_list_columns:
                 offset = getattr(table, offset_col.name)
                 self.assertEqual(offset.shape, (num_rows + 1,))
-                self.assertTrue(np.array_equal(
-                    input_data[offset_col.name][:num_rows + 1], offset))
+                self.assertTrue(
+                    np.array_equal(input_data[offset_col.name][: num_rows + 1], offset)
+                )
                 list_data = getattr(table, list_col.name)
-                self.assertTrue(np.array_equal(
-                    list_data, input_data[list_col.name][:offset[-1]]))
+                self.assertTrue(
+                    np.array_equal(list_data, input_data[list_col.name][: offset[-1]])
+                )
                 used.add(offset_col.name)
                 used.add(list_col.name)
             for name, data in input_data.items():
                 if name not in used:
-                    self.assertTrue(np.array_equal(
-                        data[:num_rows], getattr(table, name)))
+                    self.assertTrue(
+                        np.array_equal(data[:num_rows], getattr(table, name))
+                    )
 
     def test_truncate_errors(self):
         num_rows = 10
@@ -437,7 +446,7 @@ class CommonTestsMixin(object):
         table.set_columns(**input_data)
         for bad_type in [None, 0.001, {}]:
             self.assertRaises(TypeError, table.truncate, bad_type)
-        for bad_num_rows in [-1, num_rows + 1, 10**6]:
+        for bad_num_rows in [-1, num_rows + 1, 10 ** 6]:
             self.assertRaises(ValueError, table.truncate, bad_num_rows)
 
     def test_append_columns_data(self):
@@ -457,8 +466,9 @@ class CommonTestsMixin(object):
                     if colname in offset_cols:
                         input_array = np.zeros(j * num_rows + 1, dtype=np.uint32)
                         for k in range(j):
-                            input_array[k * num_rows: (k + 1) * num_rows + 1] = (
-                                k * values[-1]) + values
+                            input_array[k * num_rows : (k + 1) * num_rows + 1] = (
+                                k * values[-1]
+                            ) + values
                         self.assertEqual(input_array.shape, output_array.shape)
                     else:
                         input_array = np.hstack([values for _ in range(j)])
@@ -572,7 +582,8 @@ class CommonTestsMixin(object):
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value
                 input_data_copy[offset_col.name] = np.arange(
-                    num_rows + 1, dtype=np.uint32)
+                    num_rows + 1, dtype=np.uint32
+                )
                 input_data_copy[offset_col.name][-1] = num_rows + 1
                 t2.set_columns(**input_data_copy)
                 self.assertNotEqual(t1, t2)
@@ -600,7 +611,7 @@ class CommonTestsMixin(object):
                 self.assertRaises(ValueError, t.set_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.set_columns(**input_data)
-                input_data[offset_col.name][num_rows // 2] = 2**31
+                input_data[offset_col.name][num_rows // 2] = 2 ** 31
                 self.assertRaises(_tskit.LibraryError, t.set_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
 
@@ -612,7 +623,7 @@ class CommonTestsMixin(object):
                 self.assertRaises(ValueError, t.append_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.append_columns(**input_data)
-                input_data[offset_col.name][num_rows // 2] = 2**31
+                input_data[offset_col.name][num_rows // 2] = 2 ** 31
                 self.assertRaises(_tskit.LibraryError, t.append_columns, **input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
 
@@ -621,6 +632,7 @@ class MetadataTestsMixin(object):
     """
     Tests for column that have metadata columns.
     """
+
     def test_random_metadata(self):
         for num_rows in [0, 10, 100]:
             input_data = {col.name: col.get_input(num_rows) for col in self.columns}
@@ -635,7 +647,8 @@ class MetadataTestsMixin(object):
             input_data["metadata_offset"] = metadata_offset
             table.set_columns(**input_data)
             unpacked_metadatas = tskit.unpack_bytes(
-                table.metadata, table.metadata_offset)
+                table.metadata, table.metadata_offset
+            )
             self.assertEqual(metadatas, unpacked_metadatas)
 
     def test_optional_metadata(self):
@@ -651,14 +664,16 @@ class MetadataTestsMixin(object):
             table.set_columns(**input_data)
             self.assertEqual(len(list(table.metadata)), 0)
             self.assertEqual(
-                list(table.metadata_offset), [0 for _ in range(num_rows + 1)])
+                list(table.metadata_offset), [0 for _ in range(num_rows + 1)]
+            )
             # Supplying None is the same not providing the column.
             input_data["metadata"] = None
             input_data["metadata_offset"] = None
             table.set_columns(**input_data)
             self.assertEqual(len(list(table.metadata)), 0)
             self.assertEqual(
-                list(table.metadata_offset), [0 for _ in range(num_rows + 1)])
+                list(table.metadata_offset), [0 for _ in range(num_rows + 1)]
+            )
 
     def test_packset_metadata(self):
         for num_rows in [0, 10, 100]:
@@ -680,8 +695,9 @@ class TestIndividualTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixi
 
     columns = [UInt32Column("flags")]
     ragged_list_columns = [
-        (DoubleColumn("location"),  UInt32Column("location_offset")),
-        (CharColumn("metadata"),  UInt32Column("metadata_offset"))]
+        (DoubleColumn("location"), UInt32Column("location_offset")),
+        (CharColumn("metadata"), UInt32Column("metadata_offset")),
+    ]
     string_colnames = []
     binary_colnames = ["metadata"]
     input_parameters = [("max_rows_increment", 1024)]
@@ -739,8 +755,9 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         UInt32Column("flags"),
         DoubleColumn("time"),
         Int32Column("individual"),
-        Int32Column("population")]
-    ragged_list_columns = [(CharColumn("metadata"),  UInt32Column("metadata_offset"))]
+        Int32Column("population"),
+    ]
+    ragged_list_columns = [(CharColumn("metadata"), UInt32Column("metadata_offset"))]
     string_colnames = []
     binary_colnames = ["metadata"]
     input_parameters = [("max_rows_increment", 1024)]
@@ -783,8 +800,11 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
             time = list(range(num_rows))
             table = tskit.NodeTable()
             table.set_columns(
-                metadata=metadata, metadata_offset=metadata_offset,
-                flags=flags, time=time)
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+                flags=flags,
+                time=time,
+            )
             self.assertEqual(list(table.population), [-1 for _ in range(num_rows)])
             self.assertEqual(list(table.flags), flags)
             self.assertEqual(list(table.time), time)
@@ -815,7 +835,8 @@ class TestEdgeTable(unittest.TestCase, CommonTestsMixin):
         DoubleColumn("left"),
         DoubleColumn("right"),
         Int32Column("parent"),
-        Int32Column("child")]
+        Int32Column("child"),
+    ]
     equal_len_columns = [["left", "right", "parent", "child"]]
     string_colnames = []
     binary_colnames = []
@@ -850,7 +871,8 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
     columns = [DoubleColumn("position")]
     ragged_list_columns = [
         (CharColumn("ancestral_state"), UInt32Column("ancestral_state_offset")),
-        (CharColumn("metadata"), UInt32Column("metadata_offset"))]
+        (CharColumn("metadata"), UInt32Column("metadata_offset")),
+    ]
     equal_len_columns = [["position"]]
     string_colnames = ["ancestral_state"]
     binary_colnames = ["metadata"]
@@ -895,21 +917,21 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
             table.set_columns(**input_data)
             ancestral_states = [tsutil.random_strings(10) for _ in range(num_rows)]
             ancestral_state, ancestral_state_offset = tskit.pack_strings(
-                    ancestral_states)
+                ancestral_states
+            )
             table.packset_ancestral_state(ancestral_states)
             self.assertTrue(np.array_equal(table.ancestral_state, ancestral_state))
-            self.assertTrue(np.array_equal(
-                table.ancestral_state_offset, ancestral_state_offset))
+            self.assertTrue(
+                np.array_equal(table.ancestral_state_offset, ancestral_state_offset)
+            )
 
 
 class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
-    columns = [
-        Int32Column("site"),
-        Int32Column("node"),
-        Int32Column("parent")]
+    columns = [Int32Column("site"), Int32Column("node"), Int32Column("parent")]
     ragged_list_columns = [
         (CharColumn("derived_state"), UInt32Column("derived_state_offset")),
-        (CharColumn("metadata"), UInt32Column("metadata_offset"))]
+        (CharColumn("metadata"), UInt32Column("metadata_offset")),
+    ]
     equal_len_columns = [["site", "node"]]
     string_colnames = ["derived_state"]
     binary_colnames = ["metadata"]
@@ -957,8 +979,9 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin)
             derived_state, derived_state_offset = tskit.pack_strings(derived_states)
             table.packset_derived_state(derived_states)
             self.assertTrue(np.array_equal(table.derived_state, derived_state))
-            self.assertTrue(np.array_equal(
-                table.derived_state_offset, derived_state_offset))
+            self.assertTrue(
+                np.array_equal(table.derived_state_offset, derived_state_offset)
+            )
 
 
 class TestMigrationTable(unittest.TestCase, CommonTestsMixin):
@@ -968,7 +991,8 @@ class TestMigrationTable(unittest.TestCase, CommonTestsMixin):
         Int32Column("node"),
         Int32Column("source"),
         Int32Column("dest"),
-        DoubleColumn("time")]
+        DoubleColumn("time"),
+    ]
     ragged_list_columns = []
     string_colnames = []
     binary_colnames = []
@@ -1005,7 +1029,8 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
     columns = []
     ragged_list_columns = [
         (CharColumn("timestamp"), UInt32Column("timestamp_offset")),
-        (CharColumn("record"), UInt32Column("record_offset"))]
+        (CharColumn("record"), UInt32Column("record_offset")),
+    ]
     equal_len_columns = [[]]
     string_colnames = ["record", "timestamp"]
     binary_colnames = []
@@ -1052,8 +1077,7 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
 
 class TestPopulationTable(unittest.TestCase, CommonTestsMixin):
     columns = []
-    ragged_list_columns = [
-        (CharColumn("metadata"), UInt32Column("metadata_offset"))]
+    ragged_list_columns = [(CharColumn("metadata"), UInt32Column("metadata_offset"))]
     equal_len_columns = [[]]
     string_colnames = []
     binary_colnames = ["metadata"]
@@ -1083,6 +1107,7 @@ class TestSortTables(unittest.TestCase):
     """
     Tests for the TableCollection.sort() method.
     """
+
     random_seed = 12345
 
     def verify_randomise_tables(self, ts):
@@ -1109,13 +1134,18 @@ class TestSortTables(unittest.TestCase):
         randomised_mutations = []
         for s in randomised_sites:
             site_id_map[s.id] = tables.sites.add_row(
-                s.position, ancestral_state=s.ancestral_state, metadata=s.metadata)
+                s.position, ancestral_state=s.ancestral_state, metadata=s.metadata
+            )
             randomised_mutations.extend(s.mutations)
         random.shuffle(randomised_mutations)
         for m in randomised_mutations:
             tables.mutations.add_row(
-                site=site_id_map[m.site], node=m.node, derived_state=m.derived_state,
-                parent=m.parent, metadata=m.metadata)
+                site=site_id_map[m.site],
+                node=m.node,
+                derived_state=m.derived_state,
+                parent=m.parent,
+                metadata=m.metadata,
+            )
         if ts.num_sites > 1:
             # Verify that import fails for randomised sites
             self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
@@ -1136,7 +1166,7 @@ class TestSortTables(unittest.TestCase):
         edges = tables.edges.copy()
         starts = [0]
         if len(edges) > 2:
-            starts = [0, 1, len(edges) // 2,  len(edges) - 2]
+            starts = [0, 1, len(edges) // 2, len(edges) - 2]
         random.seed(self.random_seed)
         for start in starts:
             # Unsort the edges starting from index start
@@ -1201,7 +1231,8 @@ class TestSortTables(unittest.TestCase):
 
     def test_many_trees_mutations(self):
         ts = msprime.simulate(
-            10, recombination_rate=2, mutation_rate=2, random_seed=self.random_seed)
+            10, recombination_rate=2, mutation_rate=2, random_seed=self.random_seed
+        )
         self.assertGreater(ts.num_trees, 2)
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
@@ -1222,9 +1253,14 @@ class TestSortTables(unittest.TestCase):
 
     def get_nonbinary_example(self, mutation_rate):
         ts = msprime.simulate(
-            sample_size=20, recombination_rate=10, random_seed=self.random_seed,
-            mutation_rate=mutation_rate, demographic_events=[
-                msprime.SimpleBottleneck(time=0.5, population=0, proportion=1)])
+            sample_size=20,
+            recombination_rate=10,
+            random_seed=self.random_seed,
+            mutation_rate=mutation_rate,
+            demographic_events=[
+                msprime.SimpleBottleneck(time=0.5, population=0, proportion=1)
+            ],
+        )
         # Make sure this really has some non-binary nodes
         found = False
         for e in ts.edgesets():
@@ -1294,29 +1330,42 @@ class TestSortMutations(unittest.TestCase):
     """
 
     def test_sort_mutations_stability(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0.1     0
         0.2     0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         1       0       1               -1
         1       1       1               -1
         0       1       1               -1
         0       0       1               -1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            sequence_length=1, strict=False)
+            nodes=nodes,
+            edges=edges,
+            sites=sites,
+            mutations=mutations,
+            sequence_length=1,
+            strict=False,
+        )
         # Load text automatically calls tables.sort(), so we can test the
         # output directly.
         sites = ts.tables.sites
@@ -1327,19 +1376,26 @@ class TestSortMutations(unittest.TestCase):
         self.assertEqual(list(mutations.node), [1, 0, 0, 1])
 
     def test_sort_mutations_remap_parent_id(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0.1     0
         0.2     0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         1       0       1               -1
         1       0       0               0
@@ -1347,10 +1403,16 @@ class TestSortMutations(unittest.TestCase):
         0       0       1               -1
         0       0       0               3
         0       0       1               4
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            sequence_length=1, strict=False)
+            nodes=nodes,
+            edges=edges,
+            sites=sites,
+            mutations=mutations,
+            sequence_length=1,
+            strict=False,
+        )
         # Load text automatically calls sort tables, so we can test the
         # output directly.
         sites = ts.tables.sites
@@ -1362,39 +1424,55 @@ class TestSortMutations(unittest.TestCase):
         self.assertEqual(list(mutations.parent), [-1, 0, 1, -1, 3, 4])
 
     def test_sort_mutations_bad_parent_id(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0.1     0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         1       0       1               -2
-        """)
+        """
+        )
         self.assertRaises(
-            _tskit.LibraryError, tskit.load_text,
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            sequence_length=1, strict=False)
+            _tskit.LibraryError,
+            tskit.load_text,
+            nodes=nodes,
+            edges=edges,
+            sites=sites,
+            mutations=mutations,
+            sequence_length=1,
+            strict=False,
+        )
 
 
 class TestTablesToTreeSequence(unittest.TestCase):
     """
     Tests for the .tree_sequence() method of a TableCollection.
     """
+
     random_seed = 42
 
     def test_round_trip(self):
-        a = msprime.simulate(5,  mutation_rate=1, random_seed=self.random_seed)
+        a = msprime.simulate(5, mutation_rate=1, random_seed=self.random_seed)
         tables = a.dump_tables()
         b = tables.tree_sequence()
         self.assertTrue(
-            all(a == b for a, b in zip(a.tables, b.tables) if a[0] != 'provenances'))
+            all(a == b for a, b in zip(a.tables, b.tables) if a[0] != "provenances")
+        )
 
 
 class TestNanDoubleValues(unittest.TestCase):
@@ -1403,38 +1481,38 @@ class TestNanDoubleValues(unittest.TestCase):
     """
 
     def test_edge_coords(self):
-        ts = msprime.simulate(5,  mutation_rate=1, random_seed=42)
+        ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
 
         tables = ts.dump_tables()
-        bad_coords = tables.edges.left + float('inf')
+        bad_coords = tables.edges.left + float("inf")
         tables.edges.left = bad_coords
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
         tables = ts.dump_tables()
-        bad_coords = tables.edges.right + float('nan')
+        bad_coords = tables.edges.right + float("nan")
         tables.edges.right = bad_coords
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
     def test_migrations(self):
-        ts = msprime.simulate(5,  mutation_rate=1, random_seed=42)
+        ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
 
         tables = ts.dump_tables()
         tables.populations.add_row()
-        tables.migrations.add_row(float('inf'), 1, time=0, node=0, source=0, dest=1)
+        tables.migrations.add_row(float("inf"), 1, time=0, node=0, source=0, dest=1)
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
         tables = ts.dump_tables()
         tables.populations.add_row()
-        tables.migrations.add_row(0, float('nan'), time=0, node=0, source=0, dest=1)
+        tables.migrations.add_row(0, float("nan"), time=0, node=0, source=0, dest=1)
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
         tables = ts.dump_tables()
         tables.populations.add_row()
-        tables.migrations.add_row(0, 1, time=float('nan'), node=0, source=0, dest=1)
+        tables.migrations.add_row(0, 1, time=float("nan"), node=0, source=0, dest=1)
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
     def test_site_positions(self):
-        ts = msprime.simulate(5,  mutation_rate=1, random_seed=42)
+        ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
         tables = ts.dump_tables()
         bad_pos = tables.sites.position.copy()
         bad_pos[-1] = np.inf
@@ -1442,7 +1520,7 @@ class TestNanDoubleValues(unittest.TestCase):
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
     def test_node_times(self):
-        ts = msprime.simulate(5,  mutation_rate=1, random_seed=42)
+        ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
         tables = ts.dump_tables()
         bad_times = tables.nodes.time.copy()
         bad_times[-1] = np.inf
@@ -1450,7 +1528,7 @@ class TestNanDoubleValues(unittest.TestCase):
         self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
 
     def test_individual(self):
-        ts = msprime.simulate(12,  mutation_rate=1, random_seed=42)
+        ts = msprime.simulate(12, mutation_rate=1, random_seed=42)
         ts = tsutil.insert_random_ploidy_individuals(ts, seed=42)
         self.assertGreater(ts.num_individuals, 1)
         tables = ts.dump_tables()
@@ -1464,10 +1542,11 @@ class TestSimplifyTables(unittest.TestCase):
     """
     Tests for the simplify_tables function.
     """
+
     random_seed = 42
 
     def test_deprecated_zero_mutation_sites(self):
-        ts = msprime.simulate(10,  mutation_rate=1, random_seed=self.random_seed)
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=self.random_seed)
         tables = ts.dump_tables()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -1476,7 +1555,7 @@ class TestSimplifyTables(unittest.TestCase):
             assert issubclass(w[-1].category, DeprecationWarning)
 
     def test_zero_mutation_sites(self):
-        ts = msprime.simulate(10,  mutation_rate=1, random_seed=self.random_seed)
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=self.random_seed)
         for filter_sites in [True, False]:
             t1 = ts.dump_tables()
             t1.simplify([0, 1], filter_zero_mutation_sites=filter_sites)
@@ -1491,7 +1570,8 @@ class TestSimplifyTables(unittest.TestCase):
     def test_full_samples(self):
         for n in [2, 10, 100, 1000]:
             ts = msprime.simulate(
-                n, recombination_rate=1, mutation_rate=1, random_seed=self.random_seed)
+                n, recombination_rate=1, mutation_rate=1, random_seed=self.random_seed
+            )
             tables = ts.dump_tables()
             nodes_before = tables.nodes.copy()
             edges_before = tables.edges.copy()
@@ -1509,9 +1589,10 @@ class TestSimplifyTables(unittest.TestCase):
         n = 10
         ts = msprime.simulate(n, random_seed=self.random_seed)
         tables = ts.dump_tables()
-        for bad_node in [-1, n, n + 1, ts.num_nodes - 1, ts.num_nodes, 2**31 - 1]:
+        for bad_node in [-1, n, n + 1, ts.num_nodes - 1, ts.num_nodes, 2 ** 31 - 1]:
             self.assertRaises(
-                _tskit.LibraryError, tables.simplify, samples=[0, bad_node])
+                _tskit.LibraryError, tables.simplify, samples=[0, bad_node]
+            )
 
     def test_bad_edge_ordering(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
@@ -1519,20 +1600,24 @@ class TestSimplifyTables(unittest.TestCase):
         edges = tables.edges
         # Reversing the edges violates the ordering constraints.
         edges.set_columns(
-            left=edges.left[::-1], right=edges.right[::-1],
-            parent=edges.parent[::-1], child=edges.child[::-1])
+            left=edges.left[::-1],
+            right=edges.right[::-1],
+            parent=edges.parent[::-1],
+            child=edges.child[::-1],
+        )
         self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
 
     def test_bad_edges(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
-        for bad_node in [-1, ts.num_nodes, ts.num_nodes + 1, 2**31 - 1]:
+        for bad_node in [-1, ts.num_nodes, ts.num_nodes + 1, 2 ** 31 - 1]:
             # Bad parent node
             tables = ts.dump_tables()
             edges = tables.edges
             parent = edges.parent
             parent[0] = bad_node
             edges.set_columns(
-                left=edges.left, right=edges.right, parent=parent, child=edges.child)
+                left=edges.left, right=edges.right, parent=parent, child=edges.child
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
             # Bad child node
             tables = ts.dump_tables()
@@ -1540,7 +1625,8 @@ class TestSimplifyTables(unittest.TestCase):
             child = edges.child
             child[0] = bad_node
             edges.set_columns(
-                left=edges.left, right=edges.right, parent=edges.parent, child=child)
+                left=edges.left, right=edges.right, parent=edges.parent, child=child
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
             # child == parent
             tables = ts.dump_tables()
@@ -1548,7 +1634,8 @@ class TestSimplifyTables(unittest.TestCase):
             child = edges.child
             child[0] = edges.parent[0]
             edges.set_columns(
-                left=edges.left, right=edges.right, parent=edges.parent, child=child)
+                left=edges.left, right=edges.right, parent=edges.parent, child=child
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
             # left == right
             tables = ts.dump_tables()
@@ -1556,7 +1643,8 @@ class TestSimplifyTables(unittest.TestCase):
             left = edges.left
             left[0] = edges.right[0]
             edges.set_columns(
-                left=left, right=edges.right, parent=edges.parent, child=edges.child)
+                left=left, right=edges.right, parent=edges.parent, child=edges.child
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
             # left > right
             tables = ts.dump_tables()
@@ -1564,33 +1652,40 @@ class TestSimplifyTables(unittest.TestCase):
             left = edges.left
             left[0] = edges.right[0] + 1
             edges.set_columns(
-                left=left, right=edges.right, parent=edges.parent, child=edges.child)
+                left=left, right=edges.right, parent=edges.parent, child=edges.child
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
 
     def test_bad_mutation_nodes(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, mutation_rate=1)
         self.assertGreater(ts.num_mutations, 0)
-        for bad_node in [-1, ts.num_nodes, 2**31 - 1]:
+        for bad_node in [-1, ts.num_nodes, 2 ** 31 - 1]:
             tables = ts.dump_tables()
             mutations = tables.mutations
             node = mutations.node
             node[0] = bad_node
             mutations.set_columns(
-                site=mutations.site, node=node, derived_state=mutations.derived_state,
-                derived_state_offset=mutations.derived_state_offset)
+                site=mutations.site,
+                node=node,
+                derived_state=mutations.derived_state,
+                derived_state_offset=mutations.derived_state_offset,
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
 
     def test_bad_mutation_sites(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, mutation_rate=1)
         self.assertGreater(ts.num_mutations, 0)
-        for bad_site in [-1, ts.num_sites, 2**31 - 1]:
+        for bad_site in [-1, ts.num_sites, 2 ** 31 - 1]:
             tables = ts.dump_tables()
             mutations = tables.mutations
             site = mutations.site
             site[0] = bad_site
             mutations.set_columns(
-                site=site, node=mutations.node, derived_state=mutations.derived_state,
-                derived_state_offset=mutations.derived_state_offset)
+                site=site,
+                node=mutations.node,
+                derived_state=mutations.derived_state,
+                derived_state_offset=mutations.derived_state_offset,
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
 
     def test_bad_site_positions(self):
@@ -1604,8 +1699,10 @@ class TestSimplifyTables(unittest.TestCase):
             position = sites.position
             position[0] = bad_position
             sites.set_columns(
-                position=position, ancestral_state=sites.ancestral_state,
-                ancestral_state_offset=sites.ancestral_state_offset)
+                position=position,
+                ancestral_state=sites.ancestral_state,
+                ancestral_state_offset=sites.ancestral_state_offset,
+            )
             self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
 
     def test_duplicate_positions(self):
@@ -1622,18 +1719,20 @@ class TestSimplifyTables(unittest.TestCase):
         tables = ts.dump_tables()
         for bad_values in [[[[]]], np.array([[0, 1], [2, 3]], dtype=np.int32)]:
             self.assertRaises(ValueError, tables.simplify, bad_values)
-        for bad_type in [[0.1], ['string'], {}, [{}]]:
+        for bad_type in [[0.1], ["string"], {}, [{}]]:
             self.assertRaises(TypeError, tables.simplify, bad_type)
         # We only convert to int if we don't overflow
-        for bad_node in [np.iinfo(np.int32).min-1, np.iinfo(np.int32).max+1]:
+        for bad_node in [np.iinfo(np.int32).min - 1, np.iinfo(np.int32).max + 1]:
             self.assertRaises(
-                OverflowError, tables.simplify, samples=np.array([0, bad_node]))
+                OverflowError, tables.simplify, samples=np.array([0, bad_node])
+            )
 
 
 class TestTableCollection(unittest.TestCase):
     """
     Tests for the convenience wrapper around a collection of related tables.
     """
+
     def test_table_references(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=1)
         tables = ts.tables
@@ -1682,7 +1781,8 @@ class TestTableCollection(unittest.TestCase):
             "sites": t.sites.asdict(),
             "mutations": t.mutations.asdict(),
             "migrations": t.migrations.asdict(),
-            "provenances": t.provenances.asdict()}
+            "provenances": t.provenances.asdict(),
+        }
         d2 = t.asdict()
         self.assertEqual(set(d1.keys()), set(d2.keys()))
 
@@ -1698,17 +1798,21 @@ class TestTableCollection(unittest.TestCase):
             "sites": t1.sites.asdict(),
             "mutations": t1.mutations.asdict(),
             "migrations": t1.migrations.asdict(),
-            "provenances": t1.provenances.asdict()}
+            "provenances": t1.provenances.asdict(),
+        }
         t2 = tskit.TableCollection.fromdict(d)
         self.assertEquals(t1, t2)
 
     def test_iter(self):
         def test_iter(table_collection):
             table_names = [
-                attr_name for attr_name in sorted(dir(table_collection))
-                if isinstance(getattr(table_collection, attr_name), tskit.BaseTable)]
+                attr_name
+                for attr_name in sorted(dir(table_collection))
+                if isinstance(getattr(table_collection, attr_name), tskit.BaseTable)
+            ]
             for n in table_names:
                 yield n, getattr(table_collection, n)
+
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
         for t1, t2 in itertools.zip_longest(test_iter(ts.tables), ts.tables):
             self.assertEquals(t1, t2)
@@ -1719,17 +1823,19 @@ class TestTableCollection(unittest.TestCase):
     def test_equals_sequence_length(self):
         self.assertNotEqual(
             tskit.TableCollection(sequence_length=1),
-            tskit.TableCollection(sequence_length=2))
+            tskit.TableCollection(sequence_length=2),
+        )
 
     def test_copy(self):
         pop_configs = [msprime.PopulationConfiguration(5) for _ in range(2)]
         migration_matrix = [[0, 1], [1, 0]]
         t1 = msprime.simulate(
-               population_configurations=pop_configs,
-               migration_matrix=migration_matrix,
-               mutation_rate=1,
-               record_migrations=True,
-               random_seed=100).dump_tables()
+            population_configurations=pop_configs,
+            migration_matrix=migration_matrix,
+            mutation_rate=1,
+            record_migrations=True,
+            random_seed=100,
+        ).dump_tables()
         t2 = t1.copy()
         self.assertIsNot(t1, t2)
         self.assertEqual(t1, t2)
@@ -1740,17 +1846,19 @@ class TestTableCollection(unittest.TestCase):
         pop_configs = [msprime.PopulationConfiguration(5) for _ in range(2)]
         migration_matrix = [[0, 1], [1, 0]]
         t1 = msprime.simulate(
-               population_configurations=pop_configs,
-               migration_matrix=migration_matrix,
-               mutation_rate=1,
-               record_migrations=True,
-               random_seed=1).dump_tables()
+            population_configurations=pop_configs,
+            migration_matrix=migration_matrix,
+            mutation_rate=1,
+            record_migrations=True,
+            random_seed=1,
+        ).dump_tables()
         t2 = msprime.simulate(
-               population_configurations=pop_configs,
-               migration_matrix=migration_matrix,
-               mutation_rate=1,
-               record_migrations=True,
-               random_seed=1).dump_tables()
+            population_configurations=pop_configs,
+            migration_matrix=migration_matrix,
+            mutation_rate=1,
+            record_migrations=True,
+            random_seed=1,
+        ).dump_tables()
         self.assertEqual(t1, t1)
         self.assertEqual(t1, t1.copy())
         self.assertEqual(t1.copy(), t1)
@@ -1857,7 +1965,7 @@ class TestTableCollection(unittest.TestCase):
 
     def test_set_sequence_length(self):
         tables = tskit.TableCollection(1)
-        for value in [-1, 100, 2**32, 1e-6]:
+        for value in [-1, 100, 2 ** 32, 1e-6]:
             tables.sequence_length = value
             self.assertEqual(tables.sequence_length, value)
 
@@ -1895,6 +2003,7 @@ class TestTableCollectionPickle(unittest.TestCase):
     """
     Tests that we can round-trip table collections through pickle.
     """
+
     def verify(self, tables):
         other_tables = pickle.loads(pickle.dumps(tables))
         self.assertEqual(tables, other_tables)
@@ -1907,10 +2016,12 @@ class TestTableCollectionPickle(unittest.TestCase):
         ts = msprime.simulate(
             population_configurations=[
                 msprime.PopulationConfiguration(10),
-                msprime.PopulationConfiguration(10)],
+                msprime.PopulationConfiguration(10),
+            ],
             migration_matrix=[[0, 1], [1, 0]],
             record_migrations=True,
-            random_seed=1)
+            random_seed=1,
+        )
         self.verify(ts.dump_tables())
 
     def test_simulation_sites(self):
@@ -1932,6 +2043,7 @@ class TestDeduplicateSites(unittest.TestCase):
     """
     Tests for the TableCollection.deduplicate_sites method.
     """
+
     def test_empty(self):
         tables = tskit.TableCollection(1)
         tables.deduplicate_sites()
@@ -1944,8 +2056,10 @@ class TestDeduplicateSites(unittest.TestCase):
         for j in range(len(position) - 1):
             position = np.roll(position, 1)
             tables.sites.set_columns(
-                position=position, ancestral_state=tables.sites.ancestral_state,
-                ancestral_state_offset=tables.sites.ancestral_state_offset)
+                position=position,
+                ancestral_state=tables.sites.ancestral_state,
+                ancestral_state_offset=tables.sites.ancestral_state_offset,
+            )
             self.assertRaises(_tskit.LibraryError, tables.deduplicate_sites)
 
     def test_bad_position(self):
@@ -1970,7 +2084,8 @@ class TestDeduplicateSites(unittest.TestCase):
         t1.sites.append_columns(
             position=t1.sites.position,
             ancestral_state=t1.sites.ancestral_state,
-            ancestral_state_offset=t1.sites.ancestral_state_offset)
+            ancestral_state_offset=t1.sites.ancestral_state_offset,
+        )
         self.assertEqual(len(t1.sites), 2 * len(t2.sites))
         t1.sort()
         t1.deduplicate_sites()
@@ -1994,11 +2109,13 @@ class TestDeduplicateSites(unittest.TestCase):
         tables.mutations.clear()
         for site in ts.sites():
             site_id = tables.sites.add_row(
-                position=site.position, ancestral_state="A" * site.id)
+                position=site.position, ancestral_state="A" * site.id
+            )
             tables.sites.add_row(position=site.position, ancestral_state="0")
             for mutation in site.mutations:
                 tables.mutations.add_row(
-                    site=site_id, node=mutation.node, derived_state="T" * site.id)
+                    site=site_id, node=mutation.node, derived_state="T" * site.id
+                )
         tables.deduplicate_sites()
         new_ts = tables.tree_sequence()
         self.assertEqual(new_ts.num_sites, ts.num_sites)
@@ -2013,12 +2130,16 @@ class TestDeduplicateSites(unittest.TestCase):
         tables.mutations.clear()
         for site in ts.sites():
             site_id = tables.sites.add_row(
-                position=site.position, ancestral_state="0", metadata=b"A" * site.id)
+                position=site.position, ancestral_state="0", metadata=b"A" * site.id
+            )
             tables.sites.add_row(position=site.position, ancestral_state="0")
             for mutation in site.mutations:
                 tables.mutations.add_row(
-                    site=site_id, node=mutation.node, derived_state="1",
-                    metadata=b"T" * site.id)
+                    site=site_id,
+                    node=mutation.node,
+                    derived_state="1",
+                    metadata=b"T" * site.id,
+                )
         tables.deduplicate_sites()
         new_ts = tables.tree_sequence()
         self.assertEqual(new_ts.num_sites, ts.num_sites)
@@ -2030,6 +2151,7 @@ class TestBaseTable(unittest.TestCase):
     """
     Tests of the table superclass.
     """
+
     def test_set_columns_not_implemented(self):
         t = tskit.BaseTable(None, None)
         with self.assertRaises(NotImplementedError):

--- a/python/tests/test_threads.py
+++ b/python/tests/test_threads.py
@@ -39,8 +39,8 @@ IS_WINDOWS = platform.system() == "Windows"
 def run_threads(worker, num_threads):
     results = [None for _ in range(num_threads)]
     threads = [
-        threading.Thread(target=worker, args=(j, results))
-        for j in range(num_threads)]
+        threading.Thread(target=worker, args=(j, results)) for j in range(num_threads)
+    ]
     for t in threads:
         t.start()
     for t in threads:
@@ -53,10 +53,13 @@ class TestLdCalculatorReplicates(unittest.TestCase):
     Tests the LdCalculator object to ensure we get correct results
     when using threads.
     """
+
     num_test_sites = 25
 
     def get_tree_sequence(self):
-        ts = msprime.simulate(20, mutation_rate=10, recombination_rate=10, random_seed=8)
+        ts = msprime.simulate(
+            20, mutation_rate=10, recombination_rate=10, random_seed=8
+        )
         return tsutil.subsample_sites(ts, self.num_test_sites)
 
     def test_get_r2_multiple_instances(self):
@@ -109,12 +112,11 @@ class TestLdCalculatorReplicates(unittest.TestCase):
 
         def worker(thread_index, results):
             ld_calc = tskit.LdCalculator(ts)
-            results[thread_index] = np.array(
-                ld_calc.get_r2_array(thread_index))
+            results[thread_index] = np.array(ld_calc.get_r2_array(thread_index))
 
         results = run_threads(worker, m)
         for j in range(m):
-            self.assertTrue(np.allclose(results[j], A[j, j + 1:]))
+            self.assertTrue(np.allclose(results[j], A[j, j + 1 :]))
 
     def test_get_r2_array_single_instance(self):
         # This is the degenerate case where we have a single LdCalculator
@@ -144,10 +146,12 @@ class TestTables(unittest.TestCase):
     Tests to ensure that attempts to access tables in threads correctly
     raise an exception.
     """
+
     def get_tables(self):
         # TODO include migrations here.
         ts = msprime.simulate(
-            100, mutation_rate=10, recombination_rate=10, random_seed=8)
+            100, mutation_rate=10, recombination_rate=10, random_seed=8
+        )
         return ts.tables
 
     def run_multiple_writers(self, writer, num_writers=32):

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -93,21 +93,21 @@ def simple_keep_intervals(tables, intervals, simplify=True, record_provenance=Tr
         for interval_left, interval_right in intervals:
             if interval_left <= site.position < interval_right:
                 site_id = tables.sites.add_row(
-                    site.position, site.ancestral_state, site.metadata)
+                    site.position, site.ancestral_state, site.metadata
+                )
                 for m in site.mutations:
                     tables.mutations.add_row(
-                        site_id, m.node, m.derived_state, tskit.NULL, m.metadata)
+                        site_id, m.node, m.derived_state, tskit.NULL, m.metadata
+                    )
     tables.build_index()
     tables.compute_mutation_parents()
     if simplify:
         tables.simplify()
     if record_provenance:
-        parameters = {
-            "command": "keep_intervals",
-            "TODO": "add parameters"
-        }
-        tables.provenances.add_row(record=json.dumps(
-            provenance.get_provenance_dict(parameters)))
+        parameters = {"command": "keep_intervals", "TODO": "add parameters"}
+        tables.provenances.add_row(
+            record=json.dumps(provenance.get_provenance_dict(parameters))
+        )
 
 
 def generate_segments(n, sequence_length=100, seed=None):
@@ -165,8 +165,7 @@ def kc_distance(tree1, tree2, lambda_=0):
             if len(tree.children(node)) == 0:
                 index = sample_index_map[node]
                 M[tree_index][index + n] = tree.branch_length(node)
-    return np.linalg.norm((1 - lambda_) *
-                          (m[0] - m[1]) + lambda_ * (M[0] - M[1]))
+    return np.linalg.norm((1 - lambda_) * (m[0] - m[1]) + lambda_ * (M[0] - M[1]))
 
 
 def kc_distance_simple(tree1, tree2, lambda_=0):
@@ -228,6 +227,7 @@ class TestKCMetric(unittest.TestCase):
     """
     Tests on the KC metric distances.
     """
+
     def test_same_tree_zero_distance(self):
         for n in range(2, 10):
             for seed in range(1, 10):
@@ -277,8 +277,7 @@ class TestKCMetric(unittest.TestCase):
             self.assertAlmostEqual(kc1, kc2)
             self.assertAlmostEqual(kc1, kc3)
             self.assertAlmostEqual(kc1, kc_distance(tree2, tree1))
-            self.assertAlmostEqual(
-                kc2, kc_distance_simple(tree2, tree1))
+            self.assertAlmostEqual(kc2, kc_distance_simple(tree2, tree1))
             self.assertAlmostEqual(kc3, tree2.kc_distance(tree1))
 
     def test_sample_3(self):
@@ -296,11 +295,13 @@ class TestKCMetric(unittest.TestCase):
     def validate_nonbinary_trees(self, n):
         demographic_events = [
             msprime.SimpleBottleneck(0.02, 0, proportion=0.25),
-            msprime.SimpleBottleneck(0.2, 0, proportion=1)]
+            msprime.SimpleBottleneck(0.2, 0, proportion=1),
+        ]
 
         for seed in range(1, 10):
             ts = msprime.simulate(
-                n, random_seed=seed, demographic_events=demographic_events)
+                n, random_seed=seed, demographic_events=demographic_events
+            )
             # Check if this is really nonbinary
             found = False
             for edgeset in ts.edgesets():
@@ -311,30 +312,27 @@ class TestKCMetric(unittest.TestCase):
             tree1 = ts.first()
 
             ts = msprime.simulate(
-                n, random_seed=seed + 1, demographic_events=demographic_events)
+                n, random_seed=seed + 1, demographic_events=demographic_events
+            )
             tree2 = ts.first()
+            self.assertAlmostEqual(kc_distance(tree1, tree2), kc_distance(tree1, tree2))
+            self.assertAlmostEqual(kc_distance(tree2, tree1), kc_distance(tree2, tree1))
             self.assertAlmostEqual(
-                kc_distance(tree1, tree2), kc_distance(tree1, tree2))
+                kc_distance_simple(tree1, tree2), kc_distance_simple(tree1, tree2)
+            )
             self.assertAlmostEqual(
-                kc_distance(tree2, tree1), kc_distance(tree2, tree1))
-            self.assertAlmostEqual(
-                kc_distance_simple(tree1, tree2),
-                kc_distance_simple(tree1, tree2))
-            self.assertAlmostEqual(
-                kc_distance_simple(tree2, tree1),
-                kc_distance_simple(tree2, tree1))
+                kc_distance_simple(tree2, tree1), kc_distance_simple(tree2, tree1)
+            )
             # compare to a binary tree also
             tree2 = msprime.simulate(n, random_seed=seed + 1).first()
+            self.assertAlmostEqual(kc_distance(tree1, tree2), kc_distance(tree1, tree2))
+            self.assertAlmostEqual(kc_distance(tree2, tree1), kc_distance(tree2, tree1))
             self.assertAlmostEqual(
-                kc_distance(tree1, tree2), kc_distance(tree1, tree2))
+                kc_distance_simple(tree1, tree2), kc_distance_simple(tree1, tree2)
+            )
             self.assertAlmostEqual(
-                kc_distance(tree2, tree1), kc_distance(tree2, tree1))
-            self.assertAlmostEqual(
-                kc_distance_simple(tree1, tree2),
-                kc_distance_simple(tree1, tree2))
-            self.assertAlmostEqual(
-                kc_distance_simple(tree2, tree1),
-                kc_distance_simple(tree2, tree1))
+                kc_distance_simple(tree2, tree1), kc_distance_simple(tree2, tree1)
+            )
 
     def test_non_binary_sample_10(self):
         self.validate_nonbinary_trees(10)
@@ -391,7 +389,8 @@ class TestKCMetric(unittest.TestCase):
         self.verify_result(tree_1, tree_2, 1, 4.243, places=3)
 
     def test_10_samples(self):
-        nodes_1 = io.StringIO("""\
+        nodes_1 = io.StringIO(
+            """\
         id  is_sample   time    population  individual  metadata
         0   1   0.000000    0   -1  b''
         1   1   0.000000    0   -1  b''
@@ -412,8 +411,10 @@ class TestKCMetric(unittest.TestCase):
         16  0   0.865193    0   -1  b''
         17  0   1.643658    0   -1  b''
         18  0   2.942350    0   -1  b''
-        """)
-        edges_1 = io.StringIO("""\
+        """
+        )
+        edges_1 = io.StringIO(
+            """\
         left    right   parent  child
         0.000000    10000.000000    10  0
         0.000000    10000.000000    10  2
@@ -433,10 +434,13 @@ class TestKCMetric(unittest.TestCase):
         0.000000    10000.000000    17  12
         0.000000    10000.000000    18  16
         0.000000    10000.000000    18  17
-        """)
-        ts_1 = tskit.load_text(nodes_1, edges_1, sequence_length=10000,
-                               strict=False, base64_metadata=False)
-        nodes_2 = io.StringIO("""\
+        """
+        )
+        ts_1 = tskit.load_text(
+            nodes_1, edges_1, sequence_length=10000, strict=False, base64_metadata=False
+        )
+        nodes_2 = io.StringIO(
+            """\
         id  is_sample   time    population  individual  metadata
         0   1   0.000000    0   -1  b''
         1   1   0.000000    0   -1  b''
@@ -457,8 +461,10 @@ class TestKCMetric(unittest.TestCase):
         16  0   0.729369    0   -1  b''
         17  0   1.604113    0   -1  b''
         18  0   1.896332    0   -1  b''
-        """)
-        edges_2 = io.StringIO("""\
+        """
+        )
+        edges_2 = io.StringIO(
+            """\
         left    right   parent  child
         0.000000    10000.000000    10  5
         0.000000    10000.000000    10  7
@@ -478,9 +484,11 @@ class TestKCMetric(unittest.TestCase):
         0.000000    10000.000000    17  16
         0.000000    10000.000000    18  15
         0.000000    10000.000000    18  17
-        """)
-        ts_2 = tskit.load_text(nodes_2, edges_2, sequence_length=10000,
-                               strict=False, base64_metadata=False)
+        """
+        )
+        ts_2 = tskit.load_text(
+            nodes_2, edges_2, sequence_length=10000, strict=False, base64_metadata=False
+        )
 
         tree_1 = ts_1.first()
         tree_2 = ts_2.first()
@@ -488,7 +496,8 @@ class TestKCMetric(unittest.TestCase):
         self.verify_result(tree_1, tree_2, 1, 10.64, places=2)
 
     def test_15_samples(self):
-        nodes_1 = io.StringIO("""\
+        nodes_1 = io.StringIO(
+            """\
         id  is_sample   time    population  individual  metadata
         0   1   0.000000    0   -1
         1   1   0.000000    0   -1
@@ -519,8 +528,10 @@ class TestKCMetric(unittest.TestCase):
         26  0   0.525632    0   -1
         27  0   1.180078    0   -1
         28  0   2.548099    0   -1
-        """)
-        edges_1 = io.StringIO("""\
+        """
+        )
+        edges_1 = io.StringIO(
+            """\
         left    right   parent  child
         0.000000    10000.000000    15  6
         0.000000    10000.000000    15  13
@@ -550,11 +561,14 @@ class TestKCMetric(unittest.TestCase):
         0.000000    10000.000000    27  26
         0.000000    10000.000000    28  3
         0.000000    10000.000000    28  27
-        """)
-        ts_1 = tskit.load_text(nodes_1, edges_1, sequence_length=10000,
-                               strict=False, base64_metadata=False)
+        """
+        )
+        ts_1 = tskit.load_text(
+            nodes_1, edges_1, sequence_length=10000, strict=False, base64_metadata=False
+        )
 
-        nodes_2 = io.StringIO("""\
+        nodes_2 = io.StringIO(
+            """\
         id  is_sample   time    population  individual  metadata
         0   1   0.000000    0   -1
         1   1   0.000000    0   -1
@@ -585,8 +599,10 @@ class TestKCMetric(unittest.TestCase):
         26  0   0.409174    0   -1
         27  0   2.090839    0   -1
         28  0   3.772716    0   -1
-        """)
-        edges_2 = io.StringIO("""\
+        """
+        )
+        edges_2 = io.StringIO(
+            """\
         left    right   parent  child
         0.000000    10000.000000    15  6
         0.000000    10000.000000    15  8
@@ -616,9 +632,11 @@ class TestKCMetric(unittest.TestCase):
         0.000000    10000.000000    27  23
         0.000000    10000.000000    28  26
         0.000000    10000.000000    28  27
-        """)
-        ts_2 = tskit.load_text(nodes_2, edges_2, sequence_length=10000,
-                               strict=False, base64_metadata=False)
+        """
+        )
+        ts_2 = tskit.load_text(
+            nodes_2, edges_2, sequence_length=10000, strict=False, base64_metadata=False
+        )
 
         tree_1 = ts_1.first()
         tree_2 = ts_2.first()
@@ -627,7 +645,8 @@ class TestKCMetric(unittest.TestCase):
         self.verify_result(tree_1, tree_2, 1, 17.74, places=2)
 
     def test_nobinary_trees(self):
-        nodes_1 = io.StringIO("""\
+        nodes_1 = io.StringIO(
+            """\
         id  is_sample   time    population  individual  metadata
         0   1   0.000000    -1  -1   e30=
         1   1   0.000000    -1  -1   e30=
@@ -648,8 +667,10 @@ class TestKCMetric(unittest.TestCase):
         16  0   4.000000    -1  -1
         17  0   11.000000   -1  -1
         18  0   12.000000   -1  -1
-        """)
-        edges_1 = io.StringIO("""\
+        """
+        )
+        edges_1 = io.StringIO(
+            """\
         left    right   parent  child
         0.000000    10000.000000    15  8
         0.000000    10000.000000    15  10
@@ -669,11 +690,14 @@ class TestKCMetric(unittest.TestCase):
         0.000000    10000.000000    17  14
         0.000000    10000.000000    18  16
         0.000000    10000.000000    18  17
-        """)
-        ts_1 = tskit.load_text(nodes_1, edges_1, sequence_length=10000,
-                               strict=False, base64_metadata=False)
+        """
+        )
+        ts_1 = tskit.load_text(
+            nodes_1, edges_1, sequence_length=10000, strict=False, base64_metadata=False
+        )
 
-        nodes_2 = io.StringIO("""\
+        nodes_2 = io.StringIO(
+            """\
         id  is_sample   time    population  individual  metadata
         0   1   0.000000    -1  -1   e30=
         1   1   0.000000    -1  -1   e30=
@@ -698,8 +722,10 @@ class TestKCMetric(unittest.TestCase):
         20  0   4.000000    -1  -1
         21  0   11.000000   -1  -1
         22  0   12.000000   -1  -1
-        """)
-        edges_2 = io.StringIO("""\
+        """
+        )
+        edges_2 = io.StringIO(
+            """\
         left    right   parent  child
         0.000000    10000.000000    15  12
         0.000000    10000.000000    15  14
@@ -723,9 +749,11 @@ class TestKCMetric(unittest.TestCase):
         0.000000    10000.000000    21  20
         0.000000    10000.000000    22  19
         0.000000    10000.000000    22  21
-        """)
-        ts_2 = tskit.load_text(nodes_2, edges_2, sequence_length=10000,
-                               strict=False, base64_metadata=False)
+        """
+        )
+        ts_2 = tskit.load_text(
+            nodes_2, edges_2, sequence_length=10000, strict=False, base64_metadata=False
+        )
         tree_1 = ts_1.first()
         tree_2 = ts_2.first()
         self.verify_result(tree_1, tree_2, 0, 9.434, places=3)
@@ -813,10 +841,7 @@ class TestOverlappingSegments(unittest.TestCase):
             self.assertEqual(sorted(segs), sorted(X))
 
     def test_stairs_down(self):
-        segs = [
-            tests.Segment(0, 1, 0),
-            tests.Segment(0, 2, 1),
-            tests.Segment(0, 3, 2)]
+        segs = [tests.Segment(0, 1, 0), tests.Segment(0, 2, 1), tests.Segment(0, 3, 2)]
         ret = list(tests.overlapping_segments(segs))
         self.assertEqual(len(ret), 3)
 
@@ -836,10 +861,7 @@ class TestOverlappingSegments(unittest.TestCase):
         self.assertEqual(sorted(X), sorted(segs[2:]))
 
     def test_stairs_up(self):
-        segs = [
-            tests.Segment(0, 3, 0),
-            tests.Segment(1, 3, 1),
-            tests.Segment(2, 3, 2)]
+        segs = [tests.Segment(0, 3, 0), tests.Segment(1, 3, 1), tests.Segment(2, 3, 2)]
         ret = list(tests.overlapping_segments(segs))
         self.assertEqual(len(ret), 3)
 
@@ -859,10 +881,7 @@ class TestOverlappingSegments(unittest.TestCase):
         self.assertEqual(sorted(X), sorted(segs))
 
     def test_pyramid(self):
-        segs = [
-            tests.Segment(0, 5, 0),
-            tests.Segment(1, 4, 1),
-            tests.Segment(2, 3, 2)]
+        segs = [tests.Segment(0, 5, 0), tests.Segment(1, 4, 1), tests.Segment(2, 3, 2)]
         ret = list(tests.overlapping_segments(segs))
         self.assertEqual(len(ret), 5)
 
@@ -892,9 +911,7 @@ class TestOverlappingSegments(unittest.TestCase):
         self.assertEqual(sorted(X), sorted(segs[:1]))
 
     def test_gap(self):
-        segs = [
-            tests.Segment(0, 2, 0),
-            tests.Segment(3, 4, 1)]
+        segs = [tests.Segment(0, 2, 0), tests.Segment(3, 4, 1)]
         ret = list(tests.overlapping_segments(segs))
         self.assertEqual(len(ret), 2)
 
@@ -913,6 +930,7 @@ class TopologyTestCase(unittest.TestCase):
     """
     Superclass of test cases containing common utilities.
     """
+
     random_seed = 123456
 
     def assert_haplotypes_equal(self, ts1, ts2):
@@ -970,6 +988,7 @@ class TestZeroRoots(unittest.TestCase):
     Tests that for the case in which we have zero samples and therefore
     zero roots in our trees.
     """
+
     def remove_samples(self, ts):
         tables = ts.dump_tables()
         tables.nodes.flags = np.zeros_like(tables.nodes.flags)
@@ -1000,6 +1019,7 @@ class TestEmptyTreeSequences(TopologyTestCase):
     """
     Tests covering tree sequences that have zero edges.
     """
+
     def test_zero_nodes(self):
         tables = tskit.TableCollection(1)
         ts = tables.tree_sequence()
@@ -1056,8 +1076,8 @@ class TestEmptyTreeSequences(TopologyTestCase):
     def test_one_node_zero_samples_sites(self):
         tables = tskit.TableCollection(sequence_length=1)
         tables.nodes.add_row(time=0, flags=0)
-        tables.sites.add_row(position=0.5, ancestral_state='0')
-        tables.mutations.add_row(site=0, derived_state='1', node=0)
+        tables.sites.add_row(position=0.5, ancestral_state="0")
+        tables.mutations.add_row(site=0, derived_state="1", node=0)
         ts = tables.tree_sequence()
         self.assertEqual(ts.sequence_length, 1)
         self.assertEqual(ts.num_trees, 1)
@@ -1112,8 +1132,8 @@ class TestEmptyTreeSequences(TopologyTestCase):
     def test_one_node_one_sample_sites(self):
         tables = tskit.TableCollection(sequence_length=1)
         tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
-        tables.sites.add_row(position=0.5, ancestral_state='0')
-        tables.mutations.add_row(site=0, derived_state='1', node=0)
+        tables.sites.add_row(position=0.5, ancestral_state="0")
+        tables.mutations.add_row(site=0, derived_state="1", node=0)
         ts = tables.tree_sequence()
         self.assertEqual(ts.sequence_length, 1)
         self.assertEqual(ts.num_trees, 1)
@@ -1148,6 +1168,7 @@ class TestHoleyTreeSequences(TopologyTestCase):
     Tests for tree sequences in which we have partial (or no) trees defined
     over some of the sequence.
     """
+
     def verify_trees(self, ts, expected):
         observed = []
         for t in ts.trees():
@@ -1167,152 +1188,164 @@ class TestHoleyTreeSequences(TopologyTestCase):
             self.assertEqual(tree.roots, [])
 
     def test_simple_hole(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       2       0
         2       3       2       0
         0       1       2       1
         2       3       2       1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
-        expected = [
-            ((0, 1), {0: 2, 1: 2}),
-            ((1, 2), {}),
-            ((2, 3), {0: 2, 1: 2})]
+        expected = [((0, 1), {0: 2, 1: 2}), ((1, 2), {}), ((2, 3), {0: 2, 1: 2})]
         self.verify_trees(ts, expected)
 
     def test_simple_hole_zero_roots(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   0           0
         1   0           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       2       0
         2       3       2       0
         0       1       2       1
         2       3       2       1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
-        expected = [
-            ((0, 1), {0: 2, 1: 2}),
-            ((1, 2), {}),
-            ((2, 3), {0: 2, 1: 2})]
+        expected = [((0, 1), {0: 2, 1: 2}), ((1, 2), {}), ((2, 3), {0: 2, 1: 2})]
         self.verify_trees(ts, expected)
         self.verify_zero_roots(ts)
 
     def test_initial_gap(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         1       2       2       0,1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
-        expected = [
-            ((0, 1), {}),
-            ((1, 2), {0: 2, 1: 2})]
+        expected = [((0, 1), {}), ((1, 2), {0: 2, 1: 2})]
         self.verify_trees(ts, expected)
 
     def test_initial_gap_zero_roots(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   0           0
         1   0           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         1       2       2       0,1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
-        expected = [
-            ((0, 1), {}),
-            ((1, 2), {0: 2, 1: 2})]
+        expected = [((0, 1), {}), ((1, 2), {0: 2, 1: 2})]
         self.verify_trees(ts, expected)
         self.verify_zero_roots(ts)
 
     def test_final_gap(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       2       2       0,1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sequence_length=3, strict=False)
-        expected = [
-            ((0, 2), {0: 2, 1: 2}),
-            ((2, 3), {})]
+        expected = [((0, 2), {0: 2, 1: 2}), ((2, 3), {})]
         self.verify_trees(ts, expected)
 
     def test_final_gap_zero_roots(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   0           0
         1   0           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       2       2       0,1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sequence_length=3, strict=False)
-        expected = [
-            ((0, 2), {0: 2, 1: 2}),
-            ((2, 3), {})]
+        expected = [((0, 2), {0: 2, 1: 2}), ((2, 3), {})]
         self.verify_trees(ts, expected)
         self.verify_zero_roots(ts)
 
     def test_initial_and_final_gap(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         1       2       2       0,1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sequence_length=3, strict=False)
-        expected = [
-            ((0, 1), {}),
-            ((1, 2), {0: 2, 1: 2}),
-            ((2, 3), {})]
+        expected = [((0, 1), {}), ((1, 2), {0: 2, 1: 2}), ((2, 3), {})]
         self.verify_trees(ts, expected)
 
     def test_initial_and_final_gap_zero_roots(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   0           0
         1   0           0
         2   0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         1       2       2       0,1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sequence_length=3, strict=False)
-        expected = [
-            ((0, 1), {}),
-            ((1, 2), {0: 2, 1: 2}),
-            ((2, 3), {})]
+        expected = [((0, 1), {}), ((1, 2), {0: 2, 1: 2}), ((2, 3), {})]
         self.verify_trees(ts, expected)
         self.verify_zero_roots(ts)
 
@@ -1321,10 +1354,12 @@ class TestTsinferExamples(TopologyTestCase):
     """
     Test cases on troublesome topology examples that arose from tsinfer.
     """
+
     def test_no_last_tree(self):
         # The last tree was not being generated here because of a bug in
         # the low-level tree generation code.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1       -1              3.00000000000000
         1       1       -1              2.00000000000000
@@ -1337,8 +1372,10 @@ class TestTsinferExamples(TopologyTestCase):
         8       1       -1              1.00000000000000
         9       1       -1              1.00000000000000
         10      1       -1              1.00000000000000
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       62291.41659631  79679.17408763  1       5
         1       62291.41659631  62374.60889677  1       6
@@ -1369,7 +1406,8 @@ class TestTsinferExamples(TopologyTestCase):
         26      0.00000000      200000.00000000 0       2
         27      0.00000000      200000.00000000 0       3
         28      0.00000000      200000.00000000 0       4
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sequence_length=200000, strict=False)
         pts = tests.PythonTreeSequence(ts)
         num_trees = 0
@@ -1396,17 +1434,22 @@ class TestRecordSquashing(TopologyTestCase):
     """
     Tests that we correctly squash adjacent equal records together.
     """
+
     def test_single_record(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       1       0
         1       2       1       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         tss, node_map = ts.simplify(map_nodes=True)
         self.assertEqual(list(node_map), [0, 1])
@@ -1425,8 +1468,7 @@ class TestRecordSquashing(TopologyTestCase):
         self.assertEqual(tss.dump_tables().edges, ts.dump_tables().edges)
 
     def test_many_trees(self):
-        ts = msprime.simulate(
-            20, recombination_rate=5, random_seed=self.random_seed)
+        ts = msprime.simulate(20, recombination_rate=5, random_seed=self.random_seed)
         self.assertGreater(ts.num_trees, 2)
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
         tss = ts_redundant.simplify()
@@ -1439,6 +1481,7 @@ class TestRedundantBreakpoints(TopologyTestCase):
     Tests for dealing with redundant breakpoints within the tree sequence.
     These are records that may be squashed together into a single record.
     """
+
     def test_single_tree(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
@@ -1451,8 +1494,7 @@ class TestRedundantBreakpoints(TopologyTestCase):
         self.assertEqual([t.parent_dict for t in ts.trees()][0], trees[0])
 
     def test_many_trees(self):
-        ts = msprime.simulate(
-            20, recombination_rate=5, random_seed=self.random_seed)
+        ts = msprime.simulate(20, recombination_rate=5, random_seed=self.random_seed)
         self.assertGreater(ts.num_trees, 2)
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
         self.assertEqual(ts.sample_size, ts_redundant.sample_size)
@@ -1474,9 +1516,11 @@ class TestUnaryNodes(TopologyTestCase):
     """
     Tests for situations in which we have unary nodes in the tree sequence.
     """
+
     def test_simple_case(self):
         # Simple case where we have n = 2 and some unary nodes.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -1484,14 +1528,17 @@ class TestUnaryNodes(TopologyTestCase):
         3       0           1
         4       0           2
         5       0           3
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       2       0
         0       1       3       1
         0       1       4       2,3
         0       1       5       4
-        """)
+        """
+        )
         sites = "position    ancestral_state\n"
         mutations = "site    node    derived_state\n"
         for j in range(5):
@@ -1499,8 +1546,12 @@ class TestUnaryNodes(TopologyTestCase):
             sites += "{} 0\n".format(position)
             mutations += "{} {} 1\n".format(j, j)
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=io.StringIO(sites),
-            mutations=io.StringIO(mutations), strict=False)
+            nodes=nodes,
+            edges=edges,
+            sites=io.StringIO(sites),
+            mutations=io.StringIO(mutations),
+            strict=False,
+        )
 
         self.assertEqual(ts.sample_size, 2)
         self.assertEqual(ts.num_nodes, 6)
@@ -1509,8 +1560,7 @@ class TestUnaryNodes(TopologyTestCase):
         self.assertEqual(ts.num_mutations, 5)
         self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
         t = next(ts.trees())
-        self.assertEqual(
-            t.parent_dict, {0: 2, 1: 3, 2: 4, 3: 4, 4: 5})
+        self.assertEqual(t.parent_dict, {0: 2, 1: 3, 2: 4, 3: 4, 4: 5})
         self.assertEqual(t.mrca(0, 1), 4)
         self.assertEqual(t.mrca(0, 2), 2)
         self.assertEqual(t.mrca(0, 4), 4)
@@ -1573,16 +1623,19 @@ class TestUnaryNodes(TopologyTestCase):
             t = node.time - 1e-14  # Arbitrary small value.
             next_node = len(tables.nodes)
             tables.nodes.add_row(time=t, population=node.population)
-            edges.append(tskit.Edge(
-                left=e.left, right=e.right, parent=next_node, child=e.child))
+            edges.append(
+                tskit.Edge(left=e.left, right=e.right, parent=next_node, child=e.child)
+            )
             node_times[next_node] = t
-            edges.append(tskit.Edge(
-                left=e.left, right=e.right, parent=e.parent, child=next_node))
+            edges.append(
+                tskit.Edge(left=e.left, right=e.right, parent=e.parent, child=next_node)
+            )
         edges.sort(key=lambda e: node_times[e.parent])
         tables.edges.reset()
         for e in edges:
             tables.edges.add_row(
-                left=e.left, right=e.right, child=e.child, parent=e.parent)
+                left=e.left, right=e.right, child=e.child, parent=e.parent
+            )
         ts_new = tables.tree_sequence()
         self.assertGreater(ts_new.num_edges, ts.num_edges)
         self.assert_haplotypes_equal(ts, ts_new)
@@ -1606,15 +1659,21 @@ class TestUnaryNodes(TopologyTestCase):
 
     def test_binary_tree_sequence_unary_nodes(self):
         ts = msprime.simulate(
-            20, recombination_rate=5, mutation_rate=5, random_seed=self.random_seed)
+            20, recombination_rate=5, mutation_rate=5, random_seed=self.random_seed
+        )
         self.verify_unary_tree_sequence(ts)
 
     def test_nonbinary_tree_sequence_unary_nodes(self):
         demographic_events = [
-            msprime.SimpleBottleneck(time=1.0, population=0, proportion=0.95)]
+            msprime.SimpleBottleneck(time=1.0, population=0, proportion=0.95)
+        ]
         ts = msprime.simulate(
-            20, recombination_rate=10, mutation_rate=5,
-            demographic_events=demographic_events, random_seed=self.random_seed)
+            20,
+            recombination_rate=10,
+            mutation_rate=5,
+            demographic_events=demographic_events,
+            random_seed=self.random_seed,
+        )
         found = False
         for r in ts.edgesets():
             if len(r.children) > 2:
@@ -1628,37 +1687,47 @@ class TestGeneralSamples(TopologyTestCase):
     Test cases in which we have samples at arbitrary nodes (i.e., not at
     {0,...,n - 1}).
     """
+
     def test_simple_case(self):
         # Simple case where we have n = 3 and samples starting at n.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       0           2
         1       0           1
         2       1           0
         3       1           0
         4       1           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       1       2,3
         0       1       0       1,4
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0.1     0
         0.2     0
         0.3     0
         0.4     0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       2       1
         1       3       1
         2       4       1
         3       1       1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
 
         self.assertEqual(ts.sample_size, 3)
         self.assertEqual(list(ts.samples()), [2, 3, 4])
@@ -1704,15 +1773,16 @@ class TestGeneralSamples(TopologyTestCase):
         # Change the permutation so that the relative order of samples is maintained.
         # Then, we should get back exactly the same tree sequence after simplify
         # and haplotypes and variants are also equal.
-        samples = sorted(node_map[:ts.sample_size])
-        node_map = samples + node_map[ts.sample_size:]
+        samples = sorted(node_map[: ts.sample_size])
+        node_map = samples + node_map[ts.sample_size :]
         permuted = tsutil.permute_nodes(ts, node_map)
         self.assertEqual(ts.sequence_length, permuted.sequence_length)
         self.assertEqual(list(permuted.samples()), samples)
         self.assertEqual(list(permuted.haplotypes()), list(ts.haplotypes()))
         self.assertEqual(
             [v.genotypes for v in permuted.variants(as_bytes=True)],
-            [v.genotypes for v in ts.variants(as_bytes=True)])
+            [v.genotypes for v in ts.variants(as_bytes=True)],
+        )
         self.assertEqual(ts.num_trees, permuted.num_trees)
         j = 0
         for t1, t2 in zip(ts.trees(), permuted.trees()):
@@ -1723,7 +1793,8 @@ class TestGeneralSamples(TopologyTestCase):
                 u2 = node_map[u1]
                 self.assertEqual(
                     sorted([node_map[v] for v in t1.samples(u1)]),
-                    sorted(list(t2.samples(u2))))
+                    sorted(list(t2.samples(u2))),
+                )
             j += 1
         self.assertEqual(j, ts.num_trees)
 
@@ -1737,7 +1808,8 @@ class TestGeneralSamples(TopologyTestCase):
         simplified_tables.provenances.clear()
 
         self.assertEqual(
-            original_tables.sequence_length, simplified_tables.sequence_length)
+            original_tables.sequence_length, simplified_tables.sequence_length
+        )
         self.assertEqual(original_tables.nodes, simplified_tables.nodes)
         self.assertEqual(original_tables.edges, simplified_tables.edges)
         self.assertEqual(original_tables.sites, simplified_tables.sites)
@@ -1758,23 +1830,30 @@ class TestGeneralSamples(TopologyTestCase):
         self.assertEqual(list(simplified.sites()), list(ts.sites()))
         self.assertEqual(list(simplified.haplotypes()), list(ts.haplotypes()))
         self.assertEqual(
-            list(simplified.variants(as_bytes=True)), list(ts.variants(as_bytes=True)))
+            list(simplified.variants(as_bytes=True)), list(ts.variants(as_bytes=True))
+        )
 
     def test_single_tree_permuted_nodes(self):
-        ts = msprime.simulate(10,  mutation_rate=5, random_seed=self.random_seed)
+        ts = msprime.simulate(10, mutation_rate=5, random_seed=self.random_seed)
         self.verify_permuted_nodes(ts)
 
     def test_binary_tree_sequence_permuted_nodes(self):
         ts = msprime.simulate(
-            20, recombination_rate=5, mutation_rate=5, random_seed=self.random_seed)
+            20, recombination_rate=5, mutation_rate=5, random_seed=self.random_seed
+        )
         self.verify_permuted_nodes(ts)
 
     def test_nonbinary_tree_sequence_permuted_nodes(self):
         demographic_events = [
-            msprime.SimpleBottleneck(time=1.0, population=0, proportion=0.95)]
+            msprime.SimpleBottleneck(time=1.0, population=0, proportion=0.95)
+        ]
         ts = msprime.simulate(
-            20, recombination_rate=10, mutation_rate=5,
-            demographic_events=demographic_events, random_seed=self.random_seed)
+            20,
+            recombination_rate=10,
+            mutation_rate=5,
+            demographic_events=demographic_events,
+            random_seed=self.random_seed,
+        )
         found = False
         for e in ts.edgesets():
             if len(e.children) > 2:
@@ -1788,11 +1867,21 @@ class TestSimplifyExamples(TopologyTestCase):
     Tests for simplify where we write out the input and expected output
     or we detect expected errors.
     """
+
     def verify_simplify(
-            self, samples, filter_sites=True,
-            nodes_before=None, edges_before=None, sites_before=None,
-            mutations_before=None, nodes_after=None, edges_after=None,
-            sites_after=None, mutations_after=None, debug=False):
+        self,
+        samples,
+        filter_sites=True,
+        nodes_before=None,
+        edges_before=None,
+        sites_before=None,
+        mutations_before=None,
+        nodes_after=None,
+        edges_after=None,
+        sites_after=None,
+        mutations_after=None,
+        debug=False,
+    ):
         """
         Verifies that if we run simplify on the specified input we get the
         required output.
@@ -1802,9 +1891,10 @@ class TestSimplifyExamples(TopologyTestCase):
             edges=io.StringIO(edges_before),
             sites=io.StringIO(sites_before) if sites_before is not None else None,
             mutations=(
-                io.StringIO(mutations_before)
-                if mutations_before is not None else None),
-            strict=False)
+                io.StringIO(mutations_before) if mutations_before is not None else None
+            ),
+            strict=False,
+        )
         before = ts.dump_tables()
 
         ts = tskit.load_text(
@@ -1812,10 +1902,11 @@ class TestSimplifyExamples(TopologyTestCase):
             edges=io.StringIO(edges_after),
             sites=io.StringIO(sites_after) if sites_after is not None else None,
             mutations=(
-                io.StringIO(mutations_after)
-                if mutations_after is not None else None),
+                io.StringIO(mutations_after) if mutations_after is not None else None
+            ),
             strict=False,
-            sequence_length=before.sequence_length)
+            sequence_length=before.sequence_length,
+        )
         after = ts.dump_tables()
 
         ts = before.tree_sequence()
@@ -1890,8 +1981,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 2],
-            nodes_before=nodes_before, edges_before=edges_before,
-            nodes_after=nodes_after, edges_after=edges_after)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+        )
 
     def test_single_binary_tree_no_sample_nodes(self):
         #
@@ -1926,8 +2020,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 2],
-            nodes_before=nodes_before, edges_before=edges_before,
-            nodes_after=nodes_after, edges_after=edges_after)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+        )
 
     def test_single_binary_tree_internal_sample(self):
         #
@@ -1961,8 +2058,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 3],
-            nodes_before=nodes_before, edges_before=edges_before,
-            nodes_after=nodes_after, edges_after=edges_after)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+        )
 
     def test_single_binary_tree_internal_sample_meet_at_root(self):
         # 3          5
@@ -2003,8 +2103,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 3, 6],
-            nodes_before=nodes_before, edges_before=edges_before,
-            nodes_after=nodes_after, edges_after=edges_after)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+        )
 
     def test_single_binary_tree_simple_mutations(self):
         # 3          5
@@ -2065,18 +2168,29 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 1, 6],
-            nodes_before=nodes_before, edges_before=edges_before,
-            sites_before=sites_before, mutations_before=mutations_before,
-            nodes_after=nodes_after, edges_after=edges_after,
-            sites_after=sites_after, mutations_after=mutations_after)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            sites_before=sites_before,
+            mutations_before=mutations_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+            sites_after=sites_after,
+            mutations_after=mutations_after,
+        )
         # If we don't filter the fixed sites, we should get the same
         # mutations and the original sites table back.
         self.verify_simplify(
-            samples=[0, 1, 6], filter_sites=False,
-            nodes_before=nodes_before, edges_before=edges_before,
-            sites_before=sites_before, mutations_before=mutations_before,
-            nodes_after=nodes_after, edges_after=edges_after,
-            sites_after=sites_before, mutations_after=mutations_after)
+            samples=[0, 1, 6],
+            filter_sites=False,
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            sites_before=sites_before,
+            mutations_before=mutations_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+            sites_after=sites_before,
+            mutations_after=mutations_after,
+        )
 
     def test_overlapping_edges(self):
         nodes = """\
@@ -2098,8 +2212,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 1],
-            nodes_before=nodes, edges_before=edges_before,
-            nodes_after=nodes, edges_after=edges_after)
+            nodes_before=nodes,
+            edges_before=edges_before,
+            nodes_after=nodes,
+            edges_after=edges_after,
+        )
 
     def test_overlapping_edges_internal_samples(self):
         nodes = """\
@@ -2115,7 +2232,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 1, 2],
-            nodes_before=nodes, edges_before=edges, nodes_after=nodes, edges_after=edges)
+            nodes_before=nodes,
+            edges_before=edges,
+            nodes_after=nodes,
+            edges_after=edges,
+        )
 
     def test_unary_edges_no_overlap(self):
         nodes_before = """\
@@ -2141,8 +2262,11 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 1],
-            nodes_before=nodes_before, edges_before=edges_before,
-            nodes_after=nodes_after, edges_after=edges_after)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            nodes_after=nodes_after,
+            edges_after=edges_after,
+        )
 
     def test_unary_edges_no_overlap_internal_sample(self):
         nodes_before = """\
@@ -2158,44 +2282,57 @@ class TestSimplifyExamples(TopologyTestCase):
         """
         self.verify_simplify(
             samples=[0, 1, 2],
-            nodes_before=nodes_before, edges_before=edges_before,
-            nodes_after=nodes_before, edges_after=edges_before)
+            nodes_before=nodes_before,
+            edges_before=edges_before,
+            nodes_after=nodes_before,
+            edges_after=edges_before,
+        )
 
 
 class TestNonSampleExternalNodes(TopologyTestCase):
     """
     Tests for situations in which we have tips that are not samples.
     """
+
     def test_simple_case(self):
         # Simplest case where we have n = 2 and external non-sample nodes.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
         2       0           1
         3       0           0
         4       0           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       2       0,1,3,4
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.1         0
         1   0.2         0
         2   0.3         0
         3   0.4         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       0       1
         1       1       1
         2       3       1
         3       4       1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
         self.assertEqual(ts.sample_size, 2)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_nodes, 5)
@@ -2218,7 +2355,8 @@ class TestNonSampleExternalNodes(TopologyTestCase):
         # Take an ordinary tree sequence and put a bunch of external non
         # sample nodes on it.
         ts = msprime.simulate(
-            15, recombination_rate=5, random_seed=self.random_seed, mutation_rate=5)
+            15, recombination_rate=5, random_seed=self.random_seed, mutation_rate=5
+        )
         self.assertGreater(ts.num_trees, 2)
         self.assertGreater(ts.num_mutations, 2)
         tables = ts.dump_tables()
@@ -2250,27 +2388,40 @@ class TestMultipleRoots(TopologyTestCase):
 
     def test_simplest_degenerate_case(self):
         # Simplest case where we have n = 2 and no edges.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.1         0
         1   0.2         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       0         1
         1       1         1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            sequence_length=1, strict=False)
+            nodes=nodes,
+            edges=edges,
+            sites=sites,
+            mutations=mutations,
+            sequence_length=1,
+            strict=False,
+        )
         self.assertEqual(ts.num_nodes, 2)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_sites, 2)
@@ -2281,7 +2432,8 @@ class TestMultipleRoots(TopologyTestCase):
         self.assertEqual(list(ts.haplotypes(impute_missing_data=True)), ["10", "01"])
         self.assertEqual(
             [v.genotypes for v in ts.variants(as_bytes=True, impute_missing_data=True)],
-            [b"10", b"01"])
+            [b"10", b"01"],
+        )
         simplified = ts.simplify()
         t1 = ts.dump_tables()
         t2 = simplified.dump_tables()
@@ -2290,7 +2442,8 @@ class TestMultipleRoots(TopologyTestCase):
 
     def test_simplest_non_degenerate_case(self):
         # Simplest case where we have n = 4 and two trees.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2298,28 +2451,36 @@ class TestMultipleRoots(TopologyTestCase):
         3       1           0
         4       0           1
         5       0           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       4       0,1
         0       1       5       2,3
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.1         0
         1   0.2         0
         2   0.3         0
         3   0.4         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       0       1
         1       1       1
         2       2       1
         3       3       1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
         self.assertEqual(ts.num_nodes, 6)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_sites, 4)
@@ -2329,7 +2490,8 @@ class TestMultipleRoots(TopologyTestCase):
         self.assertEqual(list(ts.haplotypes()), ["1000", "0100", "0010", "0001"])
         self.assertEqual(
             [v.genotypes for v in ts.variants(as_bytes=True)],
-            [b"1000", b"0100", b"0010", b"0001"])
+            [b"1000", b"0100", b"0010", b"0001"],
+        )
         self.assertEqual(t.mrca(0, 1), 4)
         self.assertEqual(t.mrca(0, 4), 4)
         self.assertEqual(t.mrca(2, 3), 5)
@@ -2348,7 +2510,8 @@ class TestMultipleRoots(TopologyTestCase):
 
     def test_two_reducable_trees(self):
         # We have n = 4 and two trees, with some unary nodes and non-sample leaves
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2359,32 +2522,40 @@ class TestMultipleRoots(TopologyTestCase):
         6       0           2
         7       0           3
         8       0           0   # Non sample leaf
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1      4         0
         0       1      5         1
         0       1      6         4,5
         0       1      7         2,3,8
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.1         0
         1   0.2         0
         2   0.3         0
         3   0.4         0
         4   0.5         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       0       1
         1       1       1
         2       2       1
         3       3       1
         4       8       1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
         self.assertEqual(ts.num_nodes, 9)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_sites, 5)
@@ -2394,7 +2565,8 @@ class TestMultipleRoots(TopologyTestCase):
         self.assertEqual(list(ts.haplotypes()), ["10000", "01000", "00100", "00010"])
         self.assertEqual(
             [v.genotypes for v in ts.variants(as_bytes=True)],
-            [b"1000", b"0100", b"0010", b"0001", b"0000"])
+            [b"1000", b"0100", b"0010", b"0001", b"0000"],
+        )
         self.assertEqual(t.mrca(0, 1), 6)
         self.assertEqual(t.mrca(2, 3), 7)
         self.assertEqual(t.mrca(2, 8), 7)
@@ -2409,10 +2581,12 @@ class TestMultipleRoots(TopologyTestCase):
         t = next(ts_simplified.trees())
         # print(ts_simplified.tables)
         self.assertEqual(
-            list(ts_simplified.haplotypes()), ["1000", "0100", "0010", "0001"])
+            list(ts_simplified.haplotypes()), ["1000", "0100", "0010", "0001"]
+        )
         self.assertEqual(
             [v.genotypes for v in ts_simplified.variants(as_bytes=True)],
-            [b"1000", b"0100", b"0010", b"0001"])
+            [b"1000", b"0100", b"0010", b"0001"],
+        )
         # The site over the non-sample external node should have been discarded.
         sites = list(t.sites())
         self.assertEqual(sites[-1].position, 0.4)
@@ -2420,7 +2594,8 @@ class TestMultipleRoots(TopologyTestCase):
 
     def test_one_reducable_tree(self):
         # We have n = 4 and two trees. One tree is reducable and the other isn't.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2431,14 +2606,17 @@ class TestMultipleRoots(TopologyTestCase):
         6       0           2
         7       0           3
         8       0           0   # Non sample leaf
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1      4         0
         0       1      5         1
         0       1      6         4,5
         0       1      7         2,3,8
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         self.assertEqual(ts.num_nodes, 9)
         self.assertEqual(ts.num_trees, 1)
@@ -2460,7 +2638,8 @@ class TestMultipleRoots(TopologyTestCase):
     # so there might be other problems with it.
     def test_mutations_over_roots(self):
         # Mutations over root nodes should be ok when we have multiple roots.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2468,14 +2647,18 @@ class TestMultipleRoots(TopologyTestCase):
         3       0           1
         4       0           2
         5       0           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       3       0,1
         0       1       4       3
         0       1       5       2
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.1         0
         1   0.2         0
@@ -2483,8 +2666,10 @@ class TestMultipleRoots(TopologyTestCase):
         3   0.4         0
         4   0.5         0
         5   0.6         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       0       1
         1       1       1
@@ -2492,9 +2677,11 @@ class TestMultipleRoots(TopologyTestCase):
         3       4       1
         4       2       1
         5       5       1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
         self.assertEqual(ts.num_nodes, 6)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_sites, 6)
@@ -2507,11 +2694,15 @@ class TestMultipleRoots(TopologyTestCase):
         self.assertEqual([v.genotypes for v in ts.variants(as_bytes=True)], variants)
         ts_simplified = ts.simplify(filter_sites=False)
         self.assertEqual(
-            list(ts_simplified.haplotypes(impute_missing_data=True)), haplotypes)
+            list(ts_simplified.haplotypes(impute_missing_data=True)), haplotypes
+        )
         self.assertEqual(
-            variants, [
-                v.genotypes for v in
-                ts_simplified.variants(as_bytes=True, impute_missing_data=True)])
+            variants,
+            [
+                v.genotypes
+                for v in ts_simplified.variants(as_bytes=True, impute_missing_data=True)
+            ],
+        )
 
     def test_break_single_tree(self):
         # Take a single largish tree from tskit, and remove the oldest record.
@@ -2523,7 +2714,8 @@ class TestMultipleRoots(TopologyTestCase):
             left=tables.edges.left[:-1],
             right=tables.edges.right[:-1],
             parent=tables.edges.parent[:-1],
-            child=tables.edges.child[:-1])
+            child=tables.edges.child[:-1],
+        )
         ts_new = tables.tree_sequence()
         self.assertEqual(ts.sample_size, ts_new.sample_size)
         self.assertEqual(ts.num_edges, ts_new.num_edges + 1)
@@ -2591,7 +2783,8 @@ class TestWithVisuals(TopologyTestCase):
         #
         #          (0.0, 0.2),                 (0.2, 0.8),         (0.8, 1.0)
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2601,8 +2794,10 @@ class TestWithVisuals(TopologyTestCase):
         5       0           0.5
         6       0           0.7
         7       0           1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.2     4       2,3
         0.2     0.8     4       0,2
@@ -2610,11 +2805,13 @@ class TestWithVisuals(TopologyTestCase):
         0.0     1.0     5       1,4
         0.8     1.0     6       0,5
         0.0     0.2     7       0,5
-        """)
+        """
+        )
         true_trees = [
             {0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 7, 6: -1, 7: -1},
             {0: 4, 1: 5, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1, 7: -1},
-            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}]
+            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
+        ]
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
         self.assertEqual(ts.sample_size, 3)
@@ -2645,7 +2842,8 @@ class TestWithVisuals(TopologyTestCase):
         # 0.0 0     1           2     1   0       2     0   1           2
         #
         #          (0.0, 0.2),         (0.2, 0.8),         (0.8, 1.0)
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2655,8 +2853,10 @@ class TestWithVisuals(TopologyTestCase):
         5       0           0.7
         6       0           1.0
         7       0           0    # Non sample leaf
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.2     3       2,7
         0.2     0.8     3       0,2
@@ -2666,11 +2866,13 @@ class TestWithVisuals(TopologyTestCase):
         0.8     1.0     4       1,3
         0.8     1.0     5       0,4
         0.0     0.2     6       0,4
-        """)
+        """
+        )
         true_trees = [
             {0: 6, 1: 4, 2: 3, 3: 4, 4: 6, 5: -1, 6: -1, 7: 3},
             {0: 3, 1: 4, 2: 3, 3: 4, 4: -1, 5: -1, 6: -1, 7: -1},
-            {0: 5, 1: 4, 2: 3, 3: 4, 4: 5, 5: -1, 6: -1, 7: 3}]
+            {0: 5, 1: 4, 2: 3, 3: 4, 4: 5, 5: -1, 6: -1, 7: 3},
+        ]
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
         # sample size check works here since 7 > 3
@@ -2702,7 +2904,8 @@ class TestWithVisuals(TopologyTestCase):
         # 0.0    0     1           2           1   0       2          0   1           2
         #
         #          (0.0, 0.2),               (0.2, 0.8),              (0.8, 1.0)
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id  is_sample   time
         0   1           0
         1   1           0
@@ -2712,8 +2915,10 @@ class TestWithVisuals(TopologyTestCase):
         5   0           0.5
         6   0           0.7
         7   0           1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.2     4       2,3
         0.2     0.8     4       0,2
@@ -2722,12 +2927,14 @@ class TestWithVisuals(TopologyTestCase):
         0.8     1.0     6       0,5
         0.0     0.2     6       5
         0.0     0.2     7       0,6
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         true_trees = [
             {0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: 7, 7: -1},
             {0: 4, 1: 5, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1, 7: -1},
-            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}]
+            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
+        ]
         tree_dicts = [t.parent_dict for t in ts.trees()]
         self.assertEqual(ts.sample_size, 3)
         self.assertEqual(ts.num_trees, 3)
@@ -2789,15 +2996,16 @@ class TestWithVisuals(TopologyTestCase):
             {0: 4, 1: 9, 2: 10, 3: -1, 4: 3, 5: 3, 6: 4, 7: 3, 8: 6, 9: 8, 10: 7},
             {0: 4, 1: 9, 2: 10, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 6, 9: 8, 10: 7},
             {0: 4, 1: 9, 2: 10, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 6, 9: 8, 10: 8},
-            {0: 4, 1: 9,  2: 5, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 6, 9: 8, 10: 8},
+            {0: 4, 1: 9, 2: 5, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 6, 9: 8, 10: 8},
             {0: 4, 1: 10, 2: 5, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 6, 9: 8, 10: 8},
             {0: 9, 1: 10, 2: 5, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 6, 9: 8, 10: 8},
             {0: 9, 1: 10, 2: 5, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 7, 9: 8, 10: 8},
             {0: 9, 1: 10, 2: 5, 3: -1, 4: 3, 5: 3, 6: 4, 7: 5, 8: 7, 9: 6, 10: 8},
-            {0: 9, 1: 10, 2: 5, 3: -1, 4: 3, 5: 3, 6: 3, 7: 5, 8: 7, 9: 6, 10: 8}
+            {0: 9, 1: 10, 2: 5, 3: -1, 4: 3, 5: 3, 6: 3, 7: 5, 8: 7, 9: 6, 10: 8},
         ]
-        true_haplotypes = ['0100', '0001', '1110']
-        nodes = io.StringIO("""\
+        true_haplotypes = ["0100", "0001", "1110"]
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2810,8 +3018,10 @@ class TestWithVisuals(TopologyTestCase):
         8       0           2
         9       0           1
         10      0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.5     1.0     10      1
         0.0     0.4     10      2
@@ -2831,15 +3041,19 @@ class TestWithVisuals(TopologyTestCase):
         0.9     1.0     3       4,5,6
         0.1     0.9     3       4,5
         0.0     0.1     3       4,5,7
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0.05        0
         0.15        0
         0.25        0
         0.4         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       7       1               -1
         0      10       0               0
@@ -2851,7 +3065,8 @@ class TestWithVisuals(TopologyTestCase):
         2      10       0               5
         2       2       1               7
         3       8       1               -1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sites, mutations, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
         self.assertEqual(ts.sample_size, 3)
@@ -2892,7 +3107,8 @@ class TestWithVisuals(TopologyTestCase):
         # 0   1 2   3 4  5  . 0   1 2   3 4  5  . 4   5 2   3 0  1  .
         #                   .                   .                   .
         # 0.0              0.4                 0.5                 1.0
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2907,8 +3123,10 @@ class TestWithVisuals(TopologyTestCase):
         10      0           2
         11      0           3
         12      0           4
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left right parent child
         0.0  0.5   6      0
         0.0  0.5   6      1
@@ -2926,14 +3144,54 @@ class TestWithVisuals(TopologyTestCase):
         0.0  0.4   12     8
         0.4  1.0   12     10
         0.0  0.4   12     11
-        """)
+        """
+        )
         true_trees = [
-            {0: 6, 1: 6, 2: 7, 3: 7, 4: 8, 5: 8, 6: 11,
-                7: 11, 8: 12, 9: -1, 10: -1, 11: 12, 12: -1},
-            {0: 6, 1: 6, 2: 9, 3: 9, 4: 8, 5: 8, 6: 12,
-                7: -1, 8: 10, 9: 10, 10: 12, 11: -1, 12: -1},
-            {0: 8, 1: 8, 2: 9, 3: 9, 4: 6, 5: 6, 6: 12,
-                7: -1, 8: 10, 9: 10, 10: 12, 11: -1, 12: -1}
+            {
+                0: 6,
+                1: 6,
+                2: 7,
+                3: 7,
+                4: 8,
+                5: 8,
+                6: 11,
+                7: 11,
+                8: 12,
+                9: -1,
+                10: -1,
+                11: 12,
+                12: -1,
+            },
+            {
+                0: 6,
+                1: 6,
+                2: 9,
+                3: 9,
+                4: 8,
+                5: 8,
+                6: 12,
+                7: -1,
+                8: 10,
+                9: 10,
+                10: 12,
+                11: -1,
+                12: -1,
+            },
+            {
+                0: 8,
+                1: 8,
+                2: 9,
+                3: 9,
+                4: 6,
+                5: 6,
+                6: 12,
+                7: -1,
+                8: 10,
+                9: 10,
+                10: 12,
+                11: -1,
+                12: -1,
+            },
         ]
         ts = tskit.load_text(nodes, edges, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
@@ -2977,7 +3235,8 @@ class TestWithVisuals(TopologyTestCase):
         #  . 0   1 2   3 4  5  . 4   5 2   3 0  1  .
         #  .                   .                   .
         # 0.4                 0.5                 1.0
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -2995,8 +3254,10 @@ class TestWithVisuals(TopologyTestCase):
         13      0           2
         14      0           1
         15      0           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left right parent child
         0.0  0.5   6      0,1
         0.5  1.0   6      4,5
@@ -3011,14 +3272,54 @@ class TestWithVisuals(TopologyTestCase):
         0.1  0.4   11     6,15
         0.0  0.4   12     8,11
         0.4  1.0   12     6,10
-        """)
+        """
+        )
         true_trees = [
-            {0: 6, 1: 6, 2: 7, 3: 7, 4: 8, 5: 8, 6: 11,
-                7: 11, 8: 12, 9: -1, 10: -1, 11: 12, 12: -1},
-            {0: 6, 1: 6, 2: 9, 3: 9, 4: 8, 5: 8, 6: 12,
-                7: -1, 8: 10, 9: 10, 10: 12, 11: -1, 12: -1},
-            {0: 8, 1: 8, 2: 9, 3: 9, 4: 6, 5: 6, 6: 12,
-                7: -1, 8: 10, 9: 10, 10: 12, 11: -1, 12: -1}
+            {
+                0: 6,
+                1: 6,
+                2: 7,
+                3: 7,
+                4: 8,
+                5: 8,
+                6: 11,
+                7: 11,
+                8: 12,
+                9: -1,
+                10: -1,
+                11: 12,
+                12: -1,
+            },
+            {
+                0: 6,
+                1: 6,
+                2: 9,
+                3: 9,
+                4: 8,
+                5: 8,
+                6: 12,
+                7: -1,
+                8: 10,
+                9: 10,
+                10: 12,
+                11: -1,
+                12: -1,
+            },
+            {
+                0: 8,
+                1: 8,
+                2: 9,
+                3: 9,
+                4: 6,
+                5: 6,
+                6: 12,
+                7: -1,
+                8: 10,
+                9: 10,
+                10: 12,
+                11: -1,
+                12: -1,
+            },
         ]
         big_ts = tskit.load_text(nodes, edges, strict=False)
         self.assertEqual(big_ts.num_trees, 1 + len(true_trees))
@@ -3059,7 +3360,8 @@ class TestWithVisuals(TopologyTestCase):
         #              *           *          *           *         *           *
         #          (0.0, 0.2),                 (0.2, 0.8),         (0.8, 1.0)
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       0           0
         1       1           0
@@ -3070,8 +3372,10 @@ class TestWithVisuals(TopologyTestCase):
         6       0           0.7
         7       0           1.0
         8       0           0.8
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.2     4       2,3
         0.2     0.8     4       0,2
@@ -3080,13 +3384,15 @@ class TestWithVisuals(TopologyTestCase):
         0.8     1.0     6       0,5
         0.2     0.8     8       3,5
         0.0     0.2     7       0,5
-        """)
+        """
+        )
         first_ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         ts, node_map = first_ts.simplify(map_nodes=True)
         true_trees = [
             {0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 7, 6: -1, 7: -1},
             {0: 4, 1: 5, 2: 4, 3: 8, 4: 5, 5: 8, 6: -1, 7: -1},
-            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}]
+            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
+        ]
         # maps [1,2,3] -> [0,1,2]
         self.assertEqual(node_map[1], 0)
         self.assertEqual(node_map[2], 1)
@@ -3094,7 +3400,8 @@ class TestWithVisuals(TopologyTestCase):
         true_simplified_trees = [
             {0: 4, 1: 3, 2: 3, 3: 4},
             {0: 4, 1: 4, 2: 5, 4: 5},
-            {0: 4, 1: 3, 2: 3, 3: 4}]
+            {0: 4, 1: 3, 2: 3, 3: 4},
+        ]
         self.assertEqual(first_ts.sample_size, 3)
         self.assertEqual(ts.sample_size, 3)
         self.assertEqual(first_ts.num_trees, 3)
@@ -3137,7 +3444,8 @@ class TestWithVisuals(TopologyTestCase):
         #
         #          (0.0, 0.2),                 (0.2, 0.8),         (0.8, 1.0)
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       0           0
         1       1           0.1
@@ -3148,8 +3456,10 @@ class TestWithVisuals(TopologyTestCase):
         6       0           0.7
         7       0           1.0
         8       0           0.8
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.2     4       2,3
         0.2     0.8     4       0,2
@@ -3158,12 +3468,14 @@ class TestWithVisuals(TopologyTestCase):
         0.8     1.0     6       0,5
         0.2     0.8     8       3,5
         0.0     0.2     7       0,5
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         true_trees = [
             {0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 7, 6: -1, 7: -1},
             {0: 4, 1: 5, 2: 4, 3: 8, 4: 5, 5: 8, 6: -1, 7: -1},
-            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}]
+            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
+        ]
         self.assertEqual(ts.sample_size, 3)
         self.assertEqual(ts.num_trees, 3)
         self.assertEqual(ts.num_nodes, 9)
@@ -3195,7 +3507,8 @@ class TestWithVisuals(TopologyTestCase):
         # 0.0    0      *         *            *  0      *      0    *         *
         #
         #          (0.0, 0.2),                 (0.2, 0.8),         (0.8, 1.0)
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       0           0
         1       1           0.1
@@ -3206,8 +3519,10 @@ class TestWithVisuals(TopologyTestCase):
         6       0           0.7
         7       0           1.0
         8       0           0.8
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.2     4       2,3
         0.2     0.8     4       0,2
@@ -3216,12 +3531,14 @@ class TestWithVisuals(TopologyTestCase):
         0.8     1.0     6       0,5
         0.2     0.8     8       3,5
         0.0     0.2     7       0,5
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         true_trees = [
             {0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 7, 6: -1, 7: -1},
             {0: 4, 1: 5, 2: 4, 3: 8, 4: 5, 5: 8, 6: -1, 7: -1},
-            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}]
+            {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
+        ]
         self.assertEqual(ts.sample_size, 4)
         self.assertEqual(ts.num_trees, 3)
         self.assertEqual(ts.num_nodes, 9)
@@ -3241,18 +3558,45 @@ class TestWithVisuals(TopologyTestCase):
         self.verify_simplify_topology(ts, [1, 2, 3])
         self.check_num_samples(
             ts,
-            [(0, 5, 4), (0, 2, 1), (0, 7, 4), (0, 4, 2),
-             (1, 4, 1), (1, 5, 3), (1, 8, 4), (1, 0, 0),
-             (2, 5, 4), (2, 1, 1)])
+            [
+                (0, 5, 4),
+                (0, 2, 1),
+                (0, 7, 4),
+                (0, 4, 2),
+                (1, 4, 1),
+                (1, 5, 3),
+                (1, 8, 4),
+                (1, 0, 0),
+                (2, 5, 4),
+                (2, 1, 1),
+            ],
+        )
         self.check_num_tracked_samples(
-            ts, [1, 2, 5],
-            [(0, 5, 3), (0, 2, 1), (0, 7, 3), (0, 4, 1),
-             (1, 4, 1), (1, 5, 3), (1, 8, 3), (1, 0, 0),
-             (2, 5, 3), (2, 1, 1)])
+            ts,
+            [1, 2, 5],
+            [
+                (0, 5, 3),
+                (0, 2, 1),
+                (0, 7, 3),
+                (0, 4, 1),
+                (1, 4, 1),
+                (1, 5, 3),
+                (1, 8, 3),
+                (1, 0, 0),
+                (2, 5, 3),
+                (2, 1, 1),
+            ],
+        )
         self.check_sample_iterator(
             ts,
-            [(0, 0, []), (0, 5, [5, 1, 2, 3]), (0, 4, [2, 3]),
-             (1, 5, [5, 1, 2]), (2, 4, [2, 3])])
+            [
+                (0, 0, []),
+                (0, 5, [5, 1, 2, 3]),
+                (0, 4, [2, 3]),
+                (1, 5, [5, 1, 2]),
+                (2, 4, [2, 3]),
+            ],
+        )
         # pedantically check the Tree methods on the second tree
         tst = ts.trees()
         t = next(tst)
@@ -3280,35 +3624,44 @@ class TestBadTrees(unittest.TestCase):
     Tests for bad tree sequence topologies that can only be detected when we
     try to create trees.
     """
+
     def test_simplest_contradictory_children(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
         2       0           1
         3       0           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     1.0     2       0
         0.0     1.0     3       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         self.assertRaises(_tskit.LibraryError, list, ts.trees())
 
     def test_partial_overlap_contradictory_children(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
         2       0           1
         3       0           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     1.0     2       0,1
         0.5     1.0     3       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         self.assertRaises(_tskit.LibraryError, list, ts.trees())
 
@@ -3317,6 +3670,7 @@ class TestSimplify(unittest.TestCase):
     """
     Tests that the implementations of simplify() do what they are supposed to.
     """
+
     random_seed = 23
     #
     #          8
@@ -3349,17 +3703,28 @@ class TestSimplify(unittest.TestCase):
     """
 
     def do_simplify(
-            self, ts, samples=None, compare_lib=True, filter_sites=True,
-            filter_populations=True, filter_individuals=True, keep_unary=False):
+        self,
+        ts,
+        samples=None,
+        compare_lib=True,
+        filter_sites=True,
+        filter_populations=True,
+        filter_individuals=True,
+        keep_unary=False,
+    ):
         """
         Runs the Python test implementation of simplify.
         """
         if samples is None:
             samples = ts.samples()
         s = tests.Simplifier(
-            ts, samples, filter_sites=filter_sites,
-            filter_populations=filter_populations, filter_individuals=filter_individuals,
-            keep_unary=keep_unary)
+            ts,
+            samples,
+            filter_sites=filter_sites,
+            filter_populations=filter_populations,
+            filter_individuals=filter_individuals,
+            keep_unary=keep_unary,
+        )
         new_ts, node_map = s.simplify()
         if compare_lib:
             sts, lib_node_map1 = ts.simplify(
@@ -3368,7 +3733,8 @@ class TestSimplify(unittest.TestCase):
                 filter_individuals=filter_individuals,
                 filter_populations=filter_populations,
                 keep_unary=keep_unary,
-                map_nodes=True)
+                map_nodes=True,
+            )
             lib_tables1 = sts.dump_tables()
 
             lib_tables2 = ts.dump_tables()
@@ -3377,11 +3743,14 @@ class TestSimplify(unittest.TestCase):
                 filter_sites=filter_sites,
                 keep_unary=keep_unary,
                 filter_individuals=filter_individuals,
-                filter_populations=filter_populations)
+                filter_populations=filter_populations,
+            )
 
             py_tables = new_ts.dump_tables()
             for lib_tables, lib_node_map in [
-                    (lib_tables1, lib_node_map1), (lib_tables2, lib_node_map2)]:
+                (lib_tables1, lib_node_map1),
+                (lib_tables2, lib_node_map2),
+            ]:
 
                 self.assertEqual(lib_tables.nodes, py_tables.nodes)
                 self.assertEqual(lib_tables.edges, py_tables.edges)
@@ -3401,7 +3770,8 @@ class TestSimplify(unittest.TestCase):
         t1 = ts.dump_tables()
         t1.nodes.flags = np.zeros_like(t1.nodes.flags)
         ts1, node_map1 = self.do_simplify(
-            ts, samples=ts.samples(), keep_unary=keep_unary)
+            ts, samples=ts.samples(), keep_unary=keep_unary
+        )
         t1 = ts1.dump_tables()
         ts2, node_map2 = self.do_simplify(ts, keep_unary=keep_unary)
         t2 = ts2.dump_tables()
@@ -3480,7 +3850,8 @@ class TestSimplify(unittest.TestCase):
 
     def test_many_trees_mutations(self):
         ts = msprime.simulate(
-            10, recombination_rate=1, mutation_rate=10, random_seed=self.random_seed)
+            10, recombination_rate=1, mutation_rate=10, random_seed=self.random_seed
+        )
         self.assertGreater(ts.num_trees, 2)
         self.assertGreater(ts.num_sites, 2)
         self.verify_no_samples(ts)
@@ -3504,7 +3875,9 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_internal_samples(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         nodes = tables.nodes
         flags = nodes.flags
@@ -3533,7 +3906,9 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_linear_samples(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         nodes = tables.nodes
         flags = nodes.flags
@@ -3562,7 +3937,9 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_internal_and_external_samples(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         nodes = tables.nodes
         flags = nodes.flags
@@ -3595,7 +3972,9 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_mutations(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         # Add some simple mutations here above the nodes we're keeping.
         tables.sites.add_row(position=0.25, ancestral_state="0")
@@ -3618,24 +3997,28 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_filter_zero_mutations(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         ts = tsutil.insert_branch_sites(ts)
         self.assertEqual(ts.num_sites, 8)
         self.assertEqual(ts.num_mutations, 8)
         for keep in [True, False]:
-            tss, _ = self.do_simplify(
-                ts, [4, 0, 1], filter_sites=True, keep_unary=keep)
+            tss, _ = self.do_simplify(ts, [4, 0, 1], filter_sites=True, keep_unary=keep)
             self.assertEqual(tss.num_sites, 5)
             self.assertEqual(tss.num_mutations, 5)
             tss, _ = self.do_simplify(
-                ts, [4, 0, 1], filter_sites=False, keep_unary=keep)
+                ts, [4, 0, 1], filter_sites=False, keep_unary=keep
+            )
             self.assertEqual(tss.num_sites, 8)
             self.assertEqual(tss.num_mutations, 5)
 
     def test_small_tree_fixed_sites(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         # Add some simple mutations that will be fixed after simplify
         tables.sites.add_row(position=0.25, ancestral_state="0")
@@ -3656,7 +4039,9 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_mutations_over_root(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         tables.sites.add_row(position=0.25, ancestral_state="0")
         tables.mutations.add_row(site=0, node=8, derived_state="1")
@@ -3665,14 +4050,17 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(ts.num_mutations, 1)
         for keep_unary, filter_sites in itertools.product([True, False], repeat=2):
             tss, _ = self.do_simplify(
-                ts, [0, 1], filter_sites=filter_sites, keep_unary=keep_unary)
+                ts, [0, 1], filter_sites=filter_sites, keep_unary=keep_unary
+            )
             self.assertEqual(tss.num_sites, 1)
             self.assertEqual(tss.num_mutations, 1)
 
     def test_small_tree_recurrent_mutations(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         # Add recurrent mutation on the root branches
         tables.sites.add_row(position=0.25, ancestral_state="0")
@@ -3691,7 +4079,9 @@ class TestSimplify(unittest.TestCase):
     def test_small_tree_back_mutations(self):
         ts = tskit.load_text(
             nodes=io.StringIO(self.small_tree_ex_nodes),
-            edges=io.StringIO(self.small_tree_ex_edges), strict=False)
+            edges=io.StringIO(self.small_tree_ex_edges),
+            strict=False,
+        )
         tables = ts.dump_tables()
         # Add a chain of mutations
         tables.sites.add_row(position=0.25, ancestral_state="0")
@@ -3727,17 +4117,21 @@ class TestSimplify(unittest.TestCase):
             self.assertEqual(list(tss.haplotypes()), ["1", "0", "1"])
 
     def test_overlapping_unary_edges(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
         2       0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       2       2       0
         1       3       2       1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         self.assertEqual(ts.sample_size, 2)
         self.assertEqual(ts.num_trees, 3)
@@ -3750,17 +4144,21 @@ class TestSimplify(unittest.TestCase):
                 self.assertEqual(t.parent_dict, trees[t.index])
 
     def test_overlapping_unary_edges_internal_samples(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
         2       1           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       2       2       0
         1       3       2       1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, strict=False)
         self.assertEqual(ts.sample_size, 3)
         self.assertEqual(ts.num_trees, 3)
@@ -3772,15 +4170,19 @@ class TestSimplify(unittest.TestCase):
             self.assertEqual(list(node_map), [0, 1, 2])
 
     def test_isolated_samples(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           1
         2       1           2
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
-        """)
+        """
+        )
         ts = tskit.load_text(nodes, edges, sequence_length=1, strict=False)
         self.assertEqual(ts.num_samples, 3)
         self.assertEqual(ts.num_trees, 1)
@@ -3792,7 +4194,8 @@ class TestSimplify(unittest.TestCase):
             self.assertEqual(list(node_map), [0, 1, 2])
 
     def test_internal_samples(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1       -1              1.00000000000000
         1       0       -1              1.00000000000000
@@ -3803,8 +4206,10 @@ class TestSimplify(unittest.TestCase):
         6       0       -1              0.50000000000000
         7       0       -1              1.50000000000000
 
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       0.62185118      1.00000000      1       6
         1       0.00000000      0.62185118      2       6
@@ -3812,7 +4217,8 @@ class TestSimplify(unittest.TestCase):
         3       0.00000000      1.00000000      4       7,3
         4       0.00000000      1.00000000      6       5
         5       0.00000000      1.00000000      7       1
-        """)
+        """
+        )
 
         ts = tskit.load_text(nodes, edges, strict=False)
         tss, node_map = self.do_simplify(ts, [5, 2, 0])
@@ -3841,32 +4247,43 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(node_map[7], 6)
         self.assertEqual(tss.sample_size, 3)
         self.assertEqual(tss.num_trees, 2)
-        trees = [{0: 3, 1: 5, 2: 5, 3: 1, 5: 7},
-                 {0: 3, 1: 5, 2: 5, 3: 4, 4: 6, 5: 7, 6: 7}]
+        trees = [
+            {0: 3, 1: 5, 2: 5, 3: 1, 5: 7},
+            {0: 3, 1: 5, 2: 5, 3: 4, 4: 6, 5: 7, 6: 7},
+        ]
         for t in tss.trees():
             self.assertEqual(t.parent_dict, trees[t.index])
 
     def test_many_mutations_over_single_sample_ancestral_state(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       1       0
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0           0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       0       1               -1
         0       0       0               0
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes, edges, sites=sites, mutations=mutations, strict=False)
+            nodes, edges, sites=sites, mutations=mutations, strict=False
+        )
         self.assertEqual(ts.sample_size, 1)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_sites, 1)
@@ -3878,27 +4295,36 @@ class TestSimplify(unittest.TestCase):
             self.assertEqual(list(tss.haplotypes(impute_missing_data=True)), ["0"])
 
     def test_many_mutations_over_single_sample_derived_state(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       0           1
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0       1       1       0
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0           0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       0       1               -1
         0       0       0               0
         0       0       1               1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes, edges, sites=sites, mutations=mutations, strict=False)
+            nodes, edges, sites=sites, mutations=mutations, strict=False
+        )
         self.assertEqual(ts.sample_size, 1)
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_sites, 1)
@@ -3918,7 +4344,8 @@ class TestSimplify(unittest.TestCase):
         for keep in [True, False]:
             for filter_sites in [True, False]:
                 tss, _ = self.do_simplify(
-                    ts, samples=None, filter_sites=filter_sites, keep_unary=keep)
+                    ts, samples=None, filter_sites=filter_sites, keep_unary=keep
+                )
                 self.assertEqual(ts.num_sites, tss.num_sites)
                 self.assertEqual(ts.num_mutations, tss.num_mutations)
 
@@ -3931,7 +4358,8 @@ class TestSimplify(unittest.TestCase):
         for keep in [True, False]:
             for filter_sites in [True, False]:
                 tss, _ = self.do_simplify(
-                    ts, samples=None, filter_sites=filter_sites, keep_unary=keep)
+                    ts, samples=None, filter_sites=filter_sites, keep_unary=keep
+                )
                 self.assertEqual(ts.num_sites, tss.num_sites)
                 self.assertEqual(ts.num_mutations, tss.num_mutations)
 
@@ -3942,10 +4370,12 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(len(tables.populations), 2)
         for keep in [True, False]:
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_populations=True, keep_unary=keep)
+                tables.tree_sequence(), filter_populations=True, keep_unary=keep
+            )
             self.assertEqual(tss.num_populations, 1)
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_populations=False, keep_unary=keep)
+                tables.tree_sequence(), filter_populations=False, keep_unary=keep
+            )
             self.assertEqual(tss.num_populations, 2)
 
     def test_interleaved_populations_filter(self):
@@ -3954,8 +4384,10 @@ class TestSimplify(unittest.TestCase):
                 msprime.PopulationConfiguration(),
                 msprime.PopulationConfiguration(10),
                 msprime.PopulationConfiguration(),
-                msprime.PopulationConfiguration()],
-            random_seed=2)
+                msprime.PopulationConfiguration(),
+            ],
+            random_seed=2,
+        )
         self.assertEqual(ts.num_populations, 4)
         tables = ts.dump_tables()
         # Edit the populations so we can identify the rows.
@@ -3965,15 +4397,16 @@ class TestSimplify(unittest.TestCase):
         ts = tables.tree_sequence()
         id_map = np.array([-1, 0, -1, -1], dtype=np.int32)
         for keep in [True, False]:
-            tss, _ = self.do_simplify(
-                ts, filter_populations=True, keep_unary=keep)
+            tss, _ = self.do_simplify(ts, filter_populations=True, keep_unary=keep)
             self.assertEqual(tss.num_populations, 1)
             population = tss.population(0)
             self.assertEqual(population.metadata, bytes([1]))
-            self.assertTrue(np.array_equal(
-                id_map[ts.tables.nodes.population], tss.tables.nodes.population))
-            tss, _ = self.do_simplify(
-                ts, filter_populations=False, keep_unary=keep)
+            self.assertTrue(
+                np.array_equal(
+                    id_map[ts.tables.nodes.population], tss.tables.nodes.population
+                )
+            )
+            tss, _ = self.do_simplify(ts, filter_populations=False, keep_unary=keep)
             self.assertEqual(tss.num_populations, 4)
 
     def test_removed_node_population_filter(self):
@@ -3988,7 +4421,8 @@ class TestSimplify(unittest.TestCase):
         tables.nodes.add_row(flags=1, population=2)
         for keep in [True, False]:
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_populations=True, keep_unary=keep)
+                tables.tree_sequence(), filter_populations=True, keep_unary=keep
+            )
             self.assertEqual(tss.num_nodes, 2)
             self.assertEqual(tss.num_populations, 2)
             self.assertEqual(tss.population(0).metadata, bytes(0))
@@ -3997,7 +4431,8 @@ class TestSimplify(unittest.TestCase):
             self.assertEqual(tss.node(1).population, 1)
 
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_populations=False, keep_unary=keep)
+                tables.tree_sequence(), filter_populations=False, keep_unary=keep
+            )
             self.assertEqual(tss.tables.populations, tables.populations)
 
     def test_simple_individual_filter(self):
@@ -4008,7 +4443,8 @@ class TestSimplify(unittest.TestCase):
         tables.nodes.add_row(flags=1, individual=0)
         for keep in [True, False]:
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_individuals=True, keep_unary=keep)
+                tables.tree_sequence(), filter_individuals=True, keep_unary=keep
+            )
             self.assertEqual(tss.num_nodes, 2)
             self.assertEqual(tss.num_individuals, 1)
             self.assertEqual(tss.individual(0).flags, 0)
@@ -4026,13 +4462,15 @@ class TestSimplify(unittest.TestCase):
         tables.nodes.add_row(flags=1, individual=1)
         for keep in [True, False]:
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_individuals=True, keep_unary=keep)
+                tables.tree_sequence(), filter_individuals=True, keep_unary=keep
+            )
             self.assertEqual(tss.num_nodes, 3)
             self.assertEqual(tss.num_individuals, 1)
             self.assertEqual(tss.individual(0).flags, 1)
 
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_individuals=False, keep_unary=keep)
+                tables.tree_sequence(), filter_individuals=False, keep_unary=keep
+            )
             self.assertEqual(tss.tables.individuals, tables.individuals)
 
     def test_removed_node_individual_filter(self):
@@ -4047,7 +4485,8 @@ class TestSimplify(unittest.TestCase):
         tables.nodes.add_row(flags=1, individual=2)
         for keep in [True, False]:
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_individuals=True, keep_unary=keep)
+                tables.tree_sequence(), filter_individuals=True, keep_unary=keep
+            )
             self.assertEqual(tss.num_nodes, 2)
             self.assertEqual(tss.num_individuals, 2)
             self.assertEqual(tss.individual(0).flags, 0)
@@ -4056,12 +4495,14 @@ class TestSimplify(unittest.TestCase):
             self.assertEqual(tss.node(1).individual, 1)
 
             tss, _ = self.do_simplify(
-                tables.tree_sequence(), filter_individuals=False, keep_unary=keep)
+                tables.tree_sequence(), filter_individuals=False, keep_unary=keep
+            )
             self.assertEqual(tss.tables.individuals, tables.individuals)
 
     def verify_simplify_haplotypes(self, ts, samples, keep_unary=False):
         sub_ts, node_map = self.do_simplify(
-            ts, samples, filter_sites=False, keep_unary=keep_unary)
+            ts, samples, filter_sites=False, keep_unary=keep_unary
+        )
         self.assertEqual(ts.num_sites, sub_ts.num_sites)
         sub_haplotypes = list(sub_ts.haplotypes(impute_missing_data=True))
         all_samples = list(ts.samples())
@@ -4139,6 +4580,7 @@ class TestMapToAncestors(unittest.TestCase):
     """
     Tests the AncestorMap class.
     """
+
     random_seed = 13
     #
     #          8
@@ -4379,9 +4821,11 @@ class TestMapToAncestors(unittest.TestCase):
         current_left = tss.left[0]
         current_right = tss.right[0]
         for ind, row in enumerate(tss):
-            if row.parent != current_ancestor or\
-                    row.left != current_left or\
-                    row.right != current_right:
+            if (
+                row.parent != current_ancestor
+                or row.left != current_left
+                or row.right != current_right
+            ):
                 # Loop through trees.
                 for tree in ts.trees():
                     if tree.interval[0] >= current_right:
@@ -4407,33 +4851,33 @@ class TestMapToAncestors(unittest.TestCase):
 
     def test_sim_single_coalescent_tree(self):
         ts = msprime.simulate(30, random_seed=1, length=10)
-        ancestors = [3*n for n in np.arange(0, ts.num_nodes // 3)]
+        ancestors = [3 * n for n in np.arange(0, ts.num_nodes // 3)]
         self.verify(ts, ts.samples(), ancestors)
-        random_samples = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        random_samples = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, random_samples, ancestors)
 
     def test_sim_coalescent_trees(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=1, length=2)
-        ancestors = [3*n for n in np.arange(0, ts.num_nodes // 3)]
+        ancestors = [3 * n for n in np.arange(0, ts.num_nodes // 3)]
         self.verify(ts, ts.samples(), ancestors)
-        random_samples = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        random_samples = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, random_samples, ancestors)
 
     def test_sim_coalescent_trees_internal_samples(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=10, length=2)
         self.assertGreater(ts.num_trees, 2)
-        ancestors = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        ancestors = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(tsutil.jiggle_samples(ts), ts.samples(), ancestors)
-        random_samples = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        random_samples = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(tsutil.jiggle_samples(ts), random_samples, ancestors)
 
     def test_sim_many_multiroot_trees(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
         self.assertGreater(ts.num_trees, 3)
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
-        ancestors = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        ancestors = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, ts.samples(), ancestors)
-        random_samples = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        random_samples = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, random_samples, ancestors)
 
     def test_sim_wright_fisher_generations(self):
@@ -4441,13 +4885,13 @@ class TestMapToAncestors(unittest.TestCase):
         tables = wf.wf_sim(10, number_of_gens, deep_history=False, seed=2)
         tables.sort()
         ts = tables.tree_sequence()
-        ancestors = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        ancestors = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, ts.samples(), ancestors)
         for gen in range(1, number_of_gens):
             ancestors = [u.id for u in ts.nodes() if u.time == gen]
             self.verify(ts, ts.samples(), ancestors)
 
-        random_samples = [4*n for n in np.arange(0, ts.num_nodes // 4)]
+        random_samples = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, random_samples, ancestors)
         for gen in range(1, number_of_gens):
             ancestors = [u.id for u in ts.nodes() if u.time == gen]
@@ -4459,6 +4903,7 @@ class TestMutationParent(unittest.TestCase):
     Tests that mutation parent is correctly specified, and that we correctly
     recompute it with compute_mutation_parent.
     """
+
     seed = 42
 
     def verify_parents(self, ts):
@@ -4471,15 +4916,18 @@ class TestMutationParent(unittest.TestCase):
         self.assertTrue(np.array_equal(parent, tables.mutations.parent))
 
     def test_example(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       0           2.0
         1       0           1.0
         2       0           1.0
         3       1           0
         4       1           0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0    0.5   2  3
         0.0    0.8   2  4
@@ -4487,14 +4935,18 @@ class TestMutationParent(unittest.TestCase):
         0.0    1.0   0  1
         0.0    1.0   0  2
         0.8    1.0   0  4
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         position    ancestral_state
         0.1     0
         0.5     0
         0.9     0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       1       1               -1
         0       2       1               -1
@@ -4508,30 +4960,37 @@ class TestMutationParent(unittest.TestCase):
         2       1       1               8
         2       2       1               8
         2       4       1               8
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
         self.verify_parents(ts)
 
     def test_single_muts(self):
-        ts = msprime.simulate(10, random_seed=self.seed, mutation_rate=3.0,
-                              recombination_rate=1.0)
+        ts = msprime.simulate(
+            10, random_seed=self.seed, mutation_rate=3.0, recombination_rate=1.0
+        )
         self.verify_parents(ts)
 
     def test_with_jukes_cantor(self):
-        ts = msprime.simulate(10, random_seed=self.seed, mutation_rate=0.0,
-                              recombination_rate=1.0)
+        ts = msprime.simulate(
+            10, random_seed=self.seed, mutation_rate=0.0, recombination_rate=1.0
+        )
         # make *lots* of recurrent mutations
-        mut_ts = tsutil.jukes_cantor(ts, num_sites=10, mu=1,
-                                     multiple_per_node=False, seed=self.seed)
+        mut_ts = tsutil.jukes_cantor(
+            ts, num_sites=10, mu=1, multiple_per_node=False, seed=self.seed
+        )
         self.verify_parents(mut_ts)
 
     def test_with_jukes_cantor_multiple_per_node(self):
-        ts = msprime.simulate(10, random_seed=self.seed, mutation_rate=0.0,
-                              recombination_rate=1.0)
+        ts = msprime.simulate(
+            10, random_seed=self.seed, mutation_rate=0.0, recombination_rate=1.0
+        )
         # make *lots* of recurrent mutations
-        mut_ts = tsutil.jukes_cantor(ts, num_sites=10, mu=1,
-                                     multiple_per_node=True, seed=self.seed)
+        mut_ts = tsutil.jukes_cantor(
+            ts, num_sites=10, mu=1, multiple_per_node=True, seed=self.seed
+        )
         self.verify_parents(mut_ts)
 
     def verify_branch_mutations(self, ts, mutations_per_branch):
@@ -4571,6 +5030,7 @@ class TestSimpleTreeAlgorithm(unittest.TestCase):
 
     See TestHoleyTreeSequences above for further tests on wacky topologies.
     """
+
     def test_zero_nodes(self):
         tables = tskit.TableCollection(1)
         ts = tables.tree_sequence()
@@ -4667,10 +5127,15 @@ class ExampleTopologyMixin(object):
 
     def test_nonbinary_trees(self):
         demographic_events = [
-            msprime.SimpleBottleneck(time=1.0, population=0, proportion=0.95)]
+            msprime.SimpleBottleneck(time=1.0, population=0, proportion=0.95)
+        ]
         ts = msprime.simulate(
-            20, recombination_rate=10, mutation_rate=5,
-            demographic_events=demographic_events, random_seed=7)
+            20,
+            recombination_rate=10,
+            mutation_rate=5,
+            demographic_events=demographic_events,
+            random_seed=7,
+        )
         found = False
         for e in ts.edgesets():
             if len(e.children) > 2:
@@ -4694,6 +5159,7 @@ class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
     """
     Tests for the sample lists algorithm.
     """
+
     def verify(self, ts):
         tree1 = tsutil.SampleListTree(ts)
         s = str(tree1)
@@ -4720,9 +5186,11 @@ class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
                 index = tree1.left_sample[u]
                 if index != tskit.NULL:
                     self.assertEqual(
-                        sample_index_map[tree1.left_sample[u]], samples2[0])
+                        sample_index_map[tree1.left_sample[u]], samples2[0]
+                    )
                     self.assertEqual(
-                        sample_index_map[tree1.right_sample[u]], samples2[-1])
+                        sample_index_map[tree1.right_sample[u]], samples2[-1]
+                    )
                     stop = tree1.right_sample[u]
                     while True:
                         assert index != -1
@@ -4739,6 +5207,7 @@ class TestOneSampleRoot(unittest.TestCase, ExampleTopologyMixin):
     Tests for the standard root threshold of subtending at least
     one sample.
     """
+
     def verify(self, ts):
         tree1 = tsutil.RootThresholdTree(ts, root_threshold=1)
         tree2 = tskit.Tree(ts)
@@ -4762,6 +5231,7 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
     """
     Tests for the root criteria of subtending at least k samples.
     """
+
     def verify(self, ts):
         for k in range(1, 5):
             tree1 = tsutil.RootThresholdTree(ts, root_threshold=k)
@@ -4788,6 +5258,7 @@ class TestSquashEdges(unittest.TestCase):
     """
     Tests of the squash_edges function.
     """
+
     def do_squash(self, ts, compare_lib=True):
         squashed = ts.tables.edges
         squashed.squash()
@@ -4804,19 +5275,23 @@ class TestSquashEdges(unittest.TestCase):
         #   2
         #  / \
         # 0   1
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1       0               0.00000000000000
         1       1       0               0.00000000000000
         2       0       0               1.00000000000000
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       0.00000000      0.50000000      2       0
         1       0.00000000      0.50000000      2       1
         2       0.50000000      1.00000000      2       0
         3       0.50000000      1.00000000      2       1
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
         self.assertEqual(all(edges.left), 0)
@@ -4828,16 +5303,20 @@ class TestSquashEdges(unittest.TestCase):
         # 1
         # |
         # 0
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1           0               0.0
         1       0           0               1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       0.40            1.0             1       0
         0       0.00            0.40            1       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
         self.assertEqual(edges.left[0], 0)
@@ -4849,19 +5328,23 @@ class TestSquashEdges(unittest.TestCase):
         #   2
         #  / \
         # 0   1
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1       0               0.00000000000000
         1       1       0               0.00000000000000
         2       0       0               1.00000000000000
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       0.50000000      1.00000000      2       1
         1       0.50000000      1.00000000      2       0
         2       0.00000000      0.50000000      2       1
         3       0.00000000      0.50000000      2       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
         self.assertEqual(all(edges.left), 0)
@@ -4873,19 +5356,23 @@ class TestSquashEdges(unittest.TestCase):
         #   2
         #  / \
         # 0   1
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1       0               0.00000000000000
         1       1       0               0.00000000000000
         2       0       0               1.00000000000000
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       0.50000000      1.00000000      2       1
         2       0.00000000      0.50000000      2       1
         3       0.00000000      0.50000000      2       0
         1       0.50000000      1.00000000      2       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
         self.assertEqual(all(edges.left), 0)
@@ -4897,7 +5384,8 @@ class TestSquashEdges(unittest.TestCase):
         #   4       5
         #  / \     / \
         # 0   1   2   3
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1       0               0.00000000000000
         1       1       0               0.00000000000000
@@ -4905,8 +5393,10 @@ class TestSquashEdges(unittest.TestCase):
         3       1       0               0.00000000000000
         4       0       0               1.00000000000000
         5       0       0               1.00000000000000
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         5       0.50000000      1.00000000      5       3
         6       0.50000000      1.00000000      5       2
@@ -4916,7 +5406,8 @@ class TestSquashEdges(unittest.TestCase):
         10      0.00000000      0.40000000      4       1
         11      0.40000000      1.00000000      4       0
         12      0.00000000      0.40000000      4       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
         self.assertEqual(all(edges.left), 0)
@@ -4925,17 +5416,21 @@ class TestSquashEdges(unittest.TestCase):
         self.assertEqual(list(edges.child), [0, 1, 2, 3])
 
     def test_squash_overlapping_intervals(self):
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   population      time
         0       1           0               0.0
         1       0           0               1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         id      left            right           parent  child
         0       0.00            0.50            1       0
         1       0.40            0.80            1       0
         2       0.60            1.00            1       0
-        """)
+        """
+        )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
         with self.assertRaises(tskit.LibraryError):
@@ -4970,7 +5465,7 @@ class TestSquashEdges(unittest.TestCase):
 
             # Add new edges to the list.
             for r in range(1, len(new_range)):
-                new = tskit.Edge(new_range[r-1], new_range[r], e.parent, e.child)
+                new = tskit.Edge(new_range[r - 1], new_range[r], e.parent, e.child)
                 sliced_edges.append(new)
 
         # Shuffle the edges and create a new edge table.
@@ -5008,9 +5503,10 @@ def squash_edges(ts):
     last_e = edges[0]
     for e in edges[1:]:
         condition = (
-            e.parent != last_e.parent or
-            e.child != last_e.child or
-            e.left != last_e.right)
+            e.parent != last_e.parent
+            or e.child != last_e.child
+            or e.left != last_e.right
+        )
         if condition:
             squashed.append(last_e)
             last_e = e
@@ -5118,15 +5614,18 @@ class TestReduceTopology(unittest.TestCase):
                 self.assertEqual(len(site.mutations), len(minimised_site.mutations))
 
                 for mutation, minimised_mutation in zip(
-                        site.mutations, minimised_site.mutations):
+                    site.mutations, minimised_site.mutations
+                ):
                     self.assertEqual(
-                        mutation.derived_state, minimised_mutation.derived_state)
+                        mutation.derived_state, minimised_mutation.derived_state
+                    )
                     self.assertEqual(mutation.metadata, minimised_mutation.metadata)
                     self.assertEqual(mutation.parent, minimised_mutation.parent)
                     self.assertEqual(node_map[mutation.node], minimised_mutation.node)
             if tree.num_sites > 0:
                 mapped_dict = {
-                    node_map[u]: node_map[v] for u, v in tree.parent_dict.items()}
+                    node_map[u]: node_map[v] for u, v in tree.parent_dict.items()
+                }
                 self.assertEqual(mapped_dict, minimised_tree.parent_dict)
         self.assertTrue(np.array_equal(ts.genotype_matrix(), mts.genotype_matrix()))
 
@@ -5137,13 +5636,14 @@ class TestReduceTopology(unittest.TestCase):
 
         # Verify against simplify implementations.
         s = tests.Simplifier(
-            ts, ts.samples(), reduce_to_site_topology=True, filter_sites=False)
+            ts, ts.samples(), reduce_to_site_topology=True, filter_sites=False
+        )
         sts1, _ = s.simplify()
         sts2 = ts.simplify(reduce_to_site_topology=True, filter_sites=False)
         t1 = mts.tables
         for sts in [sts2, sts2]:
             t2 = sts.tables
-            self.assertEqual(t1.nodes,  t2.nodes)
+            self.assertEqual(t1.nodes, t2.nodes)
             self.assertEqual(t1.edges, t2.edges)
             self.assertEqual(t1.sites, t2.sites)
             self.assertEqual(t1.mutations, t2.mutations)
@@ -5208,7 +5708,9 @@ class TestReduceTopology(unittest.TestCase):
         self.verify(ts)
 
     def test_large_recombination(self):
-        ts = msprime.simulate(25, random_seed=12, recombination_rate=5, mutation_rate=15)
+        ts = msprime.simulate(
+            25, random_seed=12, recombination_rate=5, mutation_rate=15
+        )
         self.verify(ts)
 
     def test_no_recombination(self):
@@ -5256,7 +5758,7 @@ def search_sorted(a, v):
     lower = 0
     while upper - lower > 1:
         mid = (upper + lower) // 2
-        if (v >= a[mid]):
+        if v >= a[mid]:
             lower = mid
         else:
             upper = mid
@@ -5270,6 +5772,7 @@ class TestSearchSorted(unittest.TestCase):
     """
     Tests for the basic implementation of search_sorted.
     """
+
     def verify(self, a):
         a = np.array(a)
         start, end = a[0], a[-1]
@@ -5327,13 +5830,14 @@ class TestDeleteSites(unittest.TestCase):
     """
     Tests for the TreeSequence.delete_sites method
     """
+
     def ts_with_4_sites(self):
         ts = msprime.simulate(8, random_seed=3)
         tables = ts.dump_tables()
-        tables.sites.set_columns(np.arange(0, 1, 0.25), *tskit.pack_strings(['G'] * 4))
-        tables.mutations.add_row(site=1, node=ts.first().parent(0), derived_state='C')
-        tables.mutations.add_row(site=1, node=0, derived_state='T', parent=0)
-        tables.mutations.add_row(site=2, node=1, derived_state='A')
+        tables.sites.set_columns(np.arange(0, 1, 0.25), *tskit.pack_strings(["G"] * 4))
+        tables.mutations.add_row(site=1, node=ts.first().parent(0), derived_state="C")
+        tables.mutations.add_row(site=1, node=0, derived_state="T", parent=0)
+        tables.mutations.add_row(site=2, node=1, derived_state="A")
         return tables.tree_sequence()
 
     def test_remove_by_index(self):
@@ -5450,6 +5954,7 @@ class TestKeepSingleInterval(unittest.TestCase):
     """
     Tests for cutting up tree sequences along the genome.
     """
+
     def test_slice_by_tree_positions(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
         breakpoints = list(ts.breakpoints())
@@ -5481,14 +5986,16 @@ class TestKeepSingleInterval(unittest.TestCase):
         self.assertAlmostEqual(ts_sliced.sequence_length, 1.0)
         self.assertEqual(
             ts_sliced.num_mutations,
-            ts.num_mutations - first_3_mutations - last_3_mutations)
+            ts.num_mutations - first_3_mutations - last_3_mutations,
+        )
 
     def test_slice_by_position(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
         ts_sliced = ts.keep_intervals([[0.4, 0.6]])
         positions = ts.tables.sites.position
         self.assertEqual(
-            ts_sliced.num_sites, np.sum((positions >= 0.4) & (positions < 0.6)))
+            ts_sliced.num_sites, np.sum((positions >= 0.4) & (positions < 0.6))
+        )
 
     def test_slice_unsimplified(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
@@ -5520,6 +6027,7 @@ class TestKeepIntervals(TopologyTestCase):
     Tests for keep_intervals operation, where we slice out multiple disjoint
     intervals concurrently.
     """
+
     def example_intervals(self, tables):
         L = tables.sequence_length
         yield []
@@ -5531,7 +6039,8 @@ class TestKeepIntervals(TopologyTestCase):
         yield [(0.25 * L, 0.5 * L), (0.75 * L, 0.8 * L)]
 
     def do_keep_intervals(
-            self, tables, intervals, simplify=True, record_provenance=True):
+        self, tables, intervals, simplify=True, record_provenance=True
+    ):
         t1 = tables.copy()
         simple_keep_intervals(t1, intervals, simplify, record_provenance)
         t2 = tables.copy()
@@ -5547,12 +6056,7 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_bad_intervals(self):
         tables = tskit.TableCollection(10)
-        bad_intervals = [
-            [[1, 1]],
-            [[-1, 0]],
-            [[0, 11]],
-            [[0, 5], [4, 6]]
-        ]
+        bad_intervals = [[[1, 1]], [[-1, 0]], [[0, 11]], [[0, 5], [4, 6]]]
         for intervals in bad_intervals:
             with self.assertRaises(ValueError):
                 tables.keep_intervals(intervals)
@@ -5561,7 +6065,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_one_interval(self):
         ts = msprime.simulate(
-            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2)
+            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2
+        )
         tables = ts.tables
         intervals = [(0.3, 0.7)]
         for simplify in (True, False):
@@ -5570,7 +6075,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_two_intervals(self):
         ts = msprime.simulate(
-            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2)
+            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2
+        )
         tables = ts.tables
         intervals = [(0.1, 0.2), (0.8, 0.9)]
         for simplify in (True, False):
@@ -5579,7 +6085,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_ten_intervals(self):
         ts = msprime.simulate(
-            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2)
+            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2
+        )
         tables = ts.tables
         intervals = [(x, x + 0.05) for x in np.arange(0.0, 1.0, 0.1)]
         for simplify in (True, False):
@@ -5588,7 +6095,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_hundred_intervals(self):
         ts = msprime.simulate(
-            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2)
+            10, random_seed=self.random_seed, recombination_rate=2, mutation_rate=2
+        )
         tables = ts.tables
         intervals = [(x, x + 0.005) for x in np.arange(0.0, 1.0, 0.01)]
         for simplify in (True, False):
@@ -5597,7 +6105,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_regular_intervals(self):
         ts = msprime.simulate(
-            3, random_seed=1234, recombination_rate=2, mutation_rate=2)
+            3, random_seed=1234, recombination_rate=2, mutation_rate=2
+        )
         tables = ts.tables
         eps = 0.0125
         for num_intervals in range(2, 10):
@@ -5644,13 +6153,19 @@ class TestKeepIntervals(TopologyTestCase):
     def test_many_trees_sequence_length_infinite_sites(self):
         for L in [0.5, 1.5, 3.3333]:
             ts = msprime.simulate(
-                6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1)
+                6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1
+            )
             self.verify(ts.tables)
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(
-            4, 5, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=10)
+            4,
+            5,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=10,
+        )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.05, random_seed=234)
         self.assertGreater(ts.num_sites, 0)
@@ -5658,8 +6173,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
-            6, 5, seed=3, deep_history=True, initial_generation_samples=True,
-            num_loci=2)
+            6, 5, seed=3, deep_history=True, initial_generation_samples=True, num_loci=2
+        )
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
@@ -5668,8 +6183,13 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_wright_fisher_initial_generation_no_deep_history(self):
         tables = wf.wf_sim(
-            7, 15, seed=202, deep_history=False, initial_generation_samples=True,
-            num_loci=5)
+            7,
+            15,
+            seed=202,
+            deep_history=False,
+            initial_generation_samples=True,
+            num_loci=5,
+        )
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.01, random_seed=2)
@@ -5678,8 +6198,13 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
         tables = wf.wf_sim(
-            8, 15, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=20)
+            8,
+            15,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=20,
+        )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.006, random_seed=2)
         self.assertGreater(ts.num_sites, 0)
@@ -5687,8 +6212,13 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            9, 10, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            9,
+            10,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
@@ -5720,7 +6250,9 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
     def test_ts_single_tree_keep_middle(self):
         ts = msprime.simulate(10, random_seed=2)
         ts_keep = ts.keep_intervals([[0.25, 0.5]], record_provenance=False)
-        ts_delete = ts.delete_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
+        ts_delete = ts.delete_intervals(
+            [[0, 0.25], [0.5, 1.0]], record_provenance=False
+        )
         self.assertTrue(ts_equal(ts_keep, ts_delete))
 
     def test_ts_single_tree_delete_middle(self):
@@ -5734,6 +6266,7 @@ class TestTrim(unittest.TestCase):
     """
     Test the trimming functionality
     """
+
     def add_mutations(self, ts, position, ancestral_state, derived_states, nodes):
         """
         Create a site at the specified position and assign mutations to the specified
@@ -5754,31 +6287,31 @@ class TestTrim(unittest.TestCase):
         self.assertEqual(len(source_sites), len(trimmed_sites))
         for source_site, trimmed_site in zip(source_sites, trimmed_sites):
             self.assertAlmostEqual(
-                source_site.position, position_offset + trimmed_site.position)
-            self.assertEqual(
-                source_site.ancestral_state, trimmed_site.ancestral_state)
+                source_site.position, position_offset + trimmed_site.position
+            )
+            self.assertEqual(source_site.ancestral_state, trimmed_site.ancestral_state)
             self.assertEqual(source_site.metadata, trimmed_site.metadata)
-            self.assertEqual(
-                len(source_site.mutations), len(trimmed_site.mutations))
+            self.assertEqual(len(source_site.mutations), len(trimmed_site.mutations))
             for source_mut, trimmed_mut in zip(
-                    source_site.mutations, trimmed_site.mutations):
+                source_site.mutations, trimmed_site.mutations
+            ):
                 self.assertEqual(source_mut.node, trimmed_mut.node)
-                self.assertEqual(
-                    source_mut.derived_state, trimmed_mut.derived_state)
-                self.assertEqual(
-                    source_mut.metadata, trimmed_mut.metadata)
+                self.assertEqual(source_mut.derived_state, trimmed_mut.derived_state)
+                self.assertEqual(source_mut.metadata, trimmed_mut.metadata)
                 # mutation.parent id may have changed after deleting redundant mutations
                 if source_mut.parent == trimmed_mut.parent == tskit.NULL:
                     pass
                 else:
                     self.assertEqual(
                         source_tree.tree_sequence.mutation(source_mut.parent).node,
-                        trimmed_tree.tree_sequence.mutation(trimmed_mut.parent).node)
+                        trimmed_tree.tree_sequence.mutation(trimmed_mut.parent).node,
+                    )
 
     def verify_ltrim(self, source_ts, trimmed_ts):
         deleted_span = source_ts.first().span
         self.assertAlmostEqual(
-            source_ts.sequence_length, trimmed_ts.sequence_length + deleted_span)
+            source_ts.sequence_length, trimmed_ts.sequence_length + deleted_span
+        )
         self.assertEqual(source_ts.num_trees, trimmed_ts.num_trees + 1)
         for j in range(trimmed_ts.num_trees):
             source_tree = source_ts.at_index(j + 1)
@@ -5786,13 +6319,15 @@ class TestTrim(unittest.TestCase):
             self.assertEqual(source_tree.parent_dict, trimmed_tree.parent_dict)
             self.assertAlmostEqual(source_tree.span, trimmed_tree.span)
             self.assertAlmostEqual(
-                source_tree.interval[0], trimmed_tree.interval[0] + deleted_span)
+                source_tree.interval[0], trimmed_tree.interval[0] + deleted_span
+            )
             self.verify_sites(source_tree, trimmed_tree, deleted_span)
 
     def verify_rtrim(self, source_ts, trimmed_ts):
         deleted_span = source_ts.last().span
         self.assertAlmostEqual(
-            source_ts.sequence_length, trimmed_ts.sequence_length + deleted_span)
+            source_ts.sequence_length, trimmed_ts.sequence_length + deleted_span
+        )
         self.assertEqual(source_ts.num_trees, trimmed_ts.num_trees + 1)
         for j in range(trimmed_ts.num_trees):
             source_tree = source_ts.at_index(j)
@@ -5808,7 +6343,7 @@ class TestTrim(unittest.TestCase):
         """
         new_ts = ts.delete_intervals([[0.0, left]])
         for j, x in enumerate(np.linspace(0, left, num_sites, endpoint=False)):
-            new_ts = self.add_mutations(new_ts, x, 'A' * j, ['T'] * j, range(j+1))
+            new_ts = self.add_mutations(new_ts, x, "A" * j, ["T"] * j, range(j + 1))
         return new_ts
 
     def clear_right_mutate(self, ts, right, num_sites):
@@ -5818,8 +6353,9 @@ class TestTrim(unittest.TestCase):
         """
         new_ts = ts.delete_intervals([[right, ts.sequence_length]])
         for j, x in enumerate(
-                np.linspace(right, ts.sequence_length, num_sites, endpoint=False)):
-            new_ts = self.add_mutations(new_ts, x, 'A' * j, ['T'] * j, range(j+1))
+            np.linspace(right, ts.sequence_length, num_sites, endpoint=False)
+        ):
+            new_ts = self.add_mutations(new_ts, x, "A" * j, ["T"] * j, range(j + 1))
         return new_ts
 
     def clear_left_right_234(self, left, right):
@@ -5838,10 +6374,11 @@ class TestTrim(unittest.TestCase):
         right_root = ts.at(right_pos).root
         # Clear
         ts = ts.keep_intervals([[left, right]], simplify=False)
-        ts = self.add_mutations(ts, left_pos, 'A', ['T', 'C'], [left_root, 0])
-        ts = self.add_mutations(ts, mid_pos, 'T', ['A', 'C', 'G'], [mid_root, 0, 1])
+        ts = self.add_mutations(ts, left_pos, "A", ["T", "C"], [left_root, 0])
+        ts = self.add_mutations(ts, mid_pos, "T", ["A", "C", "G"], [mid_root, 0, 1])
         ts = self.add_mutations(
-            ts, right_pos, 'X', ['T', 'C', 'G', 'A'], [right_root, 0, 1, 2])
+            ts, right_pos, "X", ["T", "C", "G", "A"], [right_root, 0, 1, 2]
+        )
         self.assertNotEqual(np.min(ts.tables.edges.left), 0)
         self.assertEqual(ts.num_mutations, 9)
         self.assertEqual(ts.num_sites, 3)
@@ -5863,17 +6400,23 @@ class TestTrim(unittest.TestCase):
         self.verify_ltrim(ts, ts.ltrim())
 
     def test_ltrim_many_trees(self):
-        ts = msprime.simulate(10, recombination_rate=10, mutation_rate=12, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=10, mutation_rate=12, random_seed=2
+        )
         ts = self.clear_left_mutate(ts, 0.5, 10)
         self.verify_ltrim(ts, ts.ltrim())
 
     def test_ltrim_many_trees_left_min(self):
-        ts = msprime.simulate(10, recombination_rate=10, mutation_rate=12, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=10, mutation_rate=12, random_seed=2
+        )
         ts = self.clear_left_mutate(ts, sys.float_info.min, 10)
         self.verify_ltrim(ts, ts.ltrim())
 
     def test_ltrim_many_trees_left_epsilon(self):
-        ts = msprime.simulate(10, recombination_rate=10, mutation_rate=12, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=10, mutation_rate=12, random_seed=2
+        )
         ts = self.clear_left_mutate(ts, sys.float_info.epsilon, 0)
         self.verify_ltrim(ts, ts.ltrim())
 
@@ -5907,17 +6450,23 @@ class TestTrim(unittest.TestCase):
         self.verify_rtrim(ts, ts.rtrim())
 
     def test_rtrim_many_trees(self):
-        ts = msprime.simulate(10, recombination_rate=10, mutation_rate=12, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=10, mutation_rate=12, random_seed=2
+        )
         ts = self.clear_right_mutate(ts, 0.5, 10)
         self.verify_rtrim(ts, ts.rtrim())
 
     def test_rtrim_many_trees_left_min(self):
-        ts = msprime.simulate(10, recombination_rate=10, mutation_rate=12, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=10, mutation_rate=12, random_seed=2
+        )
         ts = self.clear_right_mutate(ts, sys.float_info.min, 10)
         self.verify_rtrim(ts, ts.rtrim())
 
     def test_rtrim_many_trees_left_epsilon(self):
-        ts = msprime.simulate(10, recombination_rate=10, mutation_rate=12, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=10, mutation_rate=12, random_seed=2
+        )
         ts = self.clear_right_mutate(ts, sys.float_info.epsilon, 0)
         self.verify_rtrim(ts, ts.rtrim())
 
@@ -5933,7 +6482,8 @@ class TestTrim(unittest.TestCase):
         self.assertEqual(trimmed_ts.num_sites, 2)
         self.assertEqual(trimmed_ts.num_mutations, 5)  # We should have deleted 4
         self.assertEqual(
-            np.max(trimmed_ts.tables.edges.right), trimmed_ts.tables.sequence_length)
+            np.max(trimmed_ts.tables.edges.right), trimmed_ts.tables.sequence_length
+        )
         self.verify_rtrim(ts, trimmed_ts)
 
     def test_trim_multiple_mutations(self):
@@ -5944,7 +6494,8 @@ class TestTrim(unittest.TestCase):
         self.assertEqual(trimmed_ts.num_sites, 1)
         self.assertEqual(np.min(trimmed_ts.tables.edges.left), 0)
         self.assertEqual(
-            np.max(trimmed_ts.tables.edges.right), trimmed_ts.tables.sequence_length)
+            np.max(trimmed_ts.tables.edges.right), trimmed_ts.tables.sequence_length
+        )
 
     def test_trims_no_effect(self):
         # Deleting from middle should have no effect on any trim function

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -84,13 +84,14 @@ def path_length(tr, x, y):
 
 @contextlib.contextmanager
 def suppress_division_by_zero_warning():
-    with np.errstate(invalid='ignore', divide='ignore'):
+    with np.errstate(invalid="ignore", divide="ignore"):
         yield
 
 
 ##############################
 # Branch general stat algorithms
 ##############################
+
 
 def windowed_tree_stat(ts, stat, windows, span_normalise=True):
     shape = list(stat.shape)
@@ -125,8 +126,9 @@ def windowed_tree_stat(ts, stat, windows, span_normalise=True):
     return A
 
 
-def naive_branch_general_stat(ts, w, f, windows=None, polarised=False,
-                              span_normalise=True):
+def naive_branch_general_stat(
+    ts, w, f, windows=None, polarised=False, span_normalise=True
+):
     if windows is None:
         windows = [0.0, ts.sequence_length]
     n, k = w.shape
@@ -146,7 +148,8 @@ def naive_branch_general_stat(ts, w, f, windows=None, polarised=False,
         else:
             s = sum(
                 tree.branch_length(u) * (f(x[u]) + f(total - x[u]))
-                for u in tree.nodes())
+                for u in tree.nodes()
+            )
         sigma[tree.index] = s * tree.span
     if isinstance(windows, str) and windows == "trees":
         # need to average across the windows
@@ -158,8 +161,9 @@ def naive_branch_general_stat(ts, w, f, windows=None, polarised=False,
         return windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
 
 
-def branch_general_stat(ts, sample_weights, summary_func, windows=None,
-                        polarised=False, span_normalise=True):
+def branch_general_stat(
+    ts, sample_weights, summary_func, windows=None, polarised=False, span_normalise=True
+):
     """
     Efficient implementation of the algorithm used as the basis for the
     underlying C version.
@@ -249,6 +253,7 @@ def branch_general_stat(ts, sample_weights, summary_func, windows=None,
 # Site general stat algorithms
 ##############################
 
+
 def windowed_sitewise_stat(ts, sigma, windows, span_normalise=True):
     M = sigma.shape[1]
     A = np.zeros((len(windows) - 1, M))
@@ -265,8 +270,9 @@ def windowed_sitewise_stat(ts, sigma, windows, span_normalise=True):
     return A
 
 
-def naive_site_general_stat(ts, W, f, windows=None, polarised=False,
-                            span_normalise=True):
+def naive_site_general_stat(
+    ts, W, f, windows=None, polarised=False, span_normalise=True
+):
     n, K = W.shape
     # Hack to determine M
     M = len(f(W[0]))
@@ -291,12 +297,13 @@ def naive_site_general_stat(ts, W, f, windows=None, polarised=False,
                 del state_map[site.ancestral_state]
             sigma[site.id] += sum(map(f, state_map.values()))
     return windowed_sitewise_stat(
-        ts, sigma, ts.parse_windows(windows),
-        span_normalise=span_normalise)
+        ts, sigma, ts.parse_windows(windows), span_normalise=span_normalise
+    )
 
 
-def site_general_stat(ts, sample_weights, summary_func, windows=None, polarised=False,
-                      span_normalise=True):
+def site_general_stat(
+    ts, sample_weights, summary_func, windows=None, polarised=False, span_normalise=True
+):
     """
     Problem: 'sites' is different that the other windowing options
     because if we output by site we don't want to normalize by length of the window.
@@ -306,7 +313,7 @@ def site_general_stat(ts, sample_weights, summary_func, windows=None, polarised=
     num_windows = windows.shape[0] - 1
     n, state_dim = sample_weights.shape
     # Determine result_dim
-    result_dim, = summary_func(sample_weights[0]).shape
+    (result_dim,) = summary_func(sample_weights[0]).shape
     result = np.zeros((num_windows, result_dim))
     state = np.zeros((ts.num_nodes, state_dim))
     state[ts.samples()] = sample_weights
@@ -335,11 +342,13 @@ def site_general_stat(ts, sample_weights, summary_func, windows=None, polarised=
             assert left <= sites.position[site_index]
             ancestral_state = sites[site_index].ancestral_state
             allele_state = collections.defaultdict(
-                functools.partial(np.zeros, state_dim))
+                functools.partial(np.zeros, state_dim)
+            )
             allele_state[ancestral_state][:] = total_weight
             while (
-                    mutation_index < len(mutations)
-                    and mutations[mutation_index].site == site_index):
+                mutation_index < len(mutations)
+                and mutations[mutation_index].site == site_index
+            ):
                 mutation = mutations[mutation_index]
                 allele_state[mutation.derived_state] += state[mutation.node]
                 if mutation.parent != -1:
@@ -372,8 +381,9 @@ def site_general_stat(ts, sample_weights, summary_func, windows=None, polarised=
 ##############################
 
 
-def naive_node_general_stat(ts, W, f, windows=None, polarised=False,
-                            span_normalise=True):
+def naive_node_general_stat(
+    ts, W, f, windows=None, polarised=False, span_normalise=True
+):
     windows = ts.parse_windows(windows)
     n, K = W.shape
     M = f(W[0]).shape[0]
@@ -394,8 +404,9 @@ def naive_node_general_stat(ts, W, f, windows=None, polarised=False,
     return windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
 
 
-def node_general_stat(ts, sample_weights, summary_func, windows=None, polarised=False,
-                      span_normalise=True):
+def node_general_stat(
+    ts, sample_weights, summary_func, windows=None, polarised=False, span_normalise=True
+):
     """
     Efficient implementation of the algorithm used as the basis for the
     underlying C version.
@@ -452,7 +463,9 @@ def node_general_stat(ts, sample_weights, summary_func, windows=None, polarised=
             w_right = windows[window_index + 1]
             # Flush the contribution of all nodes to the current window.
             for u in range(ts.num_nodes):
-                result[window_index, u] += (w_right - last_update[u]) * current_values[u]
+                result[window_index, u] += (w_right - last_update[u]) * current_values[
+                    u
+                ]
                 last_update[u] = w_right
             window_index += 1
 
@@ -464,8 +477,14 @@ def node_general_stat(ts, sample_weights, summary_func, windows=None, polarised=
 
 
 def general_stat(
-        ts, sample_weights, summary_func, windows=None, polarised=False,
-        mode="site", span_normalise=True):
+    ts,
+    sample_weights,
+    summary_func,
+    windows=None,
+    polarised=False,
+    mode="site",
+    span_normalise=True,
+):
     """
     General iterface for algorithms above. Directly corresponds to the interface
     for TreeSequence.general_stat.
@@ -473,10 +492,16 @@ def general_stat(
     method_map = {
         "site": site_general_stat,
         "node": node_general_stat,
-        "branch": branch_general_stat}
+        "branch": branch_general_stat,
+    }
     return method_map[mode](
-        ts, sample_weights, summary_func, windows=windows, polarised=polarised,
-        span_normalise=span_normalise)
+        ts,
+        sample_weights,
+        summary_func,
+        windows=windows,
+        polarised=polarised,
+        span_normalise=span_normalise,
+    )
 
 
 def upper_tri_to_matrix(x):
@@ -485,7 +510,7 @@ def upper_tri_to_matrix(x):
     in row-major order, including the diagonal, return the corresponding matrix.
     """
     # n^2 + n = 2 u => n = (-1 + sqrt(1 + 8*u))/2
-    n = int((np.sqrt(1 + 8 * len(x)) - 1)/2.0)
+    n = int((np.sqrt(1 + 8 * len(x)) - 1) / 2.0)
     out = np.ones((n, n))
     k = 0
     for i in range(n):
@@ -504,6 +529,7 @@ class StatsTestCase(unittest.TestCase):
     """
     Provides convenience functions.
     """
+
     def assertListAlmostEqual(self, x, y):
         self.assertEqual(len(x), len(y))
         for a, b in zip(x, y):
@@ -531,6 +557,7 @@ class TopologyExamplesMixin(object):
     Derived classes need to define a 'verify' function which will perform the
     actual tests.
     """
+
     def test_single_tree(self):
         ts = msprime.simulate(6, random_seed=1)
         self.verify(ts)
@@ -556,16 +583,21 @@ class TopologyExamplesMixin(object):
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(
-            4, 5, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            4,
+            5,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         self.verify(ts)
 
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
-            6, 5, seed=3, deep_history=True, initial_generation_samples=True,
-            num_loci=2)
+            6, 5, seed=3, deep_history=True, initial_generation_samples=True, num_loci=2
+        )
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
@@ -573,8 +605,13 @@ class TopologyExamplesMixin(object):
 
     def test_wright_fisher_initial_generation_no_deep_history(self):
         tables = wf.wf_sim(
-            6, 15, seed=202, deep_history=False, initial_generation_samples=True,
-            num_loci=5)
+            6,
+            15,
+            seed=202,
+            deep_history=False,
+            initial_generation_samples=True,
+            num_loci=5,
+        )
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
@@ -582,24 +619,39 @@ class TopologyExamplesMixin(object):
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
         tables = wf.wf_sim(
-            6, 5, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=4)
+            6,
+            5,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=4,
+        )
         tables.sort()
         ts = tables.tree_sequence()
         self.verify(ts)
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            5, 8, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            5,
+            8,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         self.verify(ts)
 
     def test_wright_fisher_simplified_multiple_roots(self):
         tables = wf.wf_sim(
-            6, 8, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=3)
+            6,
+            8,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=3,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         self.verify(ts)
@@ -635,6 +687,7 @@ class MutatedTopologyExamplesMixin(object):
     Derived classes need to define a 'verify' function which will perform the
     actual tests.
     """
+
     def test_single_tree_no_sites(self):
         ts = msprime.simulate(6, random_seed=1)
         self.assertEqual(ts.num_sites, 0)
@@ -734,13 +787,19 @@ class MutatedTopologyExamplesMixin(object):
     def test_many_trees_sequence_length_infinite_sites(self):
         for L in [0.5, 1.5, 3.3333]:
             ts = msprime.simulate(
-                6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1)
+                6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1
+            )
             self.verify(ts)
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(
-            4, 5, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=10)
+            4,
+            5,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=10,
+        )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.05, random_seed=234)
         self.assertGreater(ts.num_sites, 0)
@@ -748,8 +807,8 @@ class MutatedTopologyExamplesMixin(object):
 
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
-            6, 5, seed=3, deep_history=True, initial_generation_samples=True,
-            num_loci=2)
+            6, 5, seed=3, deep_history=True, initial_generation_samples=True, num_loci=2
+        )
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
@@ -758,8 +817,13 @@ class MutatedTopologyExamplesMixin(object):
 
     def test_wright_fisher_initial_generation_no_deep_history(self):
         tables = wf.wf_sim(
-            7, 15, seed=202, deep_history=False, initial_generation_samples=True,
-            num_loci=5)
+            7,
+            15,
+            seed=202,
+            deep_history=False,
+            initial_generation_samples=True,
+            num_loci=5,
+        )
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.01, random_seed=2)
@@ -768,8 +832,13 @@ class MutatedTopologyExamplesMixin(object):
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
         tables = wf.wf_sim(
-            8, 15, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=20)
+            8,
+            15,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=20,
+        )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.006, random_seed=2)
         self.assertGreater(ts.num_sites, 0)
@@ -777,8 +846,13 @@ class MutatedTopologyExamplesMixin(object):
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            9, 10, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            9,
+            10,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
@@ -876,11 +950,11 @@ class WeightStatsMixin(object):
 
     def verify(self, ts):
         for W, windows in subset_combos(
-                self.example_weights(ts), example_windows(ts), p=0.1):
+            self.example_weights(ts), example_windows(ts), p=0.1
+        ):
             self.verify_weighted_stat(ts, W, windows=windows)
 
-    def verify_definition(
-            self, ts, W, windows, summary_func, ts_method, definition):
+    def verify_definition(self, ts, W, windows, summary_func, ts_method, definition):
 
         # general_stat will need an extra column for p
         gW = self.transform_weights(W)
@@ -892,15 +966,16 @@ class WeightStatsMixin(object):
         # Determine output_dim of the function
         M = len(wrapped_summary_func(gW[0]))
         for sn in [True, False]:
-            sigma1 = ts.general_stat(gW, wrapped_summary_func, M,
-                                     windows, mode=self.mode,
-                                     span_normalise=sn)
-            sigma2 = general_stat(ts, gW, wrapped_summary_func, windows, mode=self.mode,
-                                  span_normalise=sn)
-            sigma3 = ts_method(W, windows=windows, mode=self.mode,
-                               span_normalise=sn)
-            sigma4 = definition(ts, W, windows=windows, mode=self.mode,
-                                span_normalise=sn)
+            sigma1 = ts.general_stat(
+                gW, wrapped_summary_func, M, windows, mode=self.mode, span_normalise=sn
+            )
+            sigma2 = general_stat(
+                ts, gW, wrapped_summary_func, windows, mode=self.mode, span_normalise=sn
+            )
+            sigma3 = ts_method(W, windows=windows, mode=self.mode, span_normalise=sn)
+            sigma4 = definition(
+                ts, W, windows=windows, mode=self.mode, span_normalise=sn
+            )
 
             self.assertEqual(sigma1.shape, sigma2.shape)
             self.assertEqual(sigma1.shape, sigma3.shape)
@@ -915,16 +990,18 @@ class SampleSetStatsMixin(object):
     Implements the verify method and dispatches it to verify_sample_sets
     for a representative set of sample sets and windows.
     """
+
     def verify(self, ts):
         for sample_sets, windows in subset_combos(
-                example_sample_sets(ts), example_windows(ts)):
+            example_sample_sets(ts), example_windows(ts)
+        ):
             self.verify_sample_sets(ts, sample_sets, windows=windows)
 
     def verify_definition(
-            self, ts, sample_sets, windows, summary_func, ts_method, definition):
+        self, ts, sample_sets, windows, summary_func, ts_method, definition
+    ):
 
-        W = np.array(
-            [[u in A for A in sample_sets] for u in ts.samples()], dtype=float)
+        W = np.array([[u in A for A in sample_sets] for u in ts.samples()], dtype=float)
 
         def wrapped_summary_func(x):
             with suppress_division_by_zero_warning():
@@ -933,14 +1010,18 @@ class SampleSetStatsMixin(object):
         for sn in [True, False]:
             # Determine output_dim of the function
             M = len(summary_func(W[0]))
-            sigma1 = ts.general_stat(W, wrapped_summary_func, M, windows, mode=self.mode,
-                                     span_normalise=sn)
-            sigma2 = general_stat(ts, W, wrapped_summary_func, windows, mode=self.mode,
-                                  span_normalise=sn)
-            sigma3 = ts_method(sample_sets, windows=windows, mode=self.mode,
-                               span_normalise=sn)
-            sigma4 = definition(ts, sample_sets, windows=windows, mode=self.mode,
-                                span_normalise=sn)
+            sigma1 = ts.general_stat(
+                W, wrapped_summary_func, M, windows, mode=self.mode, span_normalise=sn
+            )
+            sigma2 = general_stat(
+                ts, W, wrapped_summary_func, windows, mode=self.mode, span_normalise=sn
+            )
+            sigma3 = ts_method(
+                sample_sets, windows=windows, mode=self.mode, span_normalise=sn
+            )
+            sigma4 = definition(
+                ts, sample_sets, windows=windows, mode=self.mode, span_normalise=sn
+            )
 
             self.assertEqual(sigma1.shape, sigma2.shape)
             self.assertEqual(sigma1.shape, sigma3.shape)
@@ -955,24 +1036,25 @@ class KWaySampleSetStatsMixin(SampleSetStatsMixin):
     Defines the verify definition method, which comparse the results from
     several different ways of defining and computing the same statistic.
     """
-    def verify_definition(
-            self, ts, sample_sets, indexes, windows, summary_func, ts_method,
-            definition):
 
+    def verify_definition(
+        self, ts, sample_sets, indexes, windows, summary_func, ts_method, definition
+    ):
         def wrapped_summary_func(x):
             with suppress_division_by_zero_warning():
                 return summary_func(x)
 
-        W = np.array(
-            [[u in A for A in sample_sets] for u in ts.samples()], dtype=float)
+        W = np.array([[u in A for A in sample_sets] for u in ts.samples()], dtype=float)
         # Determine output_dim of the function
         M = len(wrapped_summary_func(W[0]))
         sigma1 = ts.general_stat(W, wrapped_summary_func, M, windows, mode=self.mode)
         sigma2 = general_stat(ts, W, wrapped_summary_func, windows, mode=self.mode)
         sigma3 = ts_method(
-            sample_sets, indexes=indexes, windows=windows, mode=self.mode)
+            sample_sets, indexes=indexes, windows=windows, mode=self.mode
+        )
         sigma4 = definition(
-            ts, sample_sets, indexes=indexes, windows=windows, mode=self.mode)
+            ts, sample_sets, indexes=indexes, windows=windows, mode=self.mode
+        )
 
         self.assertEqual(sigma1.shape, sigma2.shape)
         self.assertEqual(sigma1.shape, sigma3.shape)
@@ -990,7 +1072,8 @@ class TwoWaySampleSetStatsMixin(KWaySampleSetStatsMixin):
 
     def verify(self, ts):
         for sample_sets, windows in subset_combos(
-                example_sample_sets(ts, min_size=2), example_windows(ts)):
+            example_sample_sets(ts, min_size=2), example_windows(ts)
+        ):
             for indexes in example_sample_set_index_pairs(sample_sets):
                 self.verify_sample_sets_indexes(ts, sample_sets, indexes, windows)
 
@@ -1000,9 +1083,11 @@ class ThreeWaySampleSetStatsMixin(KWaySampleSetStatsMixin):
     Implements the verify method and dispatches it to verify_sample_sets_indexes,
     which gives a representative sample of sample set indexes.
     """
+
     def verify(self, ts):
         for sample_sets, windows in subset_combos(
-                example_sample_sets(ts, min_size=3), example_windows(ts)):
+            example_sample_sets(ts, min_size=3), example_windows(ts)
+        ):
             for indexes in example_sample_set_index_triples(sample_sets):
                 self.verify_sample_sets_indexes(ts, sample_sets, indexes, windows)
 
@@ -1012,9 +1097,11 @@ class FourWaySampleSetStatsMixin(KWaySampleSetStatsMixin):
     Implements the verify method and dispatches it to verify_sample_sets_indexes,
     which gives a representative sample of sample set indexes.
     """
+
     def verify(self, ts):
         for sample_sets, windows in subset_combos(
-                example_sample_sets(ts, min_size=4), example_windows(ts)):
+            example_sample_sets(ts, min_size=4), example_windows(ts)
+        ):
             for indexes in example_sample_set_index_quads(sample_sets):
                 self.verify_sample_sets_indexes(ts, sample_sets, indexes, windows)
 
@@ -1051,7 +1138,7 @@ def site_diversity(ts, sample_sets, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1076,12 +1163,12 @@ def branch_diversity(ts, sample_sets, windows=None, span_normalise=True):
                 for x in X:
                     for y in set(X) - set([x]):
                         SS += path_length(tr, x, y)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             if has_trees:
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1107,11 +1194,11 @@ def node_diversity(ts, sample_sets, windows=None, span_normalise=True):
                     # count number of pairwise paths going through u
                     n = tr.num_tracked_samples(u)
                     SS[u] += 2 * n * (tX - n)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, k] = S / denom
             if span_normalise:
-                out[j, :, k] /= (end - begin)
+                out[j, :, k] /= end - begin
     return out
 
 
@@ -1123,9 +1210,11 @@ def diversity(ts, sample_sets, windows=None, mode="site", span_normalise=True):
     method_map = {
         "site": site_diversity,
         "node": node_diversity,
-        "branch": branch_diversity}
-    return method_map[mode](ts, sample_sets, windows=windows,
-                            span_normalise=span_normalise)
+        "branch": branch_diversity,
+    }
+    return method_map[mode](
+        ts, sample_sets, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestDiversity(StatsTestCase, SampleSetStatsMixin):
@@ -1136,11 +1225,10 @@ class TestDiversity(StatsTestCase, SampleSetStatsMixin):
         n = np.array([len(x) for x in sample_sets])
 
         def f(x):
-            with np.errstate(invalid='ignore', divide='ignore'):
+            with np.errstate(invalid="ignore", divide="ignore"):
                 return x * (n - x) / (n * (n - 1))
 
-        self.verify_definition(
-            ts, sample_sets, windows, f, ts.diversity, diversity)
+        self.verify_definition(ts, sample_sets, windows, f, ts.diversity, diversity)
 
 
 class TestBranchDiversity(TestDiversity, TopologyExamplesMixin):
@@ -1159,6 +1247,7 @@ class TestSiteDiversity(TestDiversity, MutatedTopologyExamplesMixin):
 # Segregating sites
 ############################################
 
+
 def site_segregating_sites(ts, sample_sets, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(sample_sets)))
@@ -1173,9 +1262,9 @@ def site_segregating_sites(ts, sample_sets, windows=None, span_normalise=True):
             for k in range(ts.num_sites):
                 if (site_positions[k] >= begin) and (site_positions[k] < end):
                     num_alleles = len(set(haps[k, X_index]))
-                    out[j][i] += (num_alleles - 1)
+                    out[j][i] += num_alleles - 1
             if span_normalise:
-                out[j][i] /= (end - begin)
+                out[j][i] /= end - begin
     return out
 
 
@@ -1197,9 +1286,11 @@ def branch_segregating_sites(ts, sample_sets, windows=None, span_normalise=True)
                     nX = tr.num_tracked_samples(u)
                     if nX > 0 and nX < tX:
                         SS += tr.branch_length(u)
-                out[j][i] += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                out[j][i] += SS * (
+                    min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                )
             if span_normalise:
-                out[j][i] /= (end - begin)
+                out[j][i] /= end - begin
     return out
 
 
@@ -1223,10 +1314,10 @@ def node_segregating_sites(ts, sample_sets, windows=None, span_normalise=True):
                 for u in tr.nodes():
                     nX = tr.num_tracked_samples(u)
                     SS[u] = (nX > 0) and (nX < tX)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             out[j, :, k] = S
             if span_normalise:
-                out[j, :, k] /= (end - begin)
+                out[j, :, k] /= end - begin
     return out
 
 
@@ -1237,9 +1328,11 @@ def segregating_sites(ts, sample_sets, windows=None, mode="site", span_normalise
     method_map = {
         "site": site_segregating_sites,
         "node": node_segregating_sites,
-        "branch": branch_segregating_sites}
-    return method_map[mode](ts, sample_sets, windows=windows,
-                            span_normalise=span_normalise)
+        "branch": branch_segregating_sites,
+    }
+    return method_map[mode](
+        ts, sample_sets, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestSegregatingSites(StatsTestCase, SampleSetStatsMixin):
@@ -1254,7 +1347,8 @@ class TestSegregatingSites(StatsTestCase, SampleSetStatsMixin):
             return (x > 0) * (1 - x / n)
 
         self.verify_definition(
-            ts, sample_sets, windows, f, ts.segregating_sites, segregating_sites)
+            ts, sample_sets, windows, f, ts.segregating_sites, segregating_sites
+        )
 
 
 class TestBranchSegregatingSites(TestSegregatingSites, TopologyExamplesMixin):
@@ -1270,7 +1364,6 @@ class TestSiteSegregatingSites(TestSegregatingSites, MutatedTopologyExamplesMixi
 
 
 class TestBranchSegregatingSitesProperties(StatsTestCase, TopologyExamplesMixin):
-
     def verify(self, ts):
         windows = ts.breakpoints(as_array=True)
         # If we split by tree, this should always be equal to the total
@@ -1281,9 +1374,12 @@ class TestBranchSegregatingSitesProperties(StatsTestCase, TopologyExamplesMixin)
         # roots.
         tbl_tree = [
             sum(
-                tree.branch_length(u) for u in tree.nodes()
-                if 0 < tree.num_samples(u) < ts.num_samples)
-            for tree in ts.trees()]
+                tree.branch_length(u)
+                for u in tree.nodes()
+                if 0 < tree.num_samples(u) < ts.num_samples
+            )
+            for tree in ts.trees()
+        ]
         # We must span_normalise, because these values are always weighted
         # by the span, so we're effectively cancelling out this contribution
         tbl = ts.segregating_sites([ts.samples()], windows=windows, mode="branch")
@@ -1294,6 +1390,7 @@ class TestBranchSegregatingSitesProperties(StatsTestCase, TopologyExamplesMixin)
 ############################################
 # Tajima's D
 ############################################
+
 
 def site_tajimas_d(ts, sample_sets, windows=None):
     windows = ts.parse_windows(windows)
@@ -1316,28 +1413,28 @@ def site_tajimas_d(ts, sample_sets, windows=None):
                     alleles = set(hX)
                     num_alleles = len(alleles)
                     n_alleles = [np.sum(hX == a) for a in alleles]
-                    S += (num_alleles - 1)
+                    S += num_alleles - 1
                     for k in n_alleles:
                         with suppress_division_by_zero_warning():
                             T += k * (nn - k) / (nn * (nn - 1))
             with suppress_division_by_zero_warning():
-                a1 = np.sum(1/np.arange(1, nn))  # this is h in the main version
-                a2 = np.sum(1/np.arange(1, nn)**2)  # this is g
-                b1 = (nn+1)/(3*(nn-1))
-                b2 = 2 * (nn**2 + nn + 3) / (9 * nn * (nn-1))
-                c1 = b1 - 1/a1
-                c2 = b2 - (nn + 2)/(a1 * nn) + a2 / a1**2
+                a1 = np.sum(1 / np.arange(1, nn))  # this is h in the main version
+                a2 = np.sum(1 / np.arange(1, nn) ** 2)  # this is g
+                b1 = (nn + 1) / (3 * (nn - 1))
+                b2 = 2 * (nn ** 2 + nn + 3) / (9 * nn * (nn - 1))
+                c1 = b1 - 1 / a1
+                c2 = b2 - (nn + 2) / (a1 * nn) + a2 / a1 ** 2
                 e1 = c1 / a1  # this is a
-                e2 = c2 / (a1**2 + a2)  # this is b
-                out[j][i] = (T - S/a1) / np.sqrt(e1*S + e2*S*(S-1))
+                e2 = c2 / (a1 ** 2 + a2)  # this is b
+                out[j][i] = (T - S / a1) / np.sqrt(e1 * S + e2 * S * (S - 1))
     return out
 
 
 def tajimas_d(ts, sample_sets, windows=None, mode="site", span_normalise=True):
-    method_map = {
-        "site": site_tajimas_d}
-    return method_map[mode](ts, sample_sets, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_tajimas_d}
+    return method_map[mode](
+        ts, sample_sets, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestTajimasD(StatsTestCase, SampleSetStatsMixin):
@@ -1370,6 +1467,7 @@ class TestSiteTajimasD(TestTajimasD, MutatedTopologyExamplesMixin):
 # Y1
 ############################################
 
+
 def branch_Y1(ts, sample_sets, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(sample_sets)))
@@ -1378,7 +1476,7 @@ def branch_Y1(ts, sample_sets, windows=None, span_normalise=True):
         end = windows[j + 1]
         for i, X in enumerate(sample_sets):
             S = 0
-            denom = np.float64(len(X) * (len(X)-1) * (len(X)-2))
+            denom = np.float64(len(X) * (len(X) - 1) * (len(X) - 2))
             has_trees = False
             for tr in ts.trees():
                 if tr.interval[1] <= begin:
@@ -1413,7 +1511,7 @@ def branch_Y1(ts, sample_sets, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1428,7 +1526,7 @@ def site_Y1(ts, sample_sets, windows=None, span_normalise=True):
         site_positions = [x.position for x in ts.sites()]
         for i, X in enumerate(sample_sets):
             S = 0
-            denom = np.float64(len(X) * (len(X)-1) * (len(X)-2))
+            denom = np.float64(len(X) * (len(X) - 1) * (len(X) - 2))
             site_in_window = False
             for k in range(ts.num_sites):
                 if (site_positions[k] >= begin) and (site_positions[k] < end):
@@ -1440,8 +1538,9 @@ def site_Y1(ts, sample_sets, windows=None, span_normalise=True):
                             for z in set(X) - {x, y}:
                                 z_index = np.where(samples == z)[0][0]
                                 condition = (
-                                    haps[x_index, k] != haps[y_index, k] and
-                                    haps[x_index, k] != haps[z_index, k])
+                                    haps[x_index, k] != haps[y_index, k]
+                                    and haps[x_index, k] != haps[z_index, k]
+                                )
                                 if condition:
                                     # x|yz
                                     S += 1
@@ -1449,7 +1548,7 @@ def site_Y1(ts, sample_sets, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1474,24 +1573,21 @@ def node_Y1(ts, sample_sets, windows=None, span_normalise=True):
                 for u in tr.nodes():
                     # count number of paths above a but not b,c
                     n = tr.num_tracked_samples(u)
-                    SS[u] += (n * (tX - n) * (tX - n - 1)
-                              + (tX - n) * n * (n - 1))
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                    SS[u] += n * (tX - n) * (tX - n - 1) + (tX - n) * n * (n - 1)
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, k] = S / denom
             if span_normalise:
-                out[j, :, k] /= (end - begin)
+                out[j, :, k] /= end - begin
     return out
 
 
 def Y1(ts, sample_sets, windows=None, mode="site", span_normalise=True):
     windows = ts.parse_windows(windows)
-    method_map = {
-        "site": site_Y1,
-        "node": node_Y1,
-        "branch": branch_Y1}
-    return method_map[mode](ts, sample_sets, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_Y1, "node": node_Y1, "branch": branch_Y1}
+    return method_map[mode](
+        ts, sample_sets, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestY1(StatsTestCase, SampleSetStatsMixin):
@@ -1503,7 +1599,7 @@ class TestY1(StatsTestCase, SampleSetStatsMixin):
         denom = n * (n - 1) * (n - 2)
 
         def f(x):
-            with np.errstate(invalid='ignore', divide='ignore'):
+            with np.errstate(invalid="ignore", divide="ignore"):
                 return x * (n - x) * (n - x - 1) / denom
 
         self.verify_definition(ts, sample_sets, windows, f, ts.Y1, Y1)
@@ -1524,6 +1620,7 @@ class TestSiteY1(TestY1, MutatedTopologyExamplesMixin):
 ############################################
 # Divergence
 ############################################
+
 
 def site_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True):
     out = np.zeros((len(windows) - 1, len(indexes)))
@@ -1550,10 +1647,10 @@ def site_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True)
                                 # x|y
                                 S += 1
             if site_in_window:
-                with np.errstate(invalid='ignore', divide='ignore'):
+                with np.errstate(invalid="ignore", divide="ignore"):
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1579,12 +1676,12 @@ def branch_divergence(ts, sample_sets, indexes, windows=None, span_normalise=Tru
                 for x in X:
                     for y in Y:
                         SS += path_length(tr, x, y)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             if has_trees:
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1600,8 +1697,7 @@ def node_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True)
             begin = windows[j]
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
-            for t1, t2 in zip(ts.trees(tracked_samples=X),
-                              ts.trees(tracked_samples=Y)):
+            for t1, t2 in zip(ts.trees(tracked_samples=X), ts.trees(tracked_samples=Y)):
                 if t1.interval[1] <= begin:
                     continue
                 if t1.interval[0] >= end:
@@ -1611,17 +1707,18 @@ def node_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True)
                     # count number of pairwise paths going through u
                     nX = t1.num_tracked_samples(u)
                     nY = t2.num_tracked_samples(u)
-                    SS[u] += (nX * (tY - nY) + (tX - nX) * nY)
-                S += SS*(min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                    SS[u] += nX * (tY - nY) + (tX - nX) * nY
+                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
-def divergence(ts, sample_sets, indexes=None, windows=None, mode="site",
-               span_normalise=True):
+def divergence(
+    ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+):
     """
     Computes average pairwise divergence between two random choices from x
     over the window specified.
@@ -1632,9 +1729,11 @@ def divergence(ts, sample_sets, indexes=None, windows=None, mode="site",
     method_map = {
         "site": site_divergence,
         "node": node_divergence,
-        "branch": branch_divergence}
-    return method_map[mode](ts, sample_sets, indexes=indexes, windows=windows,
-                            span_normalise=span_normalise)
+        "branch": branch_divergence,
+    }
+    return method_map[mode](
+        ts, sample_sets, indexes=indexes, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestDivergence(StatsTestCase, TwoWaySampleSetStatsMixin):
@@ -1652,7 +1751,8 @@ class TestDivergence(StatsTestCase, TwoWaySampleSetStatsMixin):
             return numer / denom
 
         self.verify_definition(
-            ts, sample_sets, indexes, windows, f, ts.divergence, divergence)
+            ts, sample_sets, indexes, windows, f, ts.divergence, divergence
+        )
 
 
 class TestBranchDivergence(TestDivergence, TopologyExamplesMixin):
@@ -1670,6 +1770,7 @@ class TestSiteDivergence(TestDivergence, MutatedTopologyExamplesMixin):
 ############################################
 # Fst
 ############################################
+
 
 def single_site_Fst(ts, sample_sets, indexes):
     """
@@ -1719,15 +1820,19 @@ class TestFst(StatsTestCase, TwoWaySampleSetStatsMixin):
                 self.verify_persite_Fst(ts, sample_sets, indexes)
 
     def verify_persite_Fst(self, ts, sample_sets, indexes):
-        sigma1 = ts.Fst(sample_sets, indexes=indexes, windows="sites",
-                        mode=self.mode, span_normalise=False)
+        sigma1 = ts.Fst(
+            sample_sets,
+            indexes=indexes,
+            windows="sites",
+            mode=self.mode,
+            span_normalise=False,
+        )
         sigma2 = single_site_Fst(ts, sample_sets, indexes)
         self.assertEqual(sigma1.shape, sigma2.shape)
         self.assertArrayAlmostEqual(sigma1, sigma2)
 
 
 class FstInterfaceMixin(object):
-
     def test_interface(self):
         ts = msprime.simulate(10, mutation_rate=0.0)
         sample_sets = [[0, 1, 2], [6, 7], [4]]
@@ -1749,6 +1854,7 @@ class TestSiteFst(TestFst, MutatedTopologyExamplesMixin, FstInterfaceMixin):
 # Since Fst is defined using diversity and divergence, we don't seriously
 # test it for correctness for node and branch, and only test the interface.
 
+
 class TestNodeFst(StatsTestCase, FstInterfaceMixin):
     mode = "node"
 
@@ -1761,6 +1867,7 @@ class TestBranchFst(StatsTestCase, FstInterfaceMixin):
 # Y2
 ############################################
 
+
 def branch_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(indexes)))
@@ -1770,7 +1877,7 @@ def branch_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
         for i, (ix, iy) in enumerate(indexes):
             X = sample_sets[ix]
             Y = sample_sets[iy]
-            denom = np.float64(len(X) * len(Y) * (len(Y)-1))
+            denom = np.float64(len(X) * len(Y) * (len(Y) - 1))
             has_trees = False
             S = 0
             for tr in ts.trees():
@@ -1806,7 +1913,7 @@ def branch_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1822,7 +1929,7 @@ def site_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
         for i, (ix, iy) in enumerate(indexes):
             X = sample_sets[ix]
             Y = sample_sets[iy]
-            denom = np.float64(len(X) * len(Y) * (len(Y)-1))
+            denom = np.float64(len(X) * len(Y) * (len(Y) - 1))
             S = 0
             site_in_window = False
             for k in range(ts.num_sites):
@@ -1835,8 +1942,9 @@ def site_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                             for z in set(Y) - {y}:
                                 z_index = np.where(samples == z)[0][0]
                                 condition = (
-                                    haps[x_index, k] != haps[y_index, k] and
-                                    haps[x_index, k] != haps[z_index, k])
+                                    haps[x_index, k] != haps[y_index, k]
+                                    and haps[x_index, k] != haps[z_index, k]
+                                )
                                 if condition:
                                     # x|yz
                                     S += 1
@@ -1844,7 +1952,7 @@ def site_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -1860,8 +1968,7 @@ def node_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
             begin = windows[j]
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
-            for t1, t2 in zip(ts.trees(tracked_samples=X),
-                              ts.trees(tracked_samples=Y)):
+            for t1, t2 in zip(ts.trees(tracked_samples=X), ts.trees(tracked_samples=Y)):
                 if t1.interval[1] <= begin:
                     continue
                 if t1.interval[0] >= end:
@@ -1871,13 +1978,12 @@ def node_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     # count number of pairwise paths going through u
                     nX = t1.num_tracked_samples(u)
                     nY = t2.num_tracked_samples(u)
-                    SS[u] += (nX * (tY - nY) * (tY - nY - 1)
-                              + (tX - nX) * nY * (nY - 1))
-                S += SS*(min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                    SS[u] += nX * (tY - nY) * (tY - nY - 1) + (tX - nX) * nY * (nY - 1)
+                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -1885,12 +1991,10 @@ def Y2(ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=
     windows = ts.parse_windows(windows)
     if indexes is None:
         indexes = [(0, 1)]
-    method_map = {
-        "site": site_Y2,
-        "node": node_Y2,
-        "branch": branch_Y2}
-    return method_map[mode](ts, sample_sets, indexes=indexes, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_Y2, "node": node_Y2, "branch": branch_Y2}
+    return method_map[mode](
+        ts, sample_sets, indexes=indexes, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestY2(StatsTestCase, TwoWaySampleSetStatsMixin):
@@ -1904,8 +2008,9 @@ class TestY2(StatsTestCase, TwoWaySampleSetStatsMixin):
         denom = np.array([n[i] * n[j] * (n[j] - 1) for i, j in indexes])
 
         def f(x):
-            numer = np.array([
-                (x[i] * (n[j] - x[j]) * (n[j] - x[j] - 1)) for i, j in indexes])
+            numer = np.array(
+                [(x[i] * (n[j] - x[j]) * (n[j] - x[j] - 1)) for i, j in indexes]
+            )
             return numer / denom
 
         self.verify_definition(ts, sample_sets, indexes, windows, f, ts.Y2, Y2)
@@ -1926,6 +2031,7 @@ class TestSiteY2(TestY2, MutatedTopologyExamplesMixin):
 ############################################
 # Y3
 ############################################
+
 
 def branch_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
@@ -1973,7 +2079,7 @@ def branch_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2002,8 +2108,9 @@ def site_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                             y_index = np.where(samples == y)[0][0]
                             for z in Z:
                                 z_index = np.where(samples == z)[0][0]
-                                if ((haps[x_index][k] != haps[y_index][k])
-                                   and (haps[x_index][k] != haps[z_index][k])):
+                                if (haps[x_index][k] != haps[y_index][k]) and (
+                                    haps[x_index][k] != haps[z_index][k]
+                                ):
                                     # x|yz
                                     with suppress_division_by_zero_warning():
                                         S += 1
@@ -2011,7 +2118,7 @@ def site_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2029,9 +2136,11 @@ def node_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
             begin = windows[j]
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
-            for t1, t2, t3 in zip(ts.trees(tracked_samples=X),
-                                  ts.trees(tracked_samples=Y),
-                                  ts.trees(tracked_samples=Z)):
+            for t1, t2, t3 in zip(
+                ts.trees(tracked_samples=X),
+                ts.trees(tracked_samples=Y),
+                ts.trees(tracked_samples=Z),
+            ):
                 if t1.interval[1] <= begin:
                     continue
                 if t1.interval[0] >= end:
@@ -2042,13 +2151,12 @@ def node_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     nX = t1.num_tracked_samples(u)
                     nY = t2.num_tracked_samples(u)
                     nZ = t3.num_tracked_samples(u)
-                    SS[u] += (nX * (tY - nY) * (tZ - nZ)
-                              + (tX - nX) * nY * nZ)
-                S += SS*(min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                    SS[u] += nX * (tY - nY) * (tZ - nZ) + (tX - nX) * nY * nZ
+                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -2056,12 +2164,10 @@ def Y3(ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=
     windows = ts.parse_windows(windows)
     if indexes is None:
         indexes = [(0, 1, 2)]
-    method_map = {
-        "site": site_Y3,
-        "node": node_Y3,
-        "branch": branch_Y3}
-    return method_map[mode](ts, sample_sets, indexes=indexes, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_Y3, "node": node_Y3, "branch": branch_Y3}
+    return method_map[mode](
+        ts, sample_sets, indexes=indexes, windows=windows, span_normalise=span_normalise
+    )
 
 
 class TestY3(StatsTestCase, ThreeWaySampleSetStatsMixin):
@@ -2075,7 +2181,8 @@ class TestY3(StatsTestCase, ThreeWaySampleSetStatsMixin):
 
         def f(x):
             numer = np.array(
-                [x[i] * (n[j] - x[j]) * (n[k] - x[k]) for i, j, k in indexes])
+                [x[i] * (n[j] - x[j]) * (n[k] - x[k]) for i, j, k in indexes]
+            )
             return numer / denom
 
         self.verify_definition(ts, sample_sets, indexes, windows, f, ts.Y3, Y3)
@@ -2096,6 +2203,7 @@ class TestSiteY3(TestY3, MutatedTopologyExamplesMixin):
 ############################################
 # f2
 ############################################
+
 
 def branch_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
     # this is f4(A,B;A,B) but drawing distinct samples from A and B
@@ -2131,7 +2239,7 @@ def branch_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2161,21 +2269,25 @@ def site_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                                 c_index = np.where(samples == c)[0][0]
                                 for d in set(B) - {b}:
                                     d_index = np.where(samples == d)[0][0]
-                                    if ((haps[a_index][k] == haps[c_index][k])
-                                       and (haps[a_index][k] != haps[d_index][k])
-                                       and (haps[a_index][k] != haps[b_index][k])):
+                                    if (
+                                        (haps[a_index][k] == haps[c_index][k])
+                                        and (haps[a_index][k] != haps[d_index][k])
+                                        and (haps[a_index][k] != haps[b_index][k])
+                                    ):
                                         # ac|bd
                                         S += 1
-                                    elif ((haps[a_index][k] == haps[d_index][k])
-                                          and (haps[a_index][k] != haps[c_index][k])
-                                          and (haps[a_index][k] != haps[b_index][k])):
+                                    elif (
+                                        (haps[a_index][k] == haps[d_index][k])
+                                        and (haps[a_index][k] != haps[c_index][k])
+                                        and (haps[a_index][k] != haps[b_index][k])
+                                    ):
                                         # ad|bc
                                         S -= 1
             if site_in_window:
-                with np.errstate(invalid='ignore', divide='ignore'):
+                with np.errstate(invalid="ignore", divide="ignore"):
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2191,8 +2303,7 @@ def node_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
             begin = windows[j]
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
-            for t1, t2 in zip(ts.trees(tracked_samples=A),
-                              ts.trees(tracked_samples=B)):
+            for t1, t2 in zip(ts.trees(tracked_samples=A), ts.trees(tracked_samples=B)):
                 if t1.interval[1] <= begin:
                     continue
                 if t1.interval[0] >= end:
@@ -2203,14 +2314,15 @@ def node_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     nA = t1.num_tracked_samples(u)
                     nB = t2.num_tracked_samples(u)
                     # xy|uv - xv|uy with x,y in A, u, v in B
-                    SS[u] += (nA * (nA - 1) * (tB - nB) * (tB - nB - 1)
-                              + (tA - nA) * (tA - nA - 1) * nB * (nB - 1))
+                    SS[u] += nA * (nA - 1) * (tB - nB) * (tB - nB - 1) + (tA - nA) * (
+                        tA - nA - 1
+                    ) * nB * (nB - 1)
                     SS[u] -= 2 * nA * nB * (tA - nA) * (tB - nB)
-                S += SS*(min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -2221,12 +2333,10 @@ def f2(ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=
     windows = ts.parse_windows(windows)
     if indexes is None:
         indexes = [(0, 1)]
-    method_map = {
-        "site": site_f2,
-        "node": node_f2,
-        "branch": branch_f2}
-    return method_map[mode](ts, sample_sets, indexes=indexes, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_f2, "node": node_f2, "branch": branch_f2}
+    return method_map[mode](
+        ts, sample_sets, indexes=indexes, windows=windows, span_normalise=span_normalise
+    )
 
 
 class Testf2(StatsTestCase, TwoWaySampleSetStatsMixin):
@@ -2240,10 +2350,13 @@ class Testf2(StatsTestCase, TwoWaySampleSetStatsMixin):
         denom = np.array([n[i] * (n[i] - 1) * n[j] * (n[j] - 1) for i, j in indexes])
 
         def f(x):
-            numer = np.array([
-                x[i] * (x[i] - 1) * (n[j] - x[j]) * (n[j] - x[j] - 1)
-                - x[i] * (n[i] - x[i]) * (n[j] - x[j]) * x[j]
-                for i, j in indexes])
+            numer = np.array(
+                [
+                    x[i] * (x[i] - 1) * (n[j] - x[j]) * (n[j] - x[j] - 1)
+                    - x[i] * (n[i] - x[i]) * (n[j] - x[j]) * x[j]
+                    for i, j in indexes
+                ]
+            )
             return numer / denom
 
         self.verify_definition(ts, sample_sets, indexes, windows, f, ts.f2, f2)
@@ -2264,6 +2377,7 @@ class TestSitef2(Testf2, MutatedTopologyExamplesMixin):
 ############################################
 # f3
 ############################################
+
 
 def branch_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
     # this is f4(A,B;A,C) but drawing distinct samples from A
@@ -2299,7 +2413,7 @@ def branch_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2330,21 +2444,25 @@ def site_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                                 c_index = np.where(samples == c)[0][0]
                                 for d in C:
                                     d_index = np.where(samples == d)[0][0]
-                                    if ((haps[a_index][k] == haps[c_index][k])
-                                       and (haps[a_index][k] != haps[d_index][k])
-                                       and (haps[a_index][k] != haps[b_index][k])):
+                                    if (
+                                        (haps[a_index][k] == haps[c_index][k])
+                                        and (haps[a_index][k] != haps[d_index][k])
+                                        and (haps[a_index][k] != haps[b_index][k])
+                                    ):
                                         # ac|bd
                                         S += 1
-                                    elif ((haps[a_index][k] == haps[d_index][k])
-                                          and (haps[a_index][k] != haps[c_index][k])
-                                          and (haps[a_index][k] != haps[b_index][k])):
+                                    elif (
+                                        (haps[a_index][k] == haps[d_index][k])
+                                        and (haps[a_index][k] != haps[c_index][k])
+                                        and (haps[a_index][k] != haps[b_index][k])
+                                    ):
                                         # ad|bc
                                         S -= 1
             if site_in_window:
-                with np.errstate(invalid='ignore', divide='ignore'):
+                with np.errstate(invalid="ignore", divide="ignore"):
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2362,9 +2480,11 @@ def node_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
             begin = windows[j]
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
-            for t1, t2, t3 in zip(ts.trees(tracked_samples=A),
-                                  ts.trees(tracked_samples=B),
-                                  ts.trees(tracked_samples=C)):
+            for t1, t2, t3 in zip(
+                ts.trees(tracked_samples=A),
+                ts.trees(tracked_samples=B),
+                ts.trees(tracked_samples=C),
+            ):
                 if t1.interval[1] <= begin:
                     continue
                 if t1.interval[0] >= end:
@@ -2376,15 +2496,19 @@ def node_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     nB = t2.num_tracked_samples(u)
                     nC = t3.num_tracked_samples(u)
                     # xy|uv - xv|uy with x,y in A, u in B and v in C
-                    SS[u] += (nA * (nA - 1) * (tB - nB) * (tC - nC)
-                              + (tA - nA) * (tA - nA - 1) * nB * nC)
-                    SS[u] -= (nA * nC * (tA - nA) * (tB - nB)
-                              + (tA - nA) * (tC - nC) * nA * nB)
-                S += SS*(min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                    SS[u] += (
+                        nA * (nA - 1) * (tB - nB) * (tC - nC)
+                        + (tA - nA) * (tA - nA - 1) * nB * nC
+                    )
+                    SS[u] -= (
+                        nA * nC * (tA - nA) * (tB - nB)
+                        + (tA - nA) * (tC - nC) * nA * nB
+                    )
+                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -2395,12 +2519,10 @@ def f3(ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=
     windows = ts.parse_windows(windows)
     if indexes is None:
         indexes = [(0, 1, 2)]
-    method_map = {
-        "site": site_f3,
-        "node": node_f3,
-        "branch": branch_f3}
-    return method_map[mode](ts, sample_sets, indexes=indexes, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_f3, "node": node_f3, "branch": branch_f3}
+    return method_map[mode](
+        ts, sample_sets, indexes=indexes, windows=windows, span_normalise=span_normalise
+    )
 
 
 class Testf3(StatsTestCase, ThreeWaySampleSetStatsMixin):
@@ -2413,10 +2535,15 @@ class Testf3(StatsTestCase, ThreeWaySampleSetStatsMixin):
         denom = np.array([n[i] * (n[i] - 1) * n[j] * n[k] for i, j, k in indexes])
 
         def f(x):
-            numer = np.array([
-                x[i] * (x[i] - 1) * (n[j] - x[j]) * (n[k] - x[k])
-                - x[i] * (n[i] - x[i]) * (n[j] - x[j]) * x[k] for i, j, k in indexes])
+            numer = np.array(
+                [
+                    x[i] * (x[i] - 1) * (n[j] - x[j]) * (n[k] - x[k])
+                    - x[i] * (n[i] - x[i]) * (n[j] - x[j]) * x[k]
+                    for i, j, k in indexes
+                ]
+            )
             return numer / denom
+
         self.verify_definition(ts, sample_sets, indexes, windows, f, ts.f3, f3)
 
 
@@ -2435,6 +2562,7 @@ class TestSitef3(Testf3, MutatedTopologyExamplesMixin):
 ############################################
 # f4
 ############################################
+
 
 def branch_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
@@ -2471,7 +2599,7 @@ def branch_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2503,21 +2631,25 @@ def site_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
                                 c_index = np.where(samples == c)[0][0]
                                 for d in D:
                                     d_index = np.where(samples == d)[0][0]
-                                    if ((haps[a_index][k] == haps[c_index][k])
-                                       and (haps[a_index][k] != haps[d_index][k])
-                                       and (haps[a_index][k] != haps[b_index][k])):
+                                    if (
+                                        (haps[a_index][k] == haps[c_index][k])
+                                        and (haps[a_index][k] != haps[d_index][k])
+                                        and (haps[a_index][k] != haps[b_index][k])
+                                    ):
                                         # ac|bd
                                         S += 1
-                                    elif ((haps[a_index][k] == haps[d_index][k])
-                                          and (haps[a_index][k] != haps[c_index][k])
-                                          and (haps[a_index][k] != haps[b_index][k])):
+                                    elif (
+                                        (haps[a_index][k] == haps[d_index][k])
+                                        and (haps[a_index][k] != haps[c_index][k])
+                                        and (haps[a_index][k] != haps[b_index][k])
+                                    ):
                                         # ad|bc
                                         S -= 1
             if site_in_window:
-                with np.errstate(invalid='ignore', divide='ignore'):
+                with np.errstate(invalid="ignore", divide="ignore"):
                     out[j][i] = S / denom
                 if span_normalise:
-                    out[j][i] /= (end - begin)
+                    out[j][i] /= end - begin
     return out
 
 
@@ -2538,10 +2670,12 @@ def node_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
             begin = windows[j]
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
-            for t1, t2, t3, t4 in zip(ts.trees(tracked_samples=A),
-                                      ts.trees(tracked_samples=B),
-                                      ts.trees(tracked_samples=C),
-                                      ts.trees(tracked_samples=D)):
+            for t1, t2, t3, t4 in zip(
+                ts.trees(tracked_samples=A),
+                ts.trees(tracked_samples=B),
+                ts.trees(tracked_samples=C),
+                ts.trees(tracked_samples=D),
+            ):
                 if t1.interval[1] <= begin:
                     continue
                 if t1.interval[0] >= end:
@@ -2554,15 +2688,19 @@ def node_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     nC = t3.num_tracked_samples(u)
                     nD = t4.num_tracked_samples(u)
                     # ac|bd - ad|bc
-                    SS[u] += (nA * nC * (tB - nB) * (tD - nD)
-                              + (tA - nA) * (tC - nC) * nB * nD)
-                    SS[u] -= (nA * nD * (tB - nB) * (tC - nC)
-                              + (tA - nA) * (tD - nD) * nB * nC)
-                S += SS*(min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                    SS[u] += (
+                        nA * nC * (tB - nB) * (tD - nD)
+                        + (tA - nA) * (tC - nC) * nB * nD
+                    )
+                    SS[u] -= (
+                        nA * nD * (tB - nB) * (tC - nC)
+                        + (tA - nA) * (tD - nD) * nB * nC
+                    )
+                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -2572,12 +2710,10 @@ def f4(ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=
     """
     if indexes is None:
         indexes = [(0, 1, 2, 3)]
-    method_map = {
-        "site": site_f4,
-        "node": node_f4,
-        "branch": branch_f4}
-    return method_map[mode](ts, sample_sets, indexes=indexes, windows=windows,
-                            span_normalise=span_normalise)
+    method_map = {"site": site_f4, "node": node_f4, "branch": branch_f4}
+    return method_map[mode](
+        ts, sample_sets, indexes=indexes, windows=windows, span_normalise=span_normalise
+    )
 
 
 class Testf4(StatsTestCase, FourWaySampleSetStatsMixin):
@@ -2590,10 +2726,15 @@ class Testf4(StatsTestCase, FourWaySampleSetStatsMixin):
         denom = np.array([n[i] * n[j] * n[k] * n[l] for i, j, k, l in indexes])
 
         def f(x):
-            numer = np.array([
-                x[i] * x[k] * (n[j] - x[j]) * (n[l] - x[l])
-                - x[i] * x[l] * (n[j] - x[j]) * (n[k] - x[k]) for i, j, k, l in indexes])
+            numer = np.array(
+                [
+                    x[i] * x[k] * (n[j] - x[j]) * (n[l] - x[l])
+                    - x[i] * x[l] * (n[j] - x[j]) * (n[k] - x[k])
+                    for i, j, k, l in indexes
+                ]
+            )
             return numer / denom
+
         self.verify_definition(ts, sample_sets, indexes, windows, f, ts.f4, f4)
 
     def verify_interface(self, ts):
@@ -2615,6 +2756,7 @@ class TestSitef4(Testf4, MutatedTopologyExamplesMixin):
 ############################################
 # Allele frequency spectrum
 ############################################
+
 
 def fold(x, dims):
     """
@@ -2654,38 +2796,39 @@ class TestFold(unittest.TestCase):
     def test_examples(self):
         A = np.arange(12)
         Af = np.array(
-            [11., 11., 11., 11., 11., 11.,  0.,  0.,  0.,  0.,  0.,  0.])
+            [11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        )
 
         self.assertTrue(np.all(foldit(A) == Af))
 
         B = A.copy().reshape(3, 4)
-        Bf = np.array([[11., 11., 11.,  0.],
-                       [11., 11.,  0.,  0.],
-                       [11.,  0.,  0.,  0.]])
+        Bf = np.array(
+            [[11.0, 11.0, 11.0, 0.0], [11.0, 11.0, 0.0, 0.0], [11.0, 0.0, 0.0, 0.0]]
+        )
         self.assertTrue(np.all(foldit(B) == Bf))
 
         C = A.copy().reshape(3, 2, 2)
-        Cf = np.array([[[11., 11.],
-                        [11., 11.]],
-                       [[11., 11.],
-                        [0.,  0.]],
-                       [[0.,  0.],
-                        [0.,  0.]]])
+        Cf = np.array(
+            [
+                [[11.0, 11.0], [11.0, 11.0]],
+                [[11.0, 11.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0]],
+            ]
+        )
         self.assertTrue(np.all(foldit(C) == Cf))
 
         D = np.arange(9).reshape((3, 3))
-        Df = np.array([[8., 8., 8.],
-                       [8., 4., 0.],
-                       [0., 0., 0.]])
+        Df = np.array([[8.0, 8.0, 8.0], [8.0, 4.0, 0.0], [0.0, 0.0, 0.0]])
         self.assertTrue(np.all(foldit(D) == Df))
 
         E = np.arange(9)
-        Ef = np.array([8., 8., 8., 8., 4., 0., 0., 0., 0.])
+        Ef = np.array([8.0, 8.0, 8.0, 8.0, 4.0, 0.0, 0.0, 0.0, 0.0])
         self.assertTrue(np.all(foldit(E) == Ef))
 
 
 def naive_site_allele_frequency_spectrum(
-        ts, sample_sets, windows=None, polarised=False, span_normalise=True):
+    ts, sample_sets, windows=None, polarised=False, span_normalise=True
+):
     """
     The joint allele frequency spectrum for sites.
     """
@@ -2698,7 +2841,8 @@ def naive_site_allele_frequency_spectrum(
     # Indexes of the samples within the sample sets into the samples array.
     sample_set_indexes = [
         np.array([np.where(x == samples)[0][0] for x in sample_set])
-        for sample_set in sample_sets]
+        for sample_set in sample_sets
+    ]
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
@@ -2714,8 +2858,8 @@ def naive_site_allele_frequency_spectrum(
 
                 # For each allele, count the number present in each sample set.
                 count = {
-                    allele: np.zeros(len(sample_sets), dtype=int)
-                    for allele in alleles}
+                    allele: np.zeros(len(sample_sets), dtype=int) for allele in alleles
+                }
                 for k, sample_set in enumerate(sample_set_indexes):
                     allele_counts = zip(*np.unique(g[sample_set], return_counts=True))
                     for allele, c in allele_counts:
@@ -2732,13 +2876,14 @@ def naive_site_allele_frequency_spectrum(
                         x = fold(x, out_dim)
                     S[x] += increment
             if span_normalise:
-                S /= (end - begin)
+                S /= end - begin
             out[j, :] += S
     return out
 
 
 def naive_branch_allele_frequency_spectrum(
-        ts, sample_sets, windows=None, polarised=False, span_normalise=True):
+    ts, sample_sets, windows=None, polarised=False, span_normalise=True
+):
     """
     The joint allele frequency spectrum for branches.
     """
@@ -2752,8 +2897,8 @@ def naive_branch_allele_frequency_spectrum(
         for set_index, sample_set in enumerate(sample_sets):
             S = np.zeros(out_dim)
             trees = [
-                next(ts.trees(tracked_samples=sample_set))
-                for sample_set in sample_sets]
+                next(ts.trees(tracked_samples=sample_set)) for sample_set in sample_sets
+            ]
             t = trees[0]
             while True:
                 tr_len = min(end, t.interval[1]) - max(begin, t.interval[0])
@@ -2774,27 +2919,33 @@ def naive_branch_allele_frequency_spectrum(
                 if not more[0]:
                     break
             if span_normalise:
-                S /= (end - begin)
+                S /= end - begin
             out[j, :] = S
     return out
 
 
 def naive_allele_frequency_spectrum(
-        ts, sample_sets, windows=None, polarised=False, mode="site",
-        span_normalise=True):
+    ts, sample_sets, windows=None, polarised=False, mode="site", span_normalise=True
+):
     """
     Naive definition of the generalised site frequency spectrum.
     """
     method_map = {
         "site": naive_site_allele_frequency_spectrum,
-        "branch": naive_branch_allele_frequency_spectrum}
+        "branch": naive_branch_allele_frequency_spectrum,
+    }
     return method_map[mode](
-        ts, sample_sets, windows=windows, polarised=polarised,
-        span_normalise=span_normalise)
+        ts,
+        sample_sets,
+        windows=windows,
+        polarised=polarised,
+        span_normalise=span_normalise,
+    )
 
 
 def branch_allele_frequency_spectrum(
-        ts, sample_sets, windows, polarised=False, span_normalise=True):
+    ts, sample_sets, windows, polarised=False, span_normalise=True
+):
     """
     Efficient implementation of the algorithm used as the basis for the
     underlying C version.
@@ -2880,7 +3031,8 @@ def branch_allele_frequency_spectrum(
 
 
 def site_allele_frequency_spectrum(
-        ts, sample_sets, windows, polarised=False, span_normalise=True):
+    ts, sample_sets, windows, polarised=False, span_normalise=True
+):
     """
     Efficient implementation of the algorithm used as the basis for the
     underlying C version.
@@ -2924,12 +3076,15 @@ def site_allele_frequency_spectrum(
             assert t_left <= sites.position[site_index]
             ancestral_state = sites[site_index].ancestral_state
             allele_count = collections.defaultdict(
-                functools.partial(np.zeros, len(sample_sets), dtype=int))
+                functools.partial(np.zeros, len(sample_sets), dtype=int)
+            )
             allele_count[ancestral_state][:] = [
-                len(sample_set) for sample_set in sample_sets]
+                len(sample_set) for sample_set in sample_sets
+            ]
             while (
-                    mutation_index < len(mutations)
-                    and mutations[mutation_index].site == site_index):
+                mutation_index < len(mutations)
+                and mutations[mutation_index].site == site_index
+            ):
                 mutation = mutations[mutation_index]
                 allele_count[mutation.derived_state] += count[mutation.node]
                 if mutation.parent != -1:
@@ -2969,17 +3124,22 @@ def site_allele_frequency_spectrum(
 
 
 def allele_frequency_spectrum(
-        ts, sample_sets, windows=None, polarised=False, mode="site",
-        span_normalise=True):
+    ts, sample_sets, windows=None, polarised=False, mode="site", span_normalise=True
+):
     """
     Generalised site frequency spectrum.
     """
     method_map = {
         "site": site_allele_frequency_spectrum,
-        "branch": branch_allele_frequency_spectrum}
+        "branch": branch_allele_frequency_spectrum,
+    }
     return method_map[mode](
-        ts, sample_sets, windows=windows, polarised=polarised,
-        span_normalise=span_normalise)
+        ts,
+        sample_sets,
+        windows=windows,
+        polarised=polarised,
+        span_normalise=span_normalise,
+    )
 
 
 class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
@@ -2996,18 +3156,22 @@ class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
         for windows in [None, (0, L), (0, L / 2, L)]:
             a1 = ts.allele_frequency_spectrum(mode=self.mode, windows=windows)
             a2 = ts.allele_frequency_spectrum(
-                [samples], mode=self.mode, windows=windows)
+                [samples], mode=self.mode, windows=windows
+            )
             self.assertArrayEqual(a1, a2)
         for polarised in [True, False]:
             a1 = ts.allele_frequency_spectrum(mode=self.mode, polarised=polarised)
             a2 = ts.allele_frequency_spectrum(
-                [samples], mode=self.mode, polarised=polarised)
+                [samples], mode=self.mode, polarised=polarised
+            )
             self.assertArrayEqual(a1, a2)
         for span_normalise in [True, False]:
             a1 = ts.allele_frequency_spectrum(
-                mode=self.mode, span_normalise=span_normalise)
+                mode=self.mode, span_normalise=span_normalise
+            )
             a2 = ts.allele_frequency_spectrum(
-                [samples], mode=self.mode, span_normalise=span_normalise)
+                [samples], mode=self.mode, span_normalise=span_normalise
+            )
             self.assertArrayEqual(a1, a2)
 
     def verify_sample_sets(self, ts, sample_sets, windows):
@@ -3015,16 +3179,32 @@ class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
         # print(ts.draw_text())
         # print("sample_sets = ", sample_sets)
         windows = ts.parse_windows(windows)
-        for span_normalise, polarised in itertools.product([True, False], [True, False]):
+        for span_normalise, polarised in itertools.product(
+            [True, False], [True, False]
+        ):
             sfs1 = naive_allele_frequency_spectrum(
-                ts, sample_sets, windows, mode=self.mode, polarised=polarised,
-                span_normalise=span_normalise)
+                ts,
+                sample_sets,
+                windows,
+                mode=self.mode,
+                polarised=polarised,
+                span_normalise=span_normalise,
+            )
             sfs2 = allele_frequency_spectrum(
-                ts, sample_sets, windows, mode=self.mode, polarised=polarised,
-                span_normalise=span_normalise)
+                ts,
+                sample_sets,
+                windows,
+                mode=self.mode,
+                polarised=polarised,
+                span_normalise=span_normalise,
+            )
             sfs3 = ts.allele_frequency_spectrum(
-                sample_sets, windows, mode=self.mode, polarised=polarised,
-                span_normalise=span_normalise)
+                sample_sets,
+                windows,
+                mode=self.mode,
+                polarised=polarised,
+                span_normalise=span_normalise,
+            )
             self.assertEqual(sfs1.shape[0], len(windows) - 1)
             self.assertEqual(len(sfs1.shape), len(sample_sets) + 1)
             for j, sample_set in enumerate(sample_sets):
@@ -3045,7 +3225,8 @@ class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
 
 
 class TestBranchAlleleFrequencySpectrum(
-        TestAlleleFrequencySpectrum, TopologyExamplesMixin):
+    TestAlleleFrequencySpectrum, TopologyExamplesMixin
+):
     mode = "branch"
 
     def test_simple_example(self):
@@ -3061,7 +3242,8 @@ class TestBranchAlleleFrequencySpectrum(
 
 
 class TestSiteAlleleFrequencySpectrum(
-        TestAlleleFrequencySpectrum, MutatedTopologyExamplesMixin):
+    TestAlleleFrequencySpectrum, MutatedTopologyExamplesMixin
+):
     mode = "site"
 
     def test_simple_example(self):
@@ -3075,31 +3257,38 @@ class TestSiteAlleleFrequencySpectrum(
 
 
 class TestBranchAlleleFrequencySpectrumProperties(StatsTestCase, TopologyExamplesMixin):
-
     def verify(self, ts):
         # If we split by tree, the sum of the AFS should be equal to the
         # tree total branch length in each window
         windows = ts.breakpoints(as_array=True)
         S = ts.samples()
         examples = [
-            [S], [S[:1]], [S[:-1]],
-            [S[:1], S[1:]], [S[:1], S[:-1]],
+            [S],
+            [S[:1]],
+            [S[:-1]],
+            [S[:1], S[1:]],
+            [S[:1], S[:-1]],
         ]
         if len(S) > 2:
-            examples += [
-                [S[:1], S[2:], S[:3]]
-            ]
+            examples += [[S[:1], S[2:], S[:3]]]
         # This is the same definition that we use for segregating_sites
         tbl = [
             sum(
-                tree.branch_length(u) for u in tree.nodes()
-                if 0 < tree.num_samples(u) < ts.num_samples)
-            for tree in ts.trees()]
+                tree.branch_length(u)
+                for u in tree.nodes()
+                if 0 < tree.num_samples(u) < ts.num_samples
+            )
+            for tree in ts.trees()
+        ]
         for polarised in [True, False]:
             for sample_sets in examples:
                 afs = ts.allele_frequency_spectrum(
-                    sample_sets,  windows=windows, mode="branch", polarised=polarised,
-                    span_normalise=True)
+                    sample_sets,
+                    windows=windows,
+                    mode="branch",
+                    polarised=polarised,
+                    span_normalise=True,
+                )
                 if not polarised:
                     afs *= 2
                 afs_sum = [np.sum(window) for window in afs]
@@ -3116,6 +3305,7 @@ class TestWindowedTreeStat(StatsTestCase):
     Tests that the treewise windowing function defined here has the correct
     behaviour.
     """
+
     # TODO add more tests here covering the various windowing possibilities.
     def get_tree_sequence(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=1)
@@ -3200,12 +3390,14 @@ class TestSampleSets(StatsTestCase):
             return x * (x < n)
 
         # Determine output_dim of the function
-        for mode in ('site', 'branch', 'node'):
+        for mode in ("site", "branch", "node"):
             sigma1 = ts.sample_count_stat(sample_sets, f, 3, windows=windows)
-            sigma2 = ts.sample_count_stat(sample_sets, f, 3, windows=windows,
-                                          span_normalise=True)
-            sigma3 = ts.sample_count_stat(sample_sets, f, 3, windows=windows,
-                                          span_normalise=False)
+            sigma2 = ts.sample_count_stat(
+                sample_sets, f, 3, windows=windows, span_normalise=True
+            )
+            sigma3 = ts.sample_count_stat(
+                sample_sets, f, 3, windows=windows, span_normalise=False
+            )
             denom = np.diff(windows)[:, np.newaxis]
             self.assertEqual(sigma1.shape, sigma2.shape)
             self.assertEqual(sigma1.shape, sigma3.shape)
@@ -3218,6 +3410,7 @@ class TestSampleSetIndexes(StatsTestCase):
     Tests that we get the correct behaviour from the indexes argument to
     k-way stats functions.
     """
+
     def get_example_ts(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
         self.assertGreater(ts.num_mutations, 0)
@@ -3314,8 +3507,7 @@ class TestGeneralStatInterface(StatsTestCase):
     """
 
     def get_tree_sequence(self):
-        ts = msprime.simulate(10, recombination_rate=2,
-                              mutation_rate=2, random_seed=1)
+        ts = msprime.simulate(10, recombination_rate=2, mutation_rate=2, random_seed=1)
         return ts
 
     def test_function_cannot_update_state(self):
@@ -3330,11 +3522,21 @@ class TestGeneralStatInterface(StatsTestCase):
             return x
 
         x = ts.sample_count_stat(
-            [ts.samples()], f, output_dim=1, strict=False, mode="node",
-            span_normalise=False)
+            [ts.samples()],
+            f,
+            output_dim=1,
+            strict=False,
+            mode="node",
+            span_normalise=False,
+        )
         y = ts.sample_count_stat(
-            [ts.samples()], g, output_dim=1, strict=False, mode="node",
-            span_normalise=False)
+            [ts.samples()],
+            g,
+            output_dim=1,
+            strict=False,
+            mode="node",
+            span_normalise=False,
+        )
         self.assertArrayEqual(x, y)
 
     def test_default_mode(self):
@@ -3380,6 +3582,7 @@ class TestGeneralBranchStats(StatsTestCase):
     """
     Tests for general branch stats (using functions and arbitrary weights)
     """
+
     def compare_general_stat(self, ts, W, f, windows=None, polarised=False):
         # Determine output_dim of the function
         M = len(f(W[0]))
@@ -3397,16 +3600,17 @@ class TestGeneralBranchStats(StatsTestCase):
         W = np.zeros((ts.num_samples, 3))
         for polarised in [True, False]:
             sigma = self.compare_general_stat(
-                        ts, W, self.identity_f(ts),
-                        windows="trees", polarised=polarised)
+                ts, W, self.identity_f(ts), windows="trees", polarised=polarised
+            )
             self.assertEqual(sigma.shape, (ts.num_trees, W.shape[1]))
             self.assertTrue(np.all(sigma == 0))
 
     def test_simple_identity_f_w_ones(self):
         ts = msprime.simulate(10, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 2))
-        sigma = self.compare_general_stat(ts, W, self.identity_f(ts), windows="trees",
-                                          polarised=True)
+        sigma = self.compare_general_stat(
+            ts, W, self.identity_f(ts), windows="trees", polarised=True
+        )
         self.assertEqual(sigma.shape, (ts.num_trees, W.shape[1]))
         # A W of 1 for every node and identity f counts the samples in the subtree
         # if polarised is True.
@@ -3419,7 +3623,8 @@ class TestGeneralBranchStats(StatsTestCase):
         W = np.ones((ts.num_samples, 8))
         for polarised in [True, False]:
             sigma = self.compare_general_stat(
-                ts, W, self.cumsum_f(ts), windows="trees", polarised=polarised)
+                ts, W, self.cumsum_f(ts), windows="trees", polarised=polarised
+            )
             self.assertEqual(sigma.shape, (ts.num_trees, W.shape[1]))
 
     def test_simple_cumsum_f_w_ones_many_windows(self):
@@ -3435,11 +3640,16 @@ class TestGeneralBranchStats(StatsTestCase):
         W = np.ones((ts.num_samples, 1))
         for polarised in [True, False]:
             sigma_no_windows = self.compare_general_stat(
-                ts, W, self.cumsum_f(ts), windows="trees", polarised=polarised)
+                ts, W, self.cumsum_f(ts), windows="trees", polarised=polarised
+            )
             self.assertEqual(sigma_no_windows.shape, (ts.num_trees, W.shape[1]))
             sigma_windows = self.compare_general_stat(
-                ts, W, self.cumsum_f(ts), windows=ts.breakpoints(as_array=True),
-                polarised=polarised)
+                ts,
+                W,
+                self.cumsum_f(ts),
+                windows=ts.breakpoints(as_array=True),
+                polarised=polarised,
+            )
             self.assertEqual(sigma_windows.shape, sigma_no_windows.shape)
             self.assertTrue(np.allclose(sigma_windows.shape, sigma_no_windows.shape))
 
@@ -3459,8 +3669,7 @@ class TestGeneralBranchStats(StatsTestCase):
         f = self.identity_f(ts)
         windows = np.linspace(0, ts.sequence_length, num=11)
         for polarised in [True, False]:
-            sigma = self.compare_general_stat(ts, W, f, windows,
-                                              polarised=polarised)
+            sigma = self.compare_general_stat(ts, W, f, windows, polarised=polarised)
             self.assertEqual(sigma.shape, (10, W.shape[1]))
             self.assertTrue(np.all(sigma == 0))
 
@@ -3469,6 +3678,7 @@ class TestGeneralSiteStats(StatsTestCase):
     """
     Tests for general site stats (using functions and arbitrary weights)
     """
+
     def compare_general_stat(self, ts, W, f, windows=None, polarised=False):
         # Determine output_dim of the function
         M = len(f(W[0]))
@@ -3487,8 +3697,8 @@ class TestGeneralSiteStats(StatsTestCase):
         W = np.zeros((ts.num_samples, 3))
         for polarised in [True, False]:
             sigma = self.compare_general_stat(
-                        ts, W, self.identity_f(ts),
-                        windows="sites", polarised=polarised)
+                ts, W, self.identity_f(ts), windows="sites", polarised=polarised
+            )
             self.assertEqual(sigma.shape, (ts.num_sites, W.shape[1]))
             self.assertTrue(np.all(sigma == 0))
 
@@ -3499,7 +3709,8 @@ class TestGeneralSiteStats(StatsTestCase):
         windows = np.linspace(0, 1, num=11)
         for polarised in [True, False]:
             sigma = self.compare_general_stat(
-                ts, W, self.identity_f(ts), windows=windows, polarised=polarised)
+                ts, W, self.identity_f(ts), windows=windows, polarised=polarised
+            )
             self.assertEqual(sigma.shape, (windows.shape[0] - 1, W.shape[1]))
             self.assertTrue(np.all(sigma == 0))
 
@@ -3508,8 +3719,9 @@ class TestGeneralSiteStats(StatsTestCase):
         ts = tsutil.jukes_cantor(ts, 20, 1, seed=10)
         W = np.ones((ts.num_samples, 3))
         for polarised in [True, False]:
-            sigma = self.compare_general_stat(ts, W, self.cumsum_f(ts),
-                                              windows="sites", polarised=polarised)
+            sigma = self.compare_general_stat(
+                ts, W, self.cumsum_f(ts), windows="sites", polarised=polarised
+            )
             self.assertEqual(sigma.shape, (ts.num_sites, W.shape[1]))
 
     def test_cumsum_f_W_1_two_alleles(self):
@@ -3517,7 +3729,8 @@ class TestGeneralSiteStats(StatsTestCase):
         W = np.ones((ts.num_samples, 5))
         for polarised in [True, False]:
             sigma = self.compare_general_stat(
-                ts, W, self.cumsum_f(ts), windows="sites", polarised=polarised)
+                ts, W, self.cumsum_f(ts), windows="sites", polarised=polarised
+            )
             self.assertEqual(sigma.shape, (ts.num_sites, W.shape[1]))
 
 
@@ -3525,6 +3738,7 @@ class TestGeneralNodeStats(StatsTestCase):
     """
     Tests for general node stats (using functions and arbitrary weights)
     """
+
     def compare_general_stat(self, ts, W, f, windows=None, polarised=False):
         # Determine output_dim of the function
         M = len(f(W[0]))
@@ -3542,7 +3756,8 @@ class TestGeneralNodeStats(StatsTestCase):
         W = np.zeros((ts.num_samples, 3))
         for polarised in [True, False]:
             sigma = self.compare_general_stat(
-                ts, W, self.identity_f(ts), windows="trees", polarised=polarised)
+                ts, W, self.identity_f(ts), windows="trees", polarised=polarised
+            )
             self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 3))
             self.assertTrue(np.all(sigma == 0))
 
@@ -3550,23 +3765,33 @@ class TestGeneralNodeStats(StatsTestCase):
         ts = msprime.simulate(44, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 2))
         f = self.sum_f(ts)
-        sigma = self.compare_general_stat(
-            ts, W, f, windows="trees", polarised=True)
+        sigma = self.compare_general_stat(ts, W, f, windows="trees", polarised=True)
         self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 1))
         # Drop the last dimension
         sigma = sigma.reshape((ts.num_trees, ts.num_nodes))
         # A W of 1 for every node and f(x)=sum(x) counts the samples in the subtree
         # times 2 if polarised is True.
         for tree in ts.trees():
-            s = np.array([tree.num_samples(u) if tree.num_samples(u) < ts.num_samples
-                          else 0 for u in range(ts.num_nodes)])
-            self.assertArrayAlmostEqual(sigma[tree.index], 2*s)
+            s = np.array(
+                [
+                    tree.num_samples(u) if tree.num_samples(u) < ts.num_samples else 0
+                    for u in range(ts.num_nodes)
+                ]
+            )
+            self.assertArrayAlmostEqual(sigma[tree.index], 2 * s)
 
     def test_simple_sum_f_w_ones_notstrict(self):
         ts = msprime.simulate(44, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 2))
-        sigma = ts.general_stat(W, lambda x: np.array([np.sum(x)]), 1, windows="trees",
-                                polarised=True, mode="node", strict=False)
+        sigma = ts.general_stat(
+            W,
+            lambda x: np.array([np.sum(x)]),
+            1,
+            windows="trees",
+            polarised=True,
+            mode="node",
+            strict=False,
+        )
         self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 1))
         # Drop the last dimension
         sigma = sigma.reshape((ts.num_trees, ts.num_nodes))
@@ -3574,31 +3799,35 @@ class TestGeneralNodeStats(StatsTestCase):
         # times 2 if polarised is True.
         for tree in ts.trees():
             s = np.array([tree.num_samples(u) for u in range(ts.num_nodes)])
-            self.assertArrayAlmostEqual(sigma[tree.index], 2*s)
+            self.assertArrayAlmostEqual(sigma[tree.index], 2 * s)
 
     def test_small_tree_windows_polarised(self):
         ts = msprime.simulate(4, recombination_rate=0.5, random_seed=2)
         self.assertGreater(ts.num_trees, 1)
         W = np.ones((ts.num_samples, 1))
         sigma = self.compare_general_stat(
-            ts, W, self.cumsum_f(ts), windows=ts.breakpoints(as_array=True),
-            polarised=True)
+            ts,
+            W,
+            self.cumsum_f(ts),
+            windows=ts.breakpoints(as_array=True),
+            polarised=True,
+        )
         self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 1))
 
     def test_one_window_polarised(self):
         ts = msprime.simulate(4, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 1))
         sigma = self.compare_general_stat(
-            ts, W, self.cumsum_f(ts), windows=[0, ts.sequence_length],
-            polarised=True)
+            ts, W, self.cumsum_f(ts), windows=[0, ts.sequence_length], polarised=True
+        )
         self.assertEqual(sigma.shape, (1, ts.num_nodes, W.shape[1]))
 
     def test_one_window_unpolarised(self):
         ts = msprime.simulate(4, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 2))
         sigma = self.compare_general_stat(
-            ts, W, self.cumsum_f(ts), windows=[0, ts.sequence_length],
-            polarised=False)
+            ts, W, self.cumsum_f(ts), windows=[0, ts.sequence_length], polarised=False
+        )
         self.assertEqual(sigma.shape, (1, ts.num_nodes, 2))
 
     def test_many_windows(self):
@@ -3608,21 +3837,25 @@ class TestGeneralNodeStats(StatsTestCase):
             windows = np.linspace(0, 1, num=k + 1)
             for polarised in [True]:
                 sigma = self.compare_general_stat(
-                    ts, W, self.cumsum_f(ts), windows=windows, polarised=polarised)
+                    ts, W, self.cumsum_f(ts), windows=windows, polarised=polarised
+                )
             self.assertEqual(sigma.shape, (k, ts.num_nodes, 3))
 
     def test_one_tree(self):
         ts = msprime.simulate(10, random_seed=3)
         W = np.ones((ts.num_samples, 2))
         f = self.sum_f(ts, k=2)
-        sigma = self.compare_general_stat(
-            ts, W, f, windows=[0, 1], polarised=True)
+        sigma = self.compare_general_stat(ts, W, f, windows=[0, 1], polarised=True)
         self.assertEqual(sigma.shape, (1, ts.num_nodes, 2))
         # A W of 1 for every node and f(x)=sum(x) counts the samples in the subtree
         # times 2 if polarised is True.
         tree = ts.first()
-        s = np.array([tree.num_samples(u) if tree.num_samples(u) < ts.num_samples else 0
-                      for u in range(ts.num_nodes)])
+        s = np.array(
+            [
+                tree.num_samples(u) if tree.num_samples(u) < ts.num_samples else 0
+                for u in range(ts.num_nodes)
+            ]
+        )
         self.assertArrayAlmostEqual(sigma[tree.index, :, 0], 2 * s)
         self.assertArrayAlmostEqual(sigma[tree.index, :, 1], 2 * s)
 
@@ -3630,6 +3863,7 @@ class TestGeneralNodeStats(StatsTestCase):
 ##############################
 # Trait covariance
 ##############################
+
 
 def covsq(x, y):
     cov = np.dot(x - np.mean(x), y - np.mean(y)) / (len(x) - 1)
@@ -3649,7 +3883,7 @@ def site_trait_covariance(ts, W, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, K))
     for j in range(len(windows) - 1):
         begin = windows[j]
@@ -3671,7 +3905,7 @@ def site_trait_covariance(ts, W, windows=None, span_normalise=True):
             if site_in_window:
                 out[j, i] = S
                 if span_normalise:
-                    out[j, i] /= (end - begin)
+                    out[j, i] /= end - begin
     return out
 
 
@@ -3682,7 +3916,7 @@ def branch_trait_covariance(ts, W, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, K))
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -3705,11 +3939,11 @@ def branch_trait_covariance(ts, W, windows=None, span_normalise=True):
                     below = np.in1d(samples, list(tr.samples(u)))
                     branch_length = tr.branch_length(u)
                     SS += covsq(w, below) * branch_length
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             if has_trees:
                 out[j, i] = S
                 if span_normalise:
-                    out[j, i] /= (end - begin)
+                    out[j, i] /= end - begin
     return out
 
 
@@ -3720,7 +3954,7 @@ def node_trait_covariance(ts, W, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, ts.num_nodes, K))
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -3739,10 +3973,10 @@ def node_trait_covariance(ts, W, windows=None, span_normalise=True):
                 for u in range(ts.num_nodes):
                     below = np.in1d(samples, list(tr.samples(u)))
                     SS[u] += covsq(w, below)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             out[j, :, i] = S
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -3750,9 +3984,9 @@ def trait_covariance(ts, W, windows=None, mode="site", span_normalise=True):
     method_map = {
         "site": site_trait_covariance,
         "node": node_trait_covariance,
-        "branch": branch_trait_covariance}
-    return method_map[mode](ts, W, windows=windows,
-                            span_normalise=span_normalise)
+        "branch": branch_trait_covariance,
+    }
+    return method_map[mode](ts, W, windows=windows, span_normalise=span_normalise)
 
 
 class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
@@ -3777,8 +4011,7 @@ class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
         def f(x):
             return (x ** 2) / (2 * (n - 1) * (n - 1))
 
-        self.verify_definition(
-            ts, W, windows, f, ts.trait_covariance, trait_covariance)
+        self.verify_definition(ts, W, windows, f, ts.trait_covariance, trait_covariance)
 
     def verify_interface(self, ts, ts_method):
         W = np.array([np.arange(ts.num_samples)]).T
@@ -3793,7 +4026,8 @@ class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
         # Since weights are mean-centered, adding a constant shouldn't change anything.
         ts = self.get_example_ts()
         for W, windows in subset_combos(
-                self.example_weights(ts), example_windows(ts), p=0.1):
+            self.example_weights(ts), example_windows(ts), p=0.1
+        ):
             shift = np.arange(1, W.shape[1] + 1)
             sigma1 = ts_method(W, windows=windows, mode=self.mode)
             sigma2 = ts_method(W + shift, windows=windows, mode=self.mode)
@@ -3808,7 +4042,6 @@ class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
 
 
 class TraitCovarianceMixin(object):
-
     def test_interface(self):
         ts = self.get_example_ts()
         self.verify_interface(ts, ts.trait_covariance)
@@ -3825,18 +4058,20 @@ class TraitCovarianceMixin(object):
 
 
 class TestBranchTraitCovariance(
-        TestTraitCovariance, TopologyExamplesMixin, TraitCovarianceMixin):
+    TestTraitCovariance, TopologyExamplesMixin, TraitCovarianceMixin
+):
     mode = "branch"
 
 
 class TestNodeTraitCovariance(
-        TestTraitCovariance, TopologyExamplesMixin, TraitCovarianceMixin):
+    TestTraitCovariance, TopologyExamplesMixin, TraitCovarianceMixin
+):
     mode = "node"
 
 
 class TestSiteTraitCovariance(
-        TestTraitCovariance, MutatedTopologyExamplesMixin,
-        TraitCovarianceMixin):
+    TestTraitCovariance, MutatedTopologyExamplesMixin, TraitCovarianceMixin
+):
     mode = "site"
 
 
@@ -3851,7 +4086,7 @@ def site_trait_correlation(ts, W, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, K))
     for j in range(len(windows) - 1):
         begin = windows[j]
@@ -3877,7 +4112,7 @@ def site_trait_correlation(ts, W, windows=None, span_normalise=True):
             if site_in_window:
                 out[j, i] = S
                 if span_normalise:
-                    out[j, i] /= (end - begin)
+                    out[j, i] /= end - begin
     return out
 
 
@@ -3888,7 +4123,7 @@ def branch_trait_correlation(ts, W, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, K))
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -3917,11 +4152,11 @@ def branch_trait_correlation(ts, W, windows=None, span_normalise=True):
                         #         sum(w[np.logical_not(below)])**2) * branch_length
                         #        / (2 * (p * (1 - p))))
                         SS += corsq(w, below) * branch_length
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             if has_trees:
                 out[j, i] = S
                 if span_normalise:
-                    out[j, i] /= (end - begin)
+                    out[j, i] /= end - begin
     return out
 
 
@@ -3932,7 +4167,7 @@ def node_trait_correlation(ts, W, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, ts.num_nodes, K))
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -3957,10 +4192,10 @@ def node_trait_correlation(ts, W, windows=None, span_normalise=True):
                         # SS[u] += sum(w[np.logical_not(below)])**2 / 2
                         # SS[u] /= (p * (1 - p))
                         SS[u] += corsq(w, below)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             out[j, :, i] = S
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -3968,9 +4203,9 @@ def trait_correlation(ts, W, windows=None, mode="site", span_normalise=True):
     method_map = {
         "site": site_trait_correlation,
         "node": node_trait_correlation,
-        "branch": branch_trait_correlation}
-    return method_map[mode](ts, W, windows=windows,
-                            span_normalise=span_normalise)
+        "branch": branch_trait_correlation,
+    }
+    return method_map[mode](ts, W, windows=windows, span_normalise=span_normalise)
 
 
 class TestTraitCorrelation(TestTraitCovariance):
@@ -3986,7 +4221,7 @@ class TestTraitCorrelation(TestTraitCovariance):
         n = W.shape[0]
         with suppress_division_by_zero_warning():
             W /= np.std(W, axis=0) * np.sqrt(n / (n - 1))
-        return np.column_stack((W, np.ones(W.shape[0])/W.shape[0]))
+        return np.column_stack((W, np.ones(W.shape[0]) / W.shape[0]))
 
     def verify_weighted_stat(self, ts, W, windows):
         n = W.shape[0]
@@ -3999,7 +4234,8 @@ class TestTraitCorrelation(TestTraitCovariance):
                 return x[:-1] * 0.0
 
         self.verify_definition(
-            ts, W, windows, f, ts.trait_correlation, trait_correlation)
+            ts, W, windows, f, ts.trait_correlation, trait_correlation
+        )
 
     def test_errors(self):
         ts = self.get_example_ts()
@@ -4015,7 +4251,8 @@ class TestTraitCorrelation(TestTraitCovariance):
         change anything.
         """
         for W, windows in subset_combos(
-                self.example_weights(ts), example_windows(ts), p=0.1):
+            self.example_weights(ts), example_windows(ts), p=0.1
+        ):
             scale = np.arange(1, W.shape[1] + 1)
             sigma1 = ts_method(W, windows=windows, mode=self.mode)
             sigma2 = ts_method(W * scale, windows=windows, mode=self.mode)
@@ -4028,7 +4265,6 @@ class TestTraitCorrelation(TestTraitCovariance):
 
 
 class TraitCorrelationMixin(object):
-
     def test_interface(self):
         ts = self.get_example_ts()
         self.verify_interface(ts, ts.trait_correlation)
@@ -4036,23 +4272,24 @@ class TraitCorrelationMixin(object):
     def test_normalisation(self):
         ts = self.get_example_ts()
         self.verify_centering(ts, trait_correlation, ts.trait_correlation)
-        self.verify_standardising(
-                ts, trait_correlation, ts.trait_correlation)
+        self.verify_standardising(ts, trait_correlation, ts.trait_correlation)
 
 
 class TestBranchTraitCorrelation(
-        TestTraitCorrelation, TopologyExamplesMixin, TraitCorrelationMixin):
+    TestTraitCorrelation, TopologyExamplesMixin, TraitCorrelationMixin
+):
     mode = "branch"
 
 
 class TestNodeTraitCorrelation(
-        TestTraitCorrelation, TopologyExamplesMixin, TraitCorrelationMixin):
+    TestTraitCorrelation, TopologyExamplesMixin, TraitCorrelationMixin
+):
     mode = "node"
 
 
 class TestSiteTraitCorrelation(
-        TestTraitCorrelation, MutatedTopologyExamplesMixin,
-        TraitCorrelationMixin):
+    TestTraitCorrelation, MutatedTopologyExamplesMixin, TraitCorrelationMixin
+):
     mode = "site"
 
 
@@ -4092,7 +4329,7 @@ def site_trait_regression(ts, W, Z, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, K))
     for j in range(len(windows) - 1):
         begin = windows[j]
@@ -4115,7 +4352,7 @@ def site_trait_regression(ts, W, Z, windows=None, span_normalise=True):
             if site_in_window:
                 out[j, i] = S
                 if span_normalise:
-                    out[j, i] /= (end - begin)
+                    out[j, i] /= end - begin
     return out
 
 
@@ -4127,7 +4364,7 @@ def branch_trait_regression(ts, W, Z, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, K))
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -4149,11 +4386,11 @@ def branch_trait_regression(ts, W, Z, windows=None, span_normalise=True):
                     below = np.in1d(samples, list(tr.samples(u)))
                     branch_length = tr.branch_length(u)
                     SS += regression(w, below, Z) * branch_length
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             if has_trees:
                 out[j, i] = S
                 if span_normalise:
-                    out[j, i] /= (end - begin)
+                    out[j, i] /= end - begin
     return out
 
 
@@ -4165,7 +4402,7 @@ def node_trait_regression(ts, W, Z, windows=None, span_normalise=True):
     """
     windows = ts.parse_windows(windows)
     n, K = W.shape
-    assert(n == ts.num_samples)
+    assert n == ts.num_samples
     out = np.zeros((len(windows) - 1, ts.num_nodes, K))
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -4183,10 +4420,10 @@ def node_trait_regression(ts, W, Z, windows=None, span_normalise=True):
                 for u in range(ts.num_nodes):
                     below = np.in1d(samples, list(tr.samples(u)))
                     SS[u] += regression(w, below, Z)
-                S += SS*(min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
             out[j, :, i] = S
             if span_normalise:
-                out[j, :, i] /= (end - begin)
+                out[j, :, i] /= end - begin
     return out
 
 
@@ -4194,9 +4431,9 @@ def trait_regression(ts, W, Z, windows=None, mode="site", span_normalise=True):
     method_map = {
         "site": site_trait_regression,
         "node": node_trait_regression,
-        "branch": branch_trait_regression}
-    return method_map[mode](ts, W, Z, windows=windows,
-                            span_normalise=span_normalise)
+        "branch": branch_trait_regression,
+    }
+    return method_map[mode](ts, W, Z, windows=windows, span_normalise=span_normalise)
 
 
 class TestTraitRegression(StatsTestCase, WeightStatsMixin):
@@ -4213,7 +4450,7 @@ class TestTraitRegression(StatsTestCase, WeightStatsMixin):
         for k in [1, 2, 5]:
             k = min(k, ts.num_samples)
             Z = np.ones((N, k))
-            Z[1, :] = np.arange(k, 2*k)
+            Z[1, :] = np.arange(k, 2 * k)
             yield Z
             for j in range(k):
                 Z[:, j] = np.random.normal(0, 1, N)
@@ -4227,18 +4464,19 @@ class TestTraitRegression(StatsTestCase, WeightStatsMixin):
         tZ = np.column_stack([Z, np.ones((Z.shape[0], 1))])
         if np.linalg.matrix_rank(tZ) == tZ.shape[1]:
             Z = tZ
-        assert(np.linalg.matrix_rank(Z) == Z.shape[1])
+        assert np.linalg.matrix_rank(Z) == Z.shape[1]
         K = np.linalg.cholesky(np.matmul(Z.T, Z)).T
         Z = np.matmul(Z, np.linalg.inv(K))
         return Z
 
     def verify(self, ts):
         for W, Z, windows in subset_combos(
-                self.example_weights(ts),
-                self.example_covariates(ts),
-                example_windows(ts), p=0.04):
-            self.verify_trait_regression(
-                    ts, W, Z, windows=windows)
+            self.example_weights(ts),
+            self.example_covariates(ts),
+            example_windows(ts),
+            p=0.04,
+        ):
+            self.verify_trait_regression(ts, W, Z, windows=windows)
 
     def verify_trait_regression(self, ts, W, Z, windows):
         n, result_dim = W.shape
@@ -4279,15 +4517,18 @@ class TestTraitRegression(StatsTestCase, WeightStatsMixin):
         # Determine output_dim of the function
         M = len(wrapped_summary_func(gW[0]))
         for sn in [True, False]:
-            sigma1 = ts.general_stat(gW, wrapped_summary_func, M,
-                                     windows, mode=self.mode,
-                                     span_normalise=sn)
-            sigma2 = general_stat(ts, gW, wrapped_summary_func, windows, mode=self.mode,
-                                  span_normalise=sn)
-            sigma3 = ts.trait_regression(W, Z, windows=windows, mode=self.mode,
-                                         span_normalise=sn)
-            sigma4 = trait_regression(ts, W, Z, windows=windows, mode=self.mode,
-                                      span_normalise=sn)
+            sigma1 = ts.general_stat(
+                gW, wrapped_summary_func, M, windows, mode=self.mode, span_normalise=sn
+            )
+            sigma2 = general_stat(
+                ts, gW, wrapped_summary_func, windows, mode=self.mode, span_normalise=sn
+            )
+            sigma3 = ts.trait_regression(
+                W, Z, windows=windows, mode=self.mode, span_normalise=sn
+            )
+            sigma4 = trait_regression(
+                ts, W, Z, windows=windows, mode=self.mode, span_normalise=sn
+            )
 
             self.assertEqual(sigma1.shape, sigma2.shape)
             self.assertEqual(sigma1.shape, sigma3.shape)
@@ -4298,17 +4539,18 @@ class TestTraitRegression(StatsTestCase, WeightStatsMixin):
 
 
 class TraitRegressionMixin(object):
-
     def test_interface(self):
         ts = self.get_example_ts()
         W = np.array([np.arange(ts.num_samples)]).T
         Z = np.ones((ts.num_samples, 1))
         sigma1 = ts.trait_regression(W, Z=Z, mode=self.mode)
         sigma2 = ts.trait_regression(W, Z=Z, windows=None, mode=self.mode)
-        sigma3 = ts.trait_regression(W, Z=Z, windows=[0.0, ts.sequence_length],
-                                     mode=self.mode)
-        sigma4 = ts.trait_regression(W, Z=None, windows=[0.0, ts.sequence_length],
-                                     mode=self.mode)
+        sigma3 = ts.trait_regression(
+            W, Z=Z, windows=[0.0, ts.sequence_length], mode=self.mode
+        )
+        sigma4 = ts.trait_regression(
+            W, Z=None, windows=[0.0, ts.sequence_length], mode=self.mode
+        )
         self.assertEqual(sigma1.shape, sigma2.shape)
         self.assertEqual(sigma3.shape[0], 1)
         self.assertEqual(sigma1.shape, sigma3.shape[1:])
@@ -4322,8 +4564,13 @@ class TraitRegressionMixin(object):
         W = np.array([np.arange(ts.num_samples)]).T
         Z = np.ones((ts.num_samples, 1))
         # singular covariates
-        self.assertRaises(ValueError, ts.trait_regression, W,
-                          np.ones((ts.num_samples, 2)), mode=self.mode)
+        self.assertRaises(
+            ValueError,
+            ts.trait_regression,
+            W,
+            np.ones((ts.num_samples, 2)),
+            mode=self.mode,
+        )
         # wrong dimensions of W
         self.assertRaises(ValueError, ts.trait_regression, W[1:, :], Z, mode=self.mode)
         # wrong dimensions of Z
@@ -4331,19 +4578,22 @@ class TraitRegressionMixin(object):
 
 
 class TestBranchTraitRegression(
-        TestTraitRegression, TopologyExamplesMixin, TraitRegressionMixin):
+    TestTraitRegression, TopologyExamplesMixin, TraitRegressionMixin
+):
     mode = "branch"
 
 
 class TestNodeTraitRegression(
-        TestTraitRegression, TopologyExamplesMixin, TraitRegressionMixin):
+    TestTraitRegression, TopologyExamplesMixin, TraitRegressionMixin
+):
     mode = "node"
 
 
 class TestSiteTraitRegression(
-        TestTraitRegression, MutatedTopologyExamplesMixin,
-        TraitRegressionMixin):
+    TestTraitRegression, MutatedTopologyExamplesMixin, TraitRegressionMixin
+):
     mode = "site"
+
 
 ##############################
 # Sample set statistics
@@ -4364,10 +4614,14 @@ class SampleSetStatTestCase(StatsTestCase):
 
     def compare_sfs(self, ts, tree_fn, sample_sets, tsc_fn):
         for sample_set in sample_sets:
-            windows = [k * ts.sequence_length / 20 for k in
-                       [0] + sorted(self.rng.sample(range(1, 20), 4)) + [20]]
-            win_args = [{'begin': windows[i], 'end': windows[i+1]}
-                        for i in range(len(windows)-1)]
+            windows = [
+                k * ts.sequence_length / 20
+                for k in [0] + sorted(self.rng.sample(range(1, 20), 4)) + [20]
+            ]
+            win_args = [
+                {"begin": windows[i], "end": windows[i + 1]}
+                for i in range(len(windows) - 1)
+            ]
             tree_vals = [tree_fn(sample_set, **b) for b in win_args]
 
             tsc_vals = tsc_fn(sample_set, windows)
@@ -4379,37 +4633,64 @@ class SampleSetStatTestCase(StatsTestCase):
         samples = ts.samples()
 
         # empty sample sets will raise an error
-        self.assertRaises(ValueError, ts.site_frequency_spectrum, [],
-                          self.stat_type)
+        self.assertRaises(ValueError, ts.site_frequency_spectrum, [], self.stat_type)
         # sample_sets must be lists without repeated elements
-        self.assertRaises(ValueError, ts.site_frequency_spectrum,
-                          [samples[2], samples[2]], self.stat_type)
+        self.assertRaises(
+            ValueError,
+            ts.site_frequency_spectrum,
+            [samples[2], samples[2]],
+            self.stat_type,
+        )
         # and must all be samples
-        self.assertRaises(ValueError, ts.site_frequency_spectrum,
-                          [samples[0], max(samples)+1], self.stat_type)
+        self.assertRaises(
+            ValueError,
+            ts.site_frequency_spectrum,
+            [samples[0], max(samples) + 1],
+            self.stat_type,
+        )
         # windows must start at 0.0, be increasing, and extend to the end
-        self.assertRaises(ValueError, ts.site_frequency_spectrum,
-                          samples[0:2], [0.1, ts.sequence_length],
-                          self.stat_type)
-        self.assertRaises(ValueError, ts.site_frequency_spectrum,
-                          samples[0:2], [0.0, 0.8*ts.sequence_length],
-                          self.stat_type)
-        self.assertRaises(ValueError, ts.site_frequency_spectrum, samples[0:2],
-                          [0.0, 0.8*ts.sequence_length, 0.4*ts.sequence_length,
-                           ts.sequence_length], self.stat_type)
+        self.assertRaises(
+            ValueError,
+            ts.site_frequency_spectrum,
+            samples[0:2],
+            [0.1, ts.sequence_length],
+            self.stat_type,
+        )
+        self.assertRaises(
+            ValueError,
+            ts.site_frequency_spectrum,
+            samples[0:2],
+            [0.0, 0.8 * ts.sequence_length],
+            self.stat_type,
+        )
+        self.assertRaises(
+            ValueError,
+            ts.site_frequency_spectrum,
+            samples[0:2],
+            [
+                0.0,
+                0.8 * ts.sequence_length,
+                0.4 * ts.sequence_length,
+                ts.sequence_length,
+            ],
+            self.stat_type,
+        )
 
     def check_sfs(self, ts):
         # check site frequency spectrum
         self.check_sfs_interface(ts)
-        A = [self.rng.sample(list(ts.samples()), 2),
-             self.rng.sample(list(ts.samples()), 4),
-             self.rng.sample(list(ts.samples()), 8),
-             self.rng.sample(list(ts.samples()), 10),
-             self.rng.sample(list(ts.samples()), 12)]
+        A = [
+            self.rng.sample(list(ts.samples()), 2),
+            self.rng.sample(list(ts.samples()), 4),
+            self.rng.sample(list(ts.samples()), 8),
+            self.rng.sample(list(ts.samples()), 10),
+            self.rng.sample(list(ts.samples()), 12),
+        ]
         py_tsc = self.py_stat_class(ts)
 
-        self.compare_sfs(ts, py_tsc.site_frequency_spectrum, A,
-                         ts.site_frequency_spectrum)
+        self.compare_sfs(
+            ts, py_tsc.site_frequency_spectrum, A, ts.site_frequency_spectrum
+        )
 
 
 class BranchSampleSetStatsTestCase(SampleSetStatTestCase):
@@ -4424,8 +4705,9 @@ class BranchSampleSetStatsTestCase(SampleSetStatTestCase):
 
     def get_ts(self):
         for N in [12, 15, 20]:
-            yield msprime.simulate(N, random_seed=self.random_seed,
-                                   recombination_rate=10)
+            yield msprime.simulate(
+                N, random_seed=self.random_seed, recombination_rate=10
+            )
 
     @unittest.skip("Skipping SFS.")
     def test_sfs_interface(self):
@@ -4439,15 +4721,17 @@ class BranchSampleSetStatsTestCase(SampleSetStatTestCase):
         # Check for bad windows
         for bad_start in [-1, 1, 1e-7]:
             self.assertRaises(
-                ValueError, tsc.site_frequency_spectrum, [1, 2],
-                [bad_start, ts.sequence_length])
+                ValueError,
+                tsc.site_frequency_spectrum,
+                [1, 2],
+                [bad_start, ts.sequence_length],
+            )
         for bad_end in [0, ts.sequence_length - 1, ts.sequence_length + 1]:
             self.assertRaises(
-                ValueError, tsc.site_frequency_spectrum, [1, 2],
-                [0, bad_end])
+                ValueError, tsc.site_frequency_spectrum, [1, 2], [0, bad_end]
+            )
         # Windows must be increasing.
-        self.assertRaises(
-            ValueError, tsc.site_frequency_spectrum, [1, 2], [0, 1, 1])
+        self.assertRaises(ValueError, tsc.site_frequency_spectrum, [1, 2], [0, 1, 1])
 
     @unittest.skip("No SFS.")
     def test_branch_sfs(self):
@@ -4459,6 +4743,7 @@ class SpecificTreesTestCase(StatsTestCase):
     """
     Some particular cases, that are easy to see and debug.
     """
+
     seed = 21
 
     def test_case_1(self):
@@ -4479,70 +4764,96 @@ class SpecificTreesTestCase(StatsTestCase):
         # 0:     0   1 0  1 0         0    0              1   0 0
         # 1:     1   0 0  0 1         1    0              0   1 0
         # 2:     1   0 1  0 0         0    1              0   0 1
-        branch_true_diversity_01 = 2*(1 * (0.2-0) +
-                                      0.5 * (0.8-0.2) + 0.7 * (1.0-0.8))
-        branch_true_diversity_02 = 2*(1 * (0.2-0) +
-                                      0.4 * (0.8-0.2) + 0.7 * (1.0-0.8))
-        branch_true_diversity_12 = 2*(0.5 * (0.2-0) +
-                                      0.5 * (0.8-0.2) + 0.5 * (1.0-0.8))
-        branch_true_Y = 0.2*(1 + 0.5) + 0.6*(0.4) + 0.2*(0.7+0.2)
+        branch_true_diversity_01 = 2 * (
+            1 * (0.2 - 0) + 0.5 * (0.8 - 0.2) + 0.7 * (1.0 - 0.8)
+        )
+        branch_true_diversity_02 = 2 * (
+            1 * (0.2 - 0) + 0.4 * (0.8 - 0.2) + 0.7 * (1.0 - 0.8)
+        )
+        branch_true_diversity_12 = 2 * (
+            0.5 * (0.2 - 0) + 0.5 * (0.8 - 0.2) + 0.5 * (1.0 - 0.8)
+        )
+        branch_true_Y = 0.2 * (1 + 0.5) + 0.6 * (0.4) + 0.2 * (0.7 + 0.2)
         site_true_Y = 3 + 0 + 1
-        node_true_diversity_012 = np.array([
-                0.2 * np.array([2, 2, 2, 0, 2, 0, 0]) +
-                0.6 * np.array([2, 2, 2, 2, 0, 0, 0]) +
-                0.2 * np.array([2, 2, 2, 0, 2, 0, 0])]) / 3
-        node_true_divergence_0_12 = np.array([
-                0.2 * np.array([2, 1, 1, 0, 2, 0, 0]) +
-                0.6 * np.array([2, 1, 1, 1, 0, 0, 0]) +
-                0.2 * np.array([2, 1, 1, 0, 2, 0, 0])]) / 2
-        haplotypes = np.array([[0, 1, 1],
-                               [1, 0, 0],
-                               [0, 0, 1],
-                               [1, 0, 0],
-                               [0, 1, 0],
-                               [0, 1, 0],
-                               [0, 0, 1],
-                               [1, 0, 0],
-                               [0, 1, 0],
-                               [0, 0, 1]])
-        traits = np.array([[1, 2, 3, 0],
-                           [-5, 0, 1, 1],
-                           [3, 4, 1.2, 2]])
+        node_true_diversity_012 = (
+            np.array(
+                [
+                    0.2 * np.array([2, 2, 2, 0, 2, 0, 0])
+                    + 0.6 * np.array([2, 2, 2, 2, 0, 0, 0])
+                    + 0.2 * np.array([2, 2, 2, 0, 2, 0, 0])
+                ]
+            )
+            / 3
+        )
+        node_true_divergence_0_12 = (
+            np.array(
+                [
+                    0.2 * np.array([2, 1, 1, 0, 2, 0, 0])
+                    + 0.6 * np.array([2, 1, 1, 1, 0, 0, 0])
+                    + 0.2 * np.array([2, 1, 1, 0, 2, 0, 0])
+                ]
+            )
+            / 2
+        )
+        haplotypes = np.array(
+            [
+                [0, 1, 1],
+                [1, 0, 0],
+                [0, 0, 1],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ]
+        )
+        traits = np.array([[1, 2, 3, 0], [-5, 0, 1, 1], [3, 4, 1.2, 2]])
         # nb: verified the following with R
-        true_cov = np.cov(
-                haplotypes,
-                traits.T)[:haplotypes.shape[0], haplotypes.shape[0]:] ** 2
-        true_cor = np.corrcoef(
-                haplotypes,
-                traits.T)[:haplotypes.shape[0], haplotypes.shape[0]:] ** 2
+        true_cov = (
+            np.cov(haplotypes, traits.T)[: haplotypes.shape[0], haplotypes.shape[0] :]
+            ** 2
+        )
+        true_cor = (
+            np.corrcoef(haplotypes, traits.T)[
+                : haplotypes.shape[0], haplotypes.shape[0] :
+            ]
+            ** 2
+        )
         cov02 = np.cov(np.array([1, 0, 1]), traits.T)[:1, 1:] ** 2
-        true_branch_cov = (true_cov[1, :] * 1.0 * 0.2 +  # branch 0, tree 0
-                           true_cov[4, :] * 0.5 * 0.2 +  # branch 1, tree 0
-                           true_cov[2, :] * 0.5 * 0.2 +  # branch 2, tree 0
-                           true_cov[0, :] * 0.5 * 0.2 +  # branch 4, tree 0
-                           true_cov[1, :] * 0.4 * 0.6 +  # branch 0, tree 1
-                           true_cov[4, :] * 0.5 * 0.6 +  # branch 1, tree 1
-                           true_cov[2, :] * 0.4 * 0.6 +  # branch 2, tree 1
-                           cov02 * 0.1 * 0.6 +  # branch 3, tree 1
-                           true_cov[1, :] * 0.7 * 0.2 +  # branch 0, tree 2
-                           true_cov[4, :] * 0.5 * 0.2 +  # branch 1, tree 2
-                           true_cov[2, :] * 0.5 * 0.2 +  # branch 2, tree 2
-                           true_cov[0, :] * 0.2 * 0.2)  # branch 4, tree 2
+        true_branch_cov = (
+            true_cov[1, :] * 1.0 * 0.2
+            + true_cov[4, :] * 0.5 * 0.2  # branch 0, tree 0
+            + true_cov[2, :] * 0.5 * 0.2  # branch 1, tree 0
+            + true_cov[0, :] * 0.5 * 0.2  # branch 2, tree 0
+            + true_cov[1, :] * 0.4 * 0.6  # branch 4, tree 0
+            + true_cov[4, :] * 0.5 * 0.6  # branch 0, tree 1
+            + true_cov[2, :] * 0.4 * 0.6  # branch 1, tree 1
+            + cov02 * 0.1 * 0.6  # branch 2, tree 1
+            + true_cov[1, :] * 0.7 * 0.2  # branch 3, tree 1
+            + true_cov[4, :] * 0.5 * 0.2  # branch 0, tree 2
+            + true_cov[2, :] * 0.5 * 0.2  # branch 1, tree 2
+            + true_cov[0, :] * 0.2 * 0.2  # branch 2, tree 2
+        )  # branch 4, tree 2
         cor02 = np.corrcoef(np.array([1, 0, 1]), traits.T)[:1, 1:] ** 2
-        true_branch_cor = (true_cor[1, :] * 1.0 * 0.2 +  # branch 0, tree 0
-                           true_cor[4, :] * 0.5 * 0.2 +  # branch 1, tree 0
-                           true_cor[2, :] * 0.5 * 0.2 +  # branch 2, tree 0
-                           true_cor[0, :] * 0.5 * 0.2 +  # branch 4, tree 0
-                           true_cor[1, :] * 0.4 * 0.6 +  # branch 0, tree 1
-                           true_cor[4, :] * 0.5 * 0.6 +  # branch 1, tree 1
-                           true_cor[2, :] * 0.4 * 0.6 +  # branch 2, tree 1
-                           cor02 * 0.1 * 0.6 +  # branch 3, tree 1
-                           true_cor[1, :] * 0.7 * 0.2 +  # branch 0, tree 2
-                           true_cor[4, :] * 0.5 * 0.2 +  # branch 1, tree 2
-                           true_cor[2, :] * 0.5 * 0.2 +  # branch 2, tree 2
-                           true_cor[0, :] * 0.2 * 0.2)  # branch 4, tree 2
+        true_branch_cor = (
+            true_cor[1, :] * 1.0 * 0.2
+            + true_cor[4, :] * 0.5 * 0.2  # branch 0, tree 0
+            + true_cor[2, :] * 0.5 * 0.2  # branch 1, tree 0
+            + true_cor[0, :] * 0.5 * 0.2  # branch 2, tree 0
+            + true_cor[1, :] * 0.4 * 0.6  # branch 4, tree 0
+            + true_cor[4, :] * 0.5 * 0.6  # branch 0, tree 1
+            + true_cor[2, :] * 0.4 * 0.6  # branch 1, tree 1
+            + cor02 * 0.1 * 0.6  # branch 2, tree 1
+            + true_cor[1, :] * 0.7 * 0.2  # branch 3, tree 1
+            + true_cor[4, :] * 0.5 * 0.2  # branch 0, tree 2
+            + true_cor[2, :] * 0.5 * 0.2  # branch 1, tree 2
+            + true_cor[0, :] * 0.2 * 0.2  # branch 2, tree 2
+        )  # branch 4, tree 2
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -4551,8 +4862,10 @@ class SpecificTreesTestCase(StatsTestCase):
         4       0           0.5
         5       0           0.7
         6       0           1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.2     0.8     3       0,2
         0.0     0.2     4       1,2
@@ -4560,8 +4873,10 @@ class SpecificTreesTestCase(StatsTestCase):
         0.8     1.0     4       1,2
         0.8     1.0     5       0,4
         0.0     0.2     6       0,4
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.05        0
         1   0.1         0
@@ -4573,8 +4888,10 @@ class SpecificTreesTestCase(StatsTestCase):
         7   0.9         0
         8   0.95        0
         9   0.951       0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state
         0       4       1
         1       0       1
@@ -4586,61 +4903,82 @@ class SpecificTreesTestCase(StatsTestCase):
         7       0       1
         8       1       1
         9       2       1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
 
         # diversity between 0 and 1
         A = [[0], [1]]
         n = [len(a) for a in A]
 
         def f(x):
-            return np.array([float(x[0]*(n[1]-x[1]) + (n[0]-x[0])*x[1])/(2*n[0]*n[1])])
+            return np.array(
+                [float(x[0] * (n[1] - x[1]) + (n[0] - x[0]) * x[1]) / (2 * n[0] * n[1])]
+            )
 
         # tree lengths:
         mode = "branch"
-        self.assertAlmostEqual(divergence(ts, [[0], [1]], [(0, 1)], mode=mode),
-                               branch_true_diversity_01)
-        self.assertAlmostEqual(ts.divergence([[0], [1]], [(0, 1)], mode=mode),
-                               branch_true_diversity_01)
-        self.assertAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0],
-                               branch_true_diversity_01)
-        self.assertAlmostEqual(ts.diversity([[0, 1]], mode=mode)[0],
-                               branch_true_diversity_01)
+        self.assertAlmostEqual(
+            divergence(ts, [[0], [1]], [(0, 1)], mode=mode), branch_true_diversity_01
+        )
+        self.assertAlmostEqual(
+            ts.divergence([[0], [1]], [(0, 1)], mode=mode), branch_true_diversity_01
+        )
+        self.assertAlmostEqual(
+            ts.sample_count_stat(A, f, 1, mode=mode)[0], branch_true_diversity_01
+        )
+        self.assertAlmostEqual(
+            ts.diversity([[0, 1]], mode=mode)[0], branch_true_diversity_01
+        )
 
         # mean diversity between [0, 1] and [0, 2]:
-        branch_true_mean_diversity = (0 + branch_true_diversity_02
-                                      + branch_true_diversity_01
-                                      + branch_true_diversity_12)/4
+        branch_true_mean_diversity = (
+            0
+            + branch_true_diversity_02
+            + branch_true_diversity_01
+            + branch_true_diversity_12
+        ) / 4
         A = [[0, 1], [0, 2]]
         n = [len(a) for a in A]
 
         def f(x):
-            return np.array([float(x[0]*(n[1]-x[1]) + (n[0]-x[0])*x[1])/8.0])
+            return np.array([float(x[0] * (n[1] - x[1]) + (n[0] - x[0]) * x[1]) / 8.0])
 
         # tree lengths:
-        self.assertAlmostEqual(divergence(ts, [A[0], A[1]], [(0, 1)], mode=mode),
-                               branch_true_mean_diversity)
-        self.assertAlmostEqual(ts.divergence([A[0], A[1]], [(0, 1)], mode=mode),
-                               branch_true_mean_diversity)
-        self.assertAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0],
-                               branch_true_mean_diversity)
+        self.assertAlmostEqual(
+            divergence(ts, [A[0], A[1]], [(0, 1)], mode=mode),
+            branch_true_mean_diversity,
+        )
+        self.assertAlmostEqual(
+            ts.divergence([A[0], A[1]], [(0, 1)], mode=mode), branch_true_mean_diversity
+        )
+        self.assertAlmostEqual(
+            ts.sample_count_stat(A, f, 1, mode=mode)[0], branch_true_mean_diversity
+        )
 
         # Y-statistic for (0/12)
         A = [[0], [1, 2]]
 
         def f(x):
-            return np.array([float(((x[0] == 1) and (x[1] == 0))
-                                   or ((x[0] == 0) and (x[1] == 2)))/2.0])
+            return np.array(
+                [
+                    float(
+                        ((x[0] == 1) and (x[1] == 0)) or ((x[0] == 0) and (x[1] == 2))
+                    )
+                    / 2.0
+                ]
+            )
 
         # tree lengths:
         bts_Y = ts.Y3([[0], [1], [2]], mode=mode)
         py_bsc_Y = Y3(ts, [[0], [1], [2]], [(0, 1, 2)], windows=[0.0, 1.0], mode=mode)
         self.assertArrayAlmostEqual(bts_Y, branch_true_Y)
         self.assertArrayAlmostEqual(py_bsc_Y, branch_true_Y)
-        self.assertArrayAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0],
-                                    branch_true_Y)
+        self.assertArrayAlmostEqual(
+            ts.sample_count_stat(A, f, 1, mode=mode)[0], branch_true_Y
+        )
 
         mode = "site"
         # sites, Y:
@@ -4648,15 +4986,16 @@ class SpecificTreesTestCase(StatsTestCase):
         py_ssc_Y = Y3(ts, [[0], [1], [2]], [(0, 1, 2)], windows=[0.0, 1.0], mode=mode)
         self.assertArrayAlmostEqual(sts_Y, site_true_Y)
         self.assertArrayAlmostEqual(py_ssc_Y, site_true_Y)
-        self.assertArrayAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0],
-                                    site_true_Y)
+        self.assertArrayAlmostEqual(
+            ts.sample_count_stat(A, f, 1, mode=mode)[0], site_true_Y
+        )
 
         A = [[0, 1, 2]]
         n = 3
         W = np.array([[u in A[0]] for u in ts.samples()], dtype=float)
 
         def f(x):
-            return np.array([x[0]*(n-x[0])/(n * (n - 1))])
+            return np.array([x[0] * (n - x[0]) / (n * (n - 1))])
 
         mode = "node"
         # nodes, diversity in [0,1,2]
@@ -4675,38 +5014,44 @@ class SpecificTreesTestCase(StatsTestCase):
 
         # covariance and correlation
         ts_sitewise_cov = ts.trait_covariance(
-                traits, mode="site", windows="sites", span_normalise=False)
+            traits, mode="site", windows="sites", span_normalise=False
+        )
         py_sitewise_cov = site_trait_covariance(
-                ts, traits, windows="sites", span_normalise=False)
+            ts, traits, windows="sites", span_normalise=False
+        )
         self.assertArrayAlmostEqual(py_sitewise_cov, true_cov)
         self.assertArrayAlmostEqual(ts_sitewise_cov, true_cov)
         ts_sitewise_cor = ts.trait_correlation(
-                traits, mode="site", windows="sites", span_normalise=False)
+            traits, mode="site", windows="sites", span_normalise=False
+        )
         py_sitewise_cor = site_trait_correlation(
-                ts, traits, windows="sites", span_normalise=False)
+            ts, traits, windows="sites", span_normalise=False
+        )
         self.assertArrayAlmostEqual(py_sitewise_cor, true_cor)
         self.assertArrayAlmostEqual(ts_sitewise_cor, true_cor)
         # mean
-        ts_mean_cov = ts.trait_covariance(traits, mode="site",
-                                          windows=[0, ts.sequence_length])
+        ts_mean_cov = ts.trait_covariance(
+            traits, mode="site", windows=[0, ts.sequence_length]
+        )
         py_mean_cov = site_trait_covariance(ts, traits)
-        self.assertArrayAlmostEqual(ts_mean_cov,
-                                    np.array([np.sum(true_cov, axis=0)]))
+        self.assertArrayAlmostEqual(ts_mean_cov, np.array([np.sum(true_cov, axis=0)]))
         self.assertArrayAlmostEqual(ts_mean_cov, py_mean_cov)
-        ts_mean_cor = ts.trait_correlation(traits, mode="site",
-                                           windows=[0, ts.sequence_length])
+        ts_mean_cor = ts.trait_correlation(
+            traits, mode="site", windows=[0, ts.sequence_length]
+        )
         py_mean_cor = site_trait_correlation(ts, traits)
-        self.assertArrayAlmostEqual(ts_mean_cor,
-                                    np.array([np.sum(true_cor, axis=0)]))
+        self.assertArrayAlmostEqual(ts_mean_cor, np.array([np.sum(true_cor, axis=0)]))
         self.assertArrayAlmostEqual(ts_mean_cor, py_mean_cor)
         # mode = 'branch'
-        ts_mean_cov = ts.trait_covariance(traits, mode="branch",
-                                          windows=[0, ts.sequence_length])
+        ts_mean_cov = ts.trait_covariance(
+            traits, mode="branch", windows=[0, ts.sequence_length]
+        )
         py_mean_cov = branch_trait_covariance(ts, traits)
         self.assertArrayAlmostEqual(ts_mean_cov, true_branch_cov)
         self.assertArrayAlmostEqual(ts_mean_cov, py_mean_cov)
-        ts_mean_cor = ts.trait_correlation(traits, mode="branch",
-                                           windows=[0, ts.sequence_length])
+        ts_mean_cor = ts.trait_correlation(
+            traits, mode="branch", windows=[0, ts.sequence_length]
+        )
         py_mean_cor = branch_trait_correlation(ts, traits)
         self.assertArrayAlmostEqual(ts_mean_cor, true_branch_cor)
         self.assertArrayAlmostEqual(ts_mean_cor, py_mean_cor)
@@ -4717,48 +5062,60 @@ class SpecificTreesTestCase(StatsTestCase):
         geno_var = np.var(haplotypes, axis=1) * (3 / (3 - 1))
         trait_var = np.var(traits, axis=0) * (3 / (3 - 1))
         py_r = trait_regression(
-                ts, traits, None, mode="site", windows="sites", span_normalise=False)
+            ts, traits, None, mode="site", windows="sites", span_normalise=False
+        )
         ts_r = ts.trait_regression(
-                traits, None, mode="site", windows="sites", span_normalise=False)
+            traits, None, mode="site", windows="sites", span_normalise=False
+        )
         self.assertArrayAlmostEqual(py_r, ts_r)
         self.assertArrayAlmostEqual(true_cov, py_r * (geno_var[:, np.newaxis] ** 2))
         self.assertArrayAlmostEqual(
-                true_cor,
-                ts_r * geno_var[:, np.newaxis] / trait_var)
+            true_cor, ts_r * geno_var[:, np.newaxis] / trait_var
+        )
 
     def test_case_odds_and_ends(self):
         # Tests having (a) the first site after the first window, and
         # (b) no samples having the ancestral state.
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
         2       0           0.5
         3       0           1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     0.5     2       0,1
         0.5     1.0     3       0,1
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.65        0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       0       1               -1
         0       1       2               -1
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
 
         mode = "site"
         py_div = divergence(
-            ts, [[0], [1]], indexes=[(0, 1)], windows=[0.0, 0.5, 1.0], mode=mode)
+            ts, [[0], [1]], indexes=[(0, 1)], windows=[0.0, 0.5, 1.0], mode=mode
+        )
         div = ts.divergence(
-            [[0], [1]], indexes=[(0, 1)], windows=[0.0, 0.5, 1.0], mode=mode)
+            [[0], [1]], indexes=[(0, 1)], windows=[0.0, 0.5, 1.0], mode=mode
+        )
         self.assertArrayEqual(py_div, div)
 
     def test_case_four_taxa(self):
@@ -4776,22 +5133,38 @@ class SpecificTreesTestCase(StatsTestCase):
         # f4(0, 1, 2, 3): (0 -> 1)(2 -> 3)
         branch_true_f4_0123 = (0.1 * 0.2 + (0.1 + 0.1) * 0.6 + 0.1 * 1.7) / 2.5
         windows = [0.0, 0.4, 2.5]
-        branch_true_f4_0123_windowed = np.array([(0.1 * 0.2 + (0.1 + 0.1) * 0.2) / 0.4,
-                                                 ((0.1 + 0.1) * 0.4 + 0.1 * 1.7) / 2.1])
+        branch_true_f4_0123_windowed = np.array(
+            [
+                (0.1 * 0.2 + (0.1 + 0.1) * 0.2) / 0.4,
+                ((0.1 + 0.1) * 0.4 + 0.1 * 1.7) / 2.1,
+            ]
+        )
         # f4(0, 3, 2, 1): (0 -> 3)(2 -> 1)
         branch_true_f4_0321 = (0.1 * 0.2 + (0.1 + 0.1) * 0.6 + 0.1 * 1.7) / 2.5
         # f2([0,2], [1,3]) = (1/2) (f4(0,1,2,3) + f4(0,3,2,1))
         branch_true_f2_02_13 = (branch_true_f4_0123 + branch_true_f4_0321) / 2
         # diversity([0,1,2,3])
-        branch_true_diversity_windowed = (2 / 6) * np.array([
-                [(0.2 * (1 + 1 + 1 + 0.5 + 0.4 + 0.5) +
-                  (0.4 - 0.2) * (0.5 + 0.4 + 0.5 + 0.5 + 0.4 + 0.5)) /
-                 0.4],
-                [((0.8 - 0.4) * (0.5 + 0.4 + 0.5 + 0.5 + 0.4 + 0.5) +
-                  (2.5 - 0.8) * (0.7 + 0.7 + 0.7 + 0.5 + 0.4 + 0.5)) /
-                 (2.5 - 0.4)]])
+        branch_true_diversity_windowed = (2 / 6) * np.array(
+            [
+                [
+                    (
+                        0.2 * (1 + 1 + 1 + 0.5 + 0.4 + 0.5)
+                        + (0.4 - 0.2) * (0.5 + 0.4 + 0.5 + 0.5 + 0.4 + 0.5)
+                    )
+                    / 0.4
+                ],
+                [
+                    (
+                        (0.8 - 0.4) * (0.5 + 0.4 + 0.5 + 0.5 + 0.4 + 0.5)
+                        + (2.5 - 0.8) * (0.7 + 0.7 + 0.7 + 0.5 + 0.4 + 0.5)
+                    )
+                    / (2.5 - 0.4)
+                ],
+            ]
+        )
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -4802,8 +5175,10 @@ class SpecificTreesTestCase(StatsTestCase):
         6       0           0.7
         7       0           1.0
         8       0           0.4
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.0     2.5     8       1,3
         0.2     0.8     4       0,2
@@ -4812,45 +5187,51 @@ class SpecificTreesTestCase(StatsTestCase):
         0.8     2.5     5       8,2
         0.8     2.5     6       0,5
         0.0     0.2     7       0,5
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
 
         mode = "branch"
         A = [[0], [1], [2], [3]]
         self.assertAlmostEqual(branch_true_f4_0123, f4(ts, A, mode=mode)[0][0])
         self.assertAlmostEqual(branch_true_f4_0123, ts.f4(A, mode=mode))
         self.assertArrayAlmostEqual(
-            branch_true_f4_0123_windowed,
-            ts.f4(A, windows=windows, mode=mode).flatten())
+            branch_true_f4_0123_windowed, ts.f4(A, windows=windows, mode=mode).flatten()
+        )
         A = [[0], [3], [2], [1]]
         self.assertAlmostEqual(
-            branch_true_f4_0321,
-            f4(ts, A, [(0, 1, 2, 3)], mode=mode)[0][0])
+            branch_true_f4_0321, f4(ts, A, [(0, 1, 2, 3)], mode=mode)[0][0]
+        )
         self.assertAlmostEqual(branch_true_f4_0321, ts.f4(A, mode=mode))
         A = [[0], [2], [1], [3]]
         self.assertAlmostEqual(0.0, f4(ts, A, [(0, 1, 2, 3)], mode=mode)[0])
         self.assertAlmostEqual(0.0, ts.f4(A, mode=mode))
         A = [[0, 2], [1, 3]]
         self.assertAlmostEqual(
-            branch_true_f2_02_13, f2(ts, A, [(0, 1)], mode=mode)[0][0])
+            branch_true_f2_02_13, f2(ts, A, [(0, 1)], mode=mode)[0][0]
+        )
         self.assertAlmostEqual(branch_true_f2_02_13, ts.f2(A, mode=mode))
 
         # diversity
         A = [[0, 1, 2, 3]]
         self.assertArrayAlmostEqual(
-            branch_true_diversity_windowed,
-            diversity(ts, A, windows=windows, mode=mode))
+            branch_true_diversity_windowed, diversity(ts, A, windows=windows, mode=mode)
+        )
         self.assertArrayAlmostEqual(
-            branch_true_diversity_windowed,
-            ts.diversity(A, windows=windows, mode=mode))
+            branch_true_diversity_windowed, ts.diversity(A, windows=windows, mode=mode)
+        )
 
     def test_case_recurrent_muts(self):
         # With mutations:
@@ -4868,7 +5249,8 @@ class SpecificTreesTestCase(StatsTestCase):
         #       0     2       0        1   0   1       0   2       3
         site_true_Y = 0 + 1 + 1
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         id      is_sample   time
         0       1           0
         1       1           0
@@ -4877,8 +5259,10 @@ class SpecificTreesTestCase(StatsTestCase):
         4       0           0.5
         5       0           0.7
         6       0           1.0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.2     0.8     3       0,2
         0.0     0.2     4       1,2
@@ -4886,14 +5270,18 @@ class SpecificTreesTestCase(StatsTestCase):
         0.8     1.0     4       1,2
         0.8     1.0     5       0,4
         0.0     0.2     6       0,4
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.05        0
         1   0.3         0
         2   0.9         0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       0       1               -1
         0       0       2               0
@@ -4904,9 +5292,11 @@ class SpecificTreesTestCase(StatsTestCase):
         2       4       1               -1
         2       1       2               6
         2       2       3               6
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
 
         # Y3:
         site_tsc_Y = ts.Y3([[0], [1], [2]], mode="site")
@@ -4951,19 +5341,20 @@ class SpecificTreesTestCase(StatsTestCase):
         # Above, subsequent mutations are backmutations.
 
         # divergence betw 0 and 1
-        branch_true_diversity_01 = 2*(0.6*4 + 0.2*2 + 0.2*5)
+        branch_true_diversity_01 = 2 * (0.6 * 4 + 0.2 * 2 + 0.2 * 5)
         # divergence betw 1 and 2
-        branch_true_diversity_12 = 2*(0.2*5 + 0.2*2 + 0.3*5 + 0.3*4)
+        branch_true_diversity_12 = 2 * (0.2 * 5 + 0.2 * 2 + 0.3 * 5 + 0.3 * 4)
         # divergence betw 0 and 2
-        branch_true_diversity_02 = 2*(0.2*5 + 0.2*4 + 0.3*5 + 0.1*4 + 0.2*5)
+        branch_true_diversity_02 = 2 * (0.2 * 5 + 0.2 * 4 + 0.3 * 5 + 0.1 * 4 + 0.2 * 5)
         # Y(0;1, 2)
-        branch_true_Y = 0.2*4 + 0.2*(4+2) + 0.2*4 + 0.2*2 + 0.2*(5+1)
+        branch_true_Y = 0.2 * 4 + 0.2 * (4 + 2) + 0.2 * 4 + 0.2 * 2 + 0.2 * (5 + 1)
 
         # site stats
         # Y(0;1, 2)
         site_true_Y = 1
 
-        nodes = io.StringIO("""\
+        nodes = io.StringIO(
+            """\
         is_sample       time    population
         1       0.000000        0
         1       0.000000        0
@@ -4976,8 +5367,10 @@ class SpecificTreesTestCase(StatsTestCase):
         0       2.000000        0
         0       1.000000        0
         0       1.000000        0
-        """)
-        edges = io.StringIO("""\
+        """
+        )
+        edges = io.StringIO(
+            """\
         left    right   parent  child
         0.500000        1.000000        10      1
         0.000000        0.400000        10      2
@@ -4997,15 +5390,19 @@ class SpecificTreesTestCase(StatsTestCase):
         0.900000        1.000000        3       4,5,6
         0.100000        0.900000        3       4,5
         0.000000        0.100000        3       4,5,7
-        """)
-        sites = io.StringIO("""\
+        """
+        )
+        sites = io.StringIO(
+            """\
         id  position    ancestral_state
         0   0.0         0
         1   0.55        0
         2   0.75        0
         3   0.85        0
-        """)
-        mutations = io.StringIO("""\
+        """
+        )
+        mutations = io.StringIO(
+            """\
         site    node    derived_state   parent
         0       0       1               -1
         0       10      1               -1
@@ -5014,21 +5411,25 @@ class SpecificTreesTestCase(StatsTestCase):
         1       2       1               -1
         2       8       1               -1
         2       9       0               5
-        """)
+        """
+        )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations,
-            strict=False)
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
 
         def f(x):
-            return np.array([float(x[0] == 1)/2.0])
+            return np.array([float(x[0] == 1) / 2.0])
 
         # divergence between 0 and 1
         mode = "branch"
         for A, truth in zip(
-                [[[0, 1]], [[1, 2]], [[0, 2]]],
-                [branch_true_diversity_01,
-                 branch_true_diversity_12,
-                 branch_true_diversity_02]):
+            [[[0, 1]], [[1, 2]], [[0, 2]]],
+            [
+                branch_true_diversity_01,
+                branch_true_diversity_12,
+                branch_true_diversity_02,
+            ],
+        ):
 
             self.assertAlmostEqual(diversity(ts, A, mode=mode)[0][0], truth)
             self.assertAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0], truth)
@@ -5038,16 +5439,25 @@ class SpecificTreesTestCase(StatsTestCase):
         A = [[0], [1, 2]]
 
         def f(x):
-            return np.array([float(((x[0] == 1) and (x[1] == 0))
-                                   or ((x[0] == 0) and (x[1] == 2)))/2.0])
+            return np.array(
+                [
+                    float(
+                        ((x[0] == 1) and (x[1] == 0)) or ((x[0] == 0) and (x[1] == 2))
+                    )
+                    / 2.0
+                ]
+            )
 
         # tree lengths:
-        self.assertArrayAlmostEqual(Y3(ts, [[0], [1], [2]], [(0, 1, 2)], mode=mode),
-                                    branch_true_Y)
-        self.assertArrayAlmostEqual(ts.Y3([[0], [1], [2]], [(0, 1, 2)], mode=mode),
-                                    branch_true_Y)
-        self.assertArrayAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0],
-                                    branch_true_Y)
+        self.assertArrayAlmostEqual(
+            Y3(ts, [[0], [1], [2]], [(0, 1, 2)], mode=mode), branch_true_Y
+        )
+        self.assertArrayAlmostEqual(
+            ts.Y3([[0], [1], [2]], [(0, 1, 2)], mode=mode), branch_true_Y
+        )
+        self.assertArrayAlmostEqual(
+            ts.sample_count_stat(A, f, 1, mode=mode)[0], branch_true_Y
+        )
 
         # sites:
         mode = "site"
@@ -5055,14 +5465,14 @@ class SpecificTreesTestCase(StatsTestCase):
         py_ssc_Y = Y3(ts, [[0], [1], [2]], [(0, 1, 2)], windows=[0.0, 1.0])
         self.assertAlmostEqual(site_tsc_Y, site_true_Y)
         self.assertAlmostEqual(py_ssc_Y, site_true_Y)
-        self.assertAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0],
-                               site_true_Y)
+        self.assertAlmostEqual(ts.sample_count_stat(A, f, 1, mode=mode)[0], site_true_Y)
 
 
 class TestOutputDimensions(StatsTestCase):
     """
     Tests for the dimension stripping behaviour of the stats functions.
     """
+
     def get_example_ts(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
         self.assertGreater(ts.num_sites, 1)
@@ -5078,7 +5488,8 @@ class TestOutputDimensions(StatsTestCase):
             # x is a 1D numpy array with n + 1 values
             self.assertEqual(x.shape, (n + 1,))
             self.assertArrayEqual(
-                x, ts.allele_frequency_spectrum([ts.samples()], mode=mode))
+                x, ts.allele_frequency_spectrum([ts.samples()], mode=mode)
+            )
             x = ts.allele_frequency_spectrum([A, B], mode=mode)
             self.assertEqual(x.shape, (len(A) + 1, len(B) + 1))
 
@@ -5140,11 +5551,11 @@ class TestOutputDimensions(StatsTestCase):
 
             x = method(A, windows=windows, mode=mode)
             # Dropping the outer list removes the last dimension
-            self.assertEqual(x.shape, (4, ))
+            self.assertEqual(x.shape, (4,))
 
             x = method(windows=windows, mode=mode)
             # Default returns this for all samples
-            self.assertEqual(x.shape, (4, ))
+            self.assertEqual(x.shape, (4,))
             y = method(ts.samples(), windows=windows, mode=mode)
             self.assertArrayEqual(x, y)
 
@@ -5215,8 +5626,7 @@ class TestOutputDimensions(StatsTestCase):
         A = ts.samples()[:7]
         B = ts.samples()[7:]
         for mode in ["site", "branch"]:
-            x = method(
-                [A, B, A], indexes=[[0, 1], [0, 2]], windows=windows, mode=mode)
+            x = method([A, B, A], indexes=[[0, 1], [0, 2]], windows=windows, mode=mode)
             # Three windows, 2 pairs
             self.assertEqual(x.shape, (3, 2))
 
@@ -5226,10 +5636,10 @@ class TestOutputDimensions(StatsTestCase):
 
             x = method([A, B], indexes=[0, 1], windows=windows, mode=mode)
             # Dropping the outer list removes the last dimension
-            self.assertEqual(x.shape, (3, ))
+            self.assertEqual(x.shape, (3,))
 
             y = method([A, B], windows=windows, mode=mode)
-            self.assertEqual(y.shape, (3, ))
+            self.assertEqual(y.shape, (3,))
             self.assertArrayEqual(x, y)
 
         mode = "node"
@@ -5273,11 +5683,12 @@ class TestOutputDimensions(StatsTestCase):
 
         windows = [0, L / 4, L / 2, L]
         A = ts.samples()[:2]
-        B = ts.samples()[2: 4]
+        B = ts.samples()[2:4]
         C = ts.samples()[4:]
         for mode in ["site", "branch"]:
             x = method(
-                [A, B, C], indexes=[[0, 1, 2], [0, 2, 1]], windows=windows, mode=mode)
+                [A, B, C], indexes=[[0, 1, 2], [0, 2, 1]], windows=windows, mode=mode
+            )
             # Three windows, 2 triple
             self.assertEqual(x.shape, (3, 2))
 
@@ -5287,14 +5698,16 @@ class TestOutputDimensions(StatsTestCase):
 
             x = method([A, B, C], indexes=[0, 1, 2], windows=windows, mode=mode)
             # Dropping the outer list removes the last dimension
-            self.assertEqual(x.shape, (3, ))
+            self.assertEqual(x.shape, (3,))
 
             y = method([A, B, C], windows=windows, mode=mode)
-            self.assertEqual(y.shape, (3, ))
+            self.assertEqual(y.shape, (3,))
             self.assertArrayEqual(x, y)
 
         mode = "node"
-        x = method([A, B, C], indexes=[[0, 1, 2], [0, 2, 1]], windows=windows, mode=mode)
+        x = method(
+            [A, B, C], indexes=[[0, 1, 2], [0, 2, 1]], windows=windows, mode=mode
+        )
         # Three windows, N nodes and 2 triples
         self.assertEqual(x.shape, (3, N, 2))
 

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -36,6 +36,7 @@ class TestNumpyArrayCasting(unittest.TestCase):
     """
     Tests that the safe_np_int_cast() function works.
     """
+
     dtypes_to_test = [np.int32, np.uint32, np.int8, np.uint8]
 
     def test_basic_arrays(self):
@@ -80,33 +81,44 @@ class TestNumpyArrayCasting(unittest.TestCase):
     def test_bad_types(self):
         # Shouldn't be able to convert a float (possibility of rounding error)
         for dtype in self.dtypes_to_test:
-            for bad_type in [[0.1], ['str'], {}, [{}], np.array([0, 1], dtype=np.float)]:
+            for bad_type in [
+                [0.1],
+                ["str"],
+                {},
+                [{}],
+                np.array([0, 1], dtype=np.float),
+            ]:
                 self.assertRaises(TypeError, util.safe_np_int_cast, bad_type, dtype)
 
     def test_overflow(self):
         for dtype in self.dtypes_to_test:
             for bad_node in [np.iinfo(dtype).min - 1, np.iinfo(dtype).max + 1]:
                 self.assertRaises(  # Test plain array
-                    OverflowError, util.safe_np_int_cast, [0, bad_node], dtype)
+                    OverflowError, util.safe_np_int_cast, [0, bad_node], dtype
+                )
                 self.assertRaises(  # Test numpy array
-                    OverflowError, util.safe_np_int_cast, np.array([0, bad_node]), dtype)
+                    OverflowError, util.safe_np_int_cast, np.array([0, bad_node]), dtype
+                )
             for good_node in [np.iinfo(dtype).min, np.iinfo(dtype).max]:
                 target = np.array([good_node], dtype=dtype)
                 self.assertEqual(  # Test plain array
                     pickle.dumps(target),
-                    pickle.dumps(util.safe_np_int_cast([good_node], dtype)))
+                    pickle.dumps(util.safe_np_int_cast([good_node], dtype)),
+                )
                 self.assertEqual(  # Test numpy array
                     pickle.dumps(target),
-                    pickle.dumps(util.safe_np_int_cast(np.array([good_node]), dtype)))
+                    pickle.dumps(util.safe_np_int_cast(np.array([good_node]), dtype)),
+                )
 
     def test_nonrectangular_input(self):
         bad_inputs = [
-                [0, 1, [2]],
-                [[0, 1, 2], []],
-                [(0, 1, 2), [2, 3]],
-                [(0, 1, 2), tuple()],
-                [(0, 1, 2), (2, )],
-                [(0, 1, 2), [2, 3]]]
+            [0, 1, [2]],
+            [[0, 1, 2], []],
+            [(0, 1, 2), [2, 3]],
+            [(0, 1, 2), tuple()],
+            [(0, 1, 2), (2,)],
+            [(0, 1, 2), [2, 3]],
+        ]
         for dtype in self.dtypes_to_test:
             for bad_input in bad_inputs:
                 with self.assertRaises(TypeError):
@@ -117,6 +129,7 @@ class TestIntervalOps(unittest.TestCase):
     """
     Test cases for the interval operations used in masks and slicing operations.
     """
+
     def test_bad_intervals(self):
         for bad_type in [{}, Exception]:
             with self.assertRaises(TypeError):
@@ -156,14 +169,10 @@ class TestIntervalOps(unittest.TestCase):
             ([[0, 5], [6, L]], [[5, 6]]),
             ([[0, 5]], [[5, L]]),
             ([[5, L]], [[0, 5]]),
-            (
-                [[0, 1], [2, 3], [3, 4], [5, 6]],
-                [[1, 2], [4, 5], [6, L]]
-            ),
+            ([[0, 1], [2, 3], [3, 4], [5, 6]], [[1, 2], [4, 5], [6, L]]),
         ]
         for source, dest in cases:
-            self.assertTrue(np.array_equal(
-                util.negate_intervals(source, 0, L), dest))
+            self.assertTrue(np.array_equal(util.negate_intervals(source, 0, L), dest))
 
 
 class TestStringPacking(unittest.TestCase):
@@ -198,7 +207,7 @@ class TestStringPacking(unittest.TestCase):
             self.verify_packing(strings)
 
     def test_unicode(self):
-        self.verify_packing(['abcdé', '€'])
+        self.verify_packing(["abcdé", "€"])
 
 
 class TestBytePacking(unittest.TestCase):

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -33,6 +33,7 @@ class TestJukesCantor(unittest.TestCase):
     """
     Check that the we get useable tree sequences.
     """
+
     def verify(self, ts):
         tables = ts.dump_tables()
         tables.compute_mutation_parents()
@@ -57,6 +58,7 @@ class TestCaterpillarTree(unittest.TestCase):
     """
     Tests for the caterpillar tree method.
     """
+
     def verify(self, ts, n):
         self.assertEqual(ts.num_trees, 1)
         self.assertEqual(ts.num_nodes, ts.num_samples * 2 - 1)
@@ -101,7 +103,9 @@ class TestCaterpillarTree(unittest.TestCase):
     def test_n_many_mutations(self):
         for n in range(10, 15):
             for num_mutations in range(0, n - 1):
-                ts = tsutil.caterpillar_tree(n, num_sites=1, num_mutations=num_mutations)
+                ts = tsutil.caterpillar_tree(
+                    n, num_sites=1, num_mutations=num_mutations
+                )
                 self.verify(ts, n)
                 self.assertEqual(ts.num_sites, 1)
                 self.assertEqual(ts.num_mutations, num_mutations)
@@ -114,6 +118,7 @@ class TestInsertIndividuals(unittest.TestCase):
     """
     Test that we insert individuals correctly.
     """
+
     def test_ploidy_1(self):
         ts = msprime.simulate(10, random_seed=1)
         self.assertEqual(ts.num_individuals, 0)

--- a/python/tests/test_vcf.py
+++ b/python/tests/test_vcf.py
@@ -43,6 +43,7 @@ import tests.test_wright_fisher as wf
 _pysam_imported = False
 try:
     import pysam
+
     _pysam_imported = True
 except ImportError:
     pass
@@ -108,8 +109,19 @@ def legacy_write_vcf(tree_sequence, output, ploidy, contig_id):
     print("##contig=<ID={},length={}>".format(contig_id, contig_length), file=output)
     print('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">', file=output)
     print(
-        "#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO",
-        "FORMAT", sep="\t", end="", file=output)
+        "#CHROM",
+        "POS",
+        "ID",
+        "REF",
+        "ALT",
+        "QUAL",
+        "FILTER",
+        "INFO",
+        "FORMAT",
+        sep="\t",
+        end="",
+        file=output,
+    )
     for sample_name in sample_names:
         print("\t", sample_name, sep="", end="", file=output)
     print(file=output)
@@ -117,12 +129,23 @@ def legacy_write_vcf(tree_sequence, output, ploidy, contig_id):
         pos = positions[variant.index]
         assert variant.num_alleles == 2
         print(
-            contig_id, pos, ".", variant.alleles[0], variant.alleles[1],
-            ".", "PASS", ".", "GT", sep="\t", end="", file=output)
+            contig_id,
+            pos,
+            ".",
+            variant.alleles[0],
+            variant.alleles[1],
+            ".",
+            "PASS",
+            ".",
+            "GT",
+            sep="\t",
+            end="",
+            file=output,
+        )
         for j in range(n):
             genotype = "|".join(
-                str(g) for g in
-                variant.genotypes[j * ploidy: j * ploidy + ploidy])
+                str(g) for g in variant.genotypes[j * ploidy : j * ploidy + ploidy]
+            )
             print("\t", genotype, end="", sep="", file=output)
         print(file=output)
 
@@ -132,6 +155,7 @@ class TestLegacyOutput(unittest.TestCase):
     Tests if the VCF file produced by the low level code is the
     same as one we generate here.
     """
+
     def verify(self, ts, ploidy=1, contig_id="1"):
         self.assertGreater(ts.num_sites, 0)
         f = io.StringIO()
@@ -142,8 +166,12 @@ class TestLegacyOutput(unittest.TestCase):
         individual_names = ["msp_{}".format(j) for j in range(num_individuals)]
         f = io.StringIO()
         ts.write_vcf(
-            f, ploidy=ploidy, contig_id=contig_id, position_transform="legacy",
-            individual_names=individual_names)
+            f,
+            ploidy=ploidy,
+            contig_id=contig_id,
+            position_transform="legacy",
+            individual_names=individual_names,
+        )
         vcf2 = f.getvalue()
         self.assertEqual(vcf1, vcf2)
 
@@ -168,6 +196,7 @@ class ExamplesMixin(object):
     """
     Mixin defining tests on various example tree sequences.
     """
+
     def test_simple_infinite_sites_random_ploidy(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
         ts = tsutil.insert_random_ploidy_individuals(ts)
@@ -216,15 +245,21 @@ class ExamplesMixin(object):
     def test_many_trees_sequence_length_infinite_sites(self):
         for L in [0.5, 1.5, 3.3333]:
             ts = msprime.simulate(
-                6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1)
+                6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1
+            )
             self.assertGreater(ts.num_sites, 0)
             ts = tsutil.insert_individuals(ts, ploidy=2)
             self.verify(ts)
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(
-            4, 5, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=10)
+            4,
+            5,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=10,
+        )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.05, random_seed=234)
         self.assertGreater(ts.num_sites, 0)
@@ -233,8 +268,8 @@ class ExamplesMixin(object):
 
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
-            6, 5, seed=3, deep_history=True, initial_generation_samples=True,
-            num_loci=2)
+            6, 5, seed=3, deep_history=True, initial_generation_samples=True, num_loci=2
+        )
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
@@ -244,8 +279,13 @@ class ExamplesMixin(object):
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
         tables = wf.wf_sim(
-            8, 15, seed=1, deep_history=False, initial_generation_samples=False,
-            num_loci=20)
+            8,
+            15,
+            seed=1,
+            deep_history=False,
+            initial_generation_samples=False,
+            num_loci=20,
+        )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.006, random_seed=2)
         self.assertGreater(ts.num_sites, 0)
@@ -254,8 +294,13 @@ class ExamplesMixin(object):
 
     def test_wright_fisher_simplified(self):
         tables = wf.wf_sim(
-            9, 10, seed=1, deep_history=True, initial_generation_samples=False,
-            num_loci=5)
+            9,
+            10,
+            seed=1,
+            deep_history=True,
+            initial_generation_samples=False,
+            num_loci=5,
+        )
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
@@ -268,11 +313,11 @@ class TestParseHeaderPyvcf(unittest.TestCase, ExamplesMixin):
     """
     Test that pyvcf can parse the headers correctly.
     """
+
     def verify(self, ts):
         contig_id = "pyvcf"
         for indivs, num_indivs in example_individuals(ts):
-            with ts_to_pyvcf(ts, contig_id=contig_id,
-                             individuals=indivs) as reader:
+            with ts_to_pyvcf(ts, contig_id=contig_id, individuals=indivs) as reader:
                 self.assertEqual(len(reader.contigs), 1)
                 contig = reader.contigs[contig_id]
                 self.assertEqual(contig.id, contig_id)
@@ -293,11 +338,11 @@ class TestParseHeaderPysam(unittest.TestCase, ExamplesMixin):
     """
     Test that pysam can parse the headers correctly.
     """
+
     def verify(self, ts):
         contig_id = "pysam"
         for indivs, num_indivs in example_individuals(ts):
-            with ts_to_pysam(ts, contig_id=contig_id,
-                             individuals=indivs) as bcf_file:
+            with ts_to_pysam(ts, contig_id=contig_id, individuals=indivs) as bcf_file:
                 self.assertEqual(bcf_file.format, "VCF")
                 self.assertEqual(bcf_file.version, (4, 2))
                 header = bcf_file.header
@@ -324,6 +369,7 @@ class TestRecordsEqual(unittest.TestCase, ExamplesMixin):
     """
     Tests where we parse the input using PyVCF and Pysam
     """
+
     def verify_records(self, pyvcf_records, pysam_records):
         self.assertEqual(len(pyvcf_records), len(pysam_records))
         for pyvcf_record, pysam_record in zip(pyvcf_records, pysam_records):
@@ -345,8 +391,9 @@ class TestRecordsEqual(unittest.TestCase, ExamplesMixin):
 
     def verify(self, ts):
         for indivs, num_indivs in example_individuals(ts):
-            with ts_to_pysam(ts, individuals=indivs) as bcf_file, \
-                    ts_to_pyvcf(ts, individuals=indivs) as vcf_reader:
+            with ts_to_pysam(ts, individuals=indivs) as bcf_file, ts_to_pyvcf(
+                ts, individuals=indivs
+            ) as vcf_reader:
                 pyvcf_records = list(vcf_reader)
                 pysam_records = list(bcf_file)
                 self.verify_records(pyvcf_records, pysam_records)
@@ -356,6 +403,7 @@ class TestContigLengths(unittest.TestCase):
     """
     Tests that we create sensible contig lengths under a variety of conditions.
     """
+
     def get_contig_length(self, ts):
         with ts_to_pyvcf(ts) as reader:
             contig = reader.contigs["1"]
@@ -387,6 +435,7 @@ class TestInterface(unittest.TestCase):
     """
     Tests for the interface.
     """
+
     def test_bad_ploidy(self):
         ts = msprime.simulate(10, mutation_rate=0.1, random_seed=2)
         for bad_ploidy in [-1, 0, 20]:
@@ -424,6 +473,7 @@ class TestRoundTripIndividuals(unittest.TestCase, ExamplesMixin):
     """
     Tests that we can round-trip genotype data through VCF using pyvcf.
     """
+
     def verify(self, ts):
         for indivs, num_indivs in example_individuals(ts):
             with ts_to_pyvcf(ts, individuals=indivs) as vcf_reader:
@@ -433,20 +483,23 @@ class TestRoundTripIndividuals(unittest.TestCase, ExamplesMixin):
                 for ind in map(ts.individual, indivs):
                     samples.extend(ind.nodes)
                 for variant, vcf_row in itertools.zip_longest(
-                        ts.variants(samples=samples), vcf_reader):
+                    ts.variants(samples=samples), vcf_reader
+                ):
                     self.assertEqual(vcf_row.POS, np.round(variant.site.position))
                     self.assertEqual(variant.alleles[0], vcf_row.REF)
                     self.assertEqual(list(variant.alleles[1:]), vcf_row.ALT)
                     j = 0
                     for individual, sample in itertools.zip_longest(
-                            map(ts.individual, indivs), vcf_row.samples):
+                        map(ts.individual, indivs), vcf_row.samples
+                    ):
                         calls = sample.data.GT.split("|")
                         allele_calls = sample.gt_bases.split("|")
                         self.assertEqual(len(calls), len(individual.nodes))
                         for allele_call, call in zip(allele_calls, calls):
                             self.assertEqual(int(call), variant.genotypes[j])
                             self.assertEqual(
-                                allele_call, variant.alleles[variant.genotypes[j]])
+                                allele_call, variant.alleles[variant.genotypes[j]]
+                            )
                             j += 1
 
 
@@ -454,6 +507,7 @@ class TestLimitations(unittest.TestCase):
     """
     Verify the correct error behaviour in cases we don't support.
     """
+
     def test_many_alleles(self):
         ts = msprime.simulate(20, random_seed=45)
         tables = ts.dump_tables()
@@ -482,6 +536,7 @@ class TestPositionTransformRoundTrip(unittest.TestCase, ExamplesMixin):
     """
     Tests that the position transform method is working correctly.
     """
+
     def verify(self, ts):
         for transform in [np.round, np.ceil, lambda x: list(map(int, x))]:
             with ts_to_pyvcf(ts, position_transform=transform) as vcf_reader:
@@ -493,6 +548,7 @@ class TestPositionTransformErrors(unittest.TestCase):
     """
     Tests what happens when we provide bad position transforms
     """
+
     def get_example_ts(self):
         ts = msprime.simulate(11, mutation_rate=1, random_seed=11)
         self.assertGreater(ts.num_sites, 1)
@@ -515,6 +571,7 @@ class TestIndividualNames(unittest.TestCase):
     """
     Tests for the individual names argument.
     """
+
     def test_bad_length_individuals(self):
         ts = msprime.simulate(6, mutation_rate=2, random_seed=1)
         self.assertGreater(ts.num_sites, 0)
@@ -525,14 +582,16 @@ class TestIndividualNames(unittest.TestCase):
             ts.write_vcf(io.StringIO(), individual_names=["x" for _ in range(4)])
         with self.assertRaises(ValueError):
             ts.write_vcf(
-                    io.StringIO(),
-                    individuals=list(range(ts.num_individuals)),
-                    individual_names=["x" for _ in range(ts.num_individuals - 1)])
+                io.StringIO(),
+                individuals=list(range(ts.num_individuals)),
+                individual_names=["x" for _ in range(ts.num_individuals - 1)],
+            )
         with self.assertRaises(ValueError):
             ts.write_vcf(
-                    io.StringIO(),
-                    individuals=list(range(ts.num_individuals - 1)),
-                    individual_names=["x" for _ in range(ts.num_individuals)])
+                io.StringIO(),
+                individuals=list(range(ts.num_individuals - 1)),
+                individual_names=["x" for _ in range(ts.num_individuals)],
+            )
 
     def test_bad_length_ploidy(self):
         ts = msprime.simulate(6, mutation_rate=2, random_seed=1)
@@ -541,7 +600,8 @@ class TestIndividualNames(unittest.TestCase):
             ts.write_vcf(io.StringIO(), ploidy=2, individual_names=[])
         with self.assertRaises(ValueError):
             ts.write_vcf(
-                io.StringIO(), ploidy=2, individual_names=["x" for _ in range(4)])
+                io.StringIO(), ploidy=2, individual_names=["x" for _ in range(4)]
+            )
 
     def test_bad_type(self):
         ts = msprime.simulate(2, mutation_rate=2, random_seed=1)

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -67,11 +67,15 @@ def subsample_sites(ts, num_sites):
         if site.id in sites_to_keep:
             site_id = len(t.sites)
             t.sites.add_row(
-                position=site.position, ancestral_state=site.ancestral_state)
+                position=site.position, ancestral_state=site.ancestral_state
+            )
             for mutation in site.mutations:
                 t.mutations.add_row(
-                    site=site_id, derived_state=mutation.derived_state,
-                    node=mutation.node, parent=mutation.parent)
+                    site=site_id,
+                    derived_state=mutation.derived_state,
+                    node=mutation.node,
+                    parent=mutation.parent,
+                )
     add_provenance(t.provenances, "subsample_sites")
     return t.tree_sequence()
 
@@ -83,8 +87,11 @@ def decapitate(ts, num_edges):
     """
     t = ts.dump_tables()
     t.edges.set_columns(
-        left=t.edges.left[:num_edges], right=t.edges.right[:num_edges],
-        parent=t.edges.parent[:num_edges], child=t.edges.child[:num_edges])
+        left=t.edges.left[:num_edges],
+        right=t.edges.right[:num_edges],
+        parent=t.edges.parent[:num_edges],
+        child=t.edges.child[:num_edges],
+    )
     add_provenance(t.provenances, "decapitate")
     # Simplify to get rid of any mutations that are lying around above roots.
     t.simplify()
@@ -100,7 +107,7 @@ def insert_branch_mutations(ts, mutations_per_branch=1):
     tables.sites.clear()
     tables.mutations.clear()
     for tree in ts.trees():
-        site = tables.sites.add_row(position=tree.interval[0], ancestral_state='0')
+        site = tables.sites.add_row(position=tree.interval[0], ancestral_state="0")
         for root in tree.roots:
             state = {root: 0}
             mutation = {root: -1}
@@ -115,8 +122,11 @@ def insert_branch_mutations(ts, mutations_per_branch=1):
                     for j in range(mutations_per_branch):
                         state[u] = (state[u] + 1) % 2
                         mutation[u] = tables.mutations.add_row(
-                            site=site, node=u, derived_state=str(state[u]),
-                            parent=parent)
+                            site=site,
+                            node=u,
+                            derived_state=str(state[u]),
+                            parent=parent,
+                        )
                         parent = mutation[u]
     add_provenance(tables.provenances, "insert_branch_mutations")
     return tables.tree_sequence()
@@ -136,8 +146,8 @@ def insert_branch_sites(ts):
         x = left
         for u in tree.nodes():
             if tree.parent(u) != tskit.NULL:
-                site = tables.sites.add_row(position=x, ancestral_state='0')
-                tables.mutations.add_row(site=site, node=u, derived_state='1')
+                site = tables.sites.add_row(position=x, ancestral_state="0")
+                tables.mutations.add_row(site=site, node=u, derived_state="1")
                 x += delta
     add_provenance(tables.provenances, "insert_branch_sites")
     return tables.tree_sequence()
@@ -156,7 +166,8 @@ def insert_multichar_mutations(ts, seed=1, max_len=10):
     for tree in ts.trees():
         ancestral_state = rng.choice(letters) * rng.randint(0, max_len)
         site = tables.sites.add_row(
-            position=tree.interval[0], ancestral_state=ancestral_state)
+            position=tree.interval[0], ancestral_state=ancestral_state
+        )
         nodes = list(tree.nodes())
         nodes.remove(tree.root)
         u = rng.choice(nodes)
@@ -182,7 +193,7 @@ def insert_random_ploidy_individuals(ts, max_ploidy=5, max_dimension=3, seed=1):
     individual[:] = tskit.NULL
     while j < len(samples):
         ploidy = rng.randint(0, max_ploidy)
-        nodes = samples[j: min(j + ploidy, len(samples))]
+        nodes = samples[j : min(j + ploidy, len(samples))]
         dimension = rng.randint(0, max_dimension)
         location = [rng.random() for _ in range(dimension)]
         ind_id = tables.individuals.add_row(location=location)
@@ -208,7 +219,7 @@ def insert_individuals(ts, samples=None, ploidy=1):
     individual[:] = tskit.NULL
     j = 0
     while j < len(samples):
-        nodes = samples[j: j + ploidy]
+        nodes = samples[j : j + ploidy]
         ind_id = tables.individuals.add_row()
         individual[nodes] = ind_id
         j += ploidy
@@ -233,17 +244,26 @@ def permute_nodes(ts, node_map):
     for j in range(ts.num_nodes):
         old_node = old_nodes[reverse_map[j]]
         tables.nodes.add_row(
-            flags=old_node.flags, metadata=old_node.metadata,
-            population=old_node.population, time=old_node.time)
+            flags=old_node.flags,
+            metadata=old_node.metadata,
+            population=old_node.population,
+            time=old_node.time,
+        )
     for edge in ts.edges():
         tables.edges.add_row(
-            left=edge.left, right=edge.right, parent=node_map[edge.parent],
-            child=node_map[edge.child])
+            left=edge.left,
+            right=edge.right,
+            parent=node_map[edge.parent],
+            child=node_map[edge.child],
+        )
     for site in ts.sites():
         for mutation in site.mutations:
             tables.mutations.add_row(
-                site=site.id, derived_state=mutation.derived_state,
-                node=node_map[mutation.node], metadata=mutation.metadata)
+                site=site.id,
+                derived_state=mutation.derived_state,
+                node=node_map[mutation.node],
+                metadata=mutation.metadata,
+            )
     tables.sort()
     add_provenance(tables.provenances, "permute_nodes")
     return tables.tree_sequence()
@@ -279,9 +299,11 @@ def single_childify(ts):
         t = time[edge.child] + (time[edge.parent] - time[edge.child]) / 2
         u = tables.nodes.add_row(time=t)
         tables.edges.add_row(
-            left=edge.left, right=edge.right, parent=u, child=edge.child)
+            left=edge.left, right=edge.right, parent=u, child=edge.child
+        )
         tables.edges.add_row(
-            left=edge.left, right=edge.right, parent=edge.parent, child=u)
+            left=edge.left, right=edge.right, parent=edge.parent, child=u
+        )
     tables.sort()
     add_provenance(tables.provenances, "insert_redundant_breakpoints")
     return tables.tree_sequence()
@@ -302,9 +324,13 @@ def add_random_metadata(ts, seed=1, max_length=10):
     metadata = np.random.randint(-127, 127, offset[-1]).astype(np.int8)
     nodes = tables.nodes
     nodes.set_columns(
-        flags=nodes.flags, population=nodes.population, time=nodes.time,
-        metadata_offset=offset, metadata=metadata,
-        individual=nodes.individual)
+        flags=nodes.flags,
+        population=nodes.population,
+        time=nodes.time,
+        metadata_offset=offset,
+        metadata=metadata,
+        individual=nodes.individual,
+    )
 
     length = np.random.randint(0, max_length, ts.num_sites)
     offset = np.cumsum(np.hstack(([0], length)), dtype=np.uint32)
@@ -314,7 +340,9 @@ def add_random_metadata(ts, seed=1, max_length=10):
         position=sites.position,
         ancestral_state=sites.ancestral_state,
         ancestral_state_offset=sites.ancestral_state_offset,
-        metadata_offset=offset, metadata=metadata)
+        metadata_offset=offset,
+        metadata=metadata,
+    )
 
     length = np.random.randint(0, max_length, ts.num_mutations)
     offset = np.cumsum(np.hstack(([0], length)), dtype=np.uint32)
@@ -326,7 +354,9 @@ def add_random_metadata(ts, seed=1, max_length=10):
         parent=mutations.parent,
         derived_state=mutations.derived_state,
         derived_state_offset=mutations.derived_state_offset,
-        metadata_offset=offset, metadata=metadata)
+        metadata_offset=offset,
+        metadata=metadata,
+    )
 
     length = np.random.randint(0, max_length, ts.num_individuals)
     offset = np.cumsum(np.hstack(([0], length)), dtype=np.uint32)
@@ -336,7 +366,9 @@ def add_random_metadata(ts, seed=1, max_length=10):
         flags=individuals.flags,
         location=individuals.location,
         location_offset=individuals.location_offset,
-        metadata_offset=offset, metadata=metadata)
+        metadata_offset=offset,
+        metadata=metadata,
+    )
 
     length = np.random.randint(0, max_length, ts.num_populations)
     offset = np.cumsum(np.hstack(([0], length)), dtype=np.uint32)
@@ -360,15 +392,16 @@ def jiggle_samples(ts):
     flags = nodes.flags
     oldest_parent = tables.edges.parent[-1]
     n = ts.sample_size
-    flags[:n // 2] = 0
-    flags[oldest_parent - n // 2: oldest_parent] = 1
+    flags[: n // 2] = 0
+    flags[oldest_parent - n // 2 : oldest_parent] = 1
     nodes.set_columns(flags, nodes.time)
     add_provenance(tables.provenances, "jiggle_samples")
     return tables.tree_sequence()
 
 
-def generate_site_mutations(tree, position, mu, site_table, mutation_table,
-                            multiple_per_node=True):
+def generate_site_mutations(
+    tree, position, mu, site_table, mutation_table, multiple_per_node=True
+):
     """
     Generates mutations for the site at the specified position on the specified
     tree. Mutations happen at rate mu along each branch. The site and mutation
@@ -420,8 +453,14 @@ def jukes_cantor(ts, num_sites, mu, multiple_per_node=True, seed=None):
     for position in positions:
         while position >= t.interval[1]:
             t = next(trees)
-        generate_site_mutations(t, position, mu, tables.sites, tables.mutations,
-                                multiple_per_node=multiple_per_node)
+        generate_site_mutations(
+            t,
+            position,
+            mu,
+            tables.sites,
+            tables.mutations,
+            multiple_per_node=multiple_per_node,
+        )
     add_provenance(tables.provenances, "jukes_cantor")
     new_ts = tables.tree_sequence()
     return new_ts
@@ -509,10 +548,14 @@ def algorithm_T(ts):
     edges = list(ts.edges())
     M = len(edges)
     time = [ts.node(edge.parent).time for edge in edges]
-    in_order = sorted(range(M), key=lambda j: (
-        edges[j].left, time[j], edges[j].parent, edges[j].child))
-    out_order = sorted(range(M), key=lambda j: (
-        edges[j].right, -time[j], -edges[j].parent, -edges[j].child))
+    in_order = sorted(
+        range(M),
+        key=lambda j: (edges[j].left, time[j], edges[j].parent, edges[j].child),
+    )
+    out_order = sorted(
+        range(M),
+        key=lambda j: (edges[j].right, -time[j], -edges[j].parent, -edges[j].child),
+    )
     j = 0
     k = 0
     left = 0
@@ -543,6 +586,7 @@ class SampleListTree(object):
     NOTE: The interface is pretty awkward; it's not intended for anything other
     than testing.
     """
+
     def __init__(self, tree_sequence, tracked_samples=None):
         self.tree_sequence = tree_sequence
         num_nodes = tree_sequence.num_nodes
@@ -570,14 +614,28 @@ class SampleListTree(object):
     def __str__(self):
         fmt = "{:<5}{:>8}{:>8}{:>8}{:>8}{:>8}{:>8}{:>8}{:>8}\n"
         s = fmt.format(
-            "node", "parent", "lsib", "rsib", "lchild", "rchild",
-            "nsamp", "lsamp", "rsamp")
+            "node",
+            "parent",
+            "lsib",
+            "rsib",
+            "lchild",
+            "rchild",
+            "nsamp",
+            "lsamp",
+            "rsamp",
+        )
         for u in range(self.tree_sequence.num_nodes):
             s += fmt.format(
-                u, self.parent[u],
-                self.left_sib[u], self.right_sib[u],
-                self.left_child[u], self.right_child[u],
-                self.next_sample[u], self.left_sample[u], self.right_sample[u])
+                u,
+                self.parent[u],
+                self.left_sib[u],
+                self.right_sib[u],
+                self.left_child[u],
+                self.right_child[u],
+                self.next_sample[u],
+                self.left_sample[u],
+                self.right_sample[u],
+            )
         # Strip off trailing newline
         return s[:-1]
 
@@ -661,10 +719,14 @@ class SampleListTree(object):
         edges = list(ts.edges())
         M = len(edges)
         time = [ts.node(edge.parent).time for edge in edges]
-        in_order = sorted(range(M), key=lambda j: (
-            edges[j].left, time[j], edges[j].parent, edges[j].child))
-        out_order = sorted(range(M), key=lambda j: (
-            edges[j].right, -time[j], -edges[j].parent, -edges[j].child))
+        in_order = sorted(
+            range(M),
+            key=lambda j: (edges[j].left, time[j], edges[j].parent, edges[j].child),
+        )
+        out_order = sorted(
+            range(M),
+            key=lambda j: (edges[j].right, -time[j], -edges[j].parent, -edges[j].child),
+        )
         j = 0
         k = 0
         left = 0
@@ -697,6 +759,7 @@ class RootThresholdTree(object):
     NOTE: The interface is pretty awkward; it's not intended for anything other
     than testing.
     """
+
     def __init__(self, tree_sequence, root_threshold=1):
         self.tree_sequence = tree_sequence
         self.root_threshold = root_threshold
@@ -717,14 +780,17 @@ class RootThresholdTree(object):
     def __str__(self):
         fmt = "{:<5}{:>8}{:>8}{:>8}{:>8}{:>8}{:>8}\n"
         s = f"roots = {self.roots()}\n"
-        s += fmt.format(
-            "node", "parent", "lsib", "rsib", "lchild", "rchild", "nsamp")
+        s += fmt.format("node", "parent", "lsib", "rsib", "lchild", "rchild", "nsamp")
         for u in range(self.tree_sequence.num_nodes):
             s += fmt.format(
-                u, self.parent[u],
-                self.left_sib[u], self.right_sib[u],
-                self.left_child[u], self.right_child[u],
-                self.num_samples[u])
+                u,
+                self.parent[u],
+                self.left_sib[u],
+                self.right_sib[u],
+                self.left_child[u],
+                self.right_child[u],
+                self.num_samples[u],
+            )
         # Strip off trailing newline
         return s[:-1]
 
@@ -850,10 +916,14 @@ class RootThresholdTree(object):
         edges = list(ts.edges())
         M = len(edges)
         time = [ts.node(edge.parent).time for edge in edges]
-        in_order = sorted(range(M), key=lambda j: (
-            edges[j].left, time[j], edges[j].parent, edges[j].child))
-        out_order = sorted(range(M), key=lambda j: (
-            edges[j].right, -time[j], -edges[j].parent, -edges[j].child))
+        in_order = sorted(
+            range(M),
+            key=lambda j: (edges[j].left, time[j], edges[j].parent, edges[j].child),
+        )
+        out_order = sorted(
+            range(M),
+            key=lambda j: (edges[j].right, -time[j], -edges[j].parent, -edges[j].child),
+        )
         j = 0
         k = 0
         left = 0

--- a/python/tskit/cli.py
+++ b/python/tskit/cli.py
@@ -83,9 +83,10 @@ def run_upgrade(args):
     except tskit.DuplicatePositionsError:
         exit(
             "Error: Duplicate mutation positions in the source file detected.\n\n"
-            "This is not supported in the current file format. Running \"upgrade -d\" "
+            'This is not supported in the current file format. Running "upgrade -d" '
             "will remove these duplicate positions. However, this will result in loss "
-            "of data from the original file!")
+            "of data from the original file!"
+        )
 
 
 def run_individuals(args):
@@ -123,8 +124,11 @@ def run_provenances(args):
     if args.human:
         for provenance in tree_sequence.provenances():
             d = json.loads(provenance.record)
-            print("id={}, timestamp={}, record={}".format(
-                provenance.id, provenance.timestamp, json.dumps(d, indent=4)))
+            print(
+                "id={}, timestamp={}, record={}".format(
+                    provenance.id, provenance.timestamp, json.dumps(d, indent=4)
+                )
+            )
     else:
         tree_sequence.dump_text(provenances=sys.stdout)
 
@@ -140,52 +144,60 @@ def run_vcf(args):
 
 
 def add_tree_sequence_argument(parser):
-    parser.add_argument(
-        "tree_sequence", help="The tskit tree sequence file")
+    parser.add_argument("tree_sequence", help="The tskit tree sequence file")
 
 
 def add_precision_argument(parser):
     parser.add_argument(
-        "--precision", "-p", type=int, default=6,
-        help="The number of decimal places to print in records")
+        "--precision",
+        "-p",
+        type=int,
+        default=6,
+        help="The number of decimal places to print in records",
+    )
 
 
 def get_tskit_parser():
     top_parser = argparse.ArgumentParser(
-        prog="python3 -m tskit",
-        description="Command line interface for tskit.")
+        prog="python3 -m tskit", description="Command line interface for tskit."
+    )
     top_parser.add_argument(
-        "-V", "--version", action='version',
-        version='%(prog)s {}'.format(tskit.__version__))
+        "-V",
+        "--version",
+        action="version",
+        version="%(prog)s {}".format(tskit.__version__),
+    )
     subparsers = top_parser.add_subparsers(dest="subcommand")
     subparsers.required = True
 
     parser = subparsers.add_parser(
-        "info",
-        help="Print summary information about a tree sequence.")
+        "info", help="Print summary information about a tree sequence."
+    )
     add_tree_sequence_argument(parser)
     parser.set_defaults(runner=run_info)
 
-    parser = subparsers.add_parser(
-        "trees",
-        help="Print information about trees.")
+    parser = subparsers.add_parser("trees", help="Print information about trees.")
     add_tree_sequence_argument(parser)
     add_precision_argument(parser)
     parser.add_argument(
-        "--draw", "-d", action="store_true", default=False,
-        help="Draw the trees")
+        "--draw", "-d", action="store_true", default=False, help="Draw the trees"
+    )
     parser.set_defaults(runner=run_trees)
 
     parser = subparsers.add_parser(
-        "upgrade",
-        help="Upgrade legacy tree sequence files.")
+        "upgrade", help="Upgrade legacy tree sequence files."
+    )
     parser.add_argument(
-        "source", help="The source tskit tree sequence file in legacy format")
+        "source", help="The source tskit tree sequence file in legacy format"
+    )
+    parser.add_argument("destination", help="The filename of the upgraded copy.")
     parser.add_argument(
-        "destination", help="The filename of the upgraded copy.")
-    parser.add_argument(
-        "--remove-duplicate-positions", "-d", action="store_true", default=False,
-        help="Remove any duplicated mutation positions in the source file. ")
+        "--remove-duplicate-positions",
+        "-d",
+        action="store_true",
+        default=False,
+        help="Remove any duplicated mutation positions in the source file. ",
+    )
     parser.set_defaults(runner=run_upgrade)
     # suppress fasta visibility pending https://github.com/tskit-dev/tskit/issues/353
     # parser = subparsers.add_parser(
@@ -197,67 +209,69 @@ def get_tskit_parser():
     #     help=("line-wrapping width for printed sequences"))
     # parser.set_defaults(runner=run_fasta)
     parser = subparsers.add_parser(
-        "vcf",
-        help="Convert the tree sequence genotypes to VCF format.")
+        "vcf", help="Convert the tree sequence genotypes to VCF format."
+    )
     add_tree_sequence_argument(parser)
     parser.add_argument(
-        "--ploidy", "-P", type=int, default=None,
+        "--ploidy",
+        "-P",
+        type=int,
+        default=None,
         help=(
             "If the tree sequence does not contain information about "
             "individuals, create them by combining adjacent samples nodes "
             "into individuals of the specified ploidy. It is an error "
             "to provide this argument if the tree sequence does contain "
-            "individuals"))
+            "individuals"
+        ),
+    )
     parser.set_defaults(runner=run_vcf)
 
     parser = subparsers.add_parser(
-        "individuals",
-        help="Output individuals in tabular format.")
+        "individuals", help="Output individuals in tabular format."
+    )
     add_tree_sequence_argument(parser)
     add_precision_argument(parser)
     parser.set_defaults(runner=run_individuals)
 
-    parser = subparsers.add_parser(
-        "nodes",
-        help="Output nodes in tabular format.")
+    parser = subparsers.add_parser("nodes", help="Output nodes in tabular format.")
     add_tree_sequence_argument(parser)
     add_precision_argument(parser)
     parser.set_defaults(runner=run_nodes)
 
-    parser = subparsers.add_parser(
-        "edges",
-        help="Output edges in tabular format.")
+    parser = subparsers.add_parser("edges", help="Output edges in tabular format.")
     add_tree_sequence_argument(parser)
     add_precision_argument(parser)
     parser.set_defaults(runner=run_edges)
 
-    parser = subparsers.add_parser(
-        "sites",
-        help="Output sites in tabular format.")
+    parser = subparsers.add_parser("sites", help="Output sites in tabular format.")
     add_tree_sequence_argument(parser)
     add_precision_argument(parser)
     parser.set_defaults(runner=run_sites)
 
     parser = subparsers.add_parser(
-        "mutations",
-        help="Output mutations in tabular format.")
+        "mutations", help="Output mutations in tabular format."
+    )
     add_tree_sequence_argument(parser)
     add_precision_argument(parser)
     parser.set_defaults(runner=run_mutations)
 
     parser = subparsers.add_parser(
-        "populations",
-        help="Output population information in tabular format.")
+        "populations", help="Output population information in tabular format."
+    )
     add_tree_sequence_argument(parser)
     parser.set_defaults(runner=run_populations)
 
     parser = subparsers.add_parser(
-        "provenances",
-        help="Output provenance information in tabular format.")
+        "provenances", help="Output provenance information in tabular format."
+    )
     add_tree_sequence_argument(parser)
     parser.add_argument(
-        "-H", "--human", action="store_true",
-        help="Print out the provenances in a human readable format")
+        "-H",
+        "--human",
+        action="store_true",
+        help="Print out the provenances in a human readable format",
+    )
     parser.set_defaults(runner=run_provenances)
 
     return top_parser

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -45,7 +45,8 @@ def check_orientation(orientation):
         orientations = [LEFT, RIGHT, TOP, BOTTOM]
         if orientation not in orientations:
             raise ValueError(
-                "Unknown orientiation: choose from {}".format(orientations))
+                "Unknown orientiation: choose from {}".format(orientations)
+            )
     return orientation
 
 
@@ -57,7 +58,8 @@ def check_max_tree_height(max_tree_height, allow_numeric=True):
         raise ValueError("max_tree_height must be 'tree' or 'ts'")
     if max_tree_height not in ["tree", "ts"] and (allow_numeric and not is_numeric):
         raise ValueError(
-            "max_tree_height must be a numeric value or one of 'tree' or 'ts'")
+            "max_tree_height must be a numeric value or one of 'tree' or 'ts'"
+        )
     return max_tree_height
 
 
@@ -75,15 +77,27 @@ def check_format(format):
     fmt = format.lower()
     supported_formats = ["svg", "ascii", "unicode"]
     if fmt not in supported_formats:
-        raise ValueError("Unknown format '{}'. Supported formats are {}".format(
-            format, supported_formats))
+        raise ValueError(
+            "Unknown format '{}'. Supported formats are {}".format(
+                format, supported_formats
+            )
+        )
     return fmt
 
 
 def draw_tree(
-        tree, width=None, height=None, node_labels=None, node_colours=None,
-        mutation_labels=None, mutation_colours=None, format=None, edge_colours=None,
-        tree_height_scale=None, max_tree_height=None):
+    tree,
+    width=None,
+    height=None,
+    node_labels=None,
+    node_colours=None,
+    mutation_labels=None,
+    mutation_colours=None,
+    format=None,
+    edge_colours=None,
+    tree_height_scale=None,
+    max_tree_height=None,
+):
 
     # See tree.draw() for documentation on these arguments.
     fmt = check_format(format)
@@ -106,20 +120,23 @@ def draw_tree(
 
         # Old semantics were to not draw the node if colour is None.
         # Setting opacity to zero has the same effect.
-        node_attrs = remap(node_colours, "fill", {'opacity': 0})
-        edge_attrs = remap(edge_colours, "stroke", {'opacity': 0})
-        mutation_attrs = remap(mutation_colours, "fill", {'opacity': 0})
+        node_attrs = remap(node_colours, "fill", {"opacity": 0})
+        edge_attrs = remap(edge_colours, "stroke", {"opacity": 0})
+        mutation_attrs = remap(mutation_colours, "fill", {"opacity": 0})
 
         node_label_attrs = None
         tree = SvgTree(
-            tree, (width, height),
+            tree,
+            (width, height),
             node_labels=node_labels,
             mutation_labels=mutation_labels,
             tree_height_scale=tree_height_scale,
             max_tree_height=max_tree_height,
-            node_attrs=node_attrs, edge_attrs=edge_attrs,
+            node_attrs=node_attrs,
+            edge_attrs=edge_attrs,
             node_label_attrs=node_label_attrs,
-            mutation_attrs=mutation_attrs)
+            mutation_attrs=mutation_attrs,
+        )
         return tree.drawing.tostring()
 
     else:
@@ -140,8 +157,12 @@ def draw_tree(
 
         use_ascii = fmt == "ascii"
         text_tree = VerticalTextTree(
-            tree, node_labels=node_labels, max_tree_height=max_tree_height,
-            use_ascii=use_ascii, orientation=TOP)
+            tree,
+            node_labels=node_labels,
+            max_tree_height=max_tree_height,
+            use_ascii=use_ascii,
+            orientation=TOP,
+        )
         return str(text_tree)
 
 
@@ -149,10 +170,19 @@ class SvgTreeSequence(object):
     """
     Draw a TreeSequence in SVG.
     """
+
     def __init__(
-            self, ts, size=None, tree_height_scale=None, max_tree_height=None,
-            node_labels=None, mutation_labels=None,
-            node_attrs=None, edge_attrs=None, node_label_attrs=None):
+        self,
+        ts,
+        size=None,
+        tree_height_scale=None,
+        max_tree_height=None,
+        node_labels=None,
+        mutation_labels=None,
+        node_attrs=None,
+        edge_attrs=None,
+        node_label_attrs=None,
+    ):
         self.ts = ts
         if size is None:
             size = (200 * ts.num_trees, 200)
@@ -170,14 +200,18 @@ class SvgTreeSequence(object):
         tree_width = treebox_width / ts.num_trees
         svg_trees = [
             SvgTree(
-                tree, (tree_width, treebox_height),
+                tree,
+                (tree_width, treebox_height),
                 max_tree_height="ts",
                 node_labels=node_labels,
                 mutation_labels=mutation_labels,
                 tree_height_scale=tree_height_scale,
-                node_attrs=node_attrs, edge_attrs=edge_attrs,
-                node_label_attrs=node_label_attrs)
-            for tree in ts.trees()]
+                node_attrs=node_attrs,
+                edge_attrs=edge_attrs,
+                node_label_attrs=node_label_attrs,
+            )
+            for tree in ts.trees()
+        ]
 
         ticks = []
         y = self.treebox_y_offset
@@ -213,9 +247,15 @@ class SvgTreeSequence(object):
         for x, genome_coord in ticks:
             delta = 5
             dwg.add(dwg.line((x, y - delta), (x, y + delta), stroke="black"))
-            dwg.add(dwg.text(
-                "{:.2f}".format(genome_coord), (x, y + 20),
-                font_size=14, text_anchor="middle", font_weight="bold"))
+            dwg.add(
+                dwg.text(
+                    "{:.2f}".format(genome_coord),
+                    (x, y + 20),
+                    font_size=14,
+                    text_anchor="middle",
+                    font_weight="bold",
+                )
+            )
 
 
 class SvgTree(object):
@@ -228,11 +268,21 @@ class SvgTree(object):
     be referred to and modified.
 
     """
+
     def __init__(
-            self, tree, size=None, node_labels=None, mutation_labels=None,
-            tree_height_scale=None, max_tree_height=None,
-            node_attrs=None, edge_attrs=None, node_label_attrs=None,
-            mutation_attrs=None, mutation_label_attrs=None):
+        self,
+        tree,
+        size=None,
+        node_labels=None,
+        mutation_labels=None,
+        tree_height_scale=None,
+        max_tree_height=None,
+        node_attrs=None,
+        edge_attrs=None,
+        node_label_attrs=None,
+        mutation_attrs=None,
+        mutation_label_attrs=None,
+    ):
         self.tree = tree
         if size is None:
             size = (200, 200)
@@ -243,7 +293,8 @@ class SvgTree(object):
         self.treebox_width = size[0] - 2 * self.treebox_x_offset
         self.assign_y_coordinates(tree_height_scale, max_tree_height)
         self.node_x_coord_map = self.assign_x_coordinates(
-            tree, self.treebox_x_offset, self.treebox_width)
+            tree, self.treebox_x_offset, self.treebox_width
+        )
 
         self.edge_attrs = {}
         self.node_attrs = {}
@@ -271,7 +322,9 @@ class SvgTree(object):
                 m = mutation.id
                 # We need to offset the rectangle so that it's centred
                 self.mutation_attrs[m] = {
-                    "size": (6, 6), "transform": "translate(-3, -3)"}
+                    "size": (6, 6),
+                    "transform": "translate(-3, -3)",
+                }
                 if mutation_attrs is not None and m in mutation_attrs:
                     self.mutation_attrs[m].update(mutation_attrs[m])
                 label = ""
@@ -288,15 +341,16 @@ class SvgTree(object):
     def setup_drawing(self):
         self.drawing = svgwrite.Drawing(size=self.image_size, debug=True)
         dwg = self.drawing
-        self.root_group = dwg.add(dwg.g(id='tree_{}'.format(self.tree.index)))
-        self.edges = self.root_group.add(dwg.g(id='edges',  stroke="black", fill="none"))
-        self.symbols = self.root_group.add(dwg.g(id='symbols'))
-        self.nodes = self.symbols.add(dwg.g(class_='nodes'))
-        self.mutations = self.symbols.add(dwg.g(class_='mutations', fill="red"))
-        self.labels = self.root_group.add(dwg.g(id='labels', font_size=14))
-        self.node_labels = self.labels.add(dwg.g(class_='nodes'))
+        self.root_group = dwg.add(dwg.g(id="tree_{}".format(self.tree.index)))
+        self.edges = self.root_group.add(dwg.g(id="edges", stroke="black", fill="none"))
+        self.symbols = self.root_group.add(dwg.g(id="symbols"))
+        self.nodes = self.symbols.add(dwg.g(class_="nodes"))
+        self.mutations = self.symbols.add(dwg.g(class_="mutations", fill="red"))
+        self.labels = self.root_group.add(dwg.g(id="labels", font_size=14))
+        self.node_labels = self.labels.add(dwg.g(class_="nodes"))
         self.mutation_labels = self.labels.add(
-            dwg.g(class_='mutations', font_style="italic"))
+            dwg.g(class_="mutations", font_style="italic")
+        )
         self.left_labels = self.node_labels.add(dwg.g(text_anchor="start"))
         self.mid_labels = self.node_labels.add(dwg.g(text_anchor="middle"))
         self.right_labels = self.node_labels.add(dwg.g(text_anchor="end"))
@@ -306,7 +360,8 @@ class SvgTree(object):
     def assign_y_coordinates(self, tree_height_scale, max_tree_height):
         tree_height_scale = check_tree_height_scale(tree_height_scale)
         max_tree_height = check_max_tree_height(
-            max_tree_height, tree_height_scale != "rank")
+            max_tree_height, tree_height_scale != "rank"
+        )
         ts = self.tree.tree_sequence
         node_time = ts.tables.nodes.time
 
@@ -347,7 +402,8 @@ class SvgTree(object):
         y_padding = self.treebox_y_offset + 2 * label_padding
         mutations_over_root = any(
             any(tree.parent(mut.node) == NULL for mut in tree.mutations())
-            for tree in ts.trees())
+            for tree in ts.trees()
+        )
         root_branch_length = 0
         height = self.image_size[1]
         if mutations_over_root:
@@ -355,15 +411,15 @@ class SvgTree(object):
             # 'root branch'
             root_branch_length = height / 10  # FIXME just draw branch??
         # y scaling
-        padding_numerator = (height - root_branch_length - 2 * y_padding)
+        padding_numerator = height - root_branch_length - 2 * y_padding
         if tree_height_scale == "log_time":
             # again shift time by 1 in log(max_tree_height), so consistent
             y_scale = padding_numerator / (np.log(max_tree_height + 1))
         else:
             y_scale = padding_numerator / max_tree_height
         self.node_y_coord_map = [
-                height - y_scale * node_height[u] - y_padding
-                for u in range(ts.num_nodes)]
+            height - y_scale * node_height[u] - y_padding for u in range(ts.num_nodes)
+        ]
 
     def assign_x_coordinates(self, tree, x_start, width):
         num_leaves = len(list(tree.leaves()))
@@ -416,15 +472,18 @@ class SvgTree(object):
             # TODO add ID to node label text.
             # TODO get rid of these manual positioning tweaks and add them
             # as offsets the user can access via a transform or something.
-            labels.add(dwg.text(
-                insert=(pu[0] + dx, pu[1] + dy), **self.node_label_attrs[u]))
+            labels.add(
+                dwg.text(insert=(pu[0] + dx, pu[1] + dy), **self.node_label_attrs[u])
+            )
             v = tree.parent(u)
             if v != NULL:
                 edge_id = "edge_{}_{}".format(tree.index, u)
                 pv = node_x_coord_map[v], node_y_coord_map[v]
                 path = dwg.path(
-                    [("M", pu), ("V", pv[1]), ("H", pv[0])], id=edge_id,
-                    **self.edge_attrs[u])
+                    [("M", pu), ("V", pv[1]), ("H", pv[0])],
+                    id=edge_id,
+                    **self.edge_attrs[u]
+                )
                 self.edges.add(path)
             else:
                 # FIXME this is pretty crappy for spacing mutations over a root.
@@ -436,9 +495,9 @@ class SvgTree(object):
             y = pv[1] - delta
             # TODO add mutation IDs
             for mutation in reversed(node_mutations[u]):
-                self.mutations.add(dwg.rect(
-                    insert=(x, y),
-                    **self.mutation_attrs[mutation.id]))
+                self.mutations.add(
+                    dwg.rect(insert=(x, y), **self.mutation_attrs[mutation.id])
+                )
                 dx = 5
                 if tree.left_sib(mutation.node) == NULL:
                     dx *= -1
@@ -448,9 +507,12 @@ class SvgTree(object):
                 # TODO get rid of these manual positioning tweaks and add them
                 # as offsets the user can access via a transform or something.
                 dy = 4
-                labels.add(dwg.text(
-                    insert=(x + dx, y + dy),
-                    **self.mutation_label_attrs[mutation.id]))
+                labels.add(
+                    dwg.text(
+                        insert=(x + dx, y + dy),
+                        **self.mutation_label_attrs[mutation.id]
+                    )
+                )
                 y -= delta
 
 
@@ -458,26 +520,35 @@ class TextTreeSequence(object):
     """
     Draw a tree sequence as horizontal line of trees.
     """
+
     def __init__(
-            self, ts, node_labels=None, use_ascii=False, time_label_format=None,
-            position_label_format=None):
+        self,
+        ts,
+        node_labels=None,
+        use_ascii=False,
+        time_label_format=None,
+        position_label_format=None,
+    ):
         self.ts = ts
 
-        time_label_format = (
-            "{:.2f}" if time_label_format is None else time_label_format)
+        time_label_format = "{:.2f}" if time_label_format is None else time_label_format
         position_label_format = (
-            "{:.2f}" if position_label_format is None else position_label_format)
+            "{:.2f}" if position_label_format is None else position_label_format
+        )
 
         time = ts.tables.nodes.time
         time_scale_labels = [
-            time_label_format.format(time[u]) for u in range(ts.num_nodes)]
+            time_label_format.format(time[u]) for u in range(ts.num_nodes)
+        ]
         position_scale_labels = [
-            position_label_format.format(x) for x in ts.breakpoints()]
+            position_label_format.format(x) for x in ts.breakpoints()
+        ]
         trees = [
             VerticalTextTree(
-                tree, max_tree_height="ts", node_labels=node_labels,
-                use_ascii=use_ascii)
-            for tree in self.ts.trees()]
+                tree, max_tree_height="ts", node_labels=node_labels, use_ascii=use_ascii
+            )
+            for tree in self.ts.trees()
+        ]
 
         self.height = 1 + max(tree.height for tree in trees)
         self.width = sum(tree.width + 2 for tree in trees) - 1
@@ -492,7 +563,7 @@ class TextTreeSequence(object):
         time_position = trees[0].time_position
         for u, label in enumerate(map(to_np_unicode, time_scale_labels)):
             y = time_position[u]
-            self.canvas[y, 0: label.shape[0]] = label
+            self.canvas[y, 0 : label.shape[0]] = label
         self.canvas[:, max_time_scale_label_len] = vertical_sep
         x = 2 + max_time_scale_label_len
 
@@ -500,9 +571,9 @@ class TextTreeSequence(object):
             pos_label = to_np_unicode(position_scale_labels[j])
             k = len(pos_label)
             label_x = max(x - k // 2 - 2, 0)
-            self.canvas[-1, label_x: label_x + k] = pos_label
+            self.canvas[-1, label_x : label_x + k] = pos_label
             h, w = tree.canvas.shape
-            self.canvas[-h - 1: -1, x: x + w - 1] = tree.canvas[:, :-1]
+            self.canvas[-h - 1 : -1, x : x + w - 1] = tree.canvas[:, :-1]
             x += w
             self.canvas[:, x] = vertical_sep
             x += 2
@@ -510,7 +581,7 @@ class TextTreeSequence(object):
         pos_label = to_np_unicode(position_scale_labels[-1])
         k = len(pos_label)
         label_x = max(x - k // 2 - 2, 0)
-        self.canvas[-1, label_x: label_x + k] = pos_label
+        self.canvas[-1, label_x : label_x + k] = pos_label
         self.canvas[:, -1] = "\n"
 
     def __str__(self):
@@ -595,19 +666,26 @@ class TextTree(object):
     Draws a reprentation of a tree using unicode drawing characters written
     to a 2D array.
     """
+
     def __init__(
-            self, tree, node_labels=None, max_tree_height=None, use_ascii=False,
-            orientation=None):
+        self,
+        tree,
+        node_labels=None,
+        max_tree_height=None,
+        use_ascii=False,
+        orientation=None,
+    ):
         self.tree = tree
         self.max_tree_height = check_max_tree_height(
-            max_tree_height, allow_numeric=False)
+            max_tree_height, allow_numeric=False
+        )
         self.use_ascii = use_ascii
         self.orientation = check_orientation(orientation)
-        self.horizontal_line_char = '━'
-        self.vertical_line_char = '┃'
+        self.horizontal_line_char = "━"
+        self.vertical_line_char = "┃"
         if use_ascii:
-            self.horizontal_line_char = '-'
-            self.vertical_line_char = '|'
+            self.horizontal_line_char = "-"
+            self.vertical_line_char = "|"
         # These are set below by the placement algorithms.
         self.width = None
         self.height = None
@@ -649,6 +727,7 @@ class VerticalTextTree(TextTree):
     Text tree rendering where root nodes are at the top and time goes downwards
     into the present.
     """
+
     @property
     def default_node_label(self):
         return self.vertical_line_char
@@ -659,7 +738,8 @@ class VerticalTextTree(TextTree):
         # account here. Presumably we need to get the maximum number of mutations
         # per branch.
         self.time_position, total_depth = node_time_depth(
-                tree, max_tree_height=self.max_tree_height)
+            tree, max_tree_height=self.max_tree_height
+        )
         self.height = total_depth - 1
 
     def _assign_traversal_positions(self):
@@ -719,22 +799,22 @@ class VerticalTextTree(TextTree):
             label_len = label.shape[0]
             label_x = self.label_x[u]
             assert label_x >= 0
-            self.canvas[yu, label_x: label_x + label_len] = label
+            self.canvas[yu, label_x : label_x + label_len] = label
             children = self.tree.children(u)
             if len(children) > 0:
                 if len(children) == 1:
                     yv = self.time_position[children[0]]
-                    self.canvas[yv: yu, xu] = self.vertical_line_char
+                    self.canvas[yv:yu, xu] = self.vertical_line_char
                 else:
                     left = min(self.traversal_position[v] for v in children)
                     right = max(self.traversal_position[v] for v in children)
                     y = yu - 1
-                    self.canvas[y, left + 1: right] = self.horizontal_line_char
+                    self.canvas[y, left + 1 : right] = self.horizontal_line_char
                     self.canvas[y, xu] = mid_parent
                     for v in children:
                         xv = self.traversal_position[v]
                         yv = self.time_position[v]
-                        self.canvas[yv: yu, xv] = self.vertical_line_char
+                        self.canvas[yv:yu, xv] = self.vertical_line_char
                         mid_char = mid_parent_child if xv == xu else mid_child
                         self.canvas[y, xv] = mid_char
                     self.canvas[y, left] = left_child
@@ -745,7 +825,8 @@ class VerticalTextTree(TextTree):
             # Reverse the time positions so that we can use them in the tree
             # sequence drawing as well.
             flipped_time_position = {
-                u: self.height - y - 1 for u, y in self.time_position.items()}
+                u: self.height - y - 1 for u, y in self.time_position.items()
+            }
             self.time_position = flipped_time_position
 
 
@@ -764,7 +845,8 @@ class HorizontalTextTree(TextTree):
         # account here. Presumably we need to get the maximum number of mutations
         # per branch.
         self.time_position, total_depth = node_time_depth(
-            self.tree, {u: 1 + len(self.node_labels[u]) for u in self.tree.nodes()})
+            self.tree, {u: 1 + len(self.node_labels[u]) for u in self.tree.nodes()}
+        )
         self.width = total_depth
 
     def _assign_traversal_positions(self):
@@ -815,22 +897,22 @@ class HorizontalTextTree(TextTree):
                 # We flip the array at the end so need to reverse the label.
                 label = label[::-1]
             label_len = label.shape[0]
-            self.canvas[yu, xu: xu + label_len] = label
+            self.canvas[yu, xu : xu + label_len] = label
             children = self.tree.children(u)
             if len(children) > 0:
                 if len(children) == 1:
                     xv = self.time_position[children[0]]
-                    self.canvas[yu, xv: xu] = self.horizontal_line_char
+                    self.canvas[yu, xv:xu] = self.horizontal_line_char
                 else:
                     bot = min(self.traversal_position[v] for v in children)
                     top = max(self.traversal_position[v] for v in children)
                     x = xu - 1
-                    self.canvas[bot + 1: top, x] = self.vertical_line_char
+                    self.canvas[bot + 1 : top, x] = self.vertical_line_char
                     self.canvas[yu, x] = mid_parent
                     for v in children:
                         yv = self.traversal_position[v]
                         xv = self.time_position[v]
-                        self.canvas[yv, xv: x] = self.horizontal_line_char
+                        self.canvas[yv, xv:x] = self.horizontal_line_char
                         mid_char = mid_parent_child if yv == yu else mid_child
                         self.canvas[yv, x] = mid_char
                     self.canvas[bot, x] = top_across

--- a/python/tskit/provenance.py
+++ b/python/tskit/provenance.py
@@ -62,13 +62,9 @@ def get_environment(extra_libs=None, include_tskit=True):
         "python": {
             "implementation": platform.python_implementation(),
             "version": platform.python_version(),
-        }
+        },
     }
-    libs = {
-        "kastore": {
-            "version": ".".join(map(str, _tskit.get_kastore_version()))
-        }
-    }
+    libs = {"kastore": {"version": ".".join(map(str, _tskit.get_kastore_version()))}}
     if include_tskit:
         libs["tskit"] = {"version": __version__}
     if extra_libs is not None:
@@ -84,12 +80,9 @@ def get_provenance_dict(parameters=None):
     """
     document = {
         "schema_version": "1.0.0",
-        "software": {
-            "name": "tskit",
-            "version": __version__
-        },
+        "software": {"name": "tskit", "version": __version__},
         "parameters": parameters,
-        "environment": get_environment(include_tskit=False)
+        "environment": get_environment(include_tskit=False),
     }
     return document
 

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -53,7 +53,8 @@ class LdCalculator(object):
     def __init__(self, tree_sequence):
         self._tree_sequence = tree_sequence
         self._ll_ld_calculator = _tskit.LdCalculator(
-            tree_sequence.get_ll_tree_sequence())
+            tree_sequence.get_ll_tree_sequence()
+        )
         # To protect low-level C code, only one method may execute on the
         # low-level objects at one time.
         self._instance_lock = threading.Lock()
@@ -127,12 +128,16 @@ class LdCalculator(object):
             max_mutations = -1
         if max_distance is None:
             max_distance = sys.float_info.max
-        item_size = struct.calcsize('d')
+        item_size = struct.calcsize("d")
         buffer = bytearray(self._tree_sequence.get_num_mutations() * item_size)
         with self._instance_lock:
             num_values = self._ll_ld_calculator.get_r2_array(
-                buffer, a, direction=direction,
-                max_mutations=max_mutations, max_distance=max_distance)
+                buffer,
+                a,
+                direction=direction,
+                max_mutations=max_mutations,
+                max_distance=max_distance,
+            )
         return np.frombuffer(buffer, "d", num_values)
 
     def get_r2_matrix(self):
@@ -153,6 +158,6 @@ class LdCalculator(object):
         A = np.ones((m, m), dtype=float)
         for j in range(m - 1):
             a = self.get_r2_array(j)
-            A[j, j + 1:] = a
-            A[j + 1:, j] = a
+            A[j, j + 1 :] = a
+            A[j + 1 :, j] = a
         return A

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -32,6 +32,7 @@ import warnings
 import numpy as np
 
 import _tskit
+
 # This circular import is ugly but it seems hard to avoid it since table collection
 # and tree sequence depend on each other. Unless they're in the same module they
 # need to import each other. In Py3 at least we can import the modules but we
@@ -42,43 +43,41 @@ import tskit.provenance as provenance
 
 
 IndividualTableRow = collections.namedtuple(
-    "IndividualTableRow",
-    ["flags", "location", "metadata"])
+    "IndividualTableRow", ["flags", "location", "metadata"]
+)
 
 
 NodeTableRow = collections.namedtuple(
-    "NodeTableRow",
-    ["flags", "time", "population", "individual", "metadata"])
+    "NodeTableRow", ["flags", "time", "population", "individual", "metadata"]
+)
 
 
 EdgeTableRow = collections.namedtuple(
-    "EdgeTableRow",
-    ["left", "right", "parent", "child"])
+    "EdgeTableRow", ["left", "right", "parent", "child"]
+)
 
 
 MigrationTableRow = collections.namedtuple(
-    "MigrationTableRow",
-    ["left", "right", "node", "source", "dest", "time"])
+    "MigrationTableRow", ["left", "right", "node", "source", "dest", "time"]
+)
 
 
 SiteTableRow = collections.namedtuple(
-    "SiteTableRow",
-    ["position", "ancestral_state", "metadata"])
+    "SiteTableRow", ["position", "ancestral_state", "metadata"]
+)
 
 
 MutationTableRow = collections.namedtuple(
-    "MutationTableRow",
-    ["site", "node", "derived_state", "parent", "metadata"])
+    "MutationTableRow", ["site", "node", "derived_state", "parent", "metadata"]
+)
 
 
-PopulationTableRow = collections.namedtuple(
-    "PopulationTableRow",
-    ["metadata"])
+PopulationTableRow = collections.namedtuple("PopulationTableRow", ["metadata"])
 
 
 ProvenanceTableRow = collections.namedtuple(
-    "ProvenanceTableRow",
-    ["timestamp", "record"])
+    "ProvenanceTableRow", ["timestamp", "record"]
+)
 
 
 def keep_with_offset(keep, data, offset):
@@ -87,16 +86,22 @@ def keep_with_offset(keep, data, offset):
     """
     # We need the astype here for 32 bit machines
     lens = np.diff(offset).astype(np.int32)
-    return (data[np.repeat(keep, lens)],
-            np.concatenate([
+    return (
+        data[np.repeat(keep, lens)],
+        np.concatenate(
+            [
                 np.array([0], dtype=offset.dtype),
-                np.cumsum(lens[keep], dtype=offset.dtype)]))
+                np.cumsum(lens[keep], dtype=offset.dtype),
+            ]
+        ),
+    )
 
 
 class BaseTable(object):
     """
     Superclass of high-level tables. Not intended for direct instantiation.
     """
+
     # The list of columns in the table. Must be set by subclasses.
     column_names = []
 
@@ -137,8 +142,9 @@ class BaseTable(object):
         if name in self.column_names:
             return getattr(self.ll_table, name)
         else:
-            raise AttributeError("{} object has no attribute {}".format(
-                self.__class__.__name__, name))
+            raise AttributeError(
+                "{} object has no attribute {}".format(self.__class__.__name__, name)
+            )
 
     def __setattr__(self, name, value):
         if name in self.column_names:
@@ -210,6 +216,7 @@ class MetadataMixin(object):
     """
     Mixin class for tables that have a metadata column.
     """
+
     def packset_metadata(self, metadatas):
         """
         Packs the specified list of metadata values and updates the ``metadata``
@@ -256,7 +263,12 @@ class IndividualTable(BaseTable, MetadataMixin):
     """
 
     column_names = [
-        "flags", "location", "location_offset", "metadata", "metadata_offset"]
+        "flags",
+        "location",
+        "location_offset",
+        "metadata",
+        "metadata_offset",
+    ]
 
     def __init__(self, max_rows_increment=0, ll_table=None):
         if ll_table is None:
@@ -269,7 +281,7 @@ class IndividualTable(BaseTable, MetadataMixin):
         metadata = util.unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tflags\tlocation\tmetadata\n"
         for j in range(self.num_rows):
-            md = base64.b64encode(metadata[j]).decode('utf8')
+            md = base64.b64encode(metadata[j]).decode("utf8")
             location_str = ",".join(map(str, location))
             ret += "{}\t{}\t{}\t{}\n".format(j, flags[j], location_str, md)
         return ret[:-1]
@@ -291,8 +303,13 @@ class IndividualTable(BaseTable, MetadataMixin):
         return self.ll_table.add_row(flags=flags, location=location, metadata=metadata)
 
     def set_columns(
-            self, flags=None, location=None, location_offset=None,
-            metadata=None, metadata_offset=None):
+        self,
+        flags=None,
+        location=None,
+        location_offset=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Sets the values for each column in this :class:`IndividualTable` using the
         values in the specified arrays. Overwrites any data currently stored in
@@ -322,13 +339,24 @@ class IndividualTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags)
-        self.ll_table.set_columns(dict(
-            flags=flags, location=location, location_offset=location_offset,
-            metadata=metadata, metadata_offset=metadata_offset))
+        self.ll_table.set_columns(
+            dict(
+                flags=flags,
+                location=location,
+                location_offset=location_offset,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def append_columns(
-            self, flags=None, location=None, location_offset=None, metadata=None,
-            metadata_offset=None):
+        self,
+        flags=None,
+        location=None,
+        location_offset=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Appends the specified arrays to the end of the columns in this
         :class:`IndividualTable`. This allows many new rows to be added at once.
@@ -357,9 +385,15 @@ class IndividualTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags)
-        self.ll_table.append_columns(dict(
-            flags=flags, location=location, location_offset=location_offset,
-            metadata=metadata, metadata_offset=metadata_offset))
+        self.ll_table.append_columns(
+            dict(
+                flags=flags,
+                location=location,
+                location_offset=location_offset,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def packset_location(self, locations):
         """
@@ -406,8 +440,15 @@ class NodeTable(BaseTable, MetadataMixin):
         :ref:`sec_tables_api_binary_columns` for more details.
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     """
+
     column_names = [
-        "time", "flags", "population", "individual", "metadata", "metadata_offset"]
+        "time",
+        "flags",
+        "population",
+        "individual",
+        "metadata",
+        "metadata_offset",
+    ]
 
     def __init__(self, max_rows_increment=0, ll_table=None):
         if ll_table is None:
@@ -422,9 +463,10 @@ class NodeTable(BaseTable, MetadataMixin):
         metadata = util.unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tflags\tpopulation\tindividual\ttime\tmetadata\n"
         for j in range(self.num_rows):
-            md = base64.b64encode(metadata[j]).decode('utf8')
+            md = base64.b64encode(metadata[j]).decode("utf8")
             ret += "{}\t{}\t{}\t{}\t{:.14f}\t{}\n".format(
-                j, flags[j], population[j], individual[j], time[j], md)
+                j, flags[j], population[j], individual[j], time[j], md
+            )
         return ret[:-1]
 
     def add_row(self, flags=0, time=0, population=-1, individual=-1, metadata=None):
@@ -446,8 +488,14 @@ class NodeTable(BaseTable, MetadataMixin):
         return self.ll_table.add_row(flags, time, population, individual, metadata)
 
     def set_columns(
-            self, flags=None, time=None, population=None, individual=None, metadata=None,
-            metadata_offset=None):
+        self,
+        flags=None,
+        time=None,
+        population=None,
+        individual=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Sets the values for each column in this :class:`NodeTable` using the values in
         the specified arrays. Overwrites any data currently stored in the table.
@@ -476,13 +524,26 @@ class NodeTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags, time=time)
-        self.ll_table.set_columns(dict(
-            flags=flags, time=time, population=population, individual=individual,
-            metadata=metadata, metadata_offset=metadata_offset))
+        self.ll_table.set_columns(
+            dict(
+                flags=flags,
+                time=time,
+                population=population,
+                individual=individual,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def append_columns(
-            self, flags=None, time=None, population=None, individual=None, metadata=None,
-            metadata_offset=None):
+        self,
+        flags=None,
+        time=None,
+        population=None,
+        individual=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Appends the specified arrays to the end of the columns in this
         :class:`NodeTable`. This allows many new rows to be added at once.
@@ -511,9 +572,16 @@ class NodeTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags, time=time)
-        self.ll_table.append_columns(dict(
-            flags=flags, time=time, population=population, individual=individual,
-            metadata=metadata, metadata_offset=metadata_offset))
+        self.ll_table.append_columns(
+            dict(
+                flags=flags,
+                time=time,
+                population=population,
+                individual=individual,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
 
 class EdgeTable(BaseTable):
@@ -555,7 +623,8 @@ class EdgeTable(BaseTable):
         ret = "id\tleft\t\tright\t\tparent\tchild\n"
         for j in range(self.num_rows):
             ret += "{}\t{:.8f}\t{:.8f}\t{}\t{}\n".format(
-                j, left[j], right[j], parent[j], child[j])
+                j, left[j], right[j], parent[j], child[j]
+            )
         return ret[:-1]
 
     def add_row(self, left, right, parent, child):
@@ -590,8 +659,9 @@ class EdgeTable(BaseTable):
         :type child: numpy.ndarray, dtype=np.int32
         """
         self._check_required_args(left=left, right=right, parent=parent, child=child)
-        self.ll_table.set_columns(dict(
-            left=left, right=right, parent=parent, child=child))
+        self.ll_table.set_columns(
+            dict(left=left, right=right, parent=parent, child=child)
+        )
 
     def append_columns(self, left, right, parent, child):
         """
@@ -611,8 +681,9 @@ class EdgeTable(BaseTable):
         :param child: The child node IDs.
         :type child: numpy.ndarray, dtype=np.int32
         """
-        self.ll_table.append_columns(dict(
-            left=left, right=right, parent=parent, child=child))
+        self.ll_table.append_columns(
+            dict(left=left, right=right, parent=parent, child=child)
+        )
 
     def squash(self):
         """
@@ -677,7 +748,8 @@ class MigrationTable(BaseTable):
         ret = "id\tleft\tright\tnode\tsource\tdest\ttime\n"
         for j in range(self.num_rows):
             ret += "{}\t{:.8f}\t{:.8f}\t{}\t{}\t{}\t{:.8f}\n".format(
-                j, left[j], right[j], node[j], source[j], dest[j], time[j])
+                j, left[j], right[j], node[j], source[j], dest[j], time[j]
+            )
         return ret[:-1]
 
     def add_row(self, left, right, node, source, dest, time):
@@ -697,7 +769,8 @@ class MigrationTable(BaseTable):
         return self.ll_table.add_row(left, right, node, source, dest, time)
 
     def set_columns(
-            self, left=None, right=None, node=None, source=None, dest=None, time=None):
+        self, left=None, right=None, node=None, source=None, dest=None, time=None
+    ):
         """
         Sets the values for each column in this :class:`MigrationTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
@@ -719,9 +792,11 @@ class MigrationTable(BaseTable):
         :type time: numpy.ndarray, dtype=np.int64
         """
         self._check_required_args(
-            left=left, right=right, node=node, source=source, dest=dest, time=time)
-        self.ll_table.set_columns(dict(
-            left=left, right=right, node=node, source=source, dest=dest, time=time))
+            left=left, right=right, node=node, source=source, dest=dest, time=time
+        )
+        self.ll_table.set_columns(
+            dict(left=left, right=right, node=node, source=source, dest=dest, time=time)
+        )
 
     def append_columns(self, left, right, node, source, dest, time):
         """
@@ -745,8 +820,9 @@ class MigrationTable(BaseTable):
         :param time: The time of each migration.
         :type time: numpy.ndarray, dtype=np.int64
         """
-        self.ll_table.append_columns(dict(
-            left=left, right=right, node=node, source=source, dest=dest, time=time))
+        self.ll_table.append_columns(
+            dict(left=left, right=right, node=node, source=source, dest=dest, time=time)
+        )
 
 
 class SiteTable(BaseTable, MetadataMixin):
@@ -781,8 +857,12 @@ class SiteTable(BaseTable, MetadataMixin):
     """
 
     column_names = [
-        "position", "ancestral_state", "ancestral_state_offset",
-        "metadata", "metadata_offset"]
+        "position",
+        "ancestral_state",
+        "ancestral_state_offset",
+        "metadata",
+        "metadata_offset",
+    ]
 
     def __init__(self, max_rows_increment=0, ll_table=None):
         if ll_table is None:
@@ -792,13 +872,13 @@ class SiteTable(BaseTable, MetadataMixin):
     def __str__(self):
         position = self.position
         ancestral_state = util.unpack_strings(
-            self.ancestral_state, self.ancestral_state_offset)
+            self.ancestral_state, self.ancestral_state_offset
+        )
         metadata = util.unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tposition\tancestral_state\tmetadata\n"
         for j in range(self.num_rows):
-            md = base64.b64encode(metadata[j]).decode('utf8')
-            ret += "{}\t{:.8f}\t{}\t{}\n".format(
-                j, position[j], ancestral_state[j], md)
+            md = base64.b64encode(metadata[j]).decode("utf8")
+            ret += "{}\t{:.8f}\t{}\t{}\n".format(j, position[j], ancestral_state[j], md)
         return ret[:-1]
 
     def add_row(self, position, ancestral_state, metadata=None):
@@ -816,8 +896,13 @@ class SiteTable(BaseTable, MetadataMixin):
         return self.ll_table.add_row(position, ancestral_state, metadata)
 
     def set_columns(
-            self, position=None, ancestral_state=None, ancestral_state_offset=None,
-            metadata=None, metadata_offset=None):
+        self,
+        position=None,
+        ancestral_state=None,
+        ancestral_state_offset=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Sets the values for each column in this :class:`SiteTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
@@ -848,16 +933,28 @@ class SiteTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(
-            position=position, ancestral_state=ancestral_state,
-            ancestral_state_offset=ancestral_state_offset)
-        self.ll_table.set_columns(dict(
-            position=position, ancestral_state=ancestral_state,
+            position=position,
+            ancestral_state=ancestral_state,
             ancestral_state_offset=ancestral_state_offset,
-            metadata=metadata, metadata_offset=metadata_offset))
+        )
+        self.ll_table.set_columns(
+            dict(
+                position=position,
+                ancestral_state=ancestral_state,
+                ancestral_state_offset=ancestral_state_offset,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def append_columns(
-            self, position, ancestral_state, ancestral_state_offset,
-            metadata=None, metadata_offset=None):
+        self,
+        position,
+        ancestral_state,
+        ancestral_state_offset,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Appends the specified arrays to the end of the columns of this
         :class:`SiteTable`. This allows many new rows to be added at once.
@@ -888,10 +985,15 @@ class SiteTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
-        self.ll_table.append_columns(dict(
-            position=position, ancestral_state=ancestral_state,
-            ancestral_state_offset=ancestral_state_offset,
-            metadata=metadata, metadata_offset=metadata_offset))
+        self.ll_table.append_columns(
+            dict(
+                position=position,
+                ancestral_state=ancestral_state,
+                ancestral_state_offset=ancestral_state_offset,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def packset_ancestral_state(self, ancestral_states):
         """
@@ -945,8 +1047,14 @@ class MutationTable(BaseTable, MetadataMixin):
     """
 
     column_names = [
-        "site", "node", "derived_state", "derived_state_offset", "parent",
-        "metadata", "metadata_offset"]
+        "site",
+        "node",
+        "derived_state",
+        "derived_state_offset",
+        "parent",
+        "metadata",
+        "metadata_offset",
+    ]
 
     def __init__(self, max_rows_increment=0, ll_table=None):
         if ll_table is None:
@@ -958,13 +1066,15 @@ class MutationTable(BaseTable, MetadataMixin):
         node = self.node
         parent = self.parent
         derived_state = util.unpack_strings(
-            self.derived_state, self.derived_state_offset)
+            self.derived_state, self.derived_state_offset
+        )
         metadata = util.unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tsite\tnode\tderived_state\tparent\tmetadata\n"
         for j in range(self.num_rows):
-            md = base64.b64encode(metadata[j]).decode('utf8')
+            md = base64.b64encode(metadata[j]).decode("utf8")
             ret += "{}\t{}\t{}\t{}\t{}\t{}\n".format(
-                j, site[j], node[j], derived_state[j], parent[j], md)
+                j, site[j], node[j], derived_state[j], parent[j], md
+            )
         return ret[:-1]
 
     def add_row(self, site, node, derived_state, parent=-1, metadata=None):
@@ -982,12 +1092,18 @@ class MutationTable(BaseTable, MetadataMixin):
         :return: The ID of the newly added mutation.
         :rtype: int
         """
-        return self.ll_table.add_row(
-                site, node, derived_state, parent, metadata)
+        return self.ll_table.add_row(site, node, derived_state, parent, metadata)
 
     def set_columns(
-            self, site=None, node=None, derived_state=None, derived_state_offset=None,
-            parent=None, metadata=None, metadata_offset=None):
+        self,
+        site=None,
+        node=None,
+        derived_state=None,
+        derived_state_offset=None,
+        parent=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Sets the values for each column in this :class:`MutationTable` using the values
         in the specified arrays. Overwrites any data currently stored in the table.
@@ -1023,16 +1139,33 @@ class MutationTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(
-            site=site, node=node, derived_state=derived_state,
-            derived_state_offset=derived_state_offset)
-        self.ll_table.set_columns(dict(
-            site=site, node=node, parent=parent,
-            derived_state=derived_state, derived_state_offset=derived_state_offset,
-            metadata=metadata, metadata_offset=metadata_offset))
+            site=site,
+            node=node,
+            derived_state=derived_state,
+            derived_state_offset=derived_state_offset,
+        )
+        self.ll_table.set_columns(
+            dict(
+                site=site,
+                node=node,
+                parent=parent,
+                derived_state=derived_state,
+                derived_state_offset=derived_state_offset,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def append_columns(
-            self, site, node, derived_state, derived_state_offset,
-            parent=None, metadata=None, metadata_offset=None):
+        self,
+        site,
+        node,
+        derived_state,
+        derived_state_offset,
+        parent=None,
+        metadata=None,
+        metadata_offset=None,
+    ):
         """
         Appends the specified arrays to the end of the columns of this
         :class:`MutationTable`. This allows many new rows to be added at once.
@@ -1068,10 +1201,17 @@ class MutationTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
-        self.ll_table.append_columns(dict(
-            site=site, node=node, parent=parent,
-            derived_state=derived_state, derived_state_offset=derived_state_offset,
-            metadata=metadata, metadata_offset=metadata_offset))
+        self.ll_table.append_columns(
+            dict(
+                site=site,
+                node=node,
+                parent=parent,
+                derived_state=derived_state,
+                derived_state_offset=derived_state_offset,
+                metadata=metadata,
+                metadata_offset=metadata_offset,
+            )
+        )
 
     def packset_derived_state(self, derived_states):
         """
@@ -1135,7 +1275,7 @@ class PopulationTable(BaseTable, MetadataMixin):
         metadata = util.unpack_bytes(self.metadata, self.metadata_offset)
         ret = "id\tmetadata\n"
         for j in range(self.num_rows):
-            md = base64.b64encode(metadata[j]).decode('utf8')
+            md = base64.b64encode(metadata[j]).decode("utf8")
             ret += "{}\t{}\n".format(j, md)
         return ret[:-1]
 
@@ -1158,7 +1298,8 @@ class PopulationTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self.ll_table.set_columns(
-            dict(metadata=metadata, metadata_offset=metadata_offset))
+            dict(metadata=metadata, metadata_offset=metadata_offset)
+        )
 
     def append_columns(self, metadata=None, metadata_offset=None):
         """
@@ -1178,7 +1319,8 @@ class PopulationTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self.ll_table.append_columns(
-            dict(metadata=metadata, metadata_offset=metadata_offset))
+            dict(metadata=metadata, metadata_offset=metadata_offset)
+        )
 
 
 class ProvenanceTable(BaseTable):
@@ -1232,8 +1374,8 @@ class ProvenanceTable(BaseTable):
         return self.ll_table.add_row(record=record, timestamp=timestamp)
 
     def set_columns(
-            self, timestamp=None, timestamp_offset=None,
-            record=None, record_offset=None):
+        self, timestamp=None, timestamp_offset=None, record=None, record_offset=None
+    ):
         """
         Sets the values for each column in this :class:`ProvenanceTable` using the
         values in the specified arrays. Overwrites any data currently stored in the
@@ -1258,13 +1400,18 @@ class ProvenanceTable(BaseTable):
         :param record_offset: The offsets into the ``record`` array.
         :type record_offset: numpy.ndarray, dtype=np.uint32.
         """
-        self.ll_table.set_columns(dict(
-            timestamp=timestamp, timestamp_offset=timestamp_offset,
-            record=record, record_offset=record_offset))
+        self.ll_table.set_columns(
+            dict(
+                timestamp=timestamp,
+                timestamp_offset=timestamp_offset,
+                record=record,
+                record_offset=record_offset,
+            )
+        )
 
     def append_columns(
-            self, timestamp=None, timestamp_offset=None,
-            record=None, record_offset=None):
+        self, timestamp=None, timestamp_offset=None, record=None, record_offset=None
+    ):
         """
         Appends the specified arrays to the end of the columns of this
         :class:`ProvenanceTable`. This allows many new rows to be added at once.
@@ -1288,9 +1435,14 @@ class ProvenanceTable(BaseTable):
         :param record_offset: The offsets into the ``record`` array.
         :type record_offset: numpy.ndarray, dtype=np.uint32.
         """
-        self.ll_table.append_columns(dict(
-            timestamp=timestamp, timestamp_offset=timestamp_offset,
-            record=record, record_offset=record_offset))
+        self.ll_table.append_columns(
+            dict(
+                timestamp=timestamp,
+                timestamp_offset=timestamp_offset,
+                record=record,
+                record_offset=record_offset,
+            )
+        )
 
     def __str__(self):
         timestamp = util.unpack_strings(self.timestamp, self.timestamp_offset)
@@ -1367,6 +1519,7 @@ class TableCollection(object):
         from, or None if not derived from a file.
     :vartype file_uuid: str
     """
+
     def __init__(self, sequence_length=0):
         self.ll_tables = _tskit.TableCollection(sequence_length)
 
@@ -1446,14 +1599,14 @@ class TableCollection(object):
         Iterate over all the tables in this TableCollection, ordered by table name
         (i.e. deterministically), returning a tuple of (table_name, table_object)
         """
-        yield 'edges', self.edges
-        yield 'individuals', self.individuals
-        yield 'migrations', self.migrations
-        yield 'mutations', self.mutations
-        yield 'nodes', self.nodes
-        yield 'populations', self.populations
-        yield 'provenances', self.provenances
-        yield 'sites', self.sites
+        yield "edges", self.edges
+        yield "individuals", self.individuals
+        yield "migrations", self.migrations
+        yield "mutations", self.mutations
+        yield "nodes", self.nodes
+        yield "populations", self.populations
+        yield "provenances", self.provenances
+        yield "sites", self.sites
 
     def __str__(self):
         s = self.__banner("Individuals")
@@ -1536,11 +1689,15 @@ class TableCollection(object):
         return tskit.TreeSequence.load_tables(self)
 
     def simplify(
-            self, samples=None,
-            filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
-            reduce_to_site_topology=False,
-            filter_populations=True, filter_individuals=True, filter_sites=True,
-            keep_unary=False):
+        self,
+        samples=None,
+        filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
+        reduce_to_site_topology=False,
+        filter_populations=True,
+        filter_individuals=True,
+        filter_sites=True,
+        keep_unary=False,
+    ):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
@@ -1594,20 +1751,24 @@ class TableCollection(object):
             # Deprecated in 0.6.1.
             warnings.warn(
                 "filter_zero_mutation_sites is deprecated; use filter_sites instead",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
             filter_sites = filter_zero_mutation_sites
         if samples is None:
             flags = self.nodes.flags
-            samples = np.where(
-                np.bitwise_and(flags, _tskit.NODE_IS_SAMPLE) != 0)[0].astype(np.int32)
+            samples = np.where(np.bitwise_and(flags, _tskit.NODE_IS_SAMPLE) != 0)[
+                0
+            ].astype(np.int32)
         else:
             samples = util.safe_np_int_cast(samples, np.int32)
         return self.ll_tables.simplify(
-            samples, filter_sites=filter_sites,
+            samples,
+            filter_sites=filter_sites,
             filter_individuals=filter_individuals,
             filter_populations=filter_populations,
             reduce_to_site_topology=reduce_to_site_topology,
-            keep_unary=keep_unary)
+            keep_unary=keep_unary,
+        )
 
     def link_ancestors(self, samples, ancestors):
         """
@@ -1761,23 +1922,28 @@ class TableCollection(object):
             raise ValueError("Site ID out of bounds")
         keep_sites[site_ids] = 0
         new_as, new_as_offset = keep_with_offset(
-            keep_sites, self.sites.ancestral_state,
-            self.sites.ancestral_state_offset)
+            keep_sites, self.sites.ancestral_state, self.sites.ancestral_state_offset
+        )
         new_md, new_md_offset = keep_with_offset(
-            keep_sites, self.sites.metadata, self.sites.metadata_offset)
+            keep_sites, self.sites.metadata, self.sites.metadata_offset
+        )
         self.sites.set_columns(
             position=self.sites.position[keep_sites],
             ancestral_state=new_as,
             ancestral_state_offset=new_as_offset,
             metadata=new_md,
-            metadata_offset=new_md_offset)
+            metadata_offset=new_md_offset,
+        )
         # We also need to adjust the mutations table, as it references into sites
         keep_mutations = keep_sites[self.mutations.site]
         new_ds, new_ds_offset = keep_with_offset(
-            keep_mutations, self.mutations.derived_state,
-            self.mutations.derived_state_offset)
+            keep_mutations,
+            self.mutations.derived_state,
+            self.mutations.derived_state_offset,
+        )
         new_md, new_md_offset = keep_with_offset(
-            keep_mutations, self.mutations.metadata, self.mutations.metadata_offset)
+            keep_mutations, self.mutations.metadata, self.mutations.metadata_offset
+        )
         # Site numbers will have changed
         site_map = np.cumsum(keep_sites, dtype=self.mutations.site.dtype) - 1
         # Mutation numbers will change, so the parent references need altering
@@ -1792,15 +1958,14 @@ class TableCollection(object):
             derived_state_offset=new_ds_offset,
             parent=mutation_map[self.mutations.parent[keep_mutations]],
             metadata=new_md,
-            metadata_offset=new_md_offset)
+            metadata_offset=new_md_offset,
+        )
         if record_provenance:
             # TODO replace with a version of https://github.com/tskit-dev/tskit/pull/243
-            parameters = {
-                "command": "delete_sites",
-                "TODO": "add parameters"
-            }
-            self.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            parameters = {"command": "delete_sites", "TODO": "add parameters"}
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
 
     def delete_intervals(self, intervals, simplify=True, record_provenance=True):
         """
@@ -1820,14 +1985,14 @@ class TableCollection(object):
         """
         self.keep_intervals(
             util.negate_intervals(intervals, 0, self.sequence_length),
-            simplify=simplify, record_provenance=False)
+            simplify=simplify,
+            record_provenance=False,
+        )
         if record_provenance:
-            parameters = {
-                "command": "delete_intervals",
-                "TODO": "add parameters"
-            }
-            self.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            parameters = {"command": "delete_intervals", "TODO": "add parameters"}
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
 
     def keep_intervals(self, intervals, simplify=True, record_provenance=True):
         """
@@ -1854,35 +2019,38 @@ class TableCollection(object):
         keep_sites = np.repeat(False, self.sites.num_rows)
         for s, e in intervals:
             curr_keep_sites = np.logical_and(
-                self.sites.position >= s, self.sites.position < e)
+                self.sites.position >= s, self.sites.position < e
+            )
             keep_sites = np.logical_or(keep_sites, curr_keep_sites)
-            keep_edges = np.logical_not(np.logical_or(edges.right <= s, edges.left >= e))
+            keep_edges = np.logical_not(
+                np.logical_or(edges.right <= s, edges.left >= e)
+            )
             self.edges.append_columns(
                 left=np.fmax(s, edges.left[keep_edges]),
                 right=np.fmin(e, edges.right[keep_edges]),
                 parent=edges.parent[keep_edges],
-                child=edges.child[keep_edges])
+                child=edges.child[keep_edges],
+            )
         self.delete_sites(
-            np.where(np.logical_not(keep_sites))[0], record_provenance=False)
+            np.where(np.logical_not(keep_sites))[0], record_provenance=False
+        )
         self.sort()
         if simplify:
             self.simplify()
         if record_provenance:
-            parameters = {
-                "command": "keep_intervals",
-                "TODO": "add parameters"
-            }
-            self.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            parameters = {"command": "keep_intervals", "TODO": "add parameters"}
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
 
     def _check_trim_conditions(self):
         if self.migrations.num_rows > 0:
-            raise ValueError(
-                "You cannot trim a tree sequence containing migrations")
+            raise ValueError("You cannot trim a tree sequence containing migrations")
         if self.edges.num_rows == 0:
             raise ValueError(
                 "Trimming a tree sequence with no edges would reduce the sequence length"
-                " to zero, which is not allowed")
+                " to zero, which is not allowed"
+            )
 
     def ltrim(self, record_provenance=True):
         """
@@ -1897,24 +2065,30 @@ class TableCollection(object):
         self._check_trim_conditions()
         leftmost = np.min(self.edges.left)
         self.delete_sites(
-            np.where(self.sites.position < leftmost), record_provenance=False)
+            np.where(self.sites.position < leftmost), record_provenance=False
+        )
         self.edges.set_columns(
-            left=self.edges.left - leftmost, right=self.edges.right - leftmost,
-            parent=self.edges.parent, child=self.edges.child)
+            left=self.edges.left - leftmost,
+            right=self.edges.right - leftmost,
+            parent=self.edges.parent,
+            child=self.edges.child,
+        )
         self.sites.set_columns(
             position=self.sites.position - leftmost,
             ancestral_state=self.sites.ancestral_state,
             ancestral_state_offset=self.sites.ancestral_state_offset,
             metadata=self.sites.metadata,
-            metadata_offset=self.sites.metadata_offset)
+            metadata_offset=self.sites.metadata_offset,
+        )
         self.sequence_length = self.sequence_length - leftmost
         if record_provenance:
             # TODO replace with a version of https://github.com/tskit-dev/tskit/pull/243
             parameters = {
                 "command": "ltrim",
             }
-            self.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
 
     def rtrim(self, record_provenance=True):
         """
@@ -1928,15 +2102,17 @@ class TableCollection(object):
         self._check_trim_conditions()
         rightmost = np.max(self.edges.right)
         self.delete_sites(
-            np.where(self.sites.position >= rightmost), record_provenance=False)
+            np.where(self.sites.position >= rightmost), record_provenance=False
+        )
         self.sequence_length = rightmost
         if record_provenance:
             # TODO replace with a version of https://github.com/tskit-dev/tskit/pull/243
             parameters = {
                 "command": "rtrim",
             }
-            self.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
 
     def trim(self, record_provenance=True):
         """
@@ -1954,8 +2130,9 @@ class TableCollection(object):
             parameters = {
                 "command": "trim",
             }
-            self.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
 
     def has_index(self):
         """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -49,14 +49,13 @@ from tskit import NULL
 
 
 CoalescenceRecord = collections.namedtuple(
-    "CoalescenceRecord",
-    ["left", "right", "node", "children", "time", "population"])
+    "CoalescenceRecord", ["left", "right", "node", "children", "time", "population"]
+)
 
 
 # TODO this interface is rubbish. Should have much better printing options.
 # TODO we should be use __slots__ here probably.
 class SimpleContainer(object):
-
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
@@ -92,6 +91,7 @@ class Individual(SimpleContainer):
     :ivar metadata: The :ref:`metadata <sec_metadata_definition>` for this individual.
     :vartype metadata: bytes
     """
+
     def __init__(self, id_=None, flags=0, location=None, nodes=None, metadata=""):
         self.id = id_
         self.flags = flags
@@ -101,11 +101,12 @@ class Individual(SimpleContainer):
 
     def __eq__(self, other):
         return (
-            self.id == other.id and
-            self.flags == other.flags and
-            self.metadata == other.metadata and
-            np.array_equal(self.nodes, other.nodes) and
-            np.array_equal(self.location, other.location))
+            self.id == other.id
+            and self.flags == other.flags
+            and self.metadata == other.metadata
+            and np.array_equal(self.nodes, other.nodes)
+            and np.array_equal(self.location, other.location)
+        )
 
 
 class Node(SimpleContainer):
@@ -132,9 +133,10 @@ class Node(SimpleContainer):
     :ivar metadata: The :ref:`metadata <sec_metadata_definition>` for this node.
     :vartype metadata: bytes
     """
+
     def __init__(
-            self, id_=None, flags=0, time=0, population=NULL,
-            individual=NULL, metadata=""):
+        self, id_=None, flags=0, time=0, population=NULL, individual=NULL, metadata=""
+    ):
         self.id = id_
         self.time = time
         self.population = population
@@ -175,6 +177,7 @@ class Edge(SimpleContainer):
         :attr:`TreeSequence.num_edges` - 1.
     :vartype id: int
     """
+
     def __init__(self, left, right, parent, child, id_=None):
         self.id = id_
         self.left = left
@@ -184,7 +187,8 @@ class Edge(SimpleContainer):
 
     def __repr__(self):
         return "{{left={:.3f}, right={:.3f}, parent={}, child={}, id={}}}".format(
-            self.left, self.right, self.parent, self.child, self.id)
+            self.left, self.right, self.parent, self.child, self.id
+        )
 
     @property
     def span(self):
@@ -221,6 +225,7 @@ class Site(SimpleContainer):
         underlying :class:`MutationTable`.
     :vartype mutations: list[:class:`Mutation`]
     """
+
     def __init__(self, id_, position, ancestral_state, mutations, metadata):
         self.id = id_
         self.position = position
@@ -261,9 +266,16 @@ class Mutation(SimpleContainer):
     :ivar metadata: The :ref:`metadata <sec_metadata_definition>` for this site.
     :vartype metadata: bytes
     """
+
     def __init__(
-            self, id_=NULL, site=NULL, node=NULL, derived_state=None, parent=NULL,
-            metadata=None):
+        self,
+        id_=NULL,
+        site=NULL,
+        node=NULL,
+        derived_state=None,
+        parent=NULL,
+        metadata=None,
+    ):
         self.id = id_
         self.site = site
         self.node = node
@@ -296,6 +308,7 @@ class Migration(SimpleContainer):
     :ivar time: The time at which this migration occured at.
     :vartype time: float
     """
+
     def __init__(self, left, right, node, source, dest, time, id_=None):
         self.id = id_
         self.left = left
@@ -319,6 +332,7 @@ class Population(SimpleContainer):
     :ivar metadata: The :ref:`metadata <sec_metadata_definition>` for this population.
     :vartype metadata: bytes
     """
+
     def __init__(self, id_, metadata=""):
         self.id = id_
         self.metadata = metadata
@@ -391,6 +405,7 @@ class Variant(SimpleContainer):
     :vartype num_alleles: int
     :vartype genotypes: numpy.ndarray
     """
+
     def __init__(self, site, alleles, genotypes):
         self.site = site
         self.alleles = alleles
@@ -403,9 +418,10 @@ class Variant(SimpleContainer):
 
     def __eq__(self, other):
         return (
-            self.site == other.site and
-            self.alleles == other.alleles and
-            np.array_equal(self.genotypes, other.genotypes))
+            self.site == other.site
+            and self.alleles == other.alleles
+            and np.array_equal(self.genotypes, other.genotypes)
+        )
 
 
 class Edgeset(SimpleContainer):
@@ -417,7 +433,8 @@ class Edgeset(SimpleContainer):
 
     def __repr__(self):
         return "{{left={:.3f}, right={:.3f}, parent={}, children={}}}".format(
-            self.left, self.right, self.parent, self.children)
+            self.left, self.right, self.parent, self.children
+        )
 
 
 class Provenance(SimpleContainer):
@@ -483,15 +500,22 @@ class Tree(object):
         those subtending meaningful topology, set this to 2. This value
         is only relevant when trees have multiple roots.
     """
+
     def __init__(
-            self, tree_sequence,
-            tracked_samples=None, sample_counts=None, sample_lists=False,
-            root_threshold=1):
+        self,
+        tree_sequence,
+        tracked_samples=None,
+        sample_counts=None,
+        sample_lists=False,
+        root_threshold=1,
+    ):
         options = 0
         if sample_counts is not None:
             warnings.warn(
                 "The sample_counts option is not supported since 0.2.4 "
-                "and is ignored", RuntimeWarning)
+                "and is ignored",
+                RuntimeWarning,
+            )
         if sample_lists:
             options |= _tskit.SAMPLE_LISTS
         kwargs = {"options": options}
@@ -1129,9 +1153,12 @@ class Tree(object):
         orientation = drawing.check_orientation(orientation)
         if orientation in (drawing.LEFT, drawing.RIGHT):
             text_tree = drawing.HorizontalTextTree(
-                self, orientation=orientation, **kwargs)
+                self, orientation=orientation, **kwargs
+            )
         else:
-            text_tree = drawing.VerticalTextTree(self, orientation=orientation, **kwargs)
+            text_tree = drawing.VerticalTextTree(
+                self, orientation=orientation, **kwargs
+            )
         return str(text_tree)
 
     def draw_svg(self, path=None, **kwargs):
@@ -1145,11 +1172,19 @@ class Tree(object):
         return output
 
     def draw(
-            self, path=None, width=None, height=None,
-            node_labels=None, node_colours=None,
-            mutation_labels=None, mutation_colours=None,
-            format=None, edge_colours=None, tree_height_scale=None,
-            max_tree_height=None):
+        self,
+        path=None,
+        width=None,
+        height=None,
+        node_labels=None,
+        node_colours=None,
+        mutation_labels=None,
+        mutation_colours=None,
+        format=None,
+        edge_colours=None,
+        tree_height_scale=None,
+        max_tree_height=None,
+    ):
         """
         Returns a drawing of this tree.
 
@@ -1239,11 +1274,18 @@ class Tree(object):
         :rtype: str
         """
         output = drawing.draw_tree(
-            self, format=format, width=width, height=height,
-            node_labels=node_labels, node_colours=node_colours,
-            mutation_labels=mutation_labels, mutation_colours=mutation_colours,
-            edge_colours=edge_colours, tree_height_scale=tree_height_scale,
-            max_tree_height=max_tree_height)
+            self,
+            format=format,
+            width=width,
+            height=height,
+            node_labels=node_labels,
+            node_colours=node_colours,
+            mutation_labels=mutation_labels,
+            mutation_colours=mutation_colours,
+            edge_colours=edge_colours,
+            tree_height_scale=tree_height_scale,
+            max_tree_height=max_tree_height,
+        )
         if path is not None:
             with open(path, "w") as f:
                 f.write(output)
@@ -1507,7 +1549,9 @@ class Tree(object):
         yield from sorted(self.nodes(u, order="levelorder"), key=self.time)
 
     def _timedesc_traversal(self, u):
-        yield from sorted(self.nodes(u, order="levelorder"), key=self.time, reverse=True)
+        yield from sorted(
+            self.nodes(u, order="levelorder"), key=self.time, reverse=True
+        )
 
     def nodes(self, root=None, order="preorder"):
         """
@@ -1534,7 +1578,7 @@ class Tree(object):
             "levelorder": self._levelorder_traversal,
             "breadthfirst": self._levelorder_traversal,
             "timeasc": self._timeasc_traversal,
-            "timedesc": self._timedesc_traversal
+            "timedesc": self._timedesc_traversal,
         }
         try:
             iterator = methods[order]
@@ -1595,7 +1639,8 @@ class Tree(object):
                 raise ValueError(
                     "Cannot get newick for multiroot trees. Try "
                     "[t.newick(root) for root in t.roots] to get a list of "
-                    "newick trees, one for each root.")
+                    "newick trees, one for each root."
+                )
             root = self.root
         if node_labels is None:
             s = self._ll_tree.get_newick(precision=precision, root=root)
@@ -1626,9 +1671,7 @@ class Tree(object):
         for parent in self.nodes():
             dod[parent] = {}
             for child in self.children(parent):
-                dod[parent][child] = {
-                    'branch_length': self.branch_length(child)
-                }
+                dod[parent][child] = {"branch_length": self.branch_length(child)}
         return dod
 
     @property
@@ -1637,8 +1680,8 @@ class Tree(object):
 
     def get_parent_dict(self):
         pi = {
-            u: self.parent(u) for u in range(self.num_nodes)
-            if self.parent(u) != NULL}
+            u: self.parent(u) for u in range(self.num_nodes) if self.parent(u) != NULL
+        }
         return pi
 
     def __str__(self):
@@ -1704,7 +1747,8 @@ class Tree(object):
         ancestral_state = alleles[ancestral_state]
         mutations = [
             Mutation(node=node, derived_state=alleles[derived_state], parent=parent)
-            for node, parent, derived_state in transitions]
+            for node, parent, derived_state in transitions
+        ]
         return ancestral_state, mutations
 
     def kc_distance(self, other, lambda_=0.0):
@@ -1747,7 +1791,8 @@ def load(path):
 
 
 def parse_individuals(
-        source, strict=True, encoding='utf8', base64_metadata=True, table=None):
+    source, strict=True, encoding="utf8", base64_metadata=True, table=None
+):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of an individual table and returns the corresponding
@@ -1796,18 +1841,16 @@ def parse_individuals(
                 location_string = tokens[location_index]
                 if len(location_string) > 0:
                     location = tuple(map(float, location_string.split(",")))
-            metadata = b''
+            metadata = b""
             if metadata_index is not None and metadata_index < len(tokens):
                 metadata = tokens[metadata_index].encode(encoding)
                 if base64_metadata:
                     metadata = base64.b64decode(metadata)
-            table.add_row(
-                flags=flags, location=location, metadata=metadata)
+            table.add_row(flags=flags, location=location, metadata=metadata)
     return table
 
 
-def parse_nodes(
-        source, strict=True, encoding='utf8', base64_metadata=True, table=None):
+def parse_nodes(source, strict=True, encoding="utf8", base64_metadata=True, table=None):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a node table and returns the corresponding :class:`NodeTable`
@@ -1866,14 +1909,18 @@ def parse_nodes(
             individual = NULL
             if individual_index is not None:
                 individual = int(tokens[individual_index])
-            metadata = b''
+            metadata = b""
             if metadata_index is not None and metadata_index < len(tokens):
                 metadata = tokens[metadata_index].encode(encoding)
                 if base64_metadata:
                     metadata = base64.b64decode(metadata)
             table.add_row(
-                flags=flags, time=time, population=population,
-                individual=individual, metadata=metadata)
+                flags=flags,
+                time=time,
+                population=population,
+                individual=individual,
+                metadata=metadata,
+            )
     return table
 
 
@@ -1916,8 +1963,7 @@ def parse_edges(source, strict=True, table=None):
     return table
 
 
-def parse_sites(
-        source, strict=True, encoding='utf8', base64_metadata=True, table=None):
+def parse_sites(source, strict=True, encoding="utf8", base64_metadata=True, table=None):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a site table and returns the corresponding :class:`SiteTable`
@@ -1956,18 +2002,20 @@ def parse_sites(
         if len(tokens) >= 2:
             position = float(tokens[position_index])
             ancestral_state = tokens[ancestral_state_index]
-            metadata = b''
+            metadata = b""
             if metadata_index is not None and metadata_index < len(tokens):
                 metadata = tokens[metadata_index].encode(encoding)
                 if base64_metadata:
                     metadata = base64.b64decode(metadata)
             table.add_row(
-                position=position, ancestral_state=ancestral_state, metadata=metadata)
+                position=position, ancestral_state=ancestral_state, metadata=metadata
+            )
     return table
 
 
 def parse_mutations(
-        source, strict=True, encoding='utf8', base64_metadata=True, table=None):
+    source, strict=True, encoding="utf8", base64_metadata=True, table=None
+):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a mutation table and returns the corresponding :class:`MutationTable`
@@ -2016,19 +2064,24 @@ def parse_mutations(
             derived_state = tokens[derived_state_index]
             if parent_index is not None:
                 parent = int(tokens[parent_index])
-            metadata = b''
+            metadata = b""
             if metadata_index is not None and metadata_index < len(tokens):
                 metadata = tokens[metadata_index].encode(encoding)
                 if base64_metadata:
                     metadata = base64.b64decode(metadata)
             table.add_row(
-                site=site, node=node, derived_state=derived_state, parent=parent,
-                metadata=metadata)
+                site=site,
+                node=node,
+                derived_state=derived_state,
+                parent=parent,
+                metadata=metadata,
+            )
     return table
 
 
 def parse_populations(
-        source, strict=True, encoding='utf8', base64_metadata=True, table=None):
+    source, strict=True, encoding="utf8", base64_metadata=True, table=None
+):
     """
     Parse the specified file-like object containing a whitespace delimited
     description of a population table and returns the corresponding
@@ -2068,9 +2121,18 @@ def parse_populations(
     return table
 
 
-def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
-              populations=None, sequence_length=0, strict=True,
-              encoding='utf8', base64_metadata=True):
+def load_text(
+    nodes,
+    edges,
+    sites=None,
+    mutations=None,
+    individuals=None,
+    populations=None,
+    sequence_length=0,
+    strict=True,
+    encoding="utf8",
+    base64_metadata=True,
+):
     """
     Parses the tree sequence data from the specified file-like objects, and
     returns the resulting :class:`TreeSequence` object. The format
@@ -2144,11 +2206,18 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
         sequence_length = edge_table.right.max()
     tc = tables.TableCollection(sequence_length)
     tc.edges.set_columns(
-        left=edge_table.left, right=edge_table.right, parent=edge_table.parent,
-        child=edge_table.child)
+        left=edge_table.left,
+        right=edge_table.right,
+        parent=edge_table.parent,
+        child=edge_table.child,
+    )
     parse_nodes(
-        nodes, strict=strict, encoding=encoding, base64_metadata=base64_metadata,
-        table=tc.nodes)
+        nodes,
+        strict=strict,
+        encoding=encoding,
+        base64_metadata=base64_metadata,
+        table=tc.nodes,
+    )
     # We need to add populations any referenced in the node table.
     if len(tc.nodes) > 0:
         max_population = tc.nodes.population.max()
@@ -2157,20 +2226,36 @@ def load_text(nodes, edges, sites=None, mutations=None, individuals=None,
                 tc.populations.add_row()
     if sites is not None:
         parse_sites(
-            sites, strict=strict, encoding=encoding, base64_metadata=base64_metadata,
-            table=tc.sites)
+            sites,
+            strict=strict,
+            encoding=encoding,
+            base64_metadata=base64_metadata,
+            table=tc.sites,
+        )
     if mutations is not None:
         parse_mutations(
-            mutations, strict=strict, encoding=encoding,
-            base64_metadata=base64_metadata, table=tc.mutations)
+            mutations,
+            strict=strict,
+            encoding=encoding,
+            base64_metadata=base64_metadata,
+            table=tc.mutations,
+        )
     if individuals is not None:
         parse_individuals(
-            individuals, strict=strict, encoding=encoding,
-            base64_metadata=base64_metadata, table=tc.individuals)
+            individuals,
+            strict=strict,
+            encoding=encoding,
+            base64_metadata=base64_metadata,
+            table=tc.individuals,
+        )
     if populations is not None:
         parse_populations(
-            populations, strict=strict, encoding=encoding,
-            base64_metadata=base64_metadata, table=tc.populations)
+            populations,
+            strict=strict,
+            encoding=encoding,
+            base64_metadata=base64_metadata,
+            table=tc.populations,
+        )
     tc.sort()
     return tc.tree_sequence()
 
@@ -2179,6 +2264,7 @@ class TreeIterator(object):
     """
     Simple class providing forward and backward iteration over a tree sequence.
     """
+
     def __init__(self, tree):
         self.tree = tree
         self.more_trees = True
@@ -2210,6 +2296,7 @@ class SimpleContainerSequence(object):
     function allowing access by index (e.g. ts.edge(i), ts.node(i)) to be treated as a
     python sequence, allowing forward and reverse iteration.
     """
+
     def __init__(self, getter, length):
         self.getter = getter
         self.length = length
@@ -2290,7 +2377,8 @@ class TreeSequence(object):
         if zlib_compression:
             warnings.warn(
                 "The zlib_compression option is no longer supported and is ignored",
-                RuntimeWarning)
+                RuntimeWarning,
+            )
         # Convert the path to str to allow us use Pathlib inputs
         self._ll_tree_sequence.dump(str(path))
 
@@ -2325,9 +2413,18 @@ class TreeSequence(object):
         return t
 
     def dump_text(
-            self, nodes=None, edges=None, sites=None, mutations=None, individuals=None,
-            populations=None, provenances=None, precision=6, encoding='utf8',
-            base64_metadata=True):
+        self,
+        nodes=None,
+        edges=None,
+        sites=None,
+        mutations=None,
+        individuals=None,
+        populations=None,
+        provenances=None,
+        precision=6,
+        encoding="utf8",
+        base64_metadata=True,
+    ):
         """
         Writes a text representation of the tables underlying the tree sequence
         to the specified connections.
@@ -2355,8 +2452,15 @@ class TreeSequence(object):
 
         if nodes is not None:
             print(
-                "id", "is_sample", "time", "population", "individual", "metadata",
-                sep="\t", file=nodes)
+                "id",
+                "is_sample",
+                "time",
+                "population",
+                "individual",
+                "metadata",
+                sep="\t",
+                file=nodes,
+            )
             for node in self.nodes():
                 metadata = node.metadata
                 if base64_metadata:
@@ -2367,12 +2471,16 @@ class TreeSequence(object):
                     "{time:.{precision}f}\t"
                     "{population:d}\t"
                     "{individual:d}\t"
-                    "{metadata}").format(
-                        precision=precision, id=node.id,
-                        is_sample=node.is_sample(), time=node.time,
-                        population=node.population,
-                        individual=node.individual,
-                        metadata=metadata)
+                    "{metadata}"
+                ).format(
+                    precision=precision,
+                    id=node.id,
+                    is_sample=node.is_sample(),
+                    time=node.time,
+                    population=node.population,
+                    individual=node.individual,
+                    metadata=metadata,
+                )
                 print(row, file=nodes)
 
         if edges is not None:
@@ -2382,9 +2490,14 @@ class TreeSequence(object):
                     "{left:.{precision}f}\t"
                     "{right:.{precision}f}\t"
                     "{parent:d}\t"
-                    "{child:d}").format(
-                        precision=precision, left=edge.left, right=edge.right,
-                        parent=edge.parent, child=edge.child)
+                    "{child:d}"
+                ).format(
+                    precision=precision,
+                    left=edge.left,
+                    right=edge.right,
+                    parent=edge.parent,
+                    child=edge.child,
+                )
                 print(row, file=edges)
 
         if sites is not None:
@@ -2394,18 +2507,25 @@ class TreeSequence(object):
                 if base64_metadata:
                     metadata = base64.b64encode(metadata).decode(encoding)
                 row = (
-                    "{position:.{precision}f}\t"
-                    "{ancestral_state}\t"
-                    "{metadata}").format(
-                        precision=precision, position=site.position,
-                        ancestral_state=site.ancestral_state,
-                        metadata=metadata)
+                    "{position:.{precision}f}\t" "{ancestral_state}\t" "{metadata}"
+                ).format(
+                    precision=precision,
+                    position=site.position,
+                    ancestral_state=site.ancestral_state,
+                    metadata=metadata,
+                )
                 print(row, file=sites)
 
         if mutations is not None:
             print(
-                "site", "node", "derived_state", "parent", "metadata",
-                sep="\t", file=mutations)
+                "site",
+                "node",
+                "derived_state",
+                "parent",
+                "metadata",
+                sep="\t",
+                file=mutations,
+            )
             for site in self.sites():
                 for mutation in site.mutations:
                     metadata = mutation.metadata
@@ -2416,54 +2536,50 @@ class TreeSequence(object):
                         "{node}\t"
                         "{derived_state}\t"
                         "{parent}\t"
-                        "{metadata}").format(
-                            site=mutation.site, node=mutation.node,
-                            derived_state=mutation.derived_state,
-                            parent=mutation.parent,
-                            metadata=metadata)
+                        "{metadata}"
+                    ).format(
+                        site=mutation.site,
+                        node=mutation.node,
+                        derived_state=mutation.derived_state,
+                        parent=mutation.parent,
+                        metadata=metadata,
+                    )
                     print(row, file=mutations)
 
         if individuals is not None:
-            print(
-                "id", "flags", "location", "metadata",
-                sep="\t", file=individuals)
+            print("id", "flags", "location", "metadata", sep="\t", file=individuals)
             for individual in self.individuals():
                 metadata = individual.metadata
                 if base64_metadata:
                     metadata = base64.b64encode(metadata).decode(encoding)
                 location = ",".join(map(str, individual.location))
-                row = (
-                    "{id}\t"
-                    "{flags}\t"
-                    "{location}\t"
-                    "{metadata}").format(
-                        id=individual.id, flags=individual.flags,
-                        location=location, metadata=metadata)
+                row = ("{id}\t" "{flags}\t" "{location}\t" "{metadata}").format(
+                    id=individual.id,
+                    flags=individual.flags,
+                    location=location,
+                    metadata=metadata,
+                )
                 print(row, file=individuals)
 
         if populations is not None:
-            print(
-                "id", "metadata",
-                sep="\t", file=populations)
+            print("id", "metadata", sep="\t", file=populations)
             for population in self.populations():
                 metadata = population.metadata
                 if base64_metadata:
                     metadata = base64.b64encode(metadata).decode(encoding)
-                row = (
-                    "{id}\t"
-                    "{metadata}").format(id=population.id, metadata=metadata)
+                row = ("{id}\t" "{metadata}").format(
+                    id=population.id, metadata=metadata
+                )
                 print(row, file=populations)
 
         if provenances is not None:
             print("id", "timestamp", "record", sep="\t", file=provenances)
             for provenance in self.provenances():
-                row = (
-                    "{id}\t"
-                    "{timestamp}\t"
-                    "{record}\t").format(
-                        id=provenance.id,
-                        timestamp=provenance.timestamp,
-                        record=provenance.record)
+                row = ("{id}\t" "{timestamp}\t" "{record}\t").format(
+                    id=provenance.id,
+                    timestamp=provenance.timestamp,
+                    record=provenance.record,
+                )
                 print(row, file=provenances)
 
     # num_samples was originally called sample_size, and so we must keep sample_size
@@ -2717,7 +2833,10 @@ class TreeSequence(object):
                 children[edge.parent].add(edge.child)
             # Update the active edgesets
             for edge in itertools.chain(edges_out, edges_in):
-                if len(children[edge.parent]) > 0 and edge.parent not in active_edgesets:
+                if (
+                    len(children[edge.parent]) > 0
+                    and edge.parent not in active_edgesets
+                ):
                     active_edgesets[edge.parent] = Edgeset(left, right, edge.parent, [])
 
         for parent in active_edgesets.keys():
@@ -2879,8 +2998,14 @@ class TreeSequence(object):
         return tree
 
     def trees(
-            self, tracked_samples=None, sample_counts=None, sample_lists=False,
-            tracked_leaves=None, leaf_counts=None, leaf_lists=None):
+        self,
+        tracked_samples=None,
+        sample_counts=None,
+        sample_lists=False,
+        tracked_leaves=None,
+        leaf_counts=None,
+        leaf_lists=None,
+    ):
         """
         Returns an iterator over the trees in this tree sequence. Each value
         returned in this iterator is an instance of :class:`Tree`. Upon
@@ -2917,8 +3042,11 @@ class TreeSequence(object):
         if leaf_lists is not None:
             sample_lists = leaf_lists
         tree = Tree(
-            self, tracked_samples=tracked_samples, sample_counts=sample_counts,
-            sample_lists=sample_lists)
+            self,
+            tracked_samples=tracked_samples,
+            sample_counts=sample_counts,
+            sample_lists=sample_lists,
+        )
         return TreeIterator(tree)
 
     def haplotypes(self, impute_missing_data=False, missing_data_character="-"):
@@ -2975,35 +3103,41 @@ class TreeSequence(object):
             if the ``missing_data_character`` exists in one of the alleles
         """
         H = np.empty((self.num_samples, self.num_sites), dtype=np.int8)
-        missing_int8 = ord(missing_data_character.encode('ascii'))
+        missing_int8 = ord(missing_data_character.encode("ascii"))
         for var in self.variants(impute_missing_data=impute_missing_data):
             alleles = np.full(len(var.alleles), missing_int8, dtype=np.int8)
             for i, allele in enumerate(var.alleles):
                 if allele is not None:
                     if len(allele) != 1:
                         raise TypeError(
-                            "Multi-letter allele or deletion detected at site {}"
-                            .format(var.site.id))
+                            "Multi-letter allele or deletion detected at site {}".format(
+                                var.site.id
+                            )
+                        )
                     try:
-                        ascii_allele = allele.encode('ascii')
+                        ascii_allele = allele.encode("ascii")
                     except UnicodeEncodeError:
                         raise TypeError(
-                            "Non-ascii character in allele at site {}"
-                            .format(var.site.id))
+                            "Non-ascii character in allele at site {}".format(
+                                var.site.id
+                            )
+                        )
                     allele_int8 = ord(ascii_allele)
                     if allele_int8 == missing_int8:
                         raise ValueError(
                             "The missing data character '{}' clashes with an "
-                            "existing allele at site {}"
-                            .format(missing_data_character, var.site.id))
+                            "existing allele at site {}".format(
+                                missing_data_character, var.site.id
+                            )
+                        )
                     alleles[i] = allele_int8
             H[:, var.site.id] = alleles[var.genotypes]
         for h in H:
-            yield h.tostring().decode('ascii')
+            yield h.tostring().decode("ascii")
 
     def variants(
-            self, as_bytes=False, samples=None, impute_missing_data=False,
-            alleles=None):
+        self, as_bytes=False, samples=None, impute_missing_data=False, alleles=None
+    ):
         """
         Returns an iterator over the variants in this tree sequence. See the
         :class:`Variant` class for details on the fields of each returned
@@ -3070,14 +3204,18 @@ class TreeSequence(object):
         # See comments for the Variant type for discussion on why the
         # present form was chosen.
         iterator = _tskit.VariantGenerator(
-            self._ll_tree_sequence, samples=samples,
-            impute_missing_data=impute_missing_data, alleles=alleles)
+            self._ll_tree_sequence,
+            samples=samples,
+            impute_missing_data=impute_missing_data,
+            alleles=alleles,
+        )
         for site_id, genotypes, alleles in iterator:
             site = self.site(site_id)
             if as_bytes:
                 if any(len(allele) > 1 for allele in alleles):
                     raise ValueError(
-                        "as_bytes only supported for single-letter alleles")
+                        "as_bytes only supported for single-letter alleles"
+                    )
                 bytes_genotypes = np.empty(self.num_samples, dtype=np.uint8)
                 lookup = np.array([ord(a[0]) for a in alleles], dtype=np.uint8)
                 bytes_genotypes[:] = lookup[genotypes]
@@ -3117,7 +3255,8 @@ class TreeSequence(object):
         :rtype: numpy.ndarray (dtype=np.int8)
         """
         return self._ll_tree_sequence.get_genotype_matrix(
-            impute_missing_data=impute_missing_data, alleles=alleles)
+            impute_missing_data=impute_missing_data, alleles=alleles
+        )
 
     def individual(self, id_):
         """
@@ -3128,7 +3267,8 @@ class TreeSequence(object):
         """
         flags, location, metadata, nodes = self._ll_tree_sequence.get_individual(id_)
         return Individual(
-            id_=id_, flags=flags, location=location, metadata=metadata, nodes=nodes)
+            id_=id_, flags=flags, location=location, metadata=metadata, nodes=nodes
+        )
 
     def node(self, id_):
         """
@@ -3137,11 +3277,21 @@ class TreeSequence(object):
 
         :rtype: :class:`Node`
         """
-        (flags, time, population, individual,
-         metadata) = self._ll_tree_sequence.get_node(id_)
+        (
+            flags,
+            time,
+            population,
+            individual,
+            metadata,
+        ) = self._ll_tree_sequence.get_node(id_)
         return Node(
-            id_=id_, flags=flags, time=time, population=population,
-            individual=individual, metadata=metadata)
+            id_=id_,
+            flags=flags,
+            time=time,
+            population=population,
+            individual=individual,
+            metadata=metadata,
+        )
 
     def edge(self, id_):
         """
@@ -3160,10 +3310,18 @@ class TreeSequence(object):
 
         :rtype: :class:`.Migration`
         """
-        left, right, node, source, dest, time = self._ll_tree_sequence.get_migration(id_)
+        left, right, node, source, dest, time = self._ll_tree_sequence.get_migration(
+            id_
+        )
         return Migration(
-            id_=id_, left=left, right=right, node=node, source=source, dest=dest,
-            time=time)
+            id_=id_,
+            left=left,
+            right=right,
+            node=node,
+            source=source,
+            dest=dest,
+            time=time,
+        )
 
     def mutation(self, id_):
         """
@@ -3172,11 +3330,21 @@ class TreeSequence(object):
 
         :rtype: :class:`Mutation`
         """
-        (site, node, derived_state, parent,
-         metadata) = self._ll_tree_sequence.get_mutation(id_)
+        (
+            site,
+            node,
+            derived_state,
+            parent,
+            metadata,
+        ) = self._ll_tree_sequence.get_mutation(id_)
         return Mutation(
-            id_=id_, site=site, node=node, derived_state=derived_state, parent=parent,
-            metadata=metadata)
+            id_=id_,
+            site=site,
+            node=node,
+            derived_state=derived_state,
+            parent=parent,
+            metadata=metadata,
+        )
 
     def site(self, id_):
         """
@@ -3189,8 +3357,12 @@ class TreeSequence(object):
         pos, ancestral_state, ll_mutations, _, metadata = ll_site
         mutations = [self.mutation(mut_id) for mut_id in ll_mutations]
         return Site(
-            id_=id_, position=pos, ancestral_state=ancestral_state,
-            mutations=mutations, metadata=metadata)
+            id_=id_,
+            position=pos,
+            ancestral_state=ancestral_state,
+            mutations=mutations,
+            metadata=metadata,
+        )
 
     def population(self, id_):
         """
@@ -3199,7 +3371,7 @@ class TreeSequence(object):
 
         :rtype: :class:`Population`
         """
-        metadata, = self._ll_tree_sequence.get_population(id_)
+        (metadata,) = self._ll_tree_sequence.get_population(id_)
         return Population(id_=id_, metadata=metadata)
 
     def provenance(self, id_):
@@ -3224,7 +3396,8 @@ class TreeSequence(object):
         """
         if population is not None and population_id is not None:
             raise ValueError(
-                "population_id and population are aliases. Cannot specify both")
+                "population_id and population are aliases. Cannot specify both"
+            )
         if population_id is not None:
             population = population_id
         samples = self._ll_tree_sequence.get_samples()
@@ -3282,13 +3455,16 @@ class TreeSequence(object):
             sequence_ids = ["tsk_{}".format(j) for j in self.samples()]
         if len(sequence_ids) != self.num_samples:
             raise ValueError(
-                "sequence_ids must have length equal to the number of samples.")
+                "sequence_ids must have length equal to the number of samples."
+            )
 
         wrap_width = int(wrap_width)
         if wrap_width < 0:
-            raise ValueError("wrap_width must be a non-negative integer. "
-                             "You may specify `wrap_width=0` "
-                             "if you do not want any wrapping.")
+            raise ValueError(
+                "wrap_width must be a non-negative integer. "
+                "You may specify `wrap_width=0` "
+                "if you do not want any wrapping."
+            )
 
         for j, hap in enumerate(self.haplotypes()):
             print(">", sequence_ids[j], sep="", file=output)
@@ -3299,8 +3475,14 @@ class TreeSequence(object):
                     print(hap_wrap, file=output)
 
     def write_vcf(
-            self, output, ploidy=None, contig_id="1", individuals=None,
-            individual_names=None, position_transform=None):
+        self,
+        output,
+        ploidy=None,
+        contig_id="1",
+        individuals=None,
+        individual_names=None,
+        position_transform=None,
+    ):
         """
         Writes a VCF formatted file to the specified file-like object.
         If there is individual information present in the tree sequence
@@ -3414,19 +3596,27 @@ class TreeSequence(object):
             by incrementing is used.
         """
         writer = vcf.VcfWriter(
-            self, ploidy=ploidy, contig_id=contig_id,
+            self,
+            ploidy=ploidy,
+            contig_id=contig_id,
             individuals=individuals,
             individual_names=individual_names,
-            position_transform=position_transform)
+            position_transform=position_transform,
+        )
         writer.write(output)
 
     def simplify(
-            self, samples=None,
-            filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
-            map_nodes=False,
-            reduce_to_site_topology=False,
-            filter_populations=True, filter_individuals=True, filter_sites=True,
-            record_provenance=True, keep_unary=False):
+        self,
+        samples=None,
+        filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
+        map_nodes=False,
+        reduce_to_site_topology=False,
+        filter_populations=True,
+        filter_individuals=True,
+        filter_sites=True,
+        record_provenance=True,
+        keep_unary=False,
+    ):
         """
         Returns a simplified tree sequence that retains only the history of
         the nodes given in the list ``samples``. If ``map_nodes`` is true,
@@ -3505,17 +3695,16 @@ class TreeSequence(object):
             filter_populations=filter_populations,
             filter_individuals=filter_individuals,
             filter_sites=filter_sites,
-            keep_unary=keep_unary)
+            keep_unary=keep_unary,
+        )
         if record_provenance:
             # TODO move this into tables.simplify. See issue #374
             # TODO also make sure we convert all the arguments so that they are
             # definitely JSON encodable.
-            parameters = {
-                "command": "simplify",
-                "TODO": "add simplify parameters"
-            }
-            tables.provenances.add_row(record=json.dumps(
-                provenance.get_provenance_dict(parameters)))
+            parameters = {"command": "simplify", "TODO": "add simplify parameters"}
+            tables.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )
         new_ts = tables.tree_sequence()
         assert new_ts.sequence_length == self.sequence_length
         if map_nodes:
@@ -3660,8 +3849,17 @@ class TreeSequence(object):
     #
     ############################################
 
-    def general_stat(self, W, f, output_dim, windows=None, polarised=False, mode=None,
-                     span_normalise=True, strict=True):
+    def general_stat(
+        self,
+        W,
+        f,
+        output_dim,
+        windows=None,
+        polarised=False,
+        mode=None,
+        span_normalise=True,
+        strict=True,
+    ):
         """
         Compute a windowed statistic from weights and a summary function.
         See the :ref:`statistics interface <sec_stats_interface>` section for details on
@@ -3721,20 +3919,36 @@ class TreeSequence(object):
         if strict:
             total_weights = np.sum(W, axis=0)
             for x in [total_weights, total_weights * 0.0]:
-                with np.errstate(invalid='ignore', divide='ignore'):
+                with np.errstate(invalid="ignore", divide="ignore"):
                     fx = np.array(f(x))
                 fx[np.isnan(fx)] = 0.0
-                if not np.allclose(fx, np.zeros((output_dim, ))):
-                    raise ValueError("Summary function does not return zero for both "
-                                     "zero weight and total weight.")
+                if not np.allclose(fx, np.zeros((output_dim,))):
+                    raise ValueError(
+                        "Summary function does not return zero for both "
+                        "zero weight and total weight."
+                    )
         return self.__run_windowed_stat(
-            windows, self.ll_tree_sequence.general_stat,
-            W, f, output_dim, polarised=polarised,
-            span_normalise=span_normalise, mode=mode)
+            windows,
+            self.ll_tree_sequence.general_stat,
+            W,
+            f,
+            output_dim,
+            polarised=polarised,
+            span_normalise=span_normalise,
+            mode=mode,
+        )
 
     def sample_count_stat(
-            self, sample_sets, f, output_dim, windows=None, polarised=False, mode=None,
-            span_normalise=True, strict=True):
+        self,
+        sample_sets,
+        f,
+        output_dim,
+        windows=None,
+        polarised=False,
+        mode=None,
+        span_normalise=True,
+        strict=True,
+    ):
         """
         Compute a windowed statistic from sample counts and a summary function.
         This is a wrapper around :meth:`.general_stat` for the common case in
@@ -3806,7 +4020,8 @@ class TreeSequence(object):
         for U in sample_sets:
             if len(U) != len(set(U)):
                 raise ValueError(
-                    "Elements of sample_sets must be lists without repeated elements.")
+                    "Elements of sample_sets must be lists without repeated elements."
+                )
             if len(U) == 0:
                 raise ValueError("Elements of sample_sets cannot be empty.")
             for u in U:
@@ -3814,9 +4029,16 @@ class TreeSequence(object):
                     raise ValueError("Not all elements of sample_sets are samples.")
 
         W = np.array([[float(u in A) for A in sample_sets] for u in self.samples()])
-        return self.general_stat(W, f, output_dim, windows=windows, polarised=polarised,
-                                 mode=mode, span_normalise=span_normalise,
-                                 strict=strict)
+        return self.general_stat(
+            W,
+            f,
+            output_dim,
+            windows=windows,
+            polarised=polarised,
+            mode=mode,
+            span_normalise=span_normalise,
+            strict=strict,
+        )
 
     def parse_windows(self, windows):
         # Note: need to make sure windows is a string or we try to compare the
@@ -3828,14 +4050,19 @@ class TreeSequence(object):
                 windows = self.breakpoints(as_array=True)
             elif windows == "sites":
                 # breakpoints are at 0.0 and at the sites and at the end
-                windows = np.concatenate([
-                                [] if self.num_sites > 0 else [0.0],
-                                self.tables.sites.position,
-                                [self.sequence_length]])
+                windows = np.concatenate(
+                    [
+                        [] if self.num_sites > 0 else [0.0],
+                        self.tables.sites.position,
+                        [self.sequence_length],
+                    ]
+                )
                 windows[0] = 0.0
             else:
-                raise ValueError("Unrecognized window specification {}:".format(windows),
-                                 "the only allowed strings are 'sites' or 'trees'")
+                raise ValueError(
+                    "Unrecognized window specification {}:".format(windows),
+                    "the only allowed strings are 'sites' or 'trees'",
+                )
         return np.array(windows)
 
     def __run_windowed_stat(self, windows, method, *args, **kwargs):
@@ -3847,8 +4074,14 @@ class TreeSequence(object):
         return stat
 
     def __one_way_sample_set_stat(
-            self, ll_method, sample_sets, windows=None, mode=None, span_normalise=True,
-            polarised=False):
+        self,
+        ll_method,
+        sample_sets,
+        windows=None,
+        mode=None,
+        span_normalise=True,
+        polarised=False,
+    ):
         if sample_sets is None:
             sample_sets = self.samples()
 
@@ -3867,23 +4100,38 @@ class TreeSequence(object):
                 drop_dimension = True
 
         sample_set_sizes = np.array(
-            [len(sample_set) for sample_set in sample_sets], dtype=np.uint32)
+            [len(sample_set) for sample_set in sample_sets], dtype=np.uint32
+        )
         if np.any(sample_set_sizes == 0):
             raise ValueError("Sample sets must contain at least one element")
 
         flattened = util.safe_np_int_cast(np.hstack(sample_sets), np.int32)
         stat = self.__run_windowed_stat(
-            windows, ll_method, sample_set_sizes, flattened,
-            mode=mode, span_normalise=span_normalise, polarised=polarised)
+            windows,
+            ll_method,
+            sample_set_sizes,
+            flattened,
+            mode=mode,
+            span_normalise=span_normalise,
+            polarised=polarised,
+        )
         if drop_dimension:
             stat = stat.reshape(stat.shape[:-1])
         return stat
 
     def __k_way_sample_set_stat(
-            self, ll_method, k, sample_sets, indexes=None, windows=None,
-            mode=None, span_normalise=True):
+        self,
+        ll_method,
+        k,
+        sample_sets,
+        indexes=None,
+        windows=None,
+        mode=None,
+        span_normalise=True,
+    ):
         sample_set_sizes = np.array(
-            [len(sample_set) for sample_set in sample_sets], dtype=np.uint32)
+            [len(sample_set) for sample_set in sample_sets], dtype=np.uint32
+        )
         if np.any(sample_set_sizes == 0):
             raise ValueError("Sample sets must contain at least one element")
         flattened = util.safe_np_int_cast(np.hstack(sample_sets), np.int32)
@@ -3891,7 +4139,8 @@ class TreeSequence(object):
             if len(sample_sets) != k:
                 raise ValueError(
                     "Must specify indexes if there are not exactly {} sample "
-                    "sets.".format(k))
+                    "sets.".format(k)
+                )
             indexes = np.arange(k, dtype=np.int32)
         drop_dimension = False
         indexes = util.safe_np_int_cast(indexes, np.int32)
@@ -3901,10 +4150,17 @@ class TreeSequence(object):
         if len(indexes.shape) != 2 or indexes.shape[1] != k:
             raise ValueError(
                 "Indexes must be convertable to a 2D numpy array with {} "
-                "columns".format(k))
+                "columns".format(k)
+            )
         stat = self.__run_windowed_stat(
-            windows, ll_method, sample_set_sizes, flattened, indexes,
-            mode=mode, span_normalise=span_normalise)
+            windows,
+            ll_method,
+            sample_set_sizes,
+            flattened,
+            indexes,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
         if drop_dimension:
             stat = stat.reshape(stat.shape[:-1])
         return stat
@@ -3913,8 +4169,9 @@ class TreeSequence(object):
     # Statistics definitions
     ############################################
 
-    def diversity(self, sample_sets=None, windows=None, mode="site",
-                  span_normalise=True):
+    def diversity(
+        self, sample_sets=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes mean genetic diversity (also knowns as "Tajima's pi") in each of the
         sets of nodes from ``sample_sets``.
@@ -3957,11 +4214,16 @@ class TreeSequence(object):
         :return: A numpy array.
         """
         return self.__one_way_sample_set_stat(
-            self._ll_tree_sequence.diversity, sample_sets, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.diversity,
+            sample_sets,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def divergence(self, sample_sets, indexes=None, windows=None, mode="site",
-                   span_normalise=True):
+    def divergence(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes mean genetic divergence between (and within) pairs of
         sets of nodes from ``sample_sets``.
@@ -4009,8 +4271,14 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__k_way_sample_set_stat(
-            self._ll_tree_sequence.divergence, 2, sample_sets, indexes=indexes,
-            windows=windows, mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.divergence,
+            2,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
     # JK: commenting this out for now to get the other methods well tested.
     # Issue: https://github.com/tskit-dev/tskit/issues/201
@@ -4100,10 +4368,16 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         if W.shape[0] != self.num_samples:
-            raise ValueError("First trait dimension must be equal to number of samples.")
+            raise ValueError(
+                "First trait dimension must be equal to number of samples."
+            )
         return self.__run_windowed_stat(
-            windows, self._ll_tree_sequence.trait_covariance, W, mode=mode,
-            span_normalise=span_normalise)
+            windows,
+            self._ll_tree_sequence.trait_covariance,
+            W,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
     def trait_correlation(self, W, windows=None, mode="site", span_normalise=True):
         """
@@ -4159,17 +4433,25 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         if W.shape[0] != self.num_samples:
-            raise ValueError("First trait dimension must be equal to number of samples.")
+            raise ValueError(
+                "First trait dimension must be equal to number of samples."
+            )
         sds = np.std(W, axis=0)
         if np.any(sds == 0):
-            raise ValueError("Weight columns must have positive variance",
-                             "to compute correlation.")
+            raise ValueError(
+                "Weight columns must have positive variance", "to compute correlation."
+            )
         return self.__run_windowed_stat(
-            windows, self._ll_tree_sequence.trait_correlation, W, mode=mode,
-            span_normalise=span_normalise)
+            windows,
+            self._ll_tree_sequence.trait_correlation,
+            W,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def trait_regression(self, W, Z=None, windows=None, mode="site",
-                         span_normalise=True):
+    def trait_regression(
+        self, W, Z=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         For each trait w (i.e., each column of W), performs the least-squares
         linear regression :math:`w ~ g + Z`,
@@ -4225,7 +4507,9 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         if W.shape[0] != self.num_samples:
-            raise ValueError("First trait dimension must be equal to number of samples.")
+            raise ValueError(
+                "First trait dimension must be equal to number of samples."
+            )
         if Z is None:
             Z = np.ones((self.num_samples, 1))
         else:
@@ -4240,11 +4524,17 @@ class TreeSequence(object):
         K = np.linalg.cholesky(np.matmul(Z.T, Z)).T
         Z = np.matmul(Z, np.linalg.inv(K))
         return self.__run_windowed_stat(
-            windows, self._ll_tree_sequence.trait_regression,
-            W, Z, mode=mode, span_normalise=span_normalise)
+            windows,
+            self._ll_tree_sequence.trait_regression,
+            W,
+            Z,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def segregating_sites(self, sample_sets=None, windows=None, mode="site",
-                          span_normalise=True):
+    def segregating_sites(
+        self, sample_sets=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes the density of segregating sites for each of the sets of nodes
         from ``sample_sets``, and related quantities.
@@ -4284,12 +4574,21 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__one_way_sample_set_stat(
-            self._ll_tree_sequence.segregating_sites, sample_sets, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.segregating_sites,
+            sample_sets,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
     def allele_frequency_spectrum(
-            self, sample_sets=None, windows=None, mode="site", span_normalise=True,
-            polarised=False):
+        self,
+        sample_sets=None,
+        windows=None,
+        mode="site",
+        span_normalise=True,
+        polarised=False,
+    ):
         """
         Computes the allele frequency spectrum (AFS) in windows across the genome for
         with respect to the specified ``sample_sets``.
@@ -4371,8 +4670,12 @@ class TreeSequence(object):
             sample_sets = [self.samples()]
         return self.__one_way_sample_set_stat(
             self._ll_tree_sequence.allele_frequency_spectrum,
-            sample_sets, windows=windows, mode=mode, span_normalise=span_normalise,
-            polarised=polarised)
+            sample_sets,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+            polarised=polarised,
+        )
 
     def Tajimas_D(self, sample_sets=None, windows=None, mode="site"):
         """
@@ -4417,19 +4720,25 @@ class TreeSequence(object):
             n = sample_set_sizes
             T = self.ll_tree_sequence.diversity(n, flattened, **kwargs)
             S = self.ll_tree_sequence.segregating_sites(n, flattened, **kwargs)
-            h = np.array([np.sum(1/np.arange(1, nn)) for nn in n])
-            g = np.array([np.sum(1/np.arange(1, nn)**2) for nn in n])
-            with np.errstate(invalid='ignore', divide='ignore'):
-                a = (n + 1) / (3 * (n - 1) * h) - 1 / h**2
-                b = 2 * (n**2 + n + 3) / (9 * n * (n - 1)) - (n + 2) / (h * n) + g / h**2
-                D = (T - S/h) / np.sqrt(a * S + (b / (h**2 + g)) * S * (S - 1))
+            h = np.array([np.sum(1 / np.arange(1, nn)) for nn in n])
+            g = np.array([np.sum(1 / np.arange(1, nn) ** 2) for nn in n])
+            with np.errstate(invalid="ignore", divide="ignore"):
+                a = (n + 1) / (3 * (n - 1) * h) - 1 / h ** 2
+                b = (
+                    2 * (n ** 2 + n + 3) / (9 * n * (n - 1))
+                    - (n + 2) / (h * n)
+                    + g / h ** 2
+                )
+                D = (T - S / h) / np.sqrt(a * S + (b / (h ** 2 + g)) * S * (S - 1))
             return D
 
         return self.__one_way_sample_set_stat(
-            tjd_func, sample_sets, windows=windows, mode=mode, span_normalise=False)
+            tjd_func, sample_sets, windows=windows, mode=mode, span_normalise=False
+        )
 
-    def Fst(self, sample_sets, indexes=None, windows=None, mode="site",
-            span_normalise=True):
+    def Fst(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes "windowed" Fst between pairs of sets of nodes from ``sample_sets``.
         Operates on ``k = 2`` sample sets at a time; please see the
@@ -4474,9 +4783,11 @@ class TreeSequence(object):
 
         def fst_func(sample_set_sizes, flattened, indexes, **kwargs):
             diversities = self._ll_tree_sequence.diversity(
-                sample_set_sizes, flattened, **kwargs)
+                sample_set_sizes, flattened, **kwargs
+            )
             divergences = self._ll_tree_sequence.divergence(
-                sample_set_sizes, flattened, indexes, **kwargs)
+                sample_set_sizes, flattened, indexes, **kwargs
+            )
 
             orig_shape = divergences.shape
             # "node" statistics produce a 3D array
@@ -4488,20 +4799,30 @@ class TreeSequence(object):
             fst.shape = divergences.shape
             for i, (u, v) in enumerate(indexes):
                 denom = (
-                    diversities[:, :, u] + diversities[:, :, v]
-                    + 2 * divergences[:, :, i])
-                with np.errstate(divide='ignore', invalid='ignore'):
-                    fst[:, :, i] -= 2 * (
-                        diversities[:, :, u] + diversities[:, :, v]) / denom
+                    diversities[:, :, u]
+                    + diversities[:, :, v]
+                    + 2 * divergences[:, :, i]
+                )
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    fst[:, :, i] -= (
+                        2 * (diversities[:, :, u] + diversities[:, :, v]) / denom
+                    )
             fst.shape = orig_shape
             return fst
 
         return self.__k_way_sample_set_stat(
-            fst_func, 2, sample_sets, indexes=indexes,
-            windows=windows, mode=mode, span_normalise=span_normalise)
+            fst_func,
+            2,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def Y3(self, sample_sets, indexes=None, windows=None, mode="site",
-           span_normalise=True):
+    def Y3(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes the 'Y' statistic between triples of sets of nodes from ``sample_sets``.
         Operates on ``k = 3`` sample sets at a time; please see the
@@ -4541,11 +4862,18 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__k_way_sample_set_stat(
-            self._ll_tree_sequence.Y3, 3, sample_sets, indexes=indexes, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.Y3,
+            3,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def Y2(self, sample_sets, indexes=None, windows=None, mode="site",
-           span_normalise=True):
+    def Y2(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes the 'Y2' statistic between pairs of sets of nodes from ``sample_sets``.
         Operates on ``k = 2`` sample sets at a time; please see the
@@ -4576,8 +4904,14 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__k_way_sample_set_stat(
-            self._ll_tree_sequence.Y2, 2, sample_sets, indexes=indexes, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.Y2,
+            2,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
     def Y1(self, sample_sets, windows=None, mode="site", span_normalise=True):
         """
@@ -4608,11 +4942,16 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__one_way_sample_set_stat(
-            self._ll_tree_sequence.Y1, sample_sets, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.Y1,
+            sample_sets,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def f4(self, sample_sets, indexes=None, windows=None, mode="site",
-           span_normalise=True):
+    def f4(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes Patterson's f4 statistic between four groups of nodes from
         ``sample_sets``.
@@ -4658,11 +4997,18 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__k_way_sample_set_stat(
-            self._ll_tree_sequence.f4, 4, sample_sets, indexes=indexes, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.f4,
+            4,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def f3(self, sample_sets, indexes=None, windows=None, mode="site",
-           span_normalise=True):
+    def f3(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes Patterson's f3 statistic between three groups of nodes from
         ``sample_sets``.
@@ -4694,11 +5040,18 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__k_way_sample_set_stat(
-            self._ll_tree_sequence.f3, 3, sample_sets, indexes=indexes, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.f3,
+            3,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
-    def f2(self, sample_sets, indexes=None, windows=None, mode="site",
-           span_normalise=True):
+    def f2(
+        self, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True
+    ):
         """
         Computes Patterson's f3 statistic between two groups of nodes from
         ``sample_sets``.
@@ -4731,8 +5084,14 @@ class TreeSequence(object):
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
         return self.__k_way_sample_set_stat(
-            self._ll_tree_sequence.f2, 2, sample_sets, indexes=indexes, windows=windows,
-            mode=mode, span_normalise=span_normalise)
+            self._ll_tree_sequence.f2,
+            2,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+        )
 
     def mean_descendants(self, sample_sets):
         """
@@ -4804,11 +5163,13 @@ class TreeSequence(object):
         # TODO add windows=None option: https://github.com/tskit-dev/tskit/issues/193
         if num_threads <= 0:
             return self._ll_tree_sequence.genealogical_nearest_neighbours(
-                focal, sample_sets)
+                focal, sample_sets
+            )
         else:
             worker = functools.partial(
                 self._ll_tree_sequence.genealogical_nearest_neighbours,
-                reference_sets=sample_sets)
+                reference_sets=sample_sets,
+            )
             focal = util.safe_np_int_cast(focal, np.int32)
             splits = np.array_split(focal, num_threads)
             with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as pool:
@@ -4847,8 +5208,11 @@ class TreeSequence(object):
         """
         if samples is None:
             samples = self.samples()
-        return float(self.diversity(
-            [samples], windows=[0, self.sequence_length], span_normalise=False)[0])
+        return float(
+            self.diversity(
+                [samples], windows=[0, self.sequence_length], span_normalise=False
+            )[0]
+        )
 
     def get_time(self, u):
         # Deprecated. Use ts.node(u).time
@@ -4870,7 +5234,8 @@ class TreeSequence(object):
         pop = [node.population for node in self.nodes()]
         for e in self.edgesets():
             yield CoalescenceRecord(
-                e.left, e.right, e.parent, e.children, t[e.parent], pop[e.parent])
+                e.left, e.right, e.parent, e.children, t[e.parent], pop[e.parent]
+            )
 
     # Unsupported old methods.
 
@@ -4881,14 +5246,17 @@ class TreeSequence(object):
             "than coalescence records. If not, please use len(list(ts.edgesets())) "
             "which should return the number of coalescence records, as previously "
             "defined. Please open an issue on GitHub if this is "
-            "important for your workflow.")
+            "important for your workflow."
+        )
 
     def diffs(self):
         raise NotImplementedError(
             "This method is no longer supported. Please use the "
-            "TreeSequence.edge_diffs() method instead")
+            "TreeSequence.edge_diffs() method instead"
+        )
 
     def newick_trees(self, precision=3, breakpoints=None, Ne=1):
         raise NotImplementedError(
             "This method is no longer supported. Please use the Tree.newick"
-            " method instead")
+            " method instead"
+        )

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -45,26 +45,27 @@ def safe_np_int_cast(int_array, dtype, copy=False):
     if int_array.size == 0:
         return int_array.astype(dtype, copy=copy)  # Allow empty arrays of any type
     try:
-        return int_array.astype(dtype, casting='safe', copy=copy)
+        return int_array.astype(dtype, casting="safe", copy=copy)
     except TypeError:
-        if int_array.dtype == np.dtype('O'):
+        if int_array.dtype == np.dtype("O"):
             # this occurs e.g. if we're passed a list of lists of different lengths
             raise TypeError("Cannot convert to a rectangular array.")
         bounds = np.iinfo(dtype)
         if np.any(int_array < bounds.min) or np.any(int_array > bounds.max):
             raise OverflowError("Cannot convert safely to {} type".format(dtype))
-        if int_array.dtype.kind == 'i' and np.dtype(dtype).kind == 'u':
+        if int_array.dtype.kind == "i" and np.dtype(dtype).kind == "u":
             # Allow casting from int to unsigned int, since we have checked bounds
-            casting = 'unsafe'
+            casting = "unsafe"
         else:
             # Raise a TypeError when we try to convert from, e.g., a float.
-            casting = 'same_kind'
+            casting = "same_kind"
         return int_array.astype(dtype, casting=casting, copy=copy)
 
 
 #
 # Pack/unpack lists of data into flattened numpy arrays.
 #
+
 
 def pack_bytes(data):
     """
@@ -83,7 +84,7 @@ def pack_bytes(data):
         offsets[j + 1] = offsets[j] + len(data[j])
     column = np.zeros(offsets[-1], dtype=np.int8)
     for j, value in enumerate(data):
-        column[offsets[j]: offsets[j + 1]] = bytearray(value)
+        column[offsets[j] : offsets[j + 1]] = bytearray(value)
     return column, offsets
 
 
@@ -101,7 +102,7 @@ def unpack_bytes(packed, offset):
     # This could be done a lot more efficiently...
     ret = []
     for j in range(offset.shape[0] - 1):
-        raw = packed[offset[j]: offset[j + 1]].tobytes()
+        raw = packed[offset[j] : offset[j + 1]].tobytes()
         ret.append(raw)
     return ret
 
@@ -161,7 +162,7 @@ def pack_arrays(list_of_lists):
         offset[j + 1] = offset[j] + len(list_of_lists[j])
     data = np.empty(offset[-1], dtype=np.float64)
     for j in range(n):
-        data[offset[j]: offset[j + 1]] = list_of_lists[j]
+        data[offset[j] : offset[j + 1]] = list_of_lists[j]
     return data, offset
 
 
@@ -179,13 +180,14 @@ def unpack_arrays(packed, offset):
     """
     ret = []
     for j in range(offset.shape[0] - 1):
-        ret.append(packed[offset[j]: offset[j + 1]])
+        ret.append(packed[offset[j] : offset[j + 1]])
     return ret
 
 
 #
 # Interval utilities
 #
+
 
 def intervals_to_np_array(intervals, start, end):
     """
@@ -204,8 +206,7 @@ def intervals_to_np_array(intervals, start, end):
     last_right = start
     for left, right in intervals:
         if left < start or right > end:
-            raise ValueError(
-                "Intervals must be within {} and {}".format(start, end))
+            raise ValueError("Intervals must be within {} and {}".format(start, end))
         if right <= left:
             raise ValueError("Bad interval: right <= left")
         if left < last_right:


### PR DESCRIPTION
This is an experiment to see what the tskit code would look like if we started using the [black](https://github.com/psf/black) python formatter. The idea is that black formats the code so that we don't have to. If we like this, then we would set up a GitHub hook to (e.g.) autoformat contributed code using black when a PR is made. This would make it easier for contributors, who wouldn't have to worry about living by pep8 rules any more.

Any thoughts? cc. @benjeffery, @petrelharp