### PR TITLE
Metadata schema (WIP)

### DIFF
--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -566,6 +566,7 @@ tsk_individual_table_print_state(tsk_individual_table_t *self, FILE *out)
     fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
         (int) self->metadata_length, (int) self->max_metadata_length,
         (int) self->max_metadata_length_increment);
+    fprintf(out, "metadata_schema = %.*s\n", self->metadata_schema_length, self->metadata_schema);
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here because we want to output
      * the offset columns. */
@@ -653,8 +654,7 @@ tsk_individual_table_dump_text(tsk_individual_table_t *self, FILE *out)
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
         err = fprintf(out, "%d\t%d\t", (int) j, (int) self->flags[j]);
-        if (err < 0) {
-            goto out;
+        if (err < 0) {err = fprintf(out, "#metadata_schema");
         }
         for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
             err = fprintf(out, "%.*g", TSK_DBL_DECIMAL_DIG, self->location[k]);

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -566,7 +566,6 @@ tsk_individual_table_print_state(tsk_individual_table_t *self, FILE *out)
     fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
         (int) self->metadata_length, (int) self->max_metadata_length,
         (int) self->max_metadata_length_increment);
-    fprintf(out, "metadata_schema = %.*s\n", self->metadata_schema_length, self->metadata_schema);
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here because we want to output
      * the offset columns. */
@@ -654,7 +653,8 @@ tsk_individual_table_dump_text(tsk_individual_table_t *self, FILE *out)
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
         err = fprintf(out, "%d\t%d\t", (int) j, (int) self->flags[j]);
-        if (err < 0) {err = fprintf(out, "#metadata_schema");
+        if (err < 0) {
+            goto out;
         }
         for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
             err = fprintf(out, "%.*g", TSK_DBL_DECIMAL_DIG, self->location[k]);

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -2500,7 +2500,7 @@ IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *
         }
     }
     ret = tsk_individual_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }
@@ -2969,7 +2969,7 @@ NodeTable_set_metadata_schema(NodeTable *self, PyObject *arg, void *closure)
         }
     }
     ret = tsk_node_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }
@@ -3455,7 +3455,7 @@ EdgeTable_set_metadata_schema(EdgeTable *self, PyObject *arg, void *closure)
         }
     }
     ret = tsk_edge_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }
@@ -3950,7 +3950,7 @@ MigrationTable_set_metadata_schema(MigrationTable *self, PyObject *arg, void *cl
         }
     }
     ret = tsk_migration_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }
@@ -4407,7 +4407,7 @@ SiteTable_set_metadata_schema(SiteTable *self, PyObject *arg, void *closure)
         }
     }
     ret = tsk_site_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }
@@ -4903,7 +4903,7 @@ MutationTable_set_metadata_schema(MutationTable *self, PyObject *arg, void *clos
         }
     }
     ret = tsk_mutation_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }
@@ -5315,7 +5315,7 @@ PopulationTable_set_metadata_schema(PopulationTable *self, PyObject *arg, void *
         }
     }
     ret = tsk_population_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret < 0) {
+    if (ret != 0) {
         handle_library_error(ret);
         goto out;
     }

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -242,6 +242,19 @@ make_metadata(const char *metadata, Py_ssize_t length)
 }
 
 static PyObject *
+make_Py_Unicode_FromStringAndLength(const char * str, size_t length) {
+    PyObject * ret;
+    /* Py_BuildValue returns Py_None for zero length */
+    if (length == 0) {
+        ret = PyUnicode_FromString("");
+    } else {
+        ret = Py_BuildValue("s#", str, length);
+    }
+    return ret;
+}
+    
+
+static PyObject *
 make_mutation(tsk_mutation_t *mutation)
 {
     PyObject *ret = NULL;
@@ -2465,7 +2478,7 @@ IndividualTable_get_metadata_schema(IndividualTable *self, void *closure)
     if (IndividualTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -2474,14 +2487,15 @@ static int
 IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (IndividualTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -2933,7 +2947,7 @@ NodeTable_get_metadata_schema(NodeTable *self, void *closure)
     if (NodeTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -2942,14 +2956,15 @@ static int
 NodeTable_set_metadata_schema(NodeTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (NodeTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -3418,7 +3433,7 @@ EdgeTable_get_metadata_schema(EdgeTable *self, void *closure)
     if (EdgeTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -3427,14 +3442,15 @@ static int
 EdgeTable_set_metadata_schema(EdgeTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (EdgeTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -3912,7 +3928,7 @@ MigrationTable_get_metadata_schema(MigrationTable *self, void *closure)
     if (MigrationTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -3921,14 +3937,15 @@ static int
 MigrationTable_set_metadata_schema(MigrationTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (MigrationTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -4368,7 +4385,7 @@ SiteTable_get_metadata_schema(SiteTable *self, void *closure)
     if (SiteTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -4377,14 +4394,15 @@ static int
 SiteTable_set_metadata_schema(SiteTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (SiteTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -4863,7 +4881,7 @@ MutationTable_get_metadata_schema(MutationTable *self, void *closure)
     if (MutationTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -4872,14 +4890,15 @@ static int
 MutationTable_set_metadata_schema(MutationTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (MutationTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -5274,7 +5293,7 @@ PopulationTable_get_metadata_schema(PopulationTable *self, void *closure)
     if (PopulationTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+    ret = make_Py_Unicode_FromStringAndLength(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -5283,14 +5302,15 @@ static int
 PopulationTable_set_metadata_schema(PopulationTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    char *metadata_schema = "";
+    const char *metadata_schema = "";
     Py_ssize_t metadata_schema_length = 0;
     
     if (PopulationTable_check_state(self) != 0) {
         goto out;
     }
     if (arg != NULL) {
-        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+        if (metadata_schema == NULL) {
             goto out;
         }
     }
@@ -6588,25 +6608,47 @@ out:
 static PyObject *
 TreeSequence_get_metadata_schemas(TreeSequence *self) {
     PyObject *ret = NULL;
+    PyObject *schema = NULL;
     tsk_table_collection_t *tables = self->tree_sequence->tables;
     ret = PyStructSequence_New(&MetadataSchemas);
     if (ret == NULL) {
         goto out;
     }
-    PyStructSequence_SetItem(ret, 0, PyBytes_FromStringAndSize(
-            tables->nodes.metadata_schema, tables->nodes.metadata_schema_length));
-    PyStructSequence_SetItem(ret, 1, PyBytes_FromStringAndSize(
-            tables->edges.metadata_schema, tables->edges.metadata_schema_length));
-    PyStructSequence_SetItem(ret, 2, PyBytes_FromStringAndSize(
-            tables->sites.metadata_schema, tables->sites.metadata_schema_length));
-    PyStructSequence_SetItem(ret, 3, PyBytes_FromStringAndSize(
-            tables->mutations.metadata_schema, tables->mutations.metadata_schema_length));
-    PyStructSequence_SetItem(ret, 4, PyBytes_FromStringAndSize(
-            tables->migrations.metadata_schema, tables->migrations.metadata_schema_length));
-    PyStructSequence_SetItem(ret, 5, PyBytes_FromStringAndSize(
-            tables->individuals.metadata_schema, tables->individuals.metadata_schema_length));
-    PyStructSequence_SetItem(ret, 6, PyBytes_FromStringAndSize(
-            tables->populations.metadata_schema, tables->populations.metadata_schema_length));
+    schema = make_Py_Unicode_FromStringAndLength(tables->nodes.metadata_schema, tables->nodes.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 0, schema);
+    schema = make_Py_Unicode_FromStringAndLength(tables->edges.metadata_schema, tables->edges.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 1, schema);
+    schema = make_Py_Unicode_FromStringAndLength(tables->sites.metadata_schema, tables->sites.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 2, schema);
+    schema = make_Py_Unicode_FromStringAndLength(tables->mutations.metadata_schema, tables->mutations.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 3, schema);
+    schema = make_Py_Unicode_FromStringAndLength(tables->migrations.metadata_schema, tables->migrations.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 4, schema);
+    schema = make_Py_Unicode_FromStringAndLength(tables->individuals.metadata_schema, tables->individuals.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 5, schema);
+    schema = make_Py_Unicode_FromStringAndLength(tables->populations.metadata_schema, tables->populations.metadata_schema_length);
+    if (schema == NULL) {
+        goto out;
+    }
+    PyStructSequence_SetItem(ret, 6, schema);
 out:
     return ret;
 }

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -185,7 +185,7 @@ typedef struct {
 } ViterbiMatrix;
 
 /* A named tuple of metadata schemas for a tree sequence */
-PyTypeObject MetadataSchemas={};
+PyTypeObject MetadataSchemas;
 
 static void
 handle_library_error(int err)

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -2454,6 +2454,45 @@ out:
     return ret;
 }
 
+static PyObject *
+IndividualTable_get_metadata_schema(IndividualTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (IndividualTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyUnicode_FromString(self->table->metadata_schema);
+out:
+    return ret;
+}
+
+static int
+IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *closure)
+{
+    int err;
+    int ret = -1;
+    char *metadata_schema = NULL;
+
+    if (!arg || !PyUnicode_Check(arg)) {
+        PyErr_SetString(PyExc_TypeError, "metadata schema should be unicode");
+        goto out;
+    }
+    if (IndividualTable_check_state(self) != 0) {
+        goto out;
+    }
+    //PyUnicode_AsUTF8 docs state the caller is not responsible for deallocating the buffer.
+    metadata_schema = PyUnicode_AsUTF8(arg);
+    err = tsk_individual_table_set_metadata_schema(self->table, metadata_schema);
+    if (err != 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+
 static PyGetSetDef IndividualTable_getsetters[] = {
     {"max_rows_increment",
         (getter) IndividualTable_get_max_rows_increment, NULL, "The size increment"},
@@ -2468,6 +2507,8 @@ static PyGetSetDef IndividualTable_getsetters[] = {
     {"metadata", (getter) IndividualTable_get_metadata, NULL, "The metadata array"},
     {"metadata_offset", (getter) IndividualTable_get_metadata_offset, NULL,
         "The metadata offset array"},
+    {"metadata_schema", (getter) IndividualTable_get_metadata_schema,
+        (setter) IndividualTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -185,7 +185,23 @@ typedef struct {
 } ViterbiMatrix;
 
 /* A named tuple of metadata schemas for a tree sequence */
-PyTypeObject MetadataSchemas;
+static PyTypeObject MetadataSchemas;
+static PyStructSequence_Field metadata_schemas_fields[] = {
+    {"node", "The node metadata schema"},
+    {"edge", "The edge metadata schema"},
+    {"site", "The site metadata schema"},
+    {"mutation", "The mutation metadata schema"},
+    {"migration", "The migration metadata schema"},
+    {"individual", "The individual metadata schema"},
+    {"population", "The node metadata schema"},
+    {NULL}
+};
+static PyStructSequence_Desc metadata_schemas_desc = {
+    "MetadataSchemas",
+    "Namedtuple of metadata schemas for this tree sequence",
+    metadata_schemas_fields,
+    7
+};
 
 static void
 handle_library_error(int err)
@@ -2487,21 +2503,25 @@ static int
 IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (IndividualTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_individual_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_individual_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -2956,21 +2976,25 @@ static int
 NodeTable_set_metadata_schema(NodeTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (NodeTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_node_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_node_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -3442,21 +3466,25 @@ static int
 EdgeTable_set_metadata_schema(EdgeTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (EdgeTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_edge_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_edge_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -3937,21 +3965,25 @@ static int
 MigrationTable_set_metadata_schema(MigrationTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (MigrationTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_migration_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_migration_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -4394,21 +4426,25 @@ static int
 SiteTable_set_metadata_schema(SiteTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (SiteTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_site_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_site_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -4890,21 +4926,25 @@ static int
 MutationTable_set_metadata_schema(MutationTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (MutationTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_mutation_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_mutation_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -5302,21 +5342,25 @@ static int
 PopulationTable_set_metadata_schema(PopulationTable *self, PyObject *arg, void *closure)
 {
     int ret = -1;
-    const char *metadata_schema = "";
-    Py_ssize_t metadata_schema_length = 0;
+    int err;
+    const char *metadata_schema;
+    Py_ssize_t metadata_schema_length;
     
+    if (arg == NULL) {
+        PyErr_Format(PyExc_ValueError, "Cannot del metadata_schema");
+        goto out;
+    }
     if (PopulationTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != NULL) {
-        metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
-        if (metadata_schema == NULL) {
-            goto out;
-        }
+    metadata_schema = PyUnicode_AsUTF8AndSize(arg, &metadata_schema_length);
+    if (metadata_schema == NULL) {
+        goto out;
     }
-    ret = tsk_population_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
-    if (ret != 0) {
-        handle_library_error(ret);
+    err = tsk_population_table_set_metadata_schema(
+        self->table, metadata_schema, metadata_schema_length);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
     ret = 0;
@@ -6608,48 +6652,42 @@ out:
 static PyObject *
 TreeSequence_get_metadata_schemas(TreeSequence *self) {
     PyObject *ret = NULL;
+    PyObject *value = NULL;
     PyObject *schema = NULL;
+    size_t j;
     tsk_table_collection_t *tables = self->tree_sequence->tables;
-    ret = PyStructSequence_New(&MetadataSchemas);
-    if (ret == NULL) {
+
+    struct schema_pair {
+        const char * schema;
+        tsk_size_t length;
+    };
+
+    struct schema_pair schema_pairs[] = {
+        {tables->nodes.metadata_schema, tables->nodes.metadata_schema_length},
+        {tables->edges.metadata_schema, tables->edges.metadata_schema_length},
+        {tables->sites.metadata_schema, tables->sites.metadata_schema_length},
+        {tables->mutations.metadata_schema, tables->mutations.metadata_schema_length},
+        {tables->migrations.metadata_schema, tables->migrations.metadata_schema_length},
+        {tables->individuals.metadata_schema, tables->individuals.metadata_schema_length},
+        {tables->populations.metadata_schema, tables->populations.metadata_schema_length},
+    };
+    
+    value = PyStructSequence_New(&MetadataSchemas);
+    if (value == NULL) {
         goto out;
     }
-    schema = make_Py_Unicode_FromStringAndLength(tables->nodes.metadata_schema, tables->nodes.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
+    for (j = 0; j < sizeof(schema_pairs) / sizeof(*schema_pairs); j++) {
+        schema = make_Py_Unicode_FromStringAndLength(
+            schema_pairs[j].schema, schema_pairs[j].length);
+        if (schema == NULL) {
+            goto out;
+        }
+        PyStructSequence_SetItem(value, j, schema);
     }
-    PyStructSequence_SetItem(ret, 0, schema);
-    schema = make_Py_Unicode_FromStringAndLength(tables->edges.metadata_schema, tables->edges.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
-    }
-    PyStructSequence_SetItem(ret, 1, schema);
-    schema = make_Py_Unicode_FromStringAndLength(tables->sites.metadata_schema, tables->sites.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
-    }
-    PyStructSequence_SetItem(ret, 2, schema);
-    schema = make_Py_Unicode_FromStringAndLength(tables->mutations.metadata_schema, tables->mutations.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
-    }
-    PyStructSequence_SetItem(ret, 3, schema);
-    schema = make_Py_Unicode_FromStringAndLength(tables->migrations.metadata_schema, tables->migrations.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
-    }
-    PyStructSequence_SetItem(ret, 4, schema);
-    schema = make_Py_Unicode_FromStringAndLength(tables->individuals.metadata_schema, tables->individuals.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
-    }
-    PyStructSequence_SetItem(ret, 5, schema);
-    schema = make_Py_Unicode_FromStringAndLength(tables->populations.metadata_schema, tables->populations.metadata_schema_length);
-    if (schema == NULL) {
-        goto out;
-    }
-    PyStructSequence_SetItem(ret, 6, schema);
+    ret = value;
+    value = NULL;
 out:
+    Py_XDECREF(value);
     return ret;
 }
 
@@ -10612,23 +10650,9 @@ PyInit__tskit(void)
     PyModule_AddObject(module, "LsHmm", (PyObject *) &LsHmmType);
 
     /* Metadata schemas namedtuple type*/
-    PyStructSequence_Field metadata_schemas_fields[] = {
-        {"node", "The node metadata schema"},
-        {"edge", "The edge metadata schema"},
-        {"site", "The site metadata schema"},
-        {"mutation", "The mutation metadata schema"},
-        {"migration", "The migration metadata schema"},
-        {"individual", "The individual metadata schema"},
-        {"population", "The node metadata schema"},
-        {NULL}
+    if (PyStructSequence_InitType2(&MetadataSchemas, &metadata_schemas_desc) < 0) {
+        return NULL;
     };
-    PyStructSequence_Desc metadata_schemas_desc = {
-        "MetadataSchemas",
-        "Namedtuple of metadata schemas for this tree sequence",
-        metadata_schemas_fields,
-        1
-    };
-    PyStructSequence_InitType(&MetadataSchemas, &metadata_schemas_desc);
     Py_INCREF(&MetadataSchemas);
     PyModule_AddObject(module, "MetadataSchemas", (PyObject*)&MetadataSchemas);
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -2480,7 +2480,7 @@ IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *
     if (IndividualTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }
@@ -2948,7 +2948,7 @@ NodeTable_set_metadata_schema(NodeTable *self, PyObject *arg, void *closure)
     if (NodeTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }
@@ -3433,7 +3433,7 @@ EdgeTable_set_metadata_schema(EdgeTable *self, PyObject *arg, void *closure)
     if (EdgeTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }
@@ -3927,7 +3927,7 @@ MigrationTable_set_metadata_schema(MigrationTable *self, PyObject *arg, void *cl
     if (MigrationTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }
@@ -4383,7 +4383,7 @@ SiteTable_set_metadata_schema(SiteTable *self, PyObject *arg, void *closure)
     if (SiteTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }
@@ -4878,7 +4878,7 @@ MutationTable_set_metadata_schema(MutationTable *self, PyObject *arg, void *clos
     if (MutationTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }
@@ -5289,7 +5289,7 @@ PopulationTable_set_metadata_schema(PopulationTable *self, PyObject *arg, void *
     if (PopulationTable_check_state(self) != 0) {
         goto out;
     }
-    if (arg != Py_None) {
+    if (arg != NULL) {
         if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
             goto out;
         }

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -2462,7 +2462,7 @@ IndividualTable_get_metadata_schema(IndividualTable *self, void *closure)
     if (IndividualTable_check_state(self) != 0) {
         goto out;
     }
-    ret = PyUnicode_FromString(self->table->metadata_schema);
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
 out:
     return ret;
 }
@@ -2470,28 +2470,27 @@ out:
 static int
 IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *closure)
 {
-    int err;
     int ret = -1;
-    char *metadata_schema = NULL;
-
-    if (!arg || !PyUnicode_Check(arg)) {
-        PyErr_SetString(PyExc_TypeError, "metadata schema should be unicode");
-        goto out;
-    }
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
     if (IndividualTable_check_state(self) != 0) {
         goto out;
     }
-    //PyUnicode_AsUTF8 docs state the caller is not responsible for deallocating the buffer.
-    metadata_schema = PyUnicode_AsUTF8(arg);
-    err = tsk_individual_table_set_metadata_schema(self->table, metadata_schema);
-    if (err != 0) {
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_individual_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
         goto out;
     }
     ret = 0;
 out:
     return ret;
 }
-
 
 static PyGetSetDef IndividualTable_getsetters[] = {
     {"max_rows_increment",
@@ -2923,6 +2922,44 @@ out:
     return ret;
 }
 
+static PyObject *
+NodeTable_get_metadata_schema(NodeTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (NodeTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+out:
+    return ret;
+}
+
+static int
+NodeTable_set_metadata_schema(NodeTable *self, PyObject *arg, void *closure)
+{
+    int ret = -1;
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
+    if (NodeTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_node_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static PyGetSetDef NodeTable_getsetters[] = {
     {"max_rows_increment",
         (getter) NodeTable_get_max_rows_increment, NULL, "The size increment"},
@@ -2937,6 +2974,8 @@ static PyGetSetDef NodeTable_getsetters[] = {
     {"metadata", (getter) NodeTable_get_metadata, NULL, "The metadata array"},
     {"metadata_offset", (getter) NodeTable_get_metadata_offset, NULL,
         "The metadata offset array"},
+    {"metadata_schema", (getter) NodeTable_get_metadata_schema,
+        (setter) NodeTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 
@@ -3368,6 +3407,44 @@ out:
     return ret;
 }
 
+static PyObject *
+EdgeTable_get_metadata_schema(EdgeTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (EdgeTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+out:
+    return ret;
+}
+
+static int
+EdgeTable_set_metadata_schema(EdgeTable *self, PyObject *arg, void *closure)
+{
+    int ret = -1;
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
+    if (EdgeTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_edge_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static PyGetSetDef EdgeTable_getsetters[] = {
     {"max_rows_increment",
         (getter) EdgeTable_get_max_rows_increment, NULL,
@@ -3383,7 +3460,8 @@ static PyGetSetDef EdgeTable_getsetters[] = {
     {"metadata", (getter) EdgeTable_get_metadata, NULL, "The metadata array"},
     {"metadata_offset", (getter) EdgeTable_get_metadata_offset, NULL,
         "The metadata offset array"},
-
+    {"metadata_schema", (getter) EdgeTable_get_metadata_schema,
+        (setter) EdgeTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 
@@ -3823,6 +3901,44 @@ out:
     return ret;
 }
 
+static PyObject *
+MigrationTable_get_metadata_schema(MigrationTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (MigrationTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+out:
+    return ret;
+}
+
+static int
+MigrationTable_set_metadata_schema(MigrationTable *self, PyObject *arg, void *closure)
+{
+    int ret = -1;
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
+    if (MigrationTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_migration_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static PyGetSetDef MigrationTable_getsetters[] = {
     {"max_rows_increment",
         (getter) MigrationTable_get_max_rows_increment, NULL, "The size increment"},
@@ -3839,6 +3955,8 @@ static PyGetSetDef MigrationTable_getsetters[] = {
     {"metadata", (getter) MigrationTable_get_metadata, NULL, "The metadata array"},
     {"metadata_offset", (getter) MigrationTable_get_metadata_offset, NULL,
         "The metadata offset array"},
+    {"metadata_schema", (getter) MigrationTable_get_metadata_schema,
+        (setter) MigrationTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 
@@ -4239,6 +4357,44 @@ out:
     return ret;
 }
 
+static PyObject *
+SiteTable_get_metadata_schema(SiteTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (SiteTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+out:
+    return ret;
+}
+
+static int
+SiteTable_set_metadata_schema(SiteTable *self, PyObject *arg, void *closure)
+{
+    int ret = -1;
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
+    if (SiteTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_site_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static PyGetSetDef SiteTable_getsetters[] = {
     {"max_rows_increment",
         (getter) SiteTable_get_max_rows_increment, NULL,
@@ -4259,6 +4415,8 @@ static PyGetSetDef SiteTable_getsetters[] = {
         "The metadata array."},
     {"metadata_offset", (getter) SiteTable_get_metadata_offset, NULL,
         "The metadata offset array."},
+    {"metadata_schema", (getter) SiteTable_get_metadata_schema,
+        (setter) SiteTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 
@@ -4694,6 +4852,44 @@ out:
     return ret;
 }
 
+static PyObject *
+MutationTable_get_metadata_schema(MutationTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (MutationTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+out:
+    return ret;
+}
+
+static int
+MutationTable_set_metadata_schema(MutationTable *self, PyObject *arg, void *closure)
+{
+    int ret = -1;
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
+    if (MutationTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_mutation_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static PyGetSetDef MutationTable_getsetters[] = {
     {"max_rows_increment",
         (getter) MutationTable_get_max_rows_increment, NULL,
@@ -4715,6 +4911,8 @@ static PyGetSetDef MutationTable_getsetters[] = {
         "The metadata array"},
     {"metadata_offset", (getter) MutationTable_get_metadata_offset, NULL,
         "The metadata_offset array"},
+    {"metadata_schema", (getter) MutationTable_get_metadata_schema,
+        (setter) MutationTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 
@@ -5065,6 +5263,44 @@ out:
     return ret;
 }
 
+static PyObject *
+PopulationTable_get_metadata_schema(PopulationTable *self, void *closure)
+{
+    PyObject *ret = NULL;
+
+    if (PopulationTable_check_state(self) != 0) {
+        goto out;
+    }
+    ret = PyBytes_FromStringAndSize(self->table->metadata_schema, self->table->metadata_schema_length);
+out:
+    return ret;
+}
+
+static int
+PopulationTable_set_metadata_schema(PopulationTable *self, PyObject *arg, void *closure)
+{
+    int ret = -1;
+    char *metadata_schema = "";
+    Py_ssize_t metadata_schema_length = 0;
+    
+    if (PopulationTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (arg != Py_None) {
+        if (PyBytes_AsStringAndSize(arg, &metadata_schema, &metadata_schema_length) < 0) {
+            goto out;
+        }
+    }
+    ret = tsk_population_table_set_metadata_schema(self->table, metadata_schema, metadata_schema_length);
+    if (ret < 0) {
+        handle_library_error(ret);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 static PyGetSetDef PopulationTable_getsetters[] = {
     {"max_rows_increment",
         (getter) PopulationTable_get_max_rows_increment, NULL, "The size increment"},
@@ -5075,6 +5311,8 @@ static PyGetSetDef PopulationTable_getsetters[] = {
     {"metadata", (getter) PopulationTable_get_metadata, NULL, "The metadata array"},
     {"metadata_offset", (getter) PopulationTable_get_metadata_offset, NULL,
         "The metadata offset array"},
+    {"metadata_schema", (getter) PopulationTable_get_metadata_schema,
+        (setter) PopulationTable_set_metadata_schema, "The metadata schema"},
     {NULL}  /* Sentinel */
 };
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6588,17 +6588,25 @@ out:
 static PyObject *
 TreeSequence_get_metadata_schemas(TreeSequence *self) {
     PyObject *ret = NULL;
-
+    tsk_table_collection_t *tables = self->tree_sequence->tables;
     ret = PyStructSequence_New(&MetadataSchemas);
     if (ret == NULL) {
         goto out;
     }
-    PyStructSequence_SetItem(
-        ret, 
-        0, 
-        PyBytes_FromStringAndSize(
-            self->tree_sequence->tables->nodes.metadata_schema, 
-            self->tree_sequence->tables->nodes.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 0, PyBytes_FromStringAndSize(
+            tables->nodes.metadata_schema, tables->nodes.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 1, PyBytes_FromStringAndSize(
+            tables->edges.metadata_schema, tables->edges.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 2, PyBytes_FromStringAndSize(
+            tables->sites.metadata_schema, tables->sites.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 3, PyBytes_FromStringAndSize(
+            tables->mutations.metadata_schema, tables->mutations.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 4, PyBytes_FromStringAndSize(
+            tables->migrations.metadata_schema, tables->migrations.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 5, PyBytes_FromStringAndSize(
+            tables->individuals.metadata_schema, tables->individuals.metadata_schema_length));
+    PyStructSequence_SetItem(ret, 6, PyBytes_FromStringAndSize(
+            tables->populations.metadata_schema, tables->populations.metadata_schema_length));
 out:
     return ret;
 }
@@ -10564,6 +10572,12 @@ PyInit__tskit(void)
     /* Metadata schemas namedtuple type*/
     PyStructSequence_Field metadata_schemas_fields[] = {
         {"node", "The node metadata schema"},
+        {"edge", "The edge metadata schema"},
+        {"site", "The site metadata schema"},
+        {"mutation", "The mutation metadata schema"},
+        {"migration", "The migration metadata schema"},
+        {"individual", "The individual metadata schema"},
+        {"population", "The node metadata schema"},
         {NULL}
     };
     PyStructSequence_Desc metadata_schemas_desc = {

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -213,7 +213,10 @@ class PythonTreeSequence:
                 node=node,
                 derived_state=derived_state,
                 parent=parent,
-                metadata=metadata,
+                encoded_metadata=metadata,
+                metadata_decoder=tskit.metadata.MetadataSchema.from_bytes(
+                    ll_ts.get_metadata_schemas().mutation
+                ).decode_row,
             )
 
         for j in range(tree_sequence.num_sites):
@@ -224,7 +227,10 @@ class PythonTreeSequence:
                     position=pos,
                     ancestral_state=ancestral_state,
                     mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
-                    metadata=metadata,
+                    encoded_metadata=metadata,
+                    metadata_decoder=tskit.metadata.MetadataSchema.from_bytes(
+                        ll_ts.get_metadata_schemas().site
+                    ).decode_row,
                 )
             )
 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -214,7 +214,7 @@ class PythonTreeSequence:
                 derived_state=derived_state,
                 parent=parent,
                 encoded_metadata=metadata,
-                metadata_decoder=tskit.metadata.MetadataSchema.from_bytes(
+                metadata_decoder=tskit.metadata.MetadataSchema.from_str(
                     ll_ts.get_metadata_schemas().mutation
                 ).decode_row,
             )
@@ -228,7 +228,7 @@ class PythonTreeSequence:
                     ancestral_state=ancestral_state,
                     mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
                     encoded_metadata=metadata,
-                    metadata_decoder=tskit.metadata.MetadataSchema.from_bytes(
+                    metadata_decoder=tskit.metadata.MetadataSchema.from_str(
                         ll_ts.get_metadata_schemas().site
                     ).decode_row,
                 )

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1372,8 +1372,7 @@ class TestTreeSequenceMetadata(unittest.TestCase):
         # Each table should get its own schema back
         for table in self.metadata_tables:
             self.assertEqual(
-                getattr(ts.metadata_schemas, table).to_bytes(),
-                schemas[table].to_bytes(),
+                getattr(ts.metadata_schemas, table).to_str(), schemas[table].to_str(),
             )
 
     def test_metadata_round_trip_via_row_getters(self):

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1331,32 +1331,84 @@ class TestTreeSequence(HighLevelTestCase):
                         self.assertEqual(i, length - 1 - n.id)
                     self.assertEqual(n.id, 0)
 
+
+class TestTreeSequenceMetadata(unittest.TestCase):
+    metadata_tables = [
+        "node",
+        "edge",
+        "site",
+        "mutation",
+        "migration",
+        "individual",
+        "population",
+    ]
+    metadata_schema = tskit.metadata.MetadataSchema(
+        encoding="json",
+        schema={
+            "title": "Example Metadata",
+            "type": "object",
+            "properties": {
+                "table": {"type": "string"},
+                "string_prop": {"type": "string"},
+                "num_prop": {"type": "number"},
+            },
+            "required": ["table", "string_prop", "num_prop"],
+            "additionalProperties": False,
+        },
+    )
+
     def test_metadata_schemas(self):
         ts = msprime.simulate(5)
         tables = ts.dump_tables()
-        metadata_tables = [
-            "node",
-            "edge",
-            "site",
-            "mutation",
-            "migration",
-            "individual",
-            "population",
-        ]
         schemas = {
             table: tskit.metadata.MetadataSchema(
                 encoding="json", schema={"TEST": f"{table}-SCHEMA"}
             )
-            for table in metadata_tables
+            for table in self.metadata_tables
         }
-        for table in metadata_tables:
+        for table in self.metadata_tables:
             getattr(tables, f"{table}s").metadata_schema = schemas[table]
         ts = tskit.TreeSequence.load_tables(tables)
-        for table in metadata_tables:
+        # Each table should get its own schema back
+        for table in self.metadata_tables:
             self.assertEqual(
                 getattr(ts.metadata_schemas, table).to_bytes(),
                 schemas[table].to_bytes(),
             )
+
+    def test_metadata_round_trip_via_row_getters(self):
+        ts = msprime.simulate(8, random_seed=3, mutation_rate=1)
+        self.assertGreater(ts.num_sites, 2)
+        new_tables = ts.dump_tables()
+        tables_copy = ts.dump_tables()
+        for table in self.metadata_tables:
+            table_obj = getattr(new_tables, f"{table}s")
+            table_obj.metadata_schema = self.metadata_schema
+            table_obj.clear()
+            # Write back the rows, but adding unique metadata
+            for j, row in enumerate(getattr(tables_copy, f"{table}s")):
+                row_data = {k: v for k, v in zip(row._fields, row)}
+                row_data["metadata"] = {
+                    "table": table,
+                    "string_prop": f"Row number{j}",
+                    "num_prop": j,
+                }
+                table_obj.add_row(**row_data)
+        new_ts = new_tables.tree_sequence()
+        for table in self.metadata_tables:
+            self.assertEqual(
+                getattr(new_ts, f"num_{table}s"), getattr(ts, f"num_{table}s")
+            )
+        for table in self.metadata_tables:
+            for row in getattr(new_ts, f"{table}s")():
+                self.assertDictEqual(
+                    row.metadata,
+                    {
+                        "table": table,
+                        "string_prop": f"Row number{row.id}",
+                        "num_prop": row.id,
+                    },
+                )
 
 
 class TestPickle(HighLevelTestCase):
@@ -2464,30 +2516,98 @@ class SimpleContainersMixin:
         self.assertGreater(len(repr(c)), 0)
 
 
-class TestIndividualContainer(unittest.TestCase, SimpleContainersMixin):
-    def get_instances(self, n):
-        return [
-            tskit.Individual(id_=j, flags=j, location=[j], nodes=[j], metadata=b"x" * j)
-            for j in range(n)
-        ]
+class SimpleContainersWithMetadataMixin:
+    """
+    Tests for the SimpleContainerWithMetadata classes.
+    """
+
+    def test_metadata(self):
+        # Test decoding
+        instances = self.get_instances(5)
+        for j, inst in enumerate(instances):
+            self.assertEqual(inst.metadata, ("x" * j) + "decoded")
+
+        # Decoder doesn't effect equality
+        (inst,) = self.get_instances(1)
+        (inst2,) = self.get_instances(1)
+        self.assertTrue(inst == inst2)
+        inst._metadata_decoder = lambda m: "different decoder"
+        self.assertTrue(inst == inst2)
+
+    def test_decoder_run_once(self):
+        # For a given instance, the decoded metadata should be cached
+        (inst,) = self.get_instances(1)
+        times_run = 0
+
+        def decoder(m):
+            nonlocal times_run
+            times_run += 1
+            return m.decode() + "decoded"
+
+        inst._metadata_decoder = decoder
+        self.assertEqual(times_run, 0)
+        _ = inst.metadata
+        self.assertEqual(times_run, 1)
+        _ = inst.metadata
+        self.assertEqual(times_run, 1)
 
 
-class TestNodeContainer(unittest.TestCase, SimpleContainersMixin):
+class TestIndividualContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
     def get_instances(self, n):
         return [
-            tskit.Node(
-                id_=j, flags=j, time=j, population=j, individual=j, metadata=b"x" * j
+            tskit.Individual(
+                id_=j,
+                flags=j,
+                location=[j],
+                nodes=[j],
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
             )
             for j in range(n)
         ]
 
 
-class TestEdgeContainer(unittest.TestCase, SimpleContainersMixin):
+class TestNodeContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
     def get_instances(self, n):
-        return [tskit.Edge(left=j, right=j, parent=j, child=j, id_=j) for j in range(n)]
+        return [
+            tskit.Node(
+                id_=j,
+                flags=j,
+                time=j,
+                population=j,
+                individual=j,
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
+            )
+            for j in range(n)
+        ]
 
 
-class TestSiteContainer(unittest.TestCase, SimpleContainersMixin):
+class TestEdgeContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
+    def get_instances(self, n):
+        return [
+            tskit.Edge(
+                left=j,
+                right=j,
+                parent=j,
+                child=j,
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
+                id_=j,
+            )
+            for j in range(n)
+        ]
+
+
+class TestSiteContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
     def get_instances(self, n):
         return [
             tskit.Site(
@@ -2495,13 +2615,16 @@ class TestSiteContainer(unittest.TestCase, SimpleContainersMixin):
                 position=j,
                 ancestral_state="A" * j,
                 mutations=TestMutationContainer().get_instances(j),
-                metadata=b"x" * j,
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
             )
             for j in range(n)
         ]
 
 
-class TestMutationContainer(unittest.TestCase, SimpleContainersMixin):
+class TestMutationContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
     def get_instances(self, n):
         return [
             tskit.Mutation(
@@ -2510,23 +2633,44 @@ class TestMutationContainer(unittest.TestCase, SimpleContainersMixin):
                 node=j,
                 derived_state="A" * j,
                 parent=j,
-                metadata=b"x" * j,
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
             )
             for j in range(n)
         ]
 
 
-class TestMigrationContainer(unittest.TestCase, SimpleContainersMixin):
+class TestMigrationContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
     def get_instances(self, n):
         return [
-            tskit.Migration(left=j, right=j, node=j, source=j, dest=j, time=j)
+            tskit.Migration(
+                left=j,
+                right=j,
+                node=j,
+                source=j,
+                dest=j,
+                time=j,
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
+            )
             for j in range(n)
         ]
 
 
-class TestPopulationContainer(unittest.TestCase, SimpleContainersMixin):
+class TestPopulationContainer(
+    unittest.TestCase, SimpleContainersMixin, SimpleContainersWithMetadataMixin
+):
     def get_instances(self, n):
-        return [tskit.Population(id_=j, metadata="x" * j) for j in range(n)]
+        return [
+            tskit.Population(
+                id_=j,
+                encoded_metadata=b"x" * j,
+                metadata_decoder=lambda m: m.decode() + "decoded",
+            )
+            for j in range(n)
+        ]
 
 
 class TestProvenanceContainer(unittest.TestCase, SimpleContainersMixin):

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1331,6 +1331,17 @@ class TestTreeSequence(HighLevelTestCase):
                         self.assertEqual(i, length - 1 - n.id)
                     self.assertEqual(n.id, 0)
 
+    def test_metadata_schemas(self):
+        ts = msprime.simulate(5)
+        tables = ts.dump_tables()
+        schema = tskit.metadata.MetadataSchema(
+            encoding="json", schema={"TEST": "SCHEMA"}
+        )
+        tables.nodes.metadata_schema = schema
+        ts = tskit.TreeSequence.load_tables(tables)
+        # TODO - SHOULD RETURN SCHEMA CLASS FOR ALL TABLES
+        self.assertEqual(ts.metadata_schemas.node, schema.to_bytes())
+
 
 class TestPickle(HighLevelTestCase):
     """

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1334,13 +1334,29 @@ class TestTreeSequence(HighLevelTestCase):
     def test_metadata_schemas(self):
         ts = msprime.simulate(5)
         tables = ts.dump_tables()
-        schema = tskit.metadata.MetadataSchema(
-            encoding="json", schema={"TEST": "SCHEMA"}
-        )
-        tables.nodes.metadata_schema = schema
+        metadata_tables = [
+            "node",
+            "edge",
+            "site",
+            "mutation",
+            "migration",
+            "individual",
+            "population",
+        ]
+        schemas = {
+            table: tskit.metadata.MetadataSchema(
+                encoding="json", schema={"TEST": f"{table}-SCHEMA"}
+            )
+            for table in metadata_tables
+        }
+        for table in metadata_tables:
+            getattr(tables, f"{table}s").metadata_schema = schemas[table]
         ts = tskit.TreeSequence.load_tables(tables)
-        # TODO - SHOULD RETURN SCHEMA CLASS FOR ALL TABLES
-        self.assertEqual(ts.metadata_schemas.node, schema.to_bytes())
+        for table in metadata_tables:
+            self.assertEqual(
+                getattr(ts.metadata_schemas, table).to_bytes(),
+                schemas[table].to_bytes(),
+            )
 
 
 class TestPickle(HighLevelTestCase):

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -284,3 +284,20 @@ class TestLoadTextMetadata(unittest.TestCase):
         expected = ["mno", ")(*&^%$#@!"]
         for a, b in zip(expected, p):
             self.assertEqual(a.encode("utf8"), b.metadata)
+
+
+class TestMetadataSchema(unittest.TestCase):
+    def test_metadata_schema(self):
+        metadata_schema = {
+            "encoding": "json",
+            "schema": {
+                "title": "Example Metadata",
+                "type": "object",
+                "properties": {"one": {"type": "string"}, "two": {"type": "number"}},
+                "required": ["one", "two"],
+            },
+        }
+        data = {"one": "val one", "two": 5}
+        individuals = tskit.tables.IndividualTable(metadata_schema=metadata_schema)
+        individuals.add_row(metadata=json.dumps(data).encode())
+        self.assertDictEqual(individuals[0].metadata, data)

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -284,3 +284,9 @@ class TestLoadTextMetadata(unittest.TestCase):
         expected = ["mno", ")(*&^%$#@!"]
         for a, b in zip(expected, p):
             self.assertEqual(a.encode("utf8"), b.metadata)
+
+
+class TestMetadataSchema(unittest.TestCase):
+    """
+    Tests that use the MetadataSchema Class
+    """

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -284,20 +284,3 @@ class TestLoadTextMetadata(unittest.TestCase):
         expected = ["mno", ")(*&^%$#@!"]
         for a, b in zip(expected, p):
             self.assertEqual(a.encode("utf8"), b.metadata)
-
-
-class TestMetadataSchema(unittest.TestCase):
-    def test_metadata_schema(self):
-        metadata_schema = {
-            "encoding": "json",
-            "schema": {
-                "title": "Example Metadata",
-                "type": "object",
-                "properties": {"one": {"type": "string"}, "two": {"type": "number"}},
-                "required": ["one", "two"],
-            },
-        }
-        data = {"one": "val one", "two": 5}
-        individuals = tskit.tables.IndividualTable(metadata_schema=metadata_schema)
-        individuals.add_row(metadata=json.dumps(data).encode())
-        self.assertDictEqual(individuals[0].metadata, data)

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -705,8 +705,11 @@ class MetadataTestsMixin:
             metadata, metadata_offset = tskit.pack_bytes(
                 [json.dumps(row).encode() for row in input_data["metadata"]]
             )
-            self.assertTrue(np.array_equal(table.metadata, metadata))
-            self.assertTrue(np.array_equal(table.metadata_offset, metadata_offset))
+            self.assertTrue(np.array_equal(table.ll_table.metadata, metadata))
+            self.assertTrue(
+                np.array_equal(table.ll_table.metadata_offset, metadata_offset)
+            )
+            self.assertEqual(table.metadata, input_data["metadata"])
 
     def test_row_round_trip_metadata_schema(self):
         metadata_schema = {

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -702,12 +702,14 @@ class MetadataTestsMixin:
 
     def test_default_metadata_schema(self):
         table = self.table_class()
+        # Default is no-op metadata codec
         self.assertEqual(
             table.metadata_schema.to_bytes(), metadata.NullMetadataSchema().to_bytes()
         )
         table.add_row(
             **{**self.input_data_for_add_row(), "metadata": b"acceptable bytes"}
         )
+        # Adding non-bytes metadata should error
         with self.assertRaises(TypeError):
             table.add_row(
                 **{
@@ -721,6 +723,8 @@ class MetadataTestsMixin:
         table.ll_table.metadata_schema = b"I'm not JSON"
         with self.assertRaises(ValueError):
             table._update_metadata_schema_cache_from_ll()
+        with self.assertRaises(AttributeError):
+            table.metadata_schema = b"I'm not JSON"
         with self.assertRaises(TypeError):
             table.ll_table.metadata_schema = "Normal string"
 

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -70,11 +70,6 @@ class DoubleColumn(Column):
         return 4 + np.arange(n, dtype=np.float64)
 
 
-class DoubleArrayColumn(Column):
-    def get_input(self, n):
-        return (4 + np.arange(n, dtype=np.float64)).reshape(n, 1)
-
-
 class CommonTestsMixin:
     """
     Abstract base class for common table tests. Because of the design of unittest,

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -32,13 +32,13 @@ import random
 import unittest
 import warnings
 
-import jsonschema
 import msprime
 import numpy as np
 
 import _tskit
 import tests.tsutil as tsutil
 import tskit
+import tskit.exceptions as exceptions
 
 
 class Column:
@@ -753,7 +753,7 @@ class MetadataTestsMixin:
             kwargs[col] = "x"
         for col in self.binary_colnames:
             kwargs[col] = b"x"
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
+        with self.assertRaises(exceptions.MetadataValidationError):
             table.add_row(**{**kwargs, "metadata": data})
         self.assertEqual(len(table), 0)
 

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -724,18 +724,6 @@ class MetadataTestsMixin:
         with self.assertRaises(AttributeError):
             table.metadata_schema = "I'm not JSON"
 
-    def test_ll_metadata_schema(self):
-        table = self.table_class()
-        ll_table = table.ll_table
-        self.assertEqual(ll_table.metadata_schema, "")
-        example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋"
-        ll_table.metadata_schema = example
-        self.assertEqual(ll_table.metadata_schema, example)
-        del ll_table.metadata_schema
-        self.assertEqual(ll_table.metadata_schema, "")
-        with self.assertRaises(TypeError):
-            table.ll_table.metadata_schema = None
-
     def test_row_round_trip_metadata_schema(self):
         data = self.metadata_example_data()
         table = self.table_class()

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -736,15 +736,17 @@ class MetadataTestsMixin:
         data["I really shouldn't be here"] = 6
         table = self.table_class()
         table.metadata_schema = self.metadata_schema
-        input_data = {col.name: col.get_input(1) for col in self.columns}
-        kwargs = {col: data[0] for col, data in input_data.items()}
-        for col in self.string_colnames:
-            kwargs[col] = "x"
-        for col in self.binary_colnames:
-            kwargs[col] = b"x"
         with self.assertRaises(exceptions.MetadataValidationError):
-            table.add_row(**{**kwargs, "metadata": data})
+            table.add_row(**{**self.input_data_for_add_row(), "metadata": data})
         self.assertEqual(len(table), 0)
+
+    def test_absent_metadata_with_required_schema(self):
+        table = self.table_class()
+        table.metadata_schema = self.metadata_schema
+        input_data = self.input_data_for_add_row()
+        del input_data["metadata"]
+        with self.assertRaises(exceptions.MetadataValidationError):
+            table.add_row(**{**input_data})
 
 
 class TestIndividualTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -26,6 +26,7 @@ between simulations and the tree sequence.
 """
 import io
 import itertools
+import json
 import pickle
 import random
 import unittest
@@ -69,11 +70,24 @@ class DoubleColumn(Column):
         return 4 + np.arange(n, dtype=np.float64)
 
 
+class DoubleArrayColumn(Column):
+    def get_input(self, n):
+        return (4 + np.arange(n, dtype=np.float64)).reshape(n, 1)
+
+
 class CommonTestsMixin:
     """
     Abstract base class for common table tests. Because of the design of unittest,
     we have to make this a mixin.
     """
+
+    def make_input_data(self, num_rows):
+        input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+        for list_col, offset_col in self.ragged_list_columns:
+            value = list_col.get_input(num_rows)
+            input_data[list_col.name] = value
+            input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+        return input_data
 
     def test_max_rows_increment(self):
         for bad_value in [-1, -(2 ** 10)]:
@@ -147,11 +161,7 @@ class CommonTestsMixin:
             self.assertRaises(TypeError, table.set_columns, **kwargs)
 
     def test_set_columns_interface(self):
-        kwargs = {c.name: c.get_input(1) for c in self.columns}
-        for list_col, offset_col in self.ragged_list_columns:
-            value = list_col.get_input(1)
-            kwargs[list_col.name] = value
-            kwargs[offset_col.name] = [0, 1]
+        kwargs = self.make_input_data(1)
         # Make sure this works.
         table = self.table_class()
         table.set_columns(**kwargs)
@@ -170,11 +180,7 @@ class CommonTestsMixin:
                 self.assertRaises(ValueError, table.append_columns, **error_kwargs)
 
     def test_set_columns_from_dict(self):
-        kwargs = {c.name: c.get_input(1) for c in self.columns}
-        for list_col, offset_col in self.ragged_list_columns:
-            value = list_col.get_input(1)
-            kwargs[list_col.name] = value
-            kwargs[offset_col.name] = [0, 1]
+        kwargs = self.make_input_data(1)
         # Make sure this works.
         t1 = self.table_class()
         t1.set_columns(**kwargs)
@@ -183,11 +189,7 @@ class CommonTestsMixin:
         self.assertEqual(t1, t2)
 
     def test_set_columns_dimension(self):
-        kwargs = {c.name: c.get_input(1) for c in self.columns}
-        for list_col, offset_col in self.ragged_list_columns:
-            value = list_col.get_input(1)
-            kwargs[list_col.name] = value
-            kwargs[offset_col.name] = [0, 1]
+        kwargs = self.make_input_data(1)
         table = self.table_class()
         table.set_columns(**kwargs)
         table.append_columns(**kwargs)
@@ -198,8 +200,7 @@ class CommonTestsMixin:
                 error_kwargs[focal_col.name] = bad_dims
                 self.assertRaises(ValueError, table.set_columns, **error_kwargs)
                 self.assertRaises(ValueError, table.append_columns, **error_kwargs)
-        for list_col, offset_col in self.ragged_list_columns:
-            value = list_col.get_input(1)
+        for _, offset_col in self.ragged_list_columns:
             error_kwargs = dict(kwargs)
             for bad_dims in [5, [[1], [1]], np.zeros((2, 2))]:
                 error_kwargs[offset_col.name] = bad_dims
@@ -210,13 +211,9 @@ class CommonTestsMixin:
             self.assertRaises(ValueError, table.set_columns, **error_kwargs)
 
     def test_set_columns_input_sizes(self):
-        num_rows = 100
-        input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+        input_data = self.make_input_data(100)
         col_map = {col.name: col for col in self.columns}
         for list_col, offset_col in self.ragged_list_columns:
-            value = list_col.get_input(num_rows)
-            input_data[list_col.name] = value
-            input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
             col_map[list_col.name] = list_col
             col_map[offset_col.name] = offset_col
         table = self.table_class()
@@ -252,11 +249,7 @@ class CommonTestsMixin:
     def test_set_column_attributes_data(self):
         table = self.table_class()
         for num_rows in [1, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table.set_columns(**input_data)
 
             for list_col, offset_col in self.ragged_list_columns:
@@ -296,11 +289,7 @@ class CommonTestsMixin:
     def test_set_column_attributes_errors(self):
         table = self.table_class()
         num_rows = 10
-        input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-        for list_col, offset_col in self.ragged_list_columns:
-            value = list_col.get_input(num_rows)
-            input_data[list_col.name] = value
-            input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+        input_data = self.make_input_data(num_rows)
         table.set_columns(**input_data)
 
         for list_col, offset_col in self.ragged_list_columns:
@@ -356,11 +345,7 @@ class CommonTestsMixin:
 
     def test_add_row_round_trip(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             t1 = self.table_class()
             t1.set_columns(**input_data)
             for colname, input_array in input_data.items():
@@ -450,12 +435,9 @@ class CommonTestsMixin:
 
     def test_append_columns_data(self):
         for num_rows in [0, 10, 100, 1000]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            input_data = self.make_input_data(num_rows)
             offset_cols = set()
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            for _, offset_col in self.ragged_list_columns:
                 offset_cols.add(offset_col.name)
             table = self.table_class()
             for j in range(1, 10):
@@ -478,11 +460,7 @@ class CommonTestsMixin:
 
     def test_append_columns_max_rows(self):
         for num_rows in [0, 10, 100, 1000]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             for max_rows in [0, 1, 8192]:
                 table = self.table_class(max_rows_increment=max_rows)
                 for j in range(1, 10):
@@ -493,11 +471,7 @@ class CommonTestsMixin:
 
     def test_str(self):
         for num_rows in [0, 10]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             table.set_columns(**input_data)
             s = str(table)
@@ -517,11 +491,7 @@ class CommonTestsMixin:
 
     def test_copy(self):
         for num_rows in [0, 10]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             table.set_columns(**input_data)
             for _ in range(10):
@@ -533,11 +503,7 @@ class CommonTestsMixin:
 
     def test_pickle(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             table.set_columns(**input_data)
             pkl = pickle.dumps(table)
@@ -550,11 +516,7 @@ class CommonTestsMixin:
 
     def test_equality(self):
         for num_rows in [1, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             t1 = self.table_class()
             t2 = self.table_class()
             self.assertEqual(t1, t1)
@@ -605,11 +567,7 @@ class CommonTestsMixin:
 
     def test_bad_offsets(self):
         for num_rows in [10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             t = self.table_class()
             t.set_columns(**input_data)
 
@@ -646,11 +604,7 @@ class MetadataTestsMixin:
 
     def test_random_metadata(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             metadatas = [tsutil.random_bytes(10) for _ in range(num_rows)]
             metadata, metadata_offset = tskit.pack_bytes(metadatas)
@@ -664,11 +618,7 @@ class MetadataTestsMixin:
 
     def test_optional_metadata(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             del input_data["metadata"]
             del input_data["metadata_offset"]
@@ -688,11 +638,7 @@ class MetadataTestsMixin:
 
     def test_packset_metadata(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             table.set_columns(**input_data)
             metadatas = [tsutil.random_bytes(10) for _ in range(num_rows)]
@@ -701,9 +647,30 @@ class MetadataTestsMixin:
             self.assertTrue(np.array_equal(table.metadata, metadata))
             self.assertTrue(np.array_equal(table.metadata_offset, metadata_offset))
 
+    def test_metadata_schema(self):
+        metadata_schema = {
+            "encoding": "json",
+            "schema": {
+                "title": "Example Metadata",
+                "type": "object",
+                "properties": {"one": {"type": "string"}, "two": {"type": "number"}},
+                "required": ["one", "two"],
+            },
+        }
+        data = {"one": "val one", "two": 5}
+        table = self.table_class()
+        table.metadata_schema = metadata_schema
+        input_data = {col.name: col.get_input(1) for col in self.columns}
+        kwargs = {col: data[0] for col, data in input_data.items()}
+        for col in self.string_colnames:
+            kwargs[col] = "x"
+        for col in self.binary_colnames:
+            kwargs[col] = b"x"
+        table.add_row(**{**kwargs, "metadata": json.dumps(data).encode()})
+        self.assertDictEqual(table[0].metadata, data)
+
 
 class TestIndividualTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
-
     columns = [UInt32Column("flags")]
     ragged_list_columns = [
         (DoubleColumn("location"), UInt32Column("location_offset")),
@@ -928,11 +895,7 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
 
     def test_packset_ancestral_state(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             table.set_columns(**input_data)
             ancestral_states = [tsutil.random_strings(10) for _ in range(num_rows)]
@@ -988,11 +951,7 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin)
 
     def test_packset_derived_state(self):
         for num_rows in [0, 10, 100]:
-            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
-            for list_col, offset_col in self.ragged_list_columns:
-                value = list_col.get_input(num_rows)
-                input_data[list_col.name] = value
-                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            input_data = self.make_input_data(num_rows)
             table = self.table_class()
             table.set_columns(**input_data)
             derived_states = [tsutil.random_strings(10) for _ in range(num_rows)]

--- a/python/tskit/exceptions.py
+++ b/python/tskit/exceptions.py
@@ -55,5 +55,11 @@ class DuplicatePositionsError(TskitException):
 
 class ProvenanceValidationError(TskitException):
     """
-    A JSON document did non validate against the provenance schema.
+    A JSON document did not validate against the provenance schema.
+    """
+
+
+class MetadataValidationError(TskitException):
+    """
+    A metadata object did not validate against the provenance schema.
     """

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -33,26 +33,22 @@ import tskit.exceptions as exceptions
 
 
 class MetadataCodec(abc.ABC):
-    @classmethod
     @abc.abstractmethod
-    def decode(cls, encoded_bytes: bytes) -> Any:
+    def decode(self, encoded_bytes: bytes) -> Any:
         pass
 
-    @classmethod
     @abc.abstractmethod
-    def encode(cls, obj: Any) -> bytes:
+    def encode(self, obj: Any) -> bytes:
         pass
 
 
 class JSONCodec(MetadataCodec):
     name = "json"
 
-    @classmethod
-    def decode(cls, encoded_bytes: bytes) -> Any:
+    def decode(self, encoded_bytes: bytes) -> Any:
         return json.loads(encoded_bytes.decode())
 
-    @classmethod
-    def encode(cls, obj: Any) -> bytes:
+    def encode(self, obj: Any) -> bytes:
         return json.dumps(obj).encode()
 
 

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -1,7 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2019 Tskit Developers
-# Copyright (c) 2017 University of Oxford
+# Copyright (c) 2020 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -1,0 +1,119 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Tskit Developers
+# Copyright (c) 2017 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Classes for metadata decoding, encoding and validation
+"""
+import abc
+import json
+from typing import Any
+
+import jsonschema
+
+import tskit.exceptions as exceptions
+
+
+class MetadataCodec(abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    def decode(cls, encoded_bytes: bytes) -> Any:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def encode(cls, obj: Any) -> bytes:
+        pass
+
+
+class JSONCodec(MetadataCodec):
+    name = "json"
+
+    @classmethod
+    def decode(cls, encoded_bytes: bytes) -> Any:
+        return json.loads(encoded_bytes.decode())
+
+    @classmethod
+    def encode(cls, obj: Any) -> bytes:
+        return json.dumps(obj).encode()
+
+
+class AbstractMetadataSchema(abc.ABC):
+    @abc.abstractmethod
+    def to_bytes(self) -> bytes:
+        pass
+
+    @abc.abstractmethod
+    def validate_and_encode_row(self, row: Any) -> bytes:
+        pass
+
+    @abc.abstractmethod
+    def decode_row(self, row: bytes) -> Any:
+        pass
+
+
+class MetadataSchema(AbstractMetadataSchema):
+    @classmethod
+    def from_bytes(cls, encoded_schema: bytes) -> AbstractMetadataSchema:
+        if encoded_schema == b"":
+            return NullMetadataSchema()
+        else:
+            try:
+                decoded = json.loads(encoded_schema.decode())
+            except json.decoder.JSONDecodeError:
+                raise ValueError(f"Metadata schema is not JSON, found {encoded_schema}")
+            return cls(decoded["encoding"], decoded["schema"])
+
+    def __init__(self, encoding, schema) -> None:
+        self.encoding: str = encoding
+        self.schema: str = schema
+
+    def _get_codec(self) -> MetadataCodec:
+        try:
+            return {codec().name: codec() for codec in MetadataCodec.__subclasses__()}[
+                self.encoding
+            ]
+        except KeyError:
+            ValueError(f"Unrecognised metadata encoding:{self.encoding}")
+
+    def to_bytes(self) -> bytes:
+        return json.dumps({"encoding": self.encoding, "schema": self.schema}).encode()
+
+    def validate_and_encode_row(self, row: Any) -> bytes:
+        try:
+            jsonschema.validate(row, self.schema)
+        except jsonschema.exceptions.ValidationError as ve:
+            raise exceptions.MetadataValidationError from ve
+        return self._get_codec().encode(row)
+
+    def decode_row(self, row: bytes) -> Any:
+        return self._get_codec().decode(row)
+
+
+class NullMetadataSchema(AbstractMetadataSchema):
+    def to_bytes(self) -> bytes:
+        return b""
+
+    def validate_and_encode_row(self, row: bytes) -> bytes:
+        return row
+
+    def decode_row(self, row: bytes) -> bytes:
+        return row

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -92,7 +92,7 @@ class MetadataSchema(AbstractMetadataSchema):
                 self.encoding
             ]
         except KeyError:
-            ValueError(f"Unrecognised metadata encoding:{self.encoding}")
+            raise ValueError(f"Unrecognised metadata encoding:{self.encoding}")
 
     def to_bytes(self) -> bytes:
         return json.dumps({"encoding": self.encoding, "schema": self.schema}).encode()

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -29,8 +29,8 @@ import datetime
 import json
 import warnings
 
+import jsonschema
 import numpy as np
-from jsonschema import validate
 
 import _tskit
 import tskit
@@ -296,7 +296,7 @@ class MetadataMixin:
         if self.metadata_schema is None:
             return metadata
         else:
-            validate(metadata, self.metadata_schema["schema"])
+            jsonschema.validate(metadata, self.metadata_schema["schema"])
             return json.dumps(metadata).encode()
 
     def validate_and_encode_metadata_column(self, metadata, metadata_offset):
@@ -304,7 +304,7 @@ class MetadataMixin:
             return metadata, metadata_offset
         else:
             for row in metadata:
-                validate(row, self.metadata_schema["schema"])
+                jsonschema.validate(row, self.metadata_schema["schema"])
             metadata, metadata_offset = util.pack_bytes(
                 [json.dumps(row).encode() for row in metadata]
             )

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -275,7 +275,7 @@ class MetadataMixin:
                 return json.loads(self.ll_table.metadata_schema)
             except json.decoder.JSONDecodeError:
                 raise ValueError(
-                    f"Metadata schema is not JSON, found{self.ll_table.metadata_schema}"
+                    f"Metadata schema is not JSON, found {self.ll_table.metadata_schema}"
                 )
         else:
             return None
@@ -289,7 +289,7 @@ class MetadataMixin:
 
     @metadata_schema.deleter
     def metadata_schema(self):
-        self.ll_table.metadata_schema = b""
+        self.ll_table.metadata_schema = None
 
     def parse_row(self, row):
         if self.metadata_schema is None:

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -278,7 +278,7 @@ class MetadataMixin:
 
     @metadata_schema.setter
     def metadata_schema(self, schema: metadata.MetadataSchema) -> None:
-        self.ll_table.metadata_schema = schema.to_bytes()
+        self.ll_table.metadata_schema = schema.to_str()
         self._update_metadata_schema_cache_from_ll()
 
     @metadata_schema.deleter
@@ -294,7 +294,7 @@ class MetadataMixin:
         )
 
     def _update_metadata_schema_cache_from_ll(self) -> None:
-        self._metadata_schema_cache = metadata.MetadataSchema.from_bytes(
+        self._metadata_schema_cache = metadata.MetadataSchema.from_str(
             self.ll_table.metadata_schema
         )
 

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -314,7 +314,7 @@ class MetadataMixin:
             for row in metadata:
                 jsonschema.validate(row, self.metadata_schema["schema"])
         except jsonschema.exceptions.ValidationError as ve:
-            raise exceptions.ProvenanceValidationError from ve
+            raise exceptions.MetadataValidationError from ve
         metadata, metadata_offset = util.pack_bytes(
             [self._metadata_encoder(row) for row in metadata]
         )

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -251,12 +251,7 @@ class MetadataMixin:
     Mixin class for tables that have a metadata column.
     """
 
-    def __init__(self, metadata_schema=None):
-        try:
-            self.metadata_schema = metadata_schema
-        except AttributeError:
-            # REMOVEME: This is only here as I haven't implemented for all tables!
-            pass
+    def __init__(self):
         self.metadata_column_index = self.row_class._fields.index("metadata")
 
     def packset_metadata(self, metadatas):
@@ -288,13 +283,13 @@ class MetadataMixin:
     @metadata_schema.setter
     def metadata_schema(self, metadata_schema):
         if metadata_schema is not None:
-            self.ll_table.metadata_schema = json.dumps(metadata_schema)
+            self.ll_table.metadata_schema = json.dumps(metadata_schema).encode()
         else:
             del self.metadata_schema
 
     @metadata_schema.deleter
     def metadata_schema(self):
-        self.ll_table.metadata_schema = ""
+        self.ll_table.metadata_schema = b""
 
     def parse_row(self, row):
         if self.metadata_schema is None:
@@ -350,10 +345,10 @@ class IndividualTable(BaseTable, MetadataMixin):
         "metadata_offset",
     ]
 
-    def __init__(self, max_rows_increment=0, ll_table=None, metadata_schema=None):
+    def __init__(self, max_rows_increment=0, ll_table=None):
         if ll_table is None:
             ll_table = _tskit.IndividualTable(max_rows_increment=max_rows_increment)
-        super().__init__(ll_table, IndividualTableRow, metadata_schema=metadata_schema)
+        super().__init__(ll_table, IndividualTableRow)
 
     def _text_header_and_rows(self):
         flags = self.flags

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -283,7 +283,7 @@ class MetadataMixin:
 
     @metadata_schema.deleter
     def metadata_schema(self) -> None:
-        self.ll_table.metadata_schema = b""
+        del self.ll_table.metadata_schema
         self._update_metadata_schema_cache_from_ll()
 
     def decode_row(self, row: Tuple[Any]) -> Tuple:

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -299,6 +299,17 @@ class MetadataMixin:
             validate(metadata, self.metadata_schema["schema"])
             return json.dumps(metadata).encode()
 
+    def validate_and_encode_metadata_column(self, metadata, metadata_offset):
+        if self.metadata_schema is None:
+            return metadata, metadata_offset
+        else:
+            for row in metadata:
+                validate(row, self.metadata_schema["schema"])
+            metadata, metadata_offset = util.pack_bytes(
+                [json.dumps(row).encode() for row in metadata]
+            )
+            return metadata, metadata_offset
+
     def parse_row(self, row):
         if self.metadata_schema is None:
             return row
@@ -424,6 +435,9 @@ class IndividualTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags)
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(
                 flags=flags,
@@ -470,6 +484,9 @@ class IndividualTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags)
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(
                 flags=flags,
@@ -613,6 +630,9 @@ class NodeTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags, time=time)
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(
                 flags=flags,
@@ -661,6 +681,9 @@ class NodeTable(BaseTable, MetadataMixin):
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
         self._check_required_args(flags=flags, time=time)
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(
                 flags=flags,
@@ -790,6 +813,9 @@ class EdgeTable(BaseTable, MetadataMixin):
 
         """
         self._check_required_args(left=left, right=right, parent=parent, child=child)
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(
                 left=left,
@@ -831,6 +857,9 @@ class EdgeTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(
                 left=left,
@@ -992,6 +1021,9 @@ class MigrationTable(BaseTable, MetadataMixin):
         self._check_required_args(
             left=left, right=right, node=node, source=source, dest=dest, time=time
         )
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(
                 left=left,
@@ -1046,6 +1078,9 @@ class MigrationTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(
                 left=left,
@@ -1178,6 +1213,9 @@ class SiteTable(BaseTable, MetadataMixin):
             ancestral_state=ancestral_state,
             ancestral_state_offset=ancestral_state_offset,
         )
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(
                 position=position,
@@ -1226,6 +1264,9 @@ class SiteTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(
                 position=position,
@@ -1389,6 +1430,9 @@ class MutationTable(BaseTable, MetadataMixin):
             derived_state=derived_state,
             derived_state_offset=derived_state_offset,
         )
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(
                 site=site,
@@ -1446,6 +1490,9 @@ class MutationTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(
                 site=site,
@@ -1544,6 +1591,9 @@ class PopulationTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.set_columns(
             dict(metadata=metadata, metadata_offset=metadata_offset)
         )
@@ -1565,6 +1615,9 @@ class PopulationTable(BaseTable, MetadataMixin):
         :param metadata_offset: The offsets into the ``metadata`` array.
         :type metadata_offset: numpy.ndarray, dtype=np.uint32.
         """
+        metadata, metadata_offset = self.validate_and_encode_metadata_column(
+            metadata, metadata_offset
+        )
         self.ll_table.append_columns(
             dict(metadata=metadata, metadata_offset=metadata_offset)
         )

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2620,6 +2620,10 @@ class TreeSequence:
         return self._ll_tree_sequence.get_num_samples()
 
     @property
+    def metadata_schemas(self):
+        return self._ll_tree_sequence.get_metadata_schemas()
+
+    @property
     def sample_size(self):
         # Deprecated alias for num_samples
         return self.num_samples

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2451,7 +2451,7 @@ class TreeSequence:
         ll_metadata_schemas = self._ll_tree_sequence.get_metadata_schemas()
         self._metadata_schemas = MetadataSchemas(
             *[
-                metadata.MetadataSchema.from_bytes(getattr(ll_metadata_schemas, name))
+                metadata.MetadataSchema.from_str(getattr(ll_metadata_schemas, name))
                 for name in MetadataSchemas._fields
             ]
         )

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -39,6 +39,7 @@ import _tskit
 import tskit.drawing as drawing
 import tskit.exceptions as exceptions
 import tskit.formats as formats
+import tskit.metadata as metadata
 import tskit.provenance as provenance
 import tskit.tables as tables
 import tskit.util as util
@@ -49,6 +50,11 @@ from tskit import NULL
 
 CoalescenceRecord = collections.namedtuple(
     "CoalescenceRecord", ["left", "right", "node", "children", "time", "population"]
+)
+
+MetadataSchemas = collections.namedtuple(
+    "MetadataSchemas",
+    ["node", "edge", "site", "mutation", "migration", "individual", "population"],
 )
 
 
@@ -2350,6 +2356,15 @@ class TreeSequence:
 
     def __init__(self, ll_tree_sequence):
         self._ll_tree_sequence = ll_tree_sequence
+        ll_metadata_schemas = self._ll_tree_sequence.get_metadata_schemas()
+        self._metadata_schemas = MetadataSchemas(
+            **{
+                name: metadata.MetadataSchema.from_bytes(
+                    getattr(ll_metadata_schemas, name)
+                )
+                for name in MetadataSchemas._fields
+            }
+        )
 
     # Implement the pickle protocol for TreeSequence
     def __getstate__(self):
@@ -2621,7 +2636,7 @@ class TreeSequence:
 
     @property
     def metadata_schemas(self):
-        return self._ll_tree_sequence.get_metadata_schemas()
+        return self._metadata_schemas
 
     @property
     def sample_size(self):


### PR DESCRIPTION
https://github.com/tskit-dev/tskit/issues/57

I've got far enough with this that I'd appreciate some feedback - on how I've modified the C code particularly. I've concentrated on the "consumer" end of things. I've only worked on the `IndividualTable` as a proof-of-concept. The added test illustrates the functionality:
```python
    def test_metadata_schema(self):
        metadata_schema = {
            "encoding": "json",
            "schema": {
                "title": "Example Metadata",
                "type": "object",
                "properties": {"one": {"type": "string"}, "two": {"type": "number"}},
                "required": ["one", "two"],
            },
        }
        data = {"one": "val one", "two": 5}
        individuals = tskit.tables.IndividualTable(metadata_schema=metadata_schema)
        individuals.add_row(metadata=json.dumps(data).encode())
        self.assertDictEqual(individuals[0].metadata, data)
```
This can be extended to other encodings such as `struct` and `msgpack`. The added row is not yet validated against the schema, but that's the plan. Could also support `individuals.add_row(metadata=data)` by encoding too.