### PR TITLE
add sphinx viewcode ext

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ TypedField.make_field = patched_make_field
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
     "sphinx.ext.todo",
     "breathe",
     "sphinxarg.ext",


### PR DESCRIPTION
This adds links in the documentation to the source code (not to github but to another page rendered in the same way containing the highlighted code). This is not so useful for functions that go directly to C but is useful for other functions: see below.  I tried this out because @mufernando mentioned he uses this feature in the scikit-allel docs all the time, why didn't we have it?  It seems to work.
![Screenshot from 2020-04-15 10-41-34](https://user-images.githubusercontent.com/1046249/79369562-02b26b00-7f06-11ea-859f-fcc88e3ce3af.png)
![Screenshot from 2020-04-15 10-41-42](https://user-images.githubusercontent.com/1046249/79369569-047c2e80-7f06-11ea-9093-daa7a2d6982e.png)
