### PR TITLE
Error on unary nodes in KC distance

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -4595,6 +4595,31 @@ test_unequal_samples_kc(void)
     tsk_tree_free(&other_t);
 }
 
+static void
+test_unary_nodes_kc(void)
+{
+    const char *nodes = "1  0   0\n"
+                        "1  0   0\n"
+                        "0  1   0\n"
+                        "0  2   0";
+    const char *edges = "0  1   2   0,1\n"
+                        "0  1   3   2";
+    tsk_treeseq_t ts;
+    tsk_tree_t t;
+    int ret;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_kc_distance(&t, &t, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNARY_NODES);
+    tsk_treeseq_free(&ts);
+    tsk_tree_free(&t);
+}
+
 /*=======================================================
  * Miscellaneous tests.
  *======================================================*/
@@ -5306,6 +5331,7 @@ main(int argc, char **argv)
         { "test_internal_samples_kc", test_internal_samples_kc },
         { "test_unequal_sample_size_kc", test_unequal_sample_size_kc },
         { "test_unequal_samples_kc", test_unequal_samples_kc },
+        { "test_unary_nodes_kc", test_unary_nodes_kc },
 
         /* Misc */
         { "test_tree_errors", test_tree_errors },

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -394,6 +394,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_MULTIPLE_ROOTS:
             ret = "Trees with multiple roots not supported.";
             break;
+        case TSK_ERR_UNARY_NODES:
+            ret = "Unsimplified trees with unary nodes are not supported.";
+            break;
 
         /* Haplotype matching errors */
         case TSK_ERR_NULL_VITERBI_MATRIX:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -237,6 +237,7 @@ the file.
 #define TSK_ERR_SAMPLES_NOT_EQUAL                                  -1201
 #define TSK_ERR_INTERNAL_SAMPLES                                   -1202
 #define TSK_ERR_MULTIPLE_ROOTS                                     -1203
+#define TSK_ERR_UNARY_NODES                                        -1204
 
 /* Haplotype matching errors */
 #define TSK_ERR_NULL_VITERBI_MATRIX                                -1300

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4593,8 +4593,9 @@ norm_kc_vectors(kc_vectors *self, kc_vectors *other, double lambda)
 int
 tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double *result)
 {
-    tsk_id_t u, n, i;
+    tsk_id_t u, n, num_nodes, i, left_child;
     kc_vectors vecs[2];
+    tsk_tree_t *t;
     tsk_tree_t *trees[2] = { self, other };
     const tsk_id_t *samples = self->tree_sequence->samples;
     const tsk_id_t *other_samples = other->tree_sequence->samples;
@@ -4615,6 +4616,18 @@ tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double 
     if (!tsk_tree_has_sample_lists(self) || !tsk_tree_has_sample_lists(other)) {
         ret = TSK_ERR_UNSUPPORTED_OPERATION;
         goto out;
+    }
+
+    for (i = 0; i < 2; i++) {
+        t = trees[i];
+        num_nodes = (tsk_id_t) tsk_treeseq_get_num_nodes(t->tree_sequence);
+        for (u = 0; u < num_nodes; u++) {
+            left_child = t->left_child[u];
+            if (left_child != TSK_NULL && left_child == t->right_child[u]) {
+                ret = TSK_ERR_UNARY_NODES;
+                goto out;
+            }
+        }
     }
 
     n = (tsk_id_t) self->tree_sequence->num_samples;

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,6 +6,9 @@ In development
 
 **New features**
 
+- Remove support for ``kc_distance`` on trees with unary nodes
+  (:user:`daniel-goldstein`, :`508`)
+
 - Improve Kendall-Colijn tree distance algorithm to operate in O(n^2) time
   instead of O(n^2 * log(n)) where n is the number of samples
   (:user:`daniel-goldstein`, :pr:`490`)


### PR DESCRIPTION
The KC distance is only defined on full trees and unary nodes greatly affect distances. `kc_distance` now errors on trees with unary nodes. Users should run `simplify` on trees before comparing.

Resolves #487 

cc @jeromekelleher @hyanwong 