### PR TITLE
Refactor LS algorithm definitions.

### DIFF
--- a/c/tests/test_haplotype_matching.c
+++ b/c/tests/test_haplotype_matching.c
@@ -32,17 +32,10 @@
  * TestHMM
  ****************************************************************/
 
-static int
-tsk_ls_hmm_finalise_site_test(tsk_ls_hmm_t *self, tsk_id_t site)
+static double
+tsk_ls_hmm_compute_normalisation_factor_site_test(tsk_ls_hmm_t *TSK_UNUSED(self))
 {
-    int ret = 0;
-    tsk_compressed_matrix_t *output = (tsk_compressed_matrix_t *) self->output;
-    tsk_value_transition_t *restrict T = self->transitions;
-    const tsk_id_t num_transitions = (tsk_id_t) self->num_transitions;
-
-    ret = tsk_compressed_matrix_store_site(
-        output, site, 1.0, (tsk_size_t) num_transitions, T);
-    return ret;
+    return 1.0;
 }
 
 static int
@@ -63,7 +56,7 @@ run_test_hmm(tsk_ls_hmm_t *hmm, int8_t *haplotype, tsk_compressed_matrix_t *outp
     srand(1);
 
     ret = tsk_ls_hmm_run(hmm, haplotype, tsk_ls_hmm_next_probability_test,
-        tsk_ls_hmm_finalise_site_test, output);
+        tsk_ls_hmm_compute_normalisation_factor_site_test, output);
     if (ret != 0) {
         goto out;
     }

--- a/c/tskit/haplotype_matching.h
+++ b/c/tskit/haplotype_matching.h
@@ -126,7 +126,7 @@ typedef struct _tsk_ls_hmm_t {
     /* Algorithms set these values before they are run */
     int (*next_probability)(
         struct _tsk_ls_hmm_t *, tsk_id_t, double, bool, tsk_id_t, double *);
-    int (*finalise_site)(struct _tsk_ls_hmm_t *, tsk_id_t);
+    double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *);
     void *output;
 } tsk_ls_hmm_t;
 
@@ -141,7 +141,7 @@ int tsk_ls_hmm_viterbi(tsk_ls_hmm_t *self, int8_t *haplotype,
     tsk_viterbi_matrix_t *output, tsk_flags_t options);
 int tsk_ls_hmm_run(tsk_ls_hmm_t *self, int8_t *haplotype,
     int (*next_probability)(tsk_ls_hmm_t *, tsk_id_t, double, bool, tsk_id_t, double *),
-    int (*finalise_site)(struct _tsk_ls_hmm_t *, tsk_id_t), void *output);
+    double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *), void *output);
 
 int tsk_compressed_matrix_init(tsk_compressed_matrix_t *self,
     tsk_treeseq_t *tree_sequence, size_t block_size, tsk_flags_t options);


### PR DESCRIPTION
Update the LS haplotype matching algorithm to round after normalisation rather than before.

Related to https://github.com/tskit-dev/tsinfer/issues/246

This part of tskit is under development @benjeffery. The goal is to have a general purpose, very efficient haplotype matching library. The method hasn't been properly analysed or validated, so it's a "private" API for the moment. A paper will be written in 2020...

I've deliberately put in some badly formatted C code here to see what happens also.
