### PR TITLE
Update setup.py to py3.6 minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: python
 matrix:
   include:
     - os: linux
-      python: 3.6
+      python: 3.7
     - os: osx
       language: generic
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -80,16 +80,16 @@ setup(
     version=tskit_version,
     # TODO setup a tskit developers email address.
     author_email="jerome.kelleher@well.ox.ac.uk",
-    python_requires=">=3.4",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
     ],
     keywords="tree sequence",


### PR DESCRIPTION
Fixes #520 
I've also changed the travis config to test 3.7 and 3.8. I think the chance of breakage is _very_ low, but only cost is some travis CPU time as they run in parallel.