### PR TITLE
Add `_repr_html_` to tables

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,8 +6,11 @@ In development
 
 **New features**
 
+- Add ``_repr_html_`` to tables, so that jupyter notebooks render them as
+  html tables (:user:`benjeffery`, :pr:`514`)
+
 - Remove support for ``kc_distance`` on trees with unary nodes
-  (:user:`daniel-goldstein`, :`508`)
+  (:user:`daniel-goldstein`, :pr:`508`)
 
 - Improve Kendall-Colijn tree distance algorithm to operate in O(n^2) time
   instead of O(n^2 * log(n)) where n is the number of samples
@@ -19,10 +22,10 @@ In development
 - Add a metadata column to the edges table. Works similarly to existing
   metadata columns on other tables(:user:`benjeffery`, :pr:`496`).
 
-- Allow sites with missing data to be output by the `haplotypes` method, by
+- Allow sites with missing data to be output by the ``haplotypes`` method, by
   default replacing with ``-``. Errors are no longer raised for missing data
-  with `impute_missing_data=False`; the error types returned for bad alleles
-  (e.g. multiletter or non-ascii) have also changed from `_tskit.LibraryError`
+  with ``impute_missing_data=False``; the error types returned for bad alleles
+  (e.g. multiletter or non-ascii) have also changed from ``_tskit.LibraryError``
   to TypeError, or ValueError if the missing data character clashes
   (:user:`hyanwong`, :pr:`426`).
 
@@ -36,7 +39,7 @@ In development
   us to efficiently iterate over 'real' roots when we have
   missing data (:user:`jeromekelleher`, :pr:`462`).
 
-- Add pickle support for `TreeSequence` (:user:`terhorst`, :pr:`473`).
+- Add pickle support for ``TreeSequence`` (:user:`terhorst`, :pr:`473`).
 
 **Bugfixes**
 
@@ -75,7 +78,7 @@ method to manipulate tree sequence data.
 
 - Fix height scaling issues with SVG tree drawing (:user:`jeromekelleher`,
   :pr:`407`, :issue:`383`, :pr:`378`).
-- Do not reuse buffers in LdCalculator (:user:`jeromekelleher`). See :pr:`397` and
+- Do not reuse buffers in ``LdCalculator`` (:user:`jeromekelleher`). See :pr:`397` and
   :issue:`396`.
 
 --------------------

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -503,6 +503,18 @@ class CommonTestsMixin:
             s = str(table)
             self.assertEqual(len(s.splitlines()), num_rows + 1)
 
+    def test_repr_html(self):
+        for num_rows in [0, 10]:
+            input_data = {col.name: col.get_input(num_rows) for col in self.columns}
+            for list_col, offset_col in self.ragged_list_columns:
+                value = list_col.get_input(num_rows)
+                input_data[list_col.name] = value
+                input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
+            table = self.table_class()
+            table.set_columns(**input_data)
+            html = table._repr_html_()
+            self.assertEqual(len(html.splitlines()), num_rows + 19)
+
     def test_copy(self):
         for num_rows in [0, 10]:
             input_data = {col.name: col.get_input(num_rows) for col in self.columns}
@@ -1767,9 +1779,8 @@ class TestTableCollection(unittest.TestCase):
         mutations = tables.mutations
         before_populations = str(tables.populations)
         populations = tables.populations
-        before_nodes = str(tables.nodes)
-        provenances = tables.provenances
         before_provenances = str(tables.provenances)
+        provenances = tables.provenances
         del tables
         self.assertEqual(str(individuals), before_individuals)
         self.assertEqual(str(nodes), before_nodes)


### PR DESCRIPTION
Closes #512 

This method is called by jupyter notebooks to display nice-looking tables. Here's a screenshot:
![Screenshot from 2020-04-07 01-01-32](https://user-images.githubusercontent.com/8552/78616294-c038c080-786b-11ea-8670-81d9804ea812.png)

