### PR TITLE
Python implementation of IBD methods.

### DIFF
--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -1,0 +1,293 @@
+# MIT License
+#
+# Copyright (c) 2018-2020 Tskit Developers
+# Copyright (c) 2015-2018 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Python implementation of the IBD-finding algorithms.
+"""
+
+import tskit
+import numpy as np
+import itertools
+import sys
+
+
+class Segment(object):
+    """
+    A class representing a single segment. Each segment has a left and right,
+    denoting the loci over which it spans, a node and a next, giving the next
+    in the chain.
+
+    The node it records is the *output* node ID.
+    """
+    def __init__(self, left=None, right=None, node=None, next=None):
+        self.left = left
+        self.right = right
+        self.node = node
+        self.next = next
+
+    def __str__(self):
+        s = "({}-{}->{}:next={})".format(
+            self.left, self.right, self.node, repr(self.next))
+        return s
+
+    def __repr__(self):
+        return repr((self.left, self.right, self.node))
+
+    def __eq__(self, other):
+        return (self.left == other.left and self.right == other.right and self.node == other.node)
+
+    def __lt__(self, other):
+        return (self.node, self.left, self.right) < (other.node, other.left, other.right)
+
+
+class IbdFinder(object):
+    """
+    Finds all IBD relationships between specified samples in a tree sequence.
+    """
+
+    def __init__(
+        self,
+        ts,
+        samples,
+        min_length=0):
+
+        self.ts = ts
+        self.samples = samples
+        self.min_length = min_length
+        self.current_parent = self.ts.tables.edges.parent[0]
+        self.A_head = [None for _ in range(ts.num_nodes)]
+        self.A_tail = [None for _ in range(ts.num_nodes)]
+        self.tables = tskit.TableCollection(sequence_length=ts.sequence_length)
+        # self.ibd_segments = dict.fromkeys(itertools.combinations(self.ts.samples(), 2), [])
+
+
+    def find_ibd_segments_of_length(self, min_length=0):
+        
+        # 1
+        A = [[] for n in range(0, self.ts.num_nodes)]
+        ibd_segments = dict.fromkeys(itertools.combinations(self.ts.samples(), 2), [])
+        edges = self.ts.edges()  
+        parent_list = self.list_of_parents() ## Needed for memory-pruning step
+        
+        # 2
+        mygen = iter(self.ts.edges())
+        e = next(mygen)
+            
+        # 3
+        while e is not None:
+
+            # 3a
+            S = []
+            self.current_parent = e.parent
+            
+            # 3b
+            while e is not None and self.current_parent == e.parent:
+                # Create the list S of immediate descendants of u.
+                S.append(Segment(e.left, e.right, e.child))
+                # if e.id < edges.num_rows - 1:
+                if e.id < self.ts.num_edges - 1:
+                    e = next(mygen)
+                    continue
+                else:
+                    e = None
+                    # break
+
+            # 3c
+            for seg in S:
+                # Create A[u] from S.
+                # Do we still need to do the initialisation if the below is there??
+                u = seg.node
+                if u in self.ts.samples():
+                    A[self.current_parent].append([seg])
+                else:
+                    list_to_add = []
+                    for s in A[u]:
+                        l = (max(seg.left, s.left), min(seg.right, s.right))
+                        if l[1] - l[0] > 0:
+                            list_to_add.append(Segment(l[0], l[1], s.node))
+                    A[self.current_parent].append(list_to_add)
+
+            # d. Squash
+            # A[self.current_parent] = self.squash(A[self.current_parent])
+            
+            # e. Process A[self.current_parent]
+            if len(A[self.current_parent]) > 1:
+                new_segs, nodes_to_remove = self.update_A_and_find_ibd_segs(
+                    A[self.current_parent], ibd_segments)
+                
+                # e. Add any new IBD segments discovered.
+                for key, val in new_segs.items():
+                    for v in val:
+                        if len(ibd_segments[key]) == 0:
+                            ibd_segments[key] = [v]
+                        else:
+                            ibd_segments[key].append(v)
+                            
+                # g. Remove elements of A[u] if they are no longer needed.
+                ## (memory-pruning step)
+                for n in nodes_to_remove:
+                    if self.current_parent in parent_list[n]:
+                        parent_list[n].remove(self.current_parent)
+                    if len(parent_list[n]) == 0:
+                        A[n] = []
+                        
+            # Unlist the ancestral segments in A.
+            A[self.current_parent] = list(itertools.chain(*A[self.current_parent]))
+
+        # 4
+        return ibd_segments
+
+
+    def update_A_and_find_ibd_segs(self, ancestral_segs, ibd_segments, mrca_ibd=False):
+    
+        new_segments = dict.fromkeys(itertools.combinations(self.ts.samples(), 2), [])
+        num_coalescing_sets = len(ancestral_segs)
+        index_pairs = list(itertools.combinations(range(0, num_coalescing_sets), 2))
+
+        for setpair in index_pairs:
+            for seg0 in ancestral_segs[setpair[0]]:
+                for seg1 in ancestral_segs[setpair[1]]:
+
+                    if seg0.node == seg1.node:
+                        continue
+                    left = max(seg0.left, seg1.left)
+                    right = min(seg0.right, seg1.right)
+                    if left >= right:
+                        continue
+                    nodes = [seg0.node, seg1.node]
+                    nodes.sort()
+
+                    if mrca_ibd:
+                        pass # for now
+                        # existing_segs = ibd_segments[(nodes[0], nodes[1])].copy()
+                        # if right - left > self.min_length:
+                        #     if len(existing_segs) == 0:
+                        #         new_segments[(nodes[0], nodes[1])] = [Segment(left, right, self.current_parent)]
+                        #         existing_segs.append(Segment(left, right, self.current_parent))
+                        #     else:
+                        #         for i in existing_segs:
+                        #             # no overlap.
+                        #             if right <= i.left or left >= i.right:
+                        #                 if len(new_segments[(nodes[0], nodes[1])]) == 0:
+                        #                     new_segments[(nodes[0], nodes[1])] = [Segment(left, right, self.current_parent)]
+                        #                 else:
+                        #                     new_segments[(nodes[0], nodes[1])].append(Segment(left, right, self.current_parent))
+                        #                 existing_segs.append(Segment(left, right, self.current_parent))
+                        #             # partial overlap -- does this even happen?
+                        #             elif (left < i.left and right < i.right) or (i.left < left and i.right < right):
+                        #                 print('partial overlap')
+                                    # Yes, but I think it's okay to leave these segments...
+                    else:
+                        if len(new_segments[(nodes[0], nodes[1])]) == 0:
+                            new_segments[(nodes[0], nodes[1])] = [Segment(left, right, self.current_parent)]
+                        else:
+                            new_segments[(nodes[0], nodes[1])].append(Segment(left, right, self.current_parent))
+
+        # iv. specify elements of A that can be removed (for memory-pruning step)
+        processed_child_nodes = []
+        for seglist in ancestral_segs:
+            processed_child_nodes += [seg.node for seg in seglist]
+            processed_child_nodes = list(set(processed_child_nodes))
+
+        return new_segments, processed_child_nodes
+
+
+    def list_of_parents(self):
+        parents = [[] for i in range(0, self.ts.num_nodes)]
+        edges = self.ts.tables.edges
+        for e in edges:
+            if len(parents[e.child]) == 0 or e.parent != parents[e.child][-1]:
+                parents[e.child].append(e.parent)
+        return parents
+
+
+    # def squash(self, segment_lists):
+    
+    #     # Concatenate the input lists and record the number of
+    #     # segments in each.
+    #     A_u = []
+    #     num_desc_edges = []
+    #     for L in segment_lists:
+    #         for l in L:
+    #             A_u.append(l)
+    #         num_desc_edges.append(len(L))
+            
+    #     # Sort the list, keeping track of the original order.
+    #     sorted_A = sorted(enumerate(A_u), key=lambda i:i[1])
+        
+    #     # Squash the list.
+    #     next_ind = len(sorted_A)
+    #     inds_to_remove = []
+    #     ind = 1
+    #     while ind < len(sorted_A):
+    #         if sorted_A[ind][1].node == sorted_A[ind - 1][1].node:
+    #             if sorted_A[ind][1].right > sorted_A[ind - 1][1].right and\
+    #                 sorted_A[ind][1].left <= sorted_A[ind - 1][1].right:
+    #                 # Squash the previous int into the current one.
+    #                 sorted_A[ind][1].left = sorted_A[ind - 1][1].left
+    #                 # Flag the interval to be removed.
+    #                 inds_to_remove.append(ind - 1)
+    #                 # Change order index.
+    #                 sorted_A[ind] = (next_ind, sorted_A[ind][1])
+    #                 next_ind += 1
+    #         ind += 1
+            
+    #     # Remove any unnecessary list items.
+    #     for i in reversed(inds_to_remove):
+    #         # Needs to be done in reverse order!!
+    #         sorted_A.pop(i)
+
+    #     # Restore the original order as lists of lists.
+    #     cum_sum = np.cumsum(num_desc_edges)
+    #     squashed_sorted_A = [[] for _ in range(0, next_ind)]
+    #     for a in sorted_A:
+    #         ind = a[0]
+    #         if ind < cum_sum[-1]:
+    #             s = 0
+    #             while s < len(cum_sum):
+    #                 if a[0] < cum_sum[s]:
+    #                     squashed_sorted_A[s].append(a[1])
+    #                     break
+    #                 s += 1
+                    
+    #         else:
+    #             squashed_sorted_A[ind].append(a[1])
+                
+    #     # Remove lists of length 0.
+    #     squashed_sorted_A = [_ for _ in squashed_sorted_A if len(_) > 0]
+                
+    #     return squashed_sorted_A
+    
+
+if __name__ == "__main__":
+    # Simple CLI for running simplifier/ancestor mapping above.
+
+    ts = tskit.load(sys.argv[1])
+    s = IbdFinder(ts, samples = ts.samples())
+    all_segs = s.find_ibd_segments_of_length()
+
+    if sys.argv[2] is not None and sys.argv[3] is not None:
+        sample0 = int(sys.argv[2])
+        sample1 = int(sys.argv[3])
+        print(all_segs[(sample0, sample1)])
+    else:
+        print(all_segs)

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -1,39 +1,48 @@
-
 """
 Tests of IBD finding algorithms.
 """
-import unittest
-import sys
-import random
 import io
 import itertools
+import random
+import unittest
 
-import tests as tests
-import tests.ibd as ibd
-
-import tskit
 import msprime
-import numpy as np
+from packaging import version
+
+import tests.ibd as ibd
+import tskit
 
 # Functions for computing IBD 'naively'.
 
-def get_ibd(sample0, sample1, treeSequence, min_length=0, max_time=None,
-           path_ibd=True, mrca_ibd=False):
+
+def get_ibd(
+    sample0,
+    sample1,
+    treeSequence,
+    min_length=0,
+    max_time=None,
+    path_ibd=True,
+    mrca_ibd=True,
+):
     """
     Returns all IBD segments for a given pair of nodes in a tree
     using a naive algorithm.
+    Note: This function probably looks more complicated than it needs to be --
+    This is because it also calculates other 'versions' of IBD (mrca_ibd=False,
+    path_ibd=False) that we have't implemented properly yet.
     """
 
     ibd_list = []
-    ts, node_map = treeSequence.simplify(samples=[sample0, sample1], keep_unary=True,
-                              map_nodes=True)
+    ts, node_map = treeSequence.simplify(
+        samples=[sample0, sample1], keep_unary=True, map_nodes=True
+    )
     node_map = node_map.tolist()
-    
+
     for n in ts.nodes():
-        
+
         if max_time is not None and n.time > max_time:
             break
-            
+
         node_id = n.id
         interval_list = []
         if n.flags == 1:
@@ -45,7 +54,7 @@ def get_ibd(sample0, sample1, treeSequence, min_length=0, max_time=None,
             if len(list(t.nodes(n.id))) == 1 or t.num_samples(n.id) < 2:
                 continue
             if mrca_ibd and n.id != t.mrca(0, 1):
-                    continue
+                continue
 
             current_int = t.get_interval()
             if len(interval_list) == 0:
@@ -54,41 +63,63 @@ def get_ibd(sample0, sample1, treeSequence, min_length=0, max_time=None,
                 prev_int = interval_list[-1]
                 if not path_ibd and prev_int[1] == current_int[0]:
                     interval_list[-1] = (prev_int[0], current_int[1])
-                elif prev_dict is not None and subtrees_are_equal(t, prev_dict, node_id):
+                elif prev_dict is not None and subtrees_are_equal(
+                    t, prev_dict, node_id
+                ):
                     interval_list[-1] = (prev_int[0], current_int[1])
                 else:
                     interval_list.append(current_int)
-                    
+
             prev_dict = t.get_parent_dict()
-                    
+
         for interval in interval_list:
             if min_length == 0 or interval[1] - interval[0] > min_length:
                 orig_id = node_map.index(node_id)
                 ibd_list.append(ibd.Segment(interval[0], interval[1], orig_id))
-        
-    return(ibd_list)
+
+    return ibd_list
 
 
-def get_ibd_all_pairs(treeSequence, samples=None, min_length=0, max_time=None,
-                      path_ibd=True, mrca_ibd=False):
-    
+def get_ibd_all_pairs(
+    treeSequence,
+    samples=None,
+    min_length=0,
+    max_time=None,
+    path_ibd=True,
+    mrca_ibd=False,
+):
+
+    """
+    Returns all IBD segments for all pairs of nodes in a tree sequence
+    using the naive algorithm above.
+    """
+
     ibd_dict = {}
-    
+
     if samples is None:
         samples = treeSequence.samples().tolist()
-    
+
     pairs = itertools.combinations(samples, 2)
     for pair in pairs:
-        ibd_list = get_ibd(pair[0], pair[1], treeSequence,
-                           min_length=min_length, max_time=max_time,
-                          path_ibd=path_ibd, mrca_ibd=mrca_ibd)
+        ibd_list = get_ibd(
+            pair[0],
+            pair[1],
+            treeSequence,
+            min_length=min_length,
+            max_time=max_time,
+            path_ibd=path_ibd,
+            mrca_ibd=mrca_ibd,
+        )
         if len(ibd_list) > 0:
             ibd_dict[pair] = ibd_list
-            
-    return(ibd_dict)
+
+    return ibd_dict
 
 
 def subtrees_are_equal(tree1, pdict0, root):
+    """
+    Checks for equality of two subtrees beneath a given root node.
+    """
     pdict1 = tree1.get_parent_dict()
     if root not in pdict0.values() or root not in pdict1.values():
         return False
@@ -100,33 +131,39 @@ def subtrees_are_equal(tree1, pdict0, root):
             if p1 not in pdict0.values():
                 return False
             p0 = pdict0[node]
-            if  p0 != p1:
-                return False  
+            if p0 != p1:
+                return False
             node = p1
-            
+
     return True
 
 
 def verify_equal_ibd(treeSequence):
     """
-    Calculates IBD segments using both the 'naive' and sophisticated algorithms, 
+    Calculates IBD segments using both the 'naive' and sophisticated algorithms,
     verifies that the same output is produced.
     NB: May be good to expand this in the future so that many different combos
     of IBD options are tested simultaneously (all the MRCA and path-IBD combos),
     for example.
     """
     ts = treeSequence
-    ibd0 = ibd.IbdFinder(ts, samples = ts.samples())
+    ibd0 = ibd.IbdFinder(ts, samples=ts.samples())
     ibd0 = ibd0.find_ibd_segments()
     ibd1 = get_ibd_all_pairs(ts, path_ibd=True, mrca_ibd=True)
 
-    for key0, val0 in ibd0.items():
+    # Convert each SegmentList object into a list of Segment objects.
+    ibd0_tolist = {}
+    for key, val in ibd0.items():
+        ibd0_tolist[key] = convert_segmentlist_to_list(val)
+
+    # Check for equality.
+    for key0, val0 in ibd0_tolist.items():
         assert key0 in ibd1.keys()
         val1 = ibd1[key0]
         val0.sort()
         val1.sort()
 
-        if val0 is None: # Get rid of this later -- don't want empty dict values at all
+        if val0 is None:  # Get rid of this later -- don't want empty dict values at all
             assert val1 is None
             continue
         elif val1 is None:
@@ -134,6 +171,38 @@ def verify_equal_ibd(treeSequence):
         assert len(val0) == len(val1)
         for i in range(0, len(val0)):
             assert val0[i] == val1[i]
+
+
+def convert_segmentlist_to_list(seglist):
+    """
+    Turns a SegmentList object into a list of Segment objects.
+    (This makes them easier to compare for testing purposes)
+    """
+    outlist = []
+    if seglist is None:
+        return outlist
+    else:
+        seg = seglist.head
+        outlist = [seg]
+        seg = seg.next
+        while seg is not None:
+            outlist.append(seg)
+            seg = seg.next
+
+    return outlist
+
+
+def convert_dict_of_segmentlists(dict0):
+    """
+    Turns a dictionary of SegmentList objects into a dictionary of lists of
+    Segment objects. (makes them easier to compare in tests).
+    """
+    dict_out = {}
+    for key, val in dict0.items():
+        dict_out[key] = convert_segmentlist_to_list(val)
+
+    return dict_out
+
 
 def ibd_is_equal(dict1, dict2):
     """
@@ -155,6 +224,10 @@ def ibd_is_equal(dict1, dict2):
 
 
 def segment_lists_are_equal(val1, val2):
+    """
+    Returns True if the two lists hold the same set of segments, otherwise
+    returns False.
+    """
 
     if len(val1) != len(val2):
         return False
@@ -162,7 +235,7 @@ def segment_lists_are_equal(val1, val2):
     val1.sort()
     val2.sort()
 
-    if val1 is None: # get rid of this later -- we don't any empty dict values!
+    if val1 is None:  # get rid of this later -- we don't any empty dict values!
         if val2 is not None:
             return False
     elif val2 is None:
@@ -177,123 +250,162 @@ def segment_lists_are_equal(val1, val2):
     return True
 
 
-class TestIbdTopologies(unittest.TestCase):
+class TestIbdSingleBinaryTree(unittest.TestCase):
 
-    def test_single_binary_tree(self):
-        #
-        # 2        4
-        #         / \
-        # 1      3   \
-        #       / \   \
-        # 0    0   1   2
-        nodes = io.StringIO(
-            """\
-        id      is_sample   time
-        0       1           0
-        1       1           0
-        2       1           0
-        3       0           1
-        4       0           2
-        """
-        )
-        edges = io.StringIO(
-            """\
-        left    right   parent  child
-        0       1       3       0,1
-        0       1       4       2,3
-        """
-        )
-        ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
-        # Basic test
-        ibd_f = ibd.IbdFinder(ts)
+    #
+    # 2        4
+    #         / \
+    # 1      3   \
+    #       / \   \
+    # 0    0   1   2
+    nodes = io.StringIO(
+        """\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    """
+    )
+    edges = io.StringIO(
+        """\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """
+    )
+    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+    # Basic test
+    def test_defaults(self):
+        ibd_f = ibd.IbdFinder(self.ts)
         ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         true_segs = {
-        (0, 1): [ibd.Segment(0.0, 1.0, 3)],
-        (0, 2): [ibd.Segment(0.0, 1.0, 4)],
-        (1, 2): [ibd.Segment(0.0, 1.0, 4)]}
+            (0, 1): [ibd.Segment(0.0, 1.0, 3)],
+            (0, 2): [ibd.Segment(0.0, 1.0, 4)],
+            (1, 2): [ibd.Segment(0.0, 1.0, 4)],
+        }
         assert ibd_is_equal(ibd_segs, true_segs)
-        # Max time = 1.5
-        ibd_f = ibd.IbdFinder(ts, max_time=1.5)
+
+    # Max time = 1.5
+    def test_time(self):
+        ibd_f = ibd.IbdFinder(self.ts, max_time=1.5)
         ibd_segs = ibd_f.find_ibd_segments()
-        true_segs = {(0, 1): [ibd.Segment(0.0, 1.0, 3)],
-        (0, 2): [], (1, 2): []}
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {(0, 1): [ibd.Segment(0.0, 1.0, 3)], (0, 2): [], (1, 2): []}
         assert ibd_is_equal(ibd_segs, true_segs)
-        # # Min length = 2
-        ibd_f = ibd.IbdFinder(ts, min_length=2)
+
+    # Min length = 2
+    def test_length(self):
+        ibd_f = ibd.IbdFinder(self.ts, min_length=2)
         ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         true_segs = {(0, 1): [], (0, 2): [], (1, 2): []}
         assert ibd_is_equal(ibd_segs, true_segs)
 
-    def test_two_samples_two_trees(self):
-        #
-        # 2  
-        #             |     3
-        # 1      2    |    / \
-        #       / \   |   /   \
-        # 0    0   1  |  0     1
-        #|------------|----------|
-        #0.0          0.4        1.0
-        nodes = io.StringIO(
-            """\
-        id      is_sample   time
-        0       1           0
-        1       1           0
-        2       0           1
-        3       0           1.5
-        """
-        )
-        edges = io.StringIO(
-            """\
-        left    right   parent  child
-        0       0.4     2       0,1
-        0.4     1.0     3       0,1
-        """
-        )
-        ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
-        # Basic test
-        ibd_f = ibd.IbdFinder(ts)
+
+class TestIbdTwoSamplesTwoTrees(unittest.TestCase):
+
+    # 2
+    #             |     3
+    # 1      2    |    / \
+    #       / \   |   /   \
+    # 0    0   1  |  0     1
+    # |------------|----------|
+    # 0.0          0.4        1.0
+    nodes = io.StringIO(
+        """\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       0           1
+    3       0           1.5
+    """
+    )
+    edges = io.StringIO(
+        """\
+    left    right   parent  child
+    0       0.4     2       0,1
+    0.4     1.0     3       0,1
+    """
+    )
+    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+    # Basic test
+    def test_basic(self):
+        ibd_f = ibd.IbdFinder(self.ts)
         ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         true_segs = {(0, 1): [ibd.Segment(0.0, 0.4, 2), ibd.Segment(0.4, 1.0, 3)]}
         assert ibd_is_equal(ibd_segs, true_segs)
-        # Max time = 1.2
-        ibd_f = ibd.IbdFinder(ts, max_time=1.2)
+
+    # Max time = 1.2
+    def test_time(self):
+        ibd_f = ibd.IbdFinder(self.ts, max_time=1.2)
         ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         true_segs = {(0, 1): [ibd.Segment(0.0, 0.4, 2)]}
         assert ibd_is_equal(ibd_segs, true_segs)
-        # Min length = 0.5
-        ibd_f = ibd.IbdFinder(ts, max_time=1.2)
+
+    # Min length = 0.5
+    def test_length(self):
+        ibd_f = ibd.IbdFinder(self.ts, min_length=0.5)
         ibd_segs = ibd_f.find_ibd_segments()
-        true_segs = {(0, 1): [ibd.Segment(0.0, 0.4, 2)]}
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {(0, 1): [ibd.Segment(0.4, 1.0, 3)]}
         assert ibd_is_equal(ibd_segs, true_segs)
 
-    def test_unrelated_samples(self):
-        #          
-        #    2   3
-        #    |   |
-        #    0   1
 
-        nodes = io.StringIO(
-            """\
-        id      is_sample   time
-        0       1           0
-        1       1           0
-        2       0           1
-        3       0           1
-        """
-        )
-        edges = io.StringIO(
-            """\
-        left    right   parent  child
-        0       1       2       0
-        0       1       3       1
-        """
-        )
-        ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
-        ibd_f = ibd.IbdFinder(ts)
+class TestIbdUnrelatedSamples(unittest.TestCase):
+
+    #
+    #    2   3
+    #    |   |
+    #    0   1
+
+    nodes = io.StringIO(
+        """\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       0           1
+    3       0           1
+    """
+    )
+    edges = io.StringIO(
+        """\
+    left    right   parent  child
+    0       1       2       0
+    0       1       3       1
+    """
+    )
+    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+    def test_basic(self):
+        ibd_f = ibd.IbdFinder(self.ts)
         ibd_segs = ibd_f.find_ibd_segments()
-        true_segs = {(0,1): []}
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {(0, 1): []}
         assert ibd_is_equal(ibd_segs, true_segs)
 
+    def test_time(self):
+        ibd_f = ibd.IbdFinder(self.ts, max_time=1.2)
+        ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {(0, 1): []}
+        assert ibd_is_equal(ibd_segs, true_segs)
+
+    def test_length(self):
+        ibd_f = ibd.IbdFinder(self.ts, min_length=0.2)
+        ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {(0, 1): []}
+        assert ibd_is_equal(ibd_segs, true_segs)
+
+
+class TestIbdNoSamples(unittest.TestCase):
     def test_no_samples(self):
         #
         #     2
@@ -317,11 +429,13 @@ class TestIbdTopologies(unittest.TestCase):
         0       1       3       1
         """
         )
-        ts = tskit.load_text(nodes=nodes, edges=edges, strict=False) 
+        ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         ibd_f = ibd.IbdFinder(ts)
         ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         true_segs = {}
         assert ibd_is_equal(ibd_segs, true_segs)
+
 
 class TestIbdSamplesAreDescendants(unittest.TestCase):
     #
@@ -345,26 +459,24 @@ class TestIbdSamplesAreDescendants(unittest.TestCase):
     0       1       2       1
     """
     )
-    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False) 
+    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
     def test_basic(self):
         ts = self.ts
         ibd_f = ibd.IbdFinder(ts)
         ibd_segs = ibd_f.find_ibd_segments()
-        # print(ibd_segs)
-        ### NOTE: At the moment, this returns an empty set:
-        # {(0, 1): []}
-        # Should modify code to account for this case. 
-        # Should return that 1 is the ancestor of samples 0 and 1. 
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {(0, 1): [ibd.Segment(0.0, 1.0, 1)]}
+        assert ibd_is_equal(ibd_segs, true_segs)
 
 
 class TestIbdDifferentPaths(unittest.TestCase):
-    # 
+    #
     #        4       |      4       |        4
     #       / \      |     / \      |       / \
     #      /   \     |    /   3     |      /   \
     #     /     \    |   2     \    |     /     \
-    #    /       \   |  /       \   |    /       \   
+    #    /       \   |  /       \   |    /       \
     #   0         1  | 0         1  |   0         1
     #                |              |
     #                0.2            0.7
@@ -398,8 +510,14 @@ class TestIbdDifferentPaths(unittest.TestCase):
         ts = self.ts
         ibd_f = ibd.IbdFinder(ts)
         ibd_segs = ibd_f.find_ibd_segments()
-        true_segs = {(0, 1): [ibd.Segment(0.0, 0.2, 4), ibd.Segment(0.7, 1.0, 4),
-        ibd.Segment(0.2, 0.7, 4)]}
+        true_segs = {
+            (0, 1): [
+                ibd.Segment(0.0, 0.2, 4),
+                ibd.Segment(0.7, 1.0, 4),
+                ibd.Segment(0.2, 0.7, 4),
+            ]
+        }
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         assert ibd_is_equal(ibd_segs, true_segs)
 
     def test_time(self):
@@ -407,11 +525,18 @@ class TestIbdDifferentPaths(unittest.TestCase):
         ibd_f = ibd.IbdFinder(ts, max_time=1.8)
         ibd_segs = ibd_f.find_ibd_segments()
         true_segs = {(0, 1): []}
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         assert ibd_is_equal(ibd_segs, true_segs)
         ibd_f = ibd.IbdFinder(ts, max_time=2.8)
         ibd_segs = ibd_f.find_ibd_segments()
-        true_segs = {(0, 1): [ibd.Segment(0.0, 0.2, 4), ibd.Segment(0.7, 1.0, 4),
-        ibd.Segment(0.2, 0.7, 4)]}
+        true_segs = {
+            (0, 1): [
+                ibd.Segment(0.0, 0.2, 4),
+                ibd.Segment(0.7, 1.0, 4),
+                ibd.Segment(0.2, 0.7, 4),
+            ]
+        }
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         assert ibd_is_equal(ibd_segs, true_segs)
 
     def test_length(self):
@@ -419,75 +544,255 @@ class TestIbdDifferentPaths(unittest.TestCase):
         ibd_f = ibd.IbdFinder(ts, min_length=0.4)
         ibd_segs = ibd_f.find_ibd_segments()
         true_segs = {(0, 1): [ibd.Segment(0.2, 0.7, 4)]}
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdByLength(unittest.TestCase):
-    """
-    Tests of length-based IBD function. 
-    """
-    #        11           *                   *                   *
-    #       /  \          *                   *                   *        10
-    #      /    \         *        9          *                   *       /  \
-    #     /      \        *       / \         *         8         *      /    8
-    #    |        |       *      /   \        *        / \        *     /    / \
-    #    |        7       *     /     7       *       /   7       *    /    /   7 
-    #    |       / \      *    |     / \      *      /   / \      *   /    /   / \
-    #    |      /   6     *    |    /   6     *     /   /   6     *  |    /   |   |    
-    #    5     |   / \    *    5   |   / \    *    5   |   / \    *  |    5   |   |    
-    #   / \    |  /   \   *   / \  |  /   \   *   / \  |  /   \   *  |   / \  |   |     
-    #  0   4   1 2     3  *  0   4 1 2     3  *  0   4 1 2     3  *  3  0   4 1   2
-    # 
-    # ------------------------------------------------------------------------------
-    # 0                  0.10                 0.50               0.75           1.00 
+class TestIbdPolytomies(unittest.TestCase):
+    #
+    #          5         |         5
+    #         / \        |        / \
+    #        4   \       |       4   \
+    #       /|\   \      |      /|\   \
+    #      / | \   \     |     / | \   \
+    #     /  |  \   \    |    /  |  \   \
+    #    /   |   \   \   |   /   |   \   \
+    #   0    1    2   3  |  0    1    3   2
+    #                    |
+    #                   0.3
 
-    small_tree_ex_nodes = """\
-    id  flags   population  individual  time
-    0   1   0   -1  0.00000000000000    
-    1   1   0   -1  0.00000000000000    
-    2   1   0   -1  0.00000000000000    
-    3   1   0   -1  0.00000000000000    
-    4   1   0   -1  0.00000000000000    
-    5   0   0   -1  1.00000000000000    
-    6   0   0   -1  2.00000000000000   
-    7   0   0   -1  3.00000000000000    
-    8   0   0   -1  4.00000000000000    
-    9   0   0   -1  5.00000000000000    
-    10  0   0   -1  6.00000000000000    
-    11  0   0   -1  7.00000000000000
+    nodes = io.StringIO(
+        """\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       1           0
+    4       0           2.5
+    5       0           3.5
     """
-    small_tree_ex_edges = """\
-    id  left        right       parent  child
-    0   0.00000000  1.00000000  5   0
-    1   0.00000000  1.00000000  5   4
-    2   0.00000000  0.75000000  6   2
-    3   0.00000000  0.75000000  6   3
-    4   0.00000000  1.00000000  7   1
-    5   0.75000000  1.00000000  7   2
-    6   0.00000000  0.75000000  7   6
-    7   0.50000000  1.00000000  8   5
-    8   0.50000000  1.00000000  8   7
-    9   0.10000000  0.50000000  9   5
-    10  0.10000000  0.50000000  9   7
-    11  0.75000000  1.00000000  10  3
-    12  0.75000000  1.00000000  10  8
-    13  0.00000000  0.10000000  11  5
-    14  0.00000000  0.10000000  11  7
+    )
+    edges = io.StringIO(
+        """\
+    left    right   parent  child
+    0.0     1.0     4       0
+    0.0     1.0     4       1
+    0.0     0.3     4       2
+    0.3     1.0     4       3
+    0.3     1.0     5       2
+    0.0     0.3     5       3
+    0.0     1.0     5       4
     """
+    )
+    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+    def test_defaults(self):
+        ts = self.ts
+        ibd_f = ibd.IbdFinder(ts)
+        ibd_segs = ibd_f.find_ibd_segments()
+        # print(ibd_segs[(0,1)])
+        true_segs = {
+            (0, 1): [ibd.Segment(0, 1, 4)],
+            (0, 2): [ibd.Segment(0, 0.3, 4), ibd.Segment(0.3, 1, 5)],
+            (0, 3): [ibd.Segment(0, 0.3, 5), ibd.Segment(0.3, 1, 4)],
+            (1, 2): [ibd.Segment(0, 0.3, 4), ibd.Segment(0.3, 1, 5)],
+            (1, 3): [ibd.Segment(0, 0.3, 5), ibd.Segment(0.3, 1, 4)],
+            (2, 3): [ibd.Segment(0.3, 1, 5), ibd.Segment(0, 0.3, 5)],
+        }
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        # print(ibd_segs)
+        assert ibd_is_equal(ibd_segs, true_segs)
+
+    def test_time(self):
+        ts = self.ts
+        ibd_f = ibd.IbdFinder(ts, max_time=3)
+        ibd_segs = ibd_f.find_ibd_segments()
+        true_segs = {
+            (0, 1): [ibd.Segment(0, 1, 4)],
+            (0, 2): [ibd.Segment(0, 0.3, 4)],
+            (0, 3): [ibd.Segment(0.3, 1, 4)],
+            (1, 2): [ibd.Segment(0, 0.3, 4)],
+            (1, 3): [ibd.Segment(0.3, 1, 4)],
+            (2, 3): [],
+        }
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        assert ibd_is_equal(ibd_segs, true_segs)
+
+    def test_length(self):
+        ts = self.ts
+        ibd_f = ibd.IbdFinder(ts, min_length=0.5)
+        ibd_segs = ibd_f.find_ibd_segments()
+        true_segs = {
+            (0, 1): [ibd.Segment(0, 1, 4)],
+            (0, 2): [ibd.Segment(0.3, 1, 5)],
+            (0, 3): [ibd.Segment(0.3, 1, 4)],
+            (1, 2): [ibd.Segment(0.3, 1, 5)],
+            (1, 3): [ibd.Segment(0.3, 1, 4)],
+            (2, 3): [ibd.Segment(0.3, 1, 5)],
+        }
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        assert ibd_is_equal(ibd_segs, true_segs)
 
 
+class TestIbdInternalSamples(unittest.TestCase):
+    #
+    #
+    #      3
+    #     / \
+    #    /   2
+    #   /     \
+    #  0      (1)
+    nodes = io.StringIO(
+        """\
+    id      is_sample   time
+    0       1           0
+    1       0           0
+    2       1           1
+    3       0           2
+    """
+    )
+    edges = io.StringIO(
+        """\
+    left    right   parent  child
+    0.0     1.0     2       1
+    0.0     1.0     3       0
+    0.0     1.0     3       2
+    """
+    )
+    ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+    def test_defaults(self):
+        ts = self.ts
+        ibd_f = ibd.IbdFinder(ts)
+        ibd_segs = ibd_f.find_ibd_segments()
+        ibd_segs = convert_dict_of_segmentlists(ibd_segs)
+        true_segs = {
+            (0, 2): [ibd.Segment(0, 1, 3)],
+        }
+        assert ibd_is_equal(ibd_segs, true_segs)
+
+
+class TestIbdRandomExamples(unittest.TestCase):
+    """
+    Randomly generated test cases.
+    """
+
+    # Infinite sites, Hudson model.
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
     def test_random_example1(self):
-        ts0 = msprime.simulate(sample_size=10, recombination_rate=.5, random_seed=2)
-        verify_equal_ibd(ts0)
+        ts = msprime.simulate(sample_size=10, recombination_rate=0.5, random_seed=2)
+        verify_equal_ibd(ts)
 
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
     def test_random_example2(self):
-        ts1 = msprime.simulate(sample_size=10, recombination_rate=.5, random_seed=23)
-        verify_equal_ibd(ts1)
+        ts = msprime.simulate(sample_size=10, recombination_rate=0.5, random_seed=23)
+        verify_equal_ibd(ts)
 
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
     def test_random_example3(self):
-        ts2 = msprime.simulate(sample_size=10, recombination_rate=.5, random_seed=232)
-        verify_equal_ibd(ts2)
+        ts = msprime.simulate(sample_size=10, recombination_rate=0.5, random_seed=232)
+        verify_equal_ibd(ts)
 
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
     def test_random_example4(self):
-        ts_r = msprime.simulate(sample_size=10, recombination_rate=.3, random_seed=726)
-        verify_equal_ibd(ts_r)
+        ts = msprime.simulate(sample_size=10, recombination_rate=0.3, random_seed=726)
+        verify_equal_ibd(ts)
+
+    # Finite sites
+    def sim_finite_sites(self, random_seed, dtwf=False):
+        seq_length = int(1e5)
+        positions = random.sample(range(1, seq_length), 98) + [0, seq_length]
+        positions.sort()
+        rates = [random.uniform(1e-9, 1e-7) for _ in range(100)]
+        r_map = msprime.RecombinationMap(
+            positions=positions, rates=rates, discrete=True
+        )
+        if dtwf:
+            model = "dtwf"
+        else:
+            model = "hudson"
+        ts = msprime.simulate(
+            sample_size=10,
+            recombination_map=r_map,
+            Ne=10,
+            random_seed=random_seed,
+            model=model,
+        )
+        return ts
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_finite_sites1(self):
+        ts = self.sim_finite_sites(9257)
+        verify_equal_ibd(ts)
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_finite_sites2(self):
+        ts = self.sim_finite_sites(835)
+        verify_equal_ibd(ts)
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_finite_sites3(self):
+        ts = self.sim_finite_sites(27278)
+        verify_equal_ibd(ts)
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_finite_sites4(self):
+        ts = self.sim_finite_sites(22446688)
+        verify_equal_ibd(ts)
+
+    # DTWF
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_dtwf1(self):
+        ts = self.sim_finite_sites(84, dtwf=True)
+        verify_equal_ibd(ts)
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_dtwf2(self):
+        ts = self.sim_finite_sites(17482, dtwf=True)
+        verify_equal_ibd(ts)
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_dtwf3(self):
+        ts = self.sim_finite_sites(846, dtwf=True)
+        verify_equal_ibd(ts)
+
+    @unittest.skipIf(
+        version.parse(msprime.__version__) < version.parse("0.7.5"),
+        "Needs finite sites simulations to work.",
+    )
+    def test_dtwf4(self):
+        ts = self.sim_finite_sites(273, dtwf=True)
+        verify_equal_ibd(ts)

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -1,0 +1,241 @@
+
+"""
+Tests of IBD finding algorithms.
+"""
+import unittest
+import sys
+import random
+import io
+import itertools
+
+import tests as tests
+import tests.ibd as ibd
+
+import tskit
+import msprime
+import numpy as np
+
+# Functions for computing IBD 'naively'.
+
+class Segment(object):
+    """
+    A class representing a single segment. Each segment has a left and right,
+    denoting the loci over which it spans, a node and a next, giving the next
+    in the chain.
+
+    The node it records is the *output* node ID.
+    """
+    def __init__(self, left=None, right=None, node=None, next=None):
+        self.left = left
+        self.right = right
+        self.node = node
+        self.next = next
+
+    def __str__(self):
+        s = "({}-{}->{}:next={})".format(
+            self.left, self.right, self.node, repr(self.next))
+        return s
+
+    def __repr__(self):
+        return repr((self.left, self.right, self.node))
+
+    def __lt__(self, other):
+        return (self.node, self.left, self.right) < (other.node, other.left, other.right)
+
+
+def get_ibd(sample0, sample1, treeSequence, min_length=0, max_time=None,
+           path_ibd=True, mrca_ibd=False):
+    """
+    Returns all IBD segments for a given pair of nodes in a tree
+    using a naive algorithm.
+    """
+
+    ibd_list = []
+    ts, node_map = treeSequence.simplify(samples=[sample0, sample1], keep_unary=True,
+                              map_nodes=True)
+    node_map = node_map.tolist()
+    
+    for n in ts.nodes():
+        
+        if max_time is not None and n.time > max_time:
+            break
+            
+        node_id = n.id
+        interval_list = []
+        if n.flags == 1:
+            continue
+
+        prev_dict = None
+        for t in ts.trees():
+
+            if len(list(t.nodes(n.id))) == 1 or t.num_samples(n.id) < 2:
+                continue
+            if mrca_ibd and n.id != t.mrca(0, 1):
+                    continue
+
+            current_int = t.get_interval()
+            if len(interval_list) == 0:
+                interval_list.append(current_int)
+            else:
+                prev_int = interval_list[-1]
+                if not path_ibd and prev_int[1] == current_int[0]:
+                    interval_list[-1] = (prev_int[0], current_int[1])
+                elif prev_dict is not None and subtrees_are_equal(t, prev_dict, node_id):
+                    interval_list[-1] = (prev_int[0], current_int[1])
+                else:
+                    interval_list.append(current_int)
+                    
+            prev_dict = t.get_parent_dict()
+                    
+        for interval in interval_list:
+            if min_length == 0 or interval[1] - interval[0] > min_length:
+                orig_id = node_map.index(node_id)
+                ibd_list.append(Segment(interval[0], interval[1], orig_id))
+        
+    return(ibd_list)
+
+
+def get_ibd_all_pairs(treeSequence, samples=None, min_length=0, max_time=None,
+                      path_ibd=True, mrca_ibd=False):
+    
+    ibd_dict = {}
+    
+    if samples is None:
+        samples = treeSequence.samples().tolist()
+    
+    pairs = itertools.combinations(samples, 2)
+    for pair in pairs:
+        ibd_list = get_ibd(pair[0], pair[1], treeSequence,
+                           min_length=min_length, max_time=max_time,
+                          path_ibd=path_ibd, mrca_ibd=mrca_ibd)
+        if len(ibd_list) > 0:
+            ibd_dict[pair] = ibd_list
+            
+    return(ibd_dict)
+
+
+def subtrees_are_equal(tree1, pdict0, root):
+    pdict1 = tree1.get_parent_dict()
+    if root not in pdict0.values() or root not in pdict1.values():
+        return False
+    leaves1 = set(tree1.leaves(root))
+    for l in leaves1:
+        node = l
+        while node != root:
+            p1 = pdict1[node]
+            if p1 not in pdict0.values():
+                return False
+            p0 = pdict0[node]
+            if  p0 != p1:
+                return False  
+            node = p1
+            
+    return True
+
+
+def verify_equal_ibd(treeSequence):
+    """
+    Calculates IBD segments using both the 'naive' and sophisticated algorithms, 
+    verifies that the same output is produced.
+    NB: May be good to expand this in the future so that many different combos
+    of IBD options are tested simultaneously (all the MRCA and path-IBD combos),
+    for example.
+    """
+    ts = treeSequence
+    ibd0 = ibd.IbdFinder(ts, samples = ts.samples())
+    ibd0 = ibd0.find_ibd_segments_of_length()
+    ibd1 = get_ibd_all_pairs(ts, path_ibd=True, mrca_ibd=True)
+
+    for key0, val0 in ibd0.items():
+        # print(key0)
+        assert key0 in ibd1.keys()
+        val1 = ibd1[key0]
+        val0.sort()
+        val1.sort()
+
+        # print('IBD from IBDFinder')
+        # print(val0)
+        # print('IBD from naive function')
+        # print(val1)
+
+        if val0 is None: # Get rid of this later -- don't want empty dict values at all
+            assert val1 is None
+            continue
+        elif val1 is None:
+        #     print(val0)
+        #     print(val1)
+            assert val0 is None
+        assert len(val0) == len(val1)
+        for i in range(0, len(val0)):
+            assert val0[i] == val1[i]
+
+
+class TestIbdByLength(unittest.TestCase):
+    """
+    Tests of length-based IBD function. 
+    """
+    #        11           *                   *                   *
+    #       /  \          *                   *                   *        10
+    #      /    \         *        9          *                   *       /  \
+    #     /      \        *       / \         *         8         *      /    8
+    #    |        |       *      /   \        *        / \        *     /    / \
+    #    |        7       *     /     7       *       /   7       *    /    /   7 
+    #    |       / \      *    |     / \      *      /   / \      *   /    /   / \
+    #    |      /   6     *    |    /   6     *     /   /   6     *  |    /   |   |    
+    #    5     |   / \    *    5   |   / \    *    5   |   / \    *  |    5   |   |    
+    #   / \    |  /   \   *   / \  |  /   \   *   / \  |  /   \   *  |   / \  |   |     
+    #  0   4   1 2     3  *  0   4 1 2     3  *  0   4 1 2     3  *  3  0   4 1   2
+    # 
+    # ------------------------------------------------------------------------------
+    # 0                  0.10                 0.50               0.75           1.00 
+
+    small_tree_ex_nodes = """\
+    id  flags   population  individual  time
+    0   1   0   -1  0.00000000000000    
+    1   1   0   -1  0.00000000000000    
+    2   1   0   -1  0.00000000000000    
+    3   1   0   -1  0.00000000000000    
+    4   1   0   -1  0.00000000000000    
+    5   0   0   -1  1.00000000000000    
+    6   0   0   -1  2.00000000000000   
+    7   0   0   -1  3.00000000000000    
+    8   0   0   -1  4.00000000000000    
+    9   0   0   -1  5.00000000000000    
+    10  0   0   -1  6.00000000000000    
+    11  0   0   -1  7.00000000000000
+    """
+    small_tree_ex_edges = """\
+    id  left        right       parent  child
+    0   0.00000000  1.00000000  5   0
+    1   0.00000000  1.00000000  5   4
+    2   0.00000000  0.75000000  6   2
+    3   0.00000000  0.75000000  6   3
+    4   0.00000000  1.00000000  7   1
+    5   0.75000000  1.00000000  7   2
+    6   0.00000000  0.75000000  7   6
+    7   0.50000000  1.00000000  8   5
+    8   0.50000000  1.00000000  8   7
+    9   0.10000000  0.50000000  9   5
+    10  0.10000000  0.50000000  9   7
+    11  0.75000000  1.00000000  10  3
+    12  0.75000000  1.00000000  10  8
+    13  0.00000000  0.10000000  11  5
+    14  0.00000000  0.10000000  11  7
+    """
+
+
+    def test_canonical_example1(self):
+        ts0 = msprime.simulate(sample_size=5, recombination_rate=.5, random_seed=2)
+        verify_equal_ibd(ts0)
+
+    def test_canonical_example2(self):
+        ts1 = msprime.simulate(sample_size=5, recombination_rate=.5, random_seed=23)
+        verify_equal_ibd(ts1)
+
+    def test_canonical_example3(self):
+        ts2 = msprime.simulate(sample_size=5, recombination_rate=.5, random_seed=232)
+        verify_equal_ibd(ts2)
+
+    def test_random_example(self):
+        ts_r = msprime.simulate(sample_size=10, recombination_rate=.3, random_seed=726)
+        verify_equal_ibd(ts_r)


### PR DESCRIPTION
Pulling this in now so that others can see my continuing progress on IBD-calculating methods for `tskit` (cc @jeromekelleher for our call tomorrow). It's very basic so far but it should work:

**Command-line implementation:**
```
python3 tests/ibd.py test.trees
```
should return IBD segments shared between all pairs of samples.

```
python3 tests/ibd.py test.trees 0 1
```

should return IBD segments shared between samples 0 and 1 (ensure the nodes are ordered).

**Tests:**
```
python3 -m nose -vs tests/test_ibd.py
```
### IBD definitions

A pair of sample nodes that have both inherited the interval `(left, right)` from a single ancestor, `node`, are IBD over the interval `(left, right)`.

Further options:

 - `path_ibd`: If `True`, the IBD segment must be inherited by two samples from a common ancestor without being broken by recombination since the time of that ancestor. Equivalently, the path of the tree connecting the sample pair must be the same along the whole span of the interval.
 - `mrca_ibd`: If `True`, only IBD segments at the MRCA of the sample pair are recorded.

Cutoff criteria:

 - `min_length`: Only segments longer than `min_length` are returned.
 - `max_time`: Only segments from common ancestors who lived more recently than `max_time` are returned.

Note: currently, the only implemented version is `path_ibd=True`, `mrca_ibd=True`, `min_length=0`, `max_time=0`, but watch this space!
