### PR TITLE
Make KC distance linear in size of KC vectors

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -4297,6 +4297,40 @@ test_internal_sample_sample_sets(void)
  *=======================================================*/
 
 static void
+test_isolated_node_kc(void)
+{
+    const char *single_leaf = "1 0 0";
+    const char *single_internal = "0 0 0";
+    const char *edges = "";
+    tsk_treeseq_t ts;
+    tsk_tree_t t;
+    int ret;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, single_leaf, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_kc_distance(&t, &t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+    tsk_treeseq_free(&ts);
+    tsk_tree_free(&t);
+
+    tsk_treeseq_from_text(&ts, 1, single_internal, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL_FATAL(t.left_root, TSK_NULL);
+    ret = tsk_tree_kc_distance(&t, &t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_ROOTS);
+    tsk_treeseq_free(&ts);
+    tsk_tree_free(&t);
+}
+
+static void
 test_single_tree_kc(void)
 {
     int ret;
@@ -4306,11 +4340,11 @@ test_single_tree_kc(void)
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
         NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    ret = tsk_tree_init(&other_t, &ts, 0);
+    ret = tsk_tree_init(&other_t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4349,13 +4383,13 @@ test_two_trees_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     tsk_treeseq_from_text(
         &other_ts, 1, nodes_other, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&other_t, &other_ts, 0);
+    ret = tsk_tree_init(&other_t, &other_ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4380,18 +4414,18 @@ test_empty_tree_kc(void)
     int ret;
     double result = 0;
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES | TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SEQUENCE_LENGTH);
     tsk_treeseq_free(&ts);
     tables.sequence_length = 1.0;
-    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES | TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     verify_empty_tree_sequence(&ts, 1.0);
 
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4423,7 +4457,7 @@ test_nonbinary_tree_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4447,7 +4481,7 @@ test_nonzero_samples_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4471,7 +4505,7 @@ test_internal_samples_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4501,13 +4535,13 @@ test_unequal_sample_size_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     tsk_treeseq_from_text(
         &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&other_t, &other_ts, 0);
+    ret = tsk_tree_init(&other_t, &other_ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -4543,13 +4577,13 @@ test_unequal_samples_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&t, &ts, 0);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     tsk_treeseq_from_text(
         &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
-    ret = tsk_tree_init(&other_t, &other_ts, 0);
+    ret = tsk_tree_init(&other_t, &other_ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -5264,6 +5298,7 @@ main(int argc, char **argv)
 
         /*KC distance tests */
         { "test_single_tree_kc", test_single_tree_kc },
+        { "test_isolated_node_kc", test_isolated_node_kc },
         { "test_two_trees_kc", test_two_trees_kc },
         { "test_empty_tree_kc", test_empty_tree_kc },
         { "test_nonbinary_tree_kc", test_nonbinary_tree_kc },

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,6 +6,10 @@ In development
 
 **New features**
 
+- Improve Kendall-Colijn tree distance algorithm to operate in O(n^2) time
+  instead of O(n^2 * log(n)) where n is the number of samples
+  (:user:`daniel-goldstein`, :pr:`490`)
+
 - Add a metadata column to the migrations table. Works similarly to existing
   metadata columns on other tables(:user:`benjeffery`, :pr:`505`).
 

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1899,7 +1899,7 @@ class TestTree(LowLevelTestCase):
 
     def test_kc_distance_errors(self):
         ts1 = self.get_example_tree_sequence(10)
-        t1 = _tskit.Tree(ts1)
+        t1 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)
         t1.first()
         self.assertRaises(TypeError, t1.get_kc_distance)
         self.assertRaises(TypeError, t1.get_kc_distance, t1)
@@ -1908,7 +1908,7 @@ class TestTree(LowLevelTestCase):
         for bad_value in ["tree", [], None]:
             self.assertRaises(TypeError, t1.get_kc_distance, t1, lambda_=bad_value)
 
-        t2 = _tskit.Tree(ts1)
+        t2 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)
         # If we don't seek to a specific tree, it has multiple roots (i.e., it's
         # in the null state). This fails because we don't accept multiple roots.
         with self.assertRaises(_tskit.LibraryError):
@@ -1916,10 +1916,15 @@ class TestTree(LowLevelTestCase):
 
         # Different numbers of samples fail.
         ts2 = self.get_example_tree_sequence(11)
+        t2 = _tskit.Tree(ts2, options=_tskit.SAMPLE_LISTS)
+        t2.first()
+        self.verify_kc_library_error(t1, t2)
+
+        # Error when tree not initialized with sample lists
+        ts2 = self.get_example_tree_sequence(10)
         t2 = _tskit.Tree(ts2)
         t2.first()
-        with self.assertRaises(_tskit.LibraryError):
-            t1.get_kc_distance(t2, 0)
+        self.verify_kc_library_error(t1, t2)
 
         # Internal samples cause errors.
         tables = _tskit.TableCollection(1.0)
@@ -1928,17 +1933,20 @@ class TestTree(LowLevelTestCase):
         tables.edges.add_row(0, 1, 1, 0)
         ts = _tskit.TreeSequence()
         ts.load_tables(tables)
-        t1 = _tskit.Tree(ts)
+        t1 = _tskit.Tree(ts, options=_tskit.SAMPLE_LISTS)
         t1.first()
+        self.verify_kc_library_error(t1, t1)
+
+    def verify_kc_library_error(self, t1, t2):
         with self.assertRaises(_tskit.LibraryError):
-            t1.get_kc_distance(t1, 0)
+            t1.get_kc_distance(t2, 0)
 
     def test_kc_distance(self):
         ts1 = self.get_example_tree_sequence(10, random_seed=123456)
-        t1 = _tskit.Tree(ts1)
+        t1 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)
         t1.first()
         ts2 = self.get_example_tree_sequence(10, random_seed=1234)
-        t2 = _tskit.Tree(ts2)
+        t2 = _tskit.Tree(ts2, options=_tskit.SAMPLE_LISTS)
         t2.first()
         for lambda_ in [-1, 0, 1, 1000, -1e300]:
             x1 = t1.get_kc_distance(t2, lambda_)


### PR DESCRIPTION
Computing the KC distance requires building two vectors per tree, `m` and `M`, where each element records, for some leaves u & v, the distance of mrca(u, v) to the root in number of edges and time, respectively. The existing implementation was essentially the above explanation, computing the mrca for each pair, which for `n` leaves, takes `O(n^2 log(n))` time.

This PR implements a slightly different approach, where we do a preorder traversal of the tree, accumulating the depth and time from the root. For each internal node, we can take the Cartesian product of the node's children's leaves and assign each pair the current depth and time. We use `sample_lists` to iterate through the leaves without any extra traversal overhead, erroring out when `sample_lists` is not available. Since each leaf pair is considered once, the overall runtime is `O(n^2)`. This approach is similar to that used in the official R package for KC-distance, tree space.
