### PR TITLE
[C API] Metadata schema field on tables

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -29,6 +29,9 @@ In development.
   but is backwards compatible.
   (:user:`benjeffery`, :pr:`505`)
 
+- The text dump of tables with metadata now includes the metadata schema as a header.
+  (:user:`benjeffery`, :pr:`493`)
+
 **New features**
 
 - Add the ``TSK_KEEP_UNARY`` option to simplify (:user:`gtsambos`). See :issue:`1`
@@ -41,6 +44,9 @@ In development.
 - Change the semantics of tsk_tree_t so that sample counts are always
   computed, and add a new ``TSK_NO_SAMPLE_COUNTS`` option to turn this
   off (:pr:`462`).
+
+- Tables with metadata now have an optional `metadata_schema` field that can contain
+  arbitary bytes. (:user:`benjeffery`, :pr:`493`)
 
 
 **Deprecated**

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -425,7 +425,7 @@ static void
 test_node_table(void)
 {
     int ret;
-    tsk_node_table_t table;
+    tsk_node_table_t table, table2;
     tsk_node_t node;
     uint32_t num_rows = 100;
     tsk_id_t j;
@@ -632,7 +632,36 @@ test_node_table(void)
     tsk_node_table_print_state(&table, _devnull);
     tsk_node_table_dump_text(&table, _devnull);
 
+    ret = tsk_node_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_node_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_node_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_node_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_node_table_equals(&table, &table2));
+    tsk_node_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_node_table_equals(&table, &table2));
+
+    tsk_node_table_clear(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(table.num_rows, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
+
     tsk_node_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    tsk_node_table_free(&table2);
+    CU_ASSERT_EQUAL(ret, 0);
     free(flags);
     free(population);
     free(time);
@@ -645,7 +674,7 @@ static void
 test_edge_table(void)
 {
     int ret;
-    tsk_edge_table_t table;
+    tsk_edge_table_t table, table2;
     tsk_size_t num_rows = 100;
     tsk_id_t j;
     tsk_edge_t edge;
@@ -827,10 +856,35 @@ test_edge_table(void)
     tsk_edge_table_print_state(&table, _devnull);
     tsk_edge_table_dump_text(&table, _devnull);
 
+    ret = tsk_edge_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_edge_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_edge_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_edge_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_edge_table_equals(&table, &table2));
+    tsk_edge_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_edge_table_equals(&table, &table2));
+
     tsk_edge_table_clear(&table);
     CU_ASSERT_EQUAL(table.num_rows, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
 
-    tsk_edge_table_free(&table);
+    ret = tsk_edge_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = tsk_edge_table_free(&table2);
+    CU_ASSERT_EQUAL(ret, 0);
     free(left);
     free(right);
     free(parent);
@@ -1023,7 +1077,7 @@ static void
 test_site_table(void)
 {
     int ret;
-    tsk_site_table_t table;
+    tsk_site_table_t table, table2;
     tsk_size_t num_rows, j;
     char *ancestral_state;
     char *metadata;
@@ -1216,6 +1270,27 @@ test_site_table(void)
         ancestral_state_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_OFFSET);
 
+    ret = tsk_site_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_site_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_site_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_site_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_site_table_equals(&table, &table2));
+    tsk_site_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_site_table_equals(&table, &table2));
+
     ret = tsk_site_table_clear(&table);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(table.num_rows, 0);
@@ -1223,6 +1298,10 @@ test_site_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     tsk_site_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    tsk_site_table_free(&table2);
+    CU_ASSERT_EQUAL(ret, 0);
+
     free(position);
     free(ancestral_state);
     free(ancestral_state_offset);
@@ -1234,7 +1313,7 @@ static void
 test_mutation_table(void)
 {
     int ret;
-    tsk_mutation_table_t table;
+    tsk_mutation_table_t table, table2;
     tsk_size_t num_rows = 100;
     tsk_size_t max_len = 20;
     tsk_size_t k, len;
@@ -1462,12 +1541,37 @@ test_mutation_table(void)
         derived_state, derived_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_OFFSET);
 
+    ret = tsk_mutation_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_mutation_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_mutation_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_mutation_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_mutation_table_equals(&table, &table2));
+    tsk_mutation_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_mutation_table_equals(&table, &table2));
+
     tsk_mutation_table_clear(&table);
+    CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.derived_state_length, 0);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     tsk_mutation_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    tsk_mutation_table_free(&table2);
+    CU_ASSERT_EQUAL(ret, 0);
     free(site);
     free(node);
     free(parent);
@@ -1481,7 +1585,7 @@ static void
 test_migration_table(void)
 {
     int ret;
-    tsk_migration_table_t table;
+    tsk_migration_table_t table, table2;
     tsk_size_t num_rows = 100;
     tsk_id_t j;
     tsk_id_t *node;
@@ -1695,10 +1799,37 @@ test_migration_table(void)
     tsk_migration_table_print_state(&table, _devnull);
     tsk_migration_table_dump_text(&table, _devnull);
 
+    ret = tsk_migration_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_migration_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_migration_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_migration_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_migration_table_equals(&table, &table2));
+    tsk_migration_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_migration_table_equals(&table, &table2));
+
     tsk_migration_table_clear(&table);
+    CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(table.num_rows, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     tsk_migration_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    tsk_migration_table_free(&table2);
+    CU_ASSERT_EQUAL(ret, 0);
+
     free(left);
     free(right);
     free(time);
@@ -1713,7 +1844,7 @@ static void
 test_individual_table(void)
 {
     int ret = 0;
-    tsk_individual_table_t table;
+    tsk_individual_table_t table, table2;
     /* tsk_table_collection_t tables, tables2; */
     tsk_size_t num_rows = 100;
     tsk_id_t j;
@@ -1939,7 +2070,35 @@ test_individual_table(void)
     tsk_individual_table_print_state(&table, _devnull);
     tsk_individual_table_dump_text(&table, _devnull);
 
+    ret = tsk_individual_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_individual_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_individual_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_individual_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_individual_table_equals(&table, &table2));
+    tsk_individual_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_individual_table_equals(&table, &table2));
+
+    tsk_individual_table_clear(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(table.num_rows, 0);
+    CU_ASSERT_EQUAL(table.metadata_length, 0);
+
     ret = tsk_individual_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = tsk_individual_table_free(&table2);
     CU_ASSERT_EQUAL(ret, 0);
     free(flags);
     free(location);
@@ -1952,7 +2111,7 @@ static void
 test_population_table(void)
 {
     int ret;
-    tsk_population_table_t table;
+    tsk_population_table_t table, table2;
     tsk_size_t num_rows = 100;
     tsk_size_t max_len = 20;
     tsk_size_t k, len;
@@ -2061,11 +2220,37 @@ test_population_table(void)
     ret = tsk_population_table_set_columns(&table, num_rows, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_OFFSET);
 
+    ret = tsk_population_table_truncate(&table, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema, NULL);
+    const char *example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example);
+    const char *example2 = "A different example 🎄🌳🌴🌲🎋";
+    tsk_size_t example2_length = (tsk_size_t) strlen(example);
+    tsk_population_table_set_metadata_schema(&table, example, example_length);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_schema, example, example_length), 0);
+
+    tsk_population_table_copy(&table, &table2, 0);
+    CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
+    CU_ASSERT_EQUAL(
+        memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
+    tsk_population_table_set_metadata_schema(&table2, example, example_length);
+    CU_ASSERT_TRUE(tsk_population_table_equals(&table, &table2));
+    tsk_population_table_set_metadata_schema(&table2, example2, example2_length);
+    CU_ASSERT_FALSE(tsk_population_table_equals(&table, &table2));
+
     tsk_population_table_clear(&table);
+    CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(table.num_rows, 0);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     tsk_population_table_free(&table);
+    CU_ASSERT_EQUAL(ret, 0);
+    tsk_population_table_free(&table2);
+    CU_ASSERT_EQUAL(ret, 0);
+
     free(metadata);
     free(metadata_offset);
 }
@@ -2719,6 +2904,41 @@ test_dump_load_unsorted(void)
 }
 
 static void
+test_dump_load_metadata_schema(void)
+{
+    int ret;
+    tsk_table_collection_t t1, t2;
+
+    ret = tsk_table_collection_init(&t1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    t1.sequence_length = 1.0;
+    char example[100] = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
+    tsk_size_t example_length = (tsk_size_t) strlen(example) + 4;
+    tsk_node_table_set_metadata_schema(
+        &t1.nodes, strcat(example, "node"), example_length);
+    tsk_edge_table_set_metadata_schema(
+        &t1.edges, strcat(example, "edge"), example_length);
+    tsk_site_table_set_metadata_schema(
+        &t1.sites, strcat(example, "site"), example_length);
+    tsk_mutation_table_set_metadata_schema(
+        &t1.mutations, strcat(example, "muta"), example_length);
+    tsk_migration_table_set_metadata_schema(
+        &t1.migrations, strcat(example, "migr"), example_length);
+    tsk_individual_table_set_metadata_schema(
+        &t1.individuals, strcat(example, "indi"), example_length);
+    tsk_population_table_set_metadata_schema(
+        &t1.populations, strcat(example, "popu"), example_length);
+    ret = tsk_table_collection_dump(&t1, _tmp_file_name, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_load(&t2, _tmp_file_name, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&t1, &t2));
+
+    tsk_table_collection_free(&t1);
+    tsk_table_collection_free(&t2);
+}
+
+static void
 test_dump_fail_no_file(void)
 {
     int ret;
@@ -2958,6 +3178,7 @@ main(int argc, char **argv)
         { "test_sort_tables_errors", test_sort_tables_errors },
         { "test_dump_load_empty", test_dump_load_empty },
         { "test_dump_load_unsorted", test_dump_load_unsorted },
+        { "test_dump_load_metadata_schema", test_dump_load_metadata_schema },
         { "test_dump_fail_no_file", test_dump_fail_no_file },
         { "test_load_reindex", test_load_reindex },
         { "test_table_overflow", test_table_overflow },

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -299,6 +299,7 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The flags column. */
     tsk_flags_t *flags;
     /** @brief The location column. */
@@ -309,6 +310,8 @@ typedef struct {
     char *metadata;
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_individual_table_t;
 
 /**
@@ -328,6 +331,7 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The flags column. */
     tsk_flags_t *flags;
     /** @brief The time column. */
@@ -340,6 +344,8 @@ typedef struct {
     char *metadata;
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_node_table_t;
 
 /**
@@ -359,6 +365,7 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The left column. */
     double *left;
     /** @brief The right column. */
@@ -372,6 +379,8 @@ typedef struct {
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
     bool metadata_malloced_locally;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_edge_table_t;
 
 /**
@@ -391,6 +400,7 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The source column. */
     tsk_id_t *source;
     /** @brief The dest column. */
@@ -408,6 +418,8 @@ typedef struct {
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
     bool metadata_malloced_locally;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_migration_table_t;
 
 /**
@@ -430,6 +442,7 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The position column. */
     double *position;
     /** @brief The ancestral_state column. */
@@ -440,6 +453,8 @@ typedef struct {
     char *metadata;
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_site_table_t;
 
 /**
@@ -462,6 +477,7 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The node column. */
     tsk_id_t *node;
     /** @brief The site column. */
@@ -476,6 +492,8 @@ typedef struct {
     char *metadata;
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_mutation_table_t;
 
 /**
@@ -495,10 +513,13 @@ typedef struct {
     tsk_size_t metadata_length;
     tsk_size_t max_metadata_length;
     tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
     /** @brief The metadata column. */
     char *metadata;
     /** @brief The metadata_offset column. */
     tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
 } tsk_population_table_t;
 
 /**
@@ -696,7 +717,8 @@ tsk_id_t tsk_individual_table_add_row(tsk_individual_table_t *self, tsk_flags_t 
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_individual_table_free` to free the table's internal resources.
+:c:func:`tsk_individual_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_individual_table_t object.
@@ -763,6 +785,21 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 */
 int tsk_individual_table_get_row(
     tsk_individual_table_t *self, tsk_id_t index, tsk_individual_t *row);
+
+/**
+@brief Set the metadata schema
+
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_set_metadata_schema(tsk_individual_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -853,7 +890,8 @@ tsk_id_t tsk_node_table_add_row(tsk_node_table_t *self, tsk_flags_t flags, doubl
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_node_table_free` to free the table's internal resources.
+:c:func:`tsk_node_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_node_table_t object.
@@ -916,6 +954,19 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_node_table_get_row(tsk_node_table_t *self, tsk_id_t index, tsk_node_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_node_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_set_metadata_schema(tsk_node_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1003,7 +1054,8 @@ tsk_id_t tsk_edge_table_add_row(tsk_edge_table_t *self, double left, double righ
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_edge_table_free` to free the table's internal resources.
+:c:func:`tsk_edge_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_edge_table_t object.
@@ -1066,6 +1118,19 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_edge_table_get_row(tsk_edge_table_t *self, tsk_id_t index, tsk_edge_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_edge_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_set_metadata_schema(tsk_edge_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1159,7 +1224,8 @@ tsk_id_t tsk_migration_table_add_row(tsk_migration_table_t *self, double left,
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_migration_table_free` to free the table's internal resources.
+:c:func:`tsk_migration_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_migration_table_t object.
@@ -1224,6 +1290,19 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 */
 int tsk_migration_table_get_row(
     tsk_migration_table_t *self, tsk_id_t index, tsk_migration_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_migration_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_set_metadata_schema(tsk_migration_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1312,7 +1391,8 @@ tsk_id_t tsk_site_table_add_row(tsk_site_table_t *self, double position,
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_site_table_free` to free the table's internal resources.
+:c:func:`tsk_site_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_site_table_t object.
@@ -1375,6 +1455,19 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_site_table_get_row(tsk_site_table_t *self, tsk_id_t index, tsk_site_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_site_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_set_metadata_schema(tsk_site_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1466,7 +1559,8 @@ tsk_id_t tsk_mutation_table_add_row(tsk_mutation_table_t *self, tsk_id_t site,
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_mutation_table_free` to free the table's internal resources.
+:c:func:`tsk_mutation_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_mutation_table_t object.
@@ -1530,6 +1624,19 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 */
 int tsk_mutation_table_get_row(
     tsk_mutation_table_t *self, tsk_id_t index, tsk_mutation_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_mutation_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_set_metadata_schema(tsk_mutation_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1623,7 +1730,8 @@ tsk_id_t tsk_population_table_add_row(
 
 @rst
 No memory is freed as a result of this operation; please use
-:c:func:`tsk_population_table_free` to free the table's internal resources.
+:c:func:`tsk_population_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
 @endrst
 
 @param self A pointer to a tsk_population_table_t object.
@@ -1688,6 +1796,19 @@ next operation that modifies the table (e.g., by adding a new row), but not afte
 */
 int tsk_population_table_get_row(
     tsk_population_table_t *self, tsk_id_t index, tsk_population_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_population_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_set_metadata_schema(tsk_population_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
 
 /**
 @brief Print out the state of this table to the specified stream.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -141,6 +141,8 @@ We will use the :meth:`Tree.kc_distance` method as an example.
     `c directory <https://github.com/tskit-dev/tskit/tree/master/c/tskit>`_.
     Your function will probably go in 
     `trees.c <https://github.com/tskit-dev/tskit/blob/master/c/tskit/trees.c>`_.
+    For C debugging you can force a debug build of the `_tskit module with
+    `CFLAGS='-Wall -O0 -g' make` in the `python` directory.
 5.  Write a few tests for your function in C: again, write your tests in  
     `tskit/c/tests/test_tree.c <https://github.com/tskit-dev/tskit/blob/master/c/tests/test_trees.c>`_.
     The key here is code coverage, you don't need to worry as much about covering every

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -30,9 +30,11 @@ Quickstart
   correct symlinks)
 - Install the Python development requirements using
   ``pip install -r python/requirements/development.txt``.
-- Build the low level module by running ``make`` in the ``python`` directory.
-- Run the tests to ensure everything has worked: ``python -m nose -vs``. These should
-  all pass.
+- Build the low level module by running ``make -C python``.
+- Run the tests to ensure everything has worked: ``python -m nose -vs python``. These
+  should
+  all pass. To speed things up you can use the ``--processes=8
+  --process-timeout=5000 options``, replacing 8 with the number of cores you have.
 - Install the pre-commit checks: ``pre-commit install``
 - Make your changes in a local branch. On each commit a `pre-commit hook
   <https://pre-commit.com/>`_  will run
@@ -45,10 +47,19 @@ Quickstart
   code. To run the checks without committing use ``pre-commit run``. To bypass
   the checks (to save or get feedback on work-in-progress) use ``git commit
   --no-verify``
-- If you have modified C code then run this to make it conform to the project style::
+- When modifying the C code this will conform it to the project style::
 
   $ sudo apt-get install clang-format
   $ clang-format -i c/tskit/* c/tests/*.c c/tests/*.h
+
+- The C API tests are prepared with::
+
+  $ sudo apt install meson libcunit1-dev ninja-build
+  $ meson build-gcc c
+
+  Then run with::
+
+  $ ninja -C build-gcc test
 
 - When ready open a pull request on GitHub. Please make sure that the tests pass before
   you open the PR, unless you want to ask the community for help with a failing test.

--- a/python/tests/test_file_format.py
+++ b/python/tests/test_file_format.py
@@ -482,6 +482,7 @@ class TestDumpFormat(TestFileFormat):
             "edges/left",
             "edges/metadata",
             "edges/metadata_offset",
+            "edges/metadata_schema",
             "edges/parent",
             "edges/right",
             "format/name",
@@ -493,10 +494,12 @@ class TestDumpFormat(TestFileFormat):
             "individuals/location_offset",
             "individuals/metadata",
             "individuals/metadata_offset",
+            "individuals/metadata_schema",
             "migrations/dest",
             "migrations/left",
             "migrations/metadata",
             "migrations/metadata_offset",
+            "migrations/metadata_schema",
             "migrations/node",
             "migrations/right",
             "migrations/source",
@@ -505,6 +508,7 @@ class TestDumpFormat(TestFileFormat):
             "mutations/derived_state_offset",
             "mutations/metadata",
             "mutations/metadata_offset",
+            "mutations/metadata_schema",
             "mutations/node",
             "mutations/parent",
             "mutations/site",
@@ -512,10 +516,12 @@ class TestDumpFormat(TestFileFormat):
             "nodes/individual",
             "nodes/metadata",
             "nodes/metadata_offset",
+            "nodes/metadata_schema",
             "nodes/population",
             "nodes/time",
             "populations/metadata",
             "populations/metadata_offset",
+            "populations/metadata_schema",
             "provenances/record",
             "provenances/record_offset",
             "provenances/timestamp",
@@ -525,6 +531,7 @@ class TestDumpFormat(TestFileFormat):
             "sites/ancestral_state_offset",
             "sites/metadata",
             "sites/metadata_offset",
+            "sites/metadata_schema",
             "sites/position",
             "uuid",
         ]
@@ -781,13 +788,16 @@ class TestFileFormatErrors(TestFileFormat):
         with kastore.load(self.temp_file) as store:
             all_data = dict(store)
         for key in all_data.keys():
-            data = dict(all_data)
-            del data[key]
-            kastore.dump(data, self.temp_file)
-            with self.assertRaises(
-                (exceptions.FileFormatError, exceptions.LibraryError)
-            ):
-                tskit.load(self.temp_file)
+            # We skip this key as it is optional
+            if "metadata_schema" not in key:
+                data = dict(all_data)
+                del data[key]
+                print(key)
+                kastore.dump(data, self.temp_file)
+                with self.assertRaises(
+                    (exceptions.FileFormatError, exceptions.LibraryError)
+                ):
+                    tskit.load(self.temp_file)
 
     def test_missing_fields(self):
         self.verify_fields(migration_example())


### PR DESCRIPTION
To split #491 up a bit I'm focusing on getting the C API right first. 
Proof-of-concept for the python is done in #491 meaning I'm pretty sure this is the (per-table) changes we want. Only `individuals` is modified for now. Once everyone is happy I'll do the other tables.
I intend to do top-level (per tree sequence) metadata in another PR.

- [x] Agree on pre-table changes
- [x] Individuals
- [x] Nodes
- [x] Edges (including adding metadata column (done in #496))
- [x] Sites
- [x] Mutations (including adding metadata column (done in #505)
- [x] Migrations
- [x] Populations
