### PR TITLE
Update kastore to 1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           command: |
             meson build-install c --prefix=/usr
             sudo ninja -C build-install install
-            clang c/examples/api_structure.c -o api_structure -ltskit
+            clang c/examples/api_structure.c -I c/subprojects/kastore -o api_structure -ltskit
             ./api_structure
 
       - run:

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2012,7 +2012,7 @@ class TestModuleFunctions(unittest.TestCase):
 
     def test_kastore_version(self):
         version = _tskit.get_kastore_version()
-        self.assertEqual(version, (1, 0, 0))
+        self.assertEqual(version, (1, 1, 0))
 
     def test_tskit_version(self):
         version = _tskit.get_tskit_version()


### PR DESCRIPTION
While figuring out the optional column storage for edge metadata I thought it would be nice to use `kastore_containss` so updated the submodule.