### PR TITLE
Pin sphinx version

### DIFF
--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -17,7 +17,7 @@ pyparsing
 pysam
 python_jsonschema_objects
 PyVCF
-sphinx
+sphinx==2.4.4 #Pinned as breathe doesn't support 3.0 yet
 sphinx-argparse
 sphinx-issues
 sphinx_rtd_theme


### PR DESCRIPTION
Sphinx have just done a major release with lots of breaking changes - `breathe` has not yet caught up so we need to pin our sphinx version.