### PR TITLE
Add metadata column to the migrations table

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -20,8 +20,14 @@ In development.
   To keep the current behaviour, set this parameter to NULL.
 
 - Edges can now have metadata. Hence edge methods now take two extra arguments:
-  metadata and metadata length. The file format has also changed to accommodate this.
+  metadata and metadata length. The file format has also changed to accommodate this,
+  but is backwards compatible.
   (:user:`benjeffery`, :pr:`496`)
+
+- Migrations can now have metadata. Hence migration methods now take two extra arguments:
+  metadata and metadata length. The file format has also changed to accommodate this,
+  but is backwards compatible.
+  (:user:`benjeffery`, :pr:`505`)
 
 **New features**
 

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -2108,7 +2108,7 @@ test_simplest_bad_migrations(void)
     ret = tsk_population_table_add_row(&tables.populations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     /* One migration, node 0 goes from population 0 to 1. */
-    ret = tsk_migration_table_add_row(&tables.migrations, 0, 1, 0, 0, 1, 1.0);
+    ret = tsk_migration_table_add_row(&tables.migrations, 0, 1, 0, 0, 1, 1.0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* We only need basic intregity checks for migrations */
@@ -2226,7 +2226,7 @@ test_simplest_migration_simplify(void)
     ret = tsk_population_table_add_row(&tables.populations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     /* One migration, node 0 goes from population 0 to 1. */
-    ret = tsk_migration_table_add_row(&tables.migrations, 0, 1, 0, 0, 1, 1.0);
+    ret = tsk_migration_table_add_row(&tables.migrations, 0, 1, 0, 0, 1, 1.0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_table_collection_simplify(&tables, samples, 2, 0, NULL);

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -228,6 +228,11 @@ typedef struct {
     double right;
     /** @brief Time. */
     double time;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Size of the metadata in bytes. */
+    tsk_size_t metadata_length;
+
 } tsk_migration_t;
 
 /**
@@ -382,6 +387,10 @@ typedef struct {
     tsk_size_t num_rows;
     tsk_size_t max_rows;
     tsk_size_t max_rows_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
     /** @brief The source column. */
     tsk_id_t *source;
     /** @brief The dest column. */
@@ -394,6 +403,11 @@ typedef struct {
     double *right;
     /** @brief The time column. */
     double *time;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    bool metadata_malloced_locally;
 } tsk_migration_table_t;
 
 /**
@@ -1117,7 +1131,7 @@ int tsk_migration_table_free(tsk_migration_table_t *self);
 
 @rst
 Add a new migration with the specified ``left``, ``right``, ``node``,
-``source``, ``dest`` and ``time`` to the table.
+``source``, ``dest``, ``time`` and ``metadata`` to the table.
 See the :ref:`table definition <sec_migration_table_definition>`
 for details of the columns in this table.
 @endrst
@@ -1129,11 +1143,16 @@ for details of the columns in this table.
 @param source The source population ID for the new migration.
 @param dest The destination population ID for the new migration.
 @param time The time for the new migration.
+@param metadata The metadata to be associated with the new migration. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+
 @return Return the ID of the newly added migration on success,
     or a negative value on failure.
 */
 tsk_id_t tsk_migration_table_add_row(tsk_migration_table_t *self, double left,
-    double right, tsk_id_t node, tsk_id_t source, tsk_id_t dest, double time);
+    double right, tsk_id_t node, tsk_id_t source, tsk_id_t dest, double time,
+    const char *metadata, tsk_size_t metadata_length);
 
 /**
 @brief Clears this table, setting the number of rows to zero.
@@ -1225,12 +1244,14 @@ void tsk_migration_table_print_state(tsk_migration_table_t *self, FILE *out);
 int tsk_migration_table_init(tsk_migration_table_t *self, tsk_flags_t options);
 int tsk_migration_table_set_max_rows_increment(
     tsk_migration_table_t *self, tsk_size_t max_rows_increment);
+int tsk_migration_table_set_max_metadata_length_increment(
+    tsk_migration_table_t *self, tsk_size_t max_metadata_length_increment);
 int tsk_migration_table_set_columns(tsk_migration_table_t *self, tsk_size_t num_rows,
     double *left, double *right, tsk_id_t *node, tsk_id_t *source, tsk_id_t *dest,
-    double *time);
+    double *time, const char *metadata, tsk_size_t *metadata_length);
 int tsk_migration_table_append_columns(tsk_migration_table_t *self, tsk_size_t num_rows,
     double *left, double *right, tsk_id_t *node, tsk_id_t *source, tsk_id_t *dest,
-    double *time);
+    double *time, const char *metadata, tsk_size_t *metadata_length);
 int tsk_migration_table_dump_text(tsk_migration_table_t *self, FILE *out);
 
 /**

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -427,6 +427,7 @@ node                int32               Node ID.
 source              int32               Source population ID.
 dest                int32               Destination population ID.
 time                double              Time of migration event.
+metadata            binary              Migration :ref:`sec_metadata_definition`
 ================    ==============      ===========
 
 
@@ -436,6 +437,10 @@ record the IDs of the respective populations. The ``node`` column records the
 ID of the node that was associated with the ancestry segment in question
 at the time of the migration event. The ``time`` column is holds floating
 point values recording the time of the event.
+
+The ``metadata`` column provides a location for client code to store
+information about each migration. See the :ref:`sec_metadata_definition` section for
+more details on how metadata columns should be used.
 
 See the :ref:`sec_migration_requirements` section for details on the properties
 required for a valid set of mutations.
@@ -1145,7 +1150,7 @@ The mutation text format must contain the columns ``site``,
 ``node`` and ``derived_state``. The ``parent`` and ``metadata`` columns
 may also be optionally present (but ``parent`` must be specified if
 more than one mutation occurs at the same site). See the
-:ref:`mutation table definitions <sec_site_table_definition>`
+:ref:`mutation table definitions <sec_mutation_table_definition>`
 for details on these columns.
 
 mutations::
@@ -1154,6 +1159,24 @@ mutations::
     0      0       A                -1
     1      0       T                -1
     1      1       A                1
+
+
+.. _sec_migration_text_format:
+
+Migration text format
+=====================
+
+The migration text format must contain the columns ``left``,
+``right``, ``node``, ``source``, ``dest`` and ``time``. The ``metadata`` column
+may also be optionally present. See the
+:ref:`migration table definitions <sec_migration_table_definition>`
+for details on these columns.
+
+migrations::
+
+    left   right   node   source   dest   time
+    0.0    0.7     5      2        3      1.0
+    0.8    0.9     8      3        4      3.0
 
 
 .. _sec_population_text_format:

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,6 +6,9 @@ In development
 
 **New features**
 
+- Add a metadata column to the migrations table. Works similarly to existing
+  metadata columns on other tables(:user:`benjeffery`, :pr:`505`).
+
 - Add a metadata column to the edges table. Works similarly to existing
   metadata columns on other tables(:user:`benjeffery`, :pr:`496`).
 

--- a/python/tests/test_dict_encoding.py
+++ b/python/tests/test_dict_encoding.py
@@ -91,6 +91,17 @@ def get_example_tables():
             derived_state="G" * mutation.id,
             metadata=b"y" * mutation.id,
         )
+    tables.migrations.clear()
+    for migration in ts.migrations():
+        tables.migrations.add_row(
+            left=migration.left,
+            right=migration.right,
+            node=migration.node,
+            source=migration.source,
+            dest=migration.dest,
+            time=migration.time,
+            metadata=b"y" * migration.id,
+        )
     for j in range(10):
         tables.populations.add_row(metadata=b"p" * j)
         tables.provenances.add_row(timestamp="x" * j, record="y" * j)

--- a/python/tests/test_file_format.py
+++ b/python/tests/test_file_format.py
@@ -169,6 +169,24 @@ def mutation_metadata_example():
     return tables.tree_sequence()
 
 
+def migration_metadata_example():
+    ts = migration_example()
+    tables = ts.dump_tables()
+    metadatas = [f"n_{u}" for u in range(ts.num_migrations)]
+    packed, offset = tskit.pack_strings(metadatas)
+    tables.migrations.set_columns(
+        metadata=packed,
+        metadata_offset=offset,
+        left=tables.migrations.left,
+        right=tables.migrations.right,
+        source=tables.migrations.source,
+        dest=tables.migrations.dest,
+        node=tables.migrations.node,
+        time=tables.migrations.time,
+    )
+    return tables.tree_sequence()
+
+
 def edge_metadata_example():
     ts = msprime.simulate(
         sample_size=100, recombination_rate=0.1, length=10, random_seed=1
@@ -357,6 +375,9 @@ class TestRoundTrip(TestFileFormat):
     def test_mutation_metadata_example(self):
         self.verify_round_trip(mutation_metadata_example(), 10)
 
+    def test_migration_metadata_example(self):
+        self.verify_round_trip(migration_metadata_example(), 10)
+
     def test_edge_metadata_example(self):
         # metadata for edges was introduced
         self.verify_round_trip_no_legacy(edge_metadata_example())
@@ -474,6 +495,8 @@ class TestDumpFormat(TestFileFormat):
             "individuals/metadata_offset",
             "migrations/dest",
             "migrations/left",
+            "migrations/metadata",
+            "migrations/metadata_offset",
             "migrations/node",
             "migrations/right",
             "migrations/source",
@@ -720,6 +743,9 @@ class TestDumpFormat(TestFileFormat):
 
     def test_mutation_metadata_example(self):
         self.verify_dump_format(mutation_metadata_example())
+
+    def test_migration_metadata_example(self):
+        self.verify_dump_format(migration_metadata_example())
 
     def test_general_mutation_example(self):
         self.verify_dump_format(general_mutation_example())

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -314,7 +314,7 @@ class Migration(SimpleContainer):
     :vartype time: float
     """
 
-    def __init__(self, left, right, node, source, dest, time, id_=None):
+    def __init__(self, left, right, node, source, dest, time, metadata=b"", id_=None):
         self.id = id_
         self.left = left
         self.right = right
@@ -322,6 +322,22 @@ class Migration(SimpleContainer):
         self.source = source
         self.dest = dest
         self.time = time
+        self.metadata = metadata
+
+    def __repr__(self):
+        return (
+            "{{left={:.3f}, right={:.3f}, node={}, source={}, dest={} time={:.3f}"
+            " id={}, metadata={}}}".format(
+                self.left,
+                self.right,
+                self.node,
+                self.source,
+                self.dest,
+                self.time,
+                self.id,
+                self.metadata,
+            )
+        )
 
 
 class Population(SimpleContainer):
@@ -3325,9 +3341,15 @@ class TreeSequence:
 
         :rtype: :class:`.Migration`
         """
-        left, right, node, source, dest, time = self._ll_tree_sequence.get_migration(
-            id_
-        )
+        (
+            left,
+            right,
+            node,
+            source,
+            dest,
+            time,
+            metadata,
+        ) = self._ll_tree_sequence.get_migration(id_)
         return Migration(
             id_=id_,
             left=left,
@@ -3336,6 +3358,7 @@ class TreeSequence:
             source=source,
             dest=dest,
             time=time,
+            metadata=metadata,
         )
 
     def mutation(self, id_):


### PR DESCRIPTION
Add migration metadata, note that like edges this is backward compatible as the columns are optional in the kastore.