### PR TITLE
Metadata - high-level python

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
 build_script:
   - cmd: cd python
   - cmd: python setup.py build_ext --inplace
+  # Install some modules needed for tests
   - cmd: python -m pip install PyVCF
   - cmd: python -m pip install newick
   - cmd: python -m pip install python_jsonschema_objects

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -492,32 +492,14 @@ record              char                Provenance record.
 Metadata
 ========
 
-Users of the tables API sometimes need to store auxiliary information for
-the various entities defined here. For example, in a forwards-time simulation,
-the simulation engine may wish to store the time at which a particular mutation
-arose or some other pertinent information. If we are representing real data,
-we may wish to store information derived from a VCF INFO field, or associate
-information relating to samples or populations. The columns defined in tables
-here are deliberately minimal: we define columns only for information which
-the library itself can use. All other information is considered to be
-**metadata**, and is stored in the ``metadata`` columns of the various
-tables.
+Each table (excluding provenance) has a metadata column for storing and passing along
+information that tskit does not use or interpret. See :ref:`sec_metadata` for details.
+The metadata columns are :ref:`binary columns <sec_tables_api_binary_columns>`.
 
-Arbitrary binary data can be stored in ``metadata`` columns, and the
-``tskit`` library makes no attempt to interpret this information. How the
-information held in this field is encoded is entirely the choice of client code.
-
-To ensure that metadata can be safely interchanged using the :ref:`sec_text_file_format`,
-each row is `base 64 encoded <https://en.wikipedia.org/wiki/Base64>`_. Thus,
-binary information can be safely printed and exchanged, but may not be
+When using the :ref:`sec_text_file_format`, to ensure that metadata can be safely
+interchanged, each row is `base 64 encoded <https://en.wikipedia.org/wiki/Base64>`_.
+Thus, binary information can be safely printed and exchanged, but may not be
 human readable.
-
-.. todo::
-    We plan on providing more sophisticated tools for working with metadata
-    in future, including the auto decoding metadata via pluggable
-    functions and the ability to store metadata schemas so that metadata
-    is self-describing.
-
 
 .. _sec_valid_tree_sequence_requirements:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Welcome to tskit's documentation!
    c-api
    cli
    data-model
+   metadata
    provenance
    development
    tutorial

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -1,0 +1,127 @@
+.. _sec_metadata:
+
+========
+Metadata
+========
+
+Every entity (nodes, mutations, edges,  etc.) in a tskit tree sequence can have
+metadata associated with it. This is intended for storing and passing on information
+that tskit itself does not use or interpret. For example information derived from a VCF
+INFO field, or administrative information (such as unique identifiers) relating to
+samples and populations. Note that provenance information about how a tree sequence
+was created should not be stored in metadata, instead the provenance mechanisms in
+tskit should be used. See :ref:`sec_provenance`.
+
+The metadata for each entity is described by a schema for each entity type. This
+schema allows the tskit Python API to encode and decode metadata and, most importantly,
+tells downstream users and tools how to decode and interpret the metadata. This schema
+is in the form of a
+`JSON Schema <http://json-schema.org/>`_. A good to guide to creating JSON Schemas is at
+`Understanding JSON Schema <https://json-schema.org/understanding-json-schema/>`_.
+
+In the most common case where the metadata schema specifies an object with properties,
+the keys and types of those properties are specified along with optional
+long-form names, descriptions
+and validations such as min/max or regex matching for strings. See
+:ref:`sec_metadata_example` below. Names and descriptions can assist
+downstream users in understanding and using the metadata. It is best practise to
+populate these fields if your files will be used by any third-party, or if you wish to
+remember what they were some time after making the file!
+
+The :ref:`sec_tutorial_metadata` Tutorial shows how to use schemas and access metadata
+in the tskit Python API.
+
+Note that the C API simply provides byte-array binary access to the metadata and
+leaves encoding and decoding to the user. The same can be achieved with the Python
+API, see :ref:`sec_tutorial_metadata_binary`.
+
+******
+Codecs
+******
+
+As the underlying metadata is in raw binary (see
+:ref:`data model <sec_metadata_definition>`) it
+must be encoded and decoded, in the case of the Python API to Python objects.
+The method for doing this is specified in the top-level schema property ``codec``.
+Currently the Python API supports the ``json`` codec which encodes metadata as
+`JSON <https://www.json.org/json-en.html>`_. We plan to support more codecs soon, such
+as an efficient binary encoding (see :issue:`535`). It is possible to define a custom
+codec using :meth:`tskit.register_metadata_codec`, however this should only be used
+when necessary as downstream users of the metadata will not be able to decode it
+without the custom codec. For an example see :ref:`sec_tutorial_metadata_custom_codec`
+
+.. _sec_metadata_example:
+
+*******
+Example
+*******
+
+
+As an example here is a schema using the ``json`` codec which could apply, for example,
+to the individuals in a tree sequence:
+
+.. code-block:: json
+
+    {
+      "codec": "json",
+      "type": "object",
+      "properties": {
+        "accession_number": {"type": "number"},
+        "collection_date": {
+          "name": "Collection date",
+          "description": "Date of sample collection in ISO format",
+          "type": "string",
+          "pattern": "^([1-9][0-9]{3})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])?$"
+        },
+      },
+      "required": ["accession_number"],
+      "additionalProperties": false,
+    }
+
+This schema states that the metadata for the each row of the table
+is an object consisting of two properties. Property ``accession_number`` is a number
+which must be specified (it is included in the ``required`` list).
+Property ``collection_date`` is an optional string which must satisfy a regex,
+which checks it is a valid `ISO8601 <https://www.iso.org/iso-8601-date-and-time-format
+.html>`_ date.
+Any other properties are not allowed (``additionalProperties`` is false).
+
+.. _sec_metadata_api_overview:
+
+****************************
+Python Metadata API Overview
+****************************
+
+Schemas are represented in the Python API by the :class:`tskit.MetadataSchema`
+class which can be assigned to, and retrieved from, tables via their ``metadata_schema``
+attribute (e.g. :attr:`tskit.IndividualTable.metadata_schema`). The schemas
+for all tables can be retrieved from a :class:`tskit.TreeSequence` by the
+:attr:`tskit.TreeSequence.table_metadata_schemas` attribute.
+
+Each table's ``add_row`` method (e.g. :meth:`tskit.IndividualTable.add_row`) will
+validate and encode the metadata using the schema.
+
+Metadata will be lazily decoded if accessed via
+``tables.individuals[0].metadata`` or ``tree_sequence.individual(0).metadata``.
+
+In the interests of efficiency the bulk methods of ``set_columns``
+(e.g. :meth:`tskit.IndividualTable.set_columns`)
+and ``append_columns`` (e.g. :meth:`tskit.IndividualTable.append_columns`) do not
+validate or encode metadata. See :ref:`sec_tutorial_metadata_bulk` for how to prepare
+metadata for these methods.
+
+Metadata processing can be disabled and raw bytes stored/retrived. See
+:ref:`sec_tutorial_metadata_binary`.
+
+.. _sec_metadata_schema_schema:
+
+***************
+Full metaschema
+***************
+
+The schema for metadata schemas is formally defined using
+`JSON Schema <http://json-schema.org/>`_ and given in full here. Any schema passed to
+:class:`tskit.MetadataSchema` is validated against this metaschema.
+
+.. literalinclude:: ../python/tskit/metadata_schema.schema.json
+    :language: json

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -321,10 +321,11 @@ Binary columns
 Columns storing binary data take the same approach as
 :ref:`sec_tables_api_text_columns` to encoding
 :ref:`variable length data <sec_encoding_ragged_columns>`.
-The difference between the two is
-only raw :class:`bytes` values are accepted: no character encoding or
-decoding is done on the data. Consider the following example::
-
+The difference between the two is only raw :class:`bytes` values are accepted: no
+character encoding or decoding is done on the data. Consider the following example
+where a table has no ``metadata_schema`` such that arbitrary bytes can be stored and
+no automatic encoding or decoding of objects is performed by the Python API and we can
+store and retrive raw ``bytes``. (See :ref:`sec_metadata` for details)::
 
     >>> t = tskit.NodeTable()
     >>> t.add_row(metadata=b"raw bytes")
@@ -388,30 +389,37 @@ and use, see :ref:`the table definitions <sec_table_definitions>`.
 .. autoclass:: tskit.IndividualTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.NodeTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.EdgeTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.MigrationTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.SiteTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.MutationTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.PopulationTable()
     :members:
     :inherited-members:
+    :special-members: __getitem__
 
 .. autoclass:: tskit.ProvenanceTable()
     :members:
@@ -460,6 +468,22 @@ Table functions
 .. autofunction:: tskit.pack_bytes
 
 .. autofunction:: tskit.unpack_bytes
+
+.. _sec_metadata_api:
+
+********
+Metadata
+********
+
+The ``metadata`` module provides validation, encoding and decoding of metadata
+using a schema. See :ref:`sec_metadata`, :ref:`sec_metadata_api_overview` and
+:ref:`sec_tutorial_metadata`.
+
+.. autoclass:: tskit.MetadataSchema
+    :members:
+    :inherited-members:
+
+.. autofunction:: tskit.register_metadata_codec
 
 .. _sec_stats_api:
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,6 +6,11 @@ In development
 
 **New features**
 
+- Tables with a metadata column now have a ``metadata_schema`` that is used to
+  validate and encode metadata that is passed to ``add_row`` and decode metadata
+  on calls to ``table[j]`` and e.g. ``tree_sequence.node(j)`` See :ref:`sec_metadata`.
+  (:user:`benjeffery`, :pr:`491`, :pr:`542`, :pr:`543`)
+
 - Add classes to SVG drawings to allow easy adjustment and styling, and document the new
   ``tskit.Tree.draw_svg()`` and ``tskit.TreeSequence.draw_svg()`` methods. This also fixes
   :issue:`467` for duplicate SVG entity ``id`` s in Jupyter notebooks.

--- a/python/requirements/CI/requirements.txt
+++ b/python/requirements/CI/requirements.txt
@@ -8,6 +8,7 @@ flake8==3.7.9
 h5py==2.10.0
 jsonschema==3.2.0
 kastore==0.2.2
+msgpack==1.0.0
 msprime==0.7.4
 networkx==2.4
 newick==1.0.0

--- a/python/requirements/conda-minimal.txt
+++ b/python/requirements/conda-minimal.txt
@@ -4,6 +4,7 @@ nose
 h5py
 jsonschema
 svgwrite
+msgpack-python
 msprime
 kastore
 biopython

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -8,6 +8,7 @@ flake8
 h5py
 jsonschema
 kastore
+msgpack
 msprime
 networkx
 newick

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -239,7 +239,10 @@ class PythonTreeSequence:
                 node=node,
                 derived_state=derived_state,
                 parent=parent,
-                metadata=metadata,
+                encoded_metadata=metadata,
+                metadata_decoder=tskit.metadata.parse_metadata_schema(
+                    ll_ts.get_table_metadata_schemas().mutation
+                ).decode_row,
             )
 
         for j in range(tree_sequence.num_sites):
@@ -250,7 +253,10 @@ class PythonTreeSequence:
                     position=pos,
                     ancestral_state=ancestral_state,
                     mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
-                    metadata=metadata,
+                    encoded_metadata=metadata,
+                    metadata_decoder=tskit.metadata.parse_metadata_schema(
+                        ll_ts.get_table_metadata_schemas().site
+                    ).decode_row,
                 )
             )
 

--- a/python/tskit/__init__.py
+++ b/python/tskit/__init__.py
@@ -54,3 +54,4 @@ from tskit.tables import *  # NOQA
 from tskit.stats import *  # NOQA
 from tskit.exceptions import *  # NOQA
 from tskit.util import *  # NOQA
+from tskit.metadata import *  # NOQA

--- a/python/tskit/exceptions.py
+++ b/python/tskit/exceptions.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2019 Tskit Developers
+# Copyright (c) 2018-2020 Tskit Developers
 # Copyright (c) 2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -55,5 +55,17 @@ class DuplicatePositionsError(TskitException):
 
 class ProvenanceValidationError(TskitException):
     """
-    A JSON document did non validate against the provenance schema.
+    A JSON document did not validate against the provenance schema.
+    """
+
+
+class MetadataValidationError(TskitException):
+    """
+    A metadata object did not validate against the provenance schema.
+    """
+
+
+class MetadataSchemaValidationError(TskitException):
+    """
+    A metadata schema object did not validate against the metaschema.
     """

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -1,0 +1,212 @@
+# MIT License
+#
+# Copyright (c) 2020 Tskit Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Classes for metadata decoding, encoding and validation
+"""
+import abc
+import copy
+import json
+from typing import Any
+from typing import Optional
+from typing import Type
+
+import jsonschema
+
+import tskit.exceptions as exceptions
+
+
+def replace_root_refs(obj):
+    if type(obj) == list:
+        return [replace_root_refs(j) for j in obj]
+    elif type(obj) == dict:
+        ret = {k: replace_root_refs(v) for k, v in obj.items()}
+        if ret.get("$ref") == "#":
+            ret["$ref"] = "#/definitions/root"
+        return ret
+    else:
+        return obj
+
+
+class TSKITMetadataSchemaValidator(jsonschema.validators.Draft7Validator):
+    """
+    Our schema is the Draft7Validator schema with added codec information.
+    """
+
+    META_SCHEMA: dict = copy.deepcopy(jsonschema.validators.Draft7Validator.META_SCHEMA)
+    # We need a top-level only required property so we need to rewite any reference
+    # to the top-level schema to a copy in a definition.
+    META_SCHEMA = replace_root_refs(META_SCHEMA)
+    META_SCHEMA["definitions"]["root"] = copy.deepcopy(META_SCHEMA)
+    META_SCHEMA["codec"] = {"type": "string"}
+    META_SCHEMA["required"] = ["codec"]
+
+
+class AbstractMetadataCodec(metaclass=abc.ABCMeta):
+    """
+    Superclass of all MetadataCodecs.
+    """
+
+    def __init__(self, schema: dict) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
+    def encode(self, obj: Any) -> bytes:
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
+    def decode(self, encoded: bytes) -> Any:
+        raise NotImplementedError  # pragma: no cover
+
+
+codec_registry = {}
+
+
+def register_metadata_codec(
+    codec_cls: Type[AbstractMetadataCodec], codec_id: str
+) -> None:
+    """
+    Register a metadata codec class.
+    This function maintains a mapping from metadata codec identifiers used in schemas
+    to codec classes. When a codec class is registered, it will replace any class
+    previously registered under the same codec identifier, if present.
+    See :ref:`sec_tutorial_metadata_custom_codec` for example usage.
+
+    :param str codec_id: String to use to refer to the codec in the schema.
+    """
+    codec_registry[codec_id] = codec_cls
+
+
+class JSONCodec(AbstractMetadataCodec):
+    def __init__(self, schema: dict) -> None:
+        pass
+
+    def encode(self, obj: Any) -> bytes:
+        return json.dumps(obj).encode()
+
+    def decode(self, encoded: bytes) -> Any:
+        return json.loads(encoded.decode())
+
+
+register_metadata_codec(JSONCodec, "json")
+
+
+class NOOPCodec(AbstractMetadataCodec):
+    def __init__(self, schema: dict) -> None:
+        pass
+
+    def encode(self, data: bytes) -> bytes:
+        return data
+
+    def decode(self, data: bytes) -> bytes:
+        return data
+
+
+def validate_bytes(data: Optional[bytes]) -> None:
+    if data is not None and not isinstance(data, bytes):
+        raise TypeError(
+            f"If no encoding is set metadata should be bytes, found {type(bytes)}"
+        )
+
+
+class MetadataSchema:
+    """
+    Class for validating, encoding and decoding metadata.
+
+    :param dict schema: A dict containing a valid JSONSchema object.
+    """
+
+    def __init__(self, schema: Optional[dict]) -> None:
+        self._schema = schema
+
+        if schema is None:
+            self._string = ""
+            self._validate_row = validate_bytes
+            self.encode_row = NOOPCodec({}).encode
+            self.decode_row = NOOPCodec({}).decode
+        else:
+            try:
+                TSKITMetadataSchemaValidator.check_schema(schema)
+            except jsonschema.exceptions.SchemaError as ve:
+                raise exceptions.MetadataSchemaValidationError from ve
+            codec = schema["codec"]
+            try:
+                codec_instance = codec_registry[codec](schema)
+            except KeyError:
+                raise exceptions.MetadataSchemaValidationError(
+                    f"Unrecognised metadata codec '{schema['codec']}'. "
+                    f"Valid options are {str(list(codec_registry.keys()))}."
+                )
+            self._string = json.dumps(schema)
+            self._validate_row = TSKITMetadataSchemaValidator(schema).validate
+            self.encode_row = codec_instance.encode
+            self.decode_row = codec_instance.decode
+
+    def __str__(self) -> str:
+        return self._string
+
+    @property
+    def schema(self) -> Optional[dict]:
+        # Make schema read-only
+        return self._schema
+
+    def validate_and_encode_row(self, row: Any) -> bytes:
+        """
+        Validate a row of metadata against this schema and return the encoded
+        representation.
+        """
+        try:
+            self._validate_row(row)
+        except jsonschema.exceptions.ValidationError as ve:
+            raise exceptions.MetadataValidationError from ve
+        return self.encode_row(row)
+
+    def decode_row(self, row: bytes) -> Any:
+        """
+        Decode an encoded row of metadata, note that no validation is performed.
+        """
+        # Set by __init__
+        pass  # pragma: no cover
+
+    def encode_row(self, row: bytes) -> Any:
+        """
+        Encode an encoded row of metadata, note that no validation is performed.
+        """
+        # Set by __init__
+        pass  # pragma: no cover
+
+
+def parse_metadata_schema(encoded_schema: str) -> MetadataSchema:
+    """
+    Create a schema object from its string encoding. The exact class returned is
+    determined by the ``encoding`` specification in the string.
+
+    :param str encoded_schema: The string encoded schema.
+    :return: A subclass of AbstractMetadataSchema.
+    """
+    if encoded_schema == "":
+        return MetadataSchema(schema=None)
+    else:
+        try:
+            decoded = json.loads(encoded_schema)
+        except json.decoder.JSONDecodeError:
+            raise ValueError(f"Metadata schema is not JSON, found {encoded_schema}")
+        return MetadataSchema(decoded)

--- a/python/tskit/metadata_schema.schema.json
+++ b/python/tskit/metadata_schema.schema.json
@@ -1,0 +1,226 @@
+{
+  "$id": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "codec": {"type": "string"},
+  "default": true,
+  "definitions": {
+    "nonNegativeInteger": {"minimum": 0, "type": "integer"},
+    "nonNegativeIntegerDefault0": {
+      "allOf": [{"$ref": "#/definitions/nonNegativeInteger"}, {"default": 0}]
+    },
+    "root": {
+      "$id": "http://json-schema.org/draft-07/schema#",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "default": true,
+      "definitions": {
+        "nonNegativeInteger": {"minimum": 0, "type": "integer"},
+        "nonNegativeIntegerDefault0": {
+          "allOf": [
+            {"$ref": "#/definitions/nonNegativeInteger"},
+            {"default": 0},
+          ]
+        },
+        "schemaArray": {
+          "items": {"$ref": "#/definitions/root"},
+          "minItems": 1,
+          "type": "array",
+        },
+        "simpleTypes": {
+          "enum": ["array", "boolean", "integer", "null", "number", "object", "string",]
+        },
+        "stringArray": {
+          "default": [],
+          "items": {"type": "string"},
+          "type": "array",
+          "uniqueItems": true,
+        },
+      },
+      "properties": {
+        "$comment": {"type": "string"},
+        "$id": {"format": "uri-reference", "type": "string"},
+        "$ref": {"format": "uri-reference", "type": "string"},
+        "$schema": {"format": "uri", "type": "string"},
+        "additionalItems": {"$ref": "#/definitions/root"},
+        "additionalProperties": {"$ref": "#/definitions/root"},
+        "allOf": {"$ref": "#/definitions/schemaArray"},
+        "anyOf": {"$ref": "#/definitions/schemaArray"},
+        "const": true,
+        "contains": {"$ref": "#/definitions/root"},
+        "contentEncoding": {"type": "string"},
+        "contentMediaType": {"type": "string"},
+        "default": true,
+        "definitions": {
+          "additionalProperties": {"$ref": "#/definitions/root"},
+          "default": {},
+          "type": "object",
+        },
+        "dependencies": {
+          "additionalProperties": {
+            "anyOf": [{"$ref": "#/definitions/root"},
+              {"$ref": "#/definitions/stringArray"},
+            ]
+          },
+          "type": "object",
+        },
+        "description": {"type": "string"},
+        "else": {"$ref": "#/definitions/root"},
+        "enum": {"items": true, "type": "array"},
+        "examples": {"items": true, "type": "array"},
+        "exclusiveMaximum": {"type": "number"},
+        "exclusiveMinimum": {"type": "number"},
+        "format": {"type": "string"},
+        "if": {"$ref": "#/definitions/root"},
+        "items": {
+          "anyOf": [
+            {"$ref": "#/definitions/root"},
+            {"$ref": "#/definitions/schemaArray"},
+          ],
+          "default": true,
+        },
+        "maxItems": {"$ref": "#/definitions/nonNegativeInteger"},
+        "maxLength": {"$ref": "#/definitions/nonNegativeInteger"},
+        "maxProperties": {"$ref": "#/definitions/nonNegativeInteger"},
+        "maximum": {"type": "number"},
+        "minItems": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+        "minLength": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+        "minProperties": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+        "minimum": {"type": "number"},
+        "multipleOf": {"exclusiveMinimum": 0, "type": "number"},
+        "not": {"$ref": "#/definitions/root"},
+        "oneOf": {"$ref": "#/definitions/schemaArray"},
+        "pattern": {"format": "regex", "type": "string"},
+        "patternProperties": {
+          "additionalProperties": {"$ref": "#/definitions/root"},
+          "default": {},
+          "propertyNames": {"format": "regex"},
+          "type": "object",
+        },
+        "properties": {
+          "additionalProperties": {"$ref": "#/definitions/root"},
+          "default": {},
+          "type": "object",
+        },
+        "propertyNames": {"$ref": "#/definitions/root"},
+        "readOnly": {"default": false, "type": "boolean"},
+        "required": {"$ref": "#/definitions/stringArray"},
+        "then": {"$ref": "#/definitions/root"},
+        "title": {"type": "string"},
+        "type": {
+          "anyOf": [
+            {"$ref": "#/definitions/simpleTypes"},
+            {
+              "items": {"$ref": "#/definitions/simpleTypes"},
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true,
+            },
+          ]
+        },
+        "uniqueItems": {"default": false, "type": "boolean"},
+      },
+      "title": "Core schema meta-schema",
+      "type": ["object", "boolean"],
+    },
+    "schemaArray": {
+      "items": {"$ref": "#/definitions/root"},
+      "minItems": 1,
+      "type": "array",
+    },
+    "simpleTypes": {
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string",]
+    },
+    "stringArray": {
+      "default": [],
+      "items": {"type": "string"},
+      "type": "array",
+      "uniqueItems": true,
+    },
+  },
+  "properties": {
+    "$comment": {"type": "string"},
+    "$id": {"format": "uri-reference", "type": "string"},
+    "$ref": {"format": "uri-reference", "type": "string"},
+    "$schema": {"format": "uri", "type": "string"},
+    "additionalItems": {"$ref": "#/definitions/root"},
+    "additionalProperties": {"$ref": "#/definitions/root"},
+    "allOf": {"$ref": "#/definitions/schemaArray"},
+    "anyOf": {"$ref": "#/definitions/schemaArray"},
+    "const": true,
+    "contains": {"$ref": "#/definitions/root"},
+    "contentEncoding": {"type": "string"},
+    "contentMediaType": {"type": "string"},
+    "default": true,
+    "definitions": {
+      "additionalProperties": {"$ref": "#/definitions/root"},
+      "default": {},
+      "type": "object",
+    },
+    "dependencies": {
+      "additionalProperties": {
+        "anyOf": [
+          {"$ref": "#/definitions/root"},
+          {"$ref": "#/definitions/stringArray"},
+        ]
+      },
+      "type": "object",
+    },
+    "description": {"type": "string"},
+    "else": {"$ref": "#/definitions/root"},
+    "enum": {"items": true, "type": "array"},
+    "examples": {"items": true, "type": "array"},
+    "exclusiveMaximum": {"type": "number"},
+    "exclusiveMinimum": {"type": "number"},
+    "format": {"type": "string"},
+    "if": {"$ref": "#/definitions/root"},
+    "items": {
+      "anyOf": [
+        {"$ref": "#/definitions/root"},
+        {"$ref": "#/definitions/schemaArray"},
+      ],
+      "default": true,
+    },
+    "maxItems": {"$ref": "#/definitions/nonNegativeInteger"},
+    "maxLength": {"$ref": "#/definitions/nonNegativeInteger"},
+    "maxProperties": {"$ref": "#/definitions/nonNegativeInteger"},
+    "maximum": {"type": "number"},
+    "minItems": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+    "minLength": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+    "minProperties": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+    "minimum": {"type": "number"},
+    "multipleOf": {"exclusiveMinimum": 0, "type": "number"},
+    "not": {"$ref": "#/definitions/root"},
+    "oneOf": {"$ref": "#/definitions/schemaArray"},
+    "pattern": {"format": "regex", "type": "string"},
+    "patternProperties": {
+      "additionalProperties": {"$ref": "#/definitions/root"},
+      "default": {},
+      "propertyNames": {"format": "regex"},
+      "type": "object",
+    },
+    "properties": {
+      "additionalProperties": {"$ref": "#/definitions/root"},
+      "default": {},
+      "type": "object",
+    },
+    "propertyNames": {"$ref": "#/definitions/root"},
+    "readOnly": {"default": false, "type": "boolean"},
+    "required": {"$ref": "#/definitions/stringArray"},
+    "then": {"$ref": "#/definitions/root"},
+    "title": {"type": "string"},
+    "type": {
+      "anyOf": [
+        {"$ref": "#/definitions/simpleTypes"},
+        {
+          "items": {"$ref": "#/definitions/simpleTypes"},
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true,
+        },
+      ]
+    },
+    "uniqueItems": {"default": false, "type": "boolean"},
+  },
+  "required": ["codec"],
+  "title": "Core schema meta-schema",
+  "type": ["object", "boolean"],
+}


### PR DESCRIPTION
Fixes #57 
Continuation of #491, this is the high-level python that validates. encodes and decodes metadata based on schemas. I've also experimented with adding type annotations, I'm liking them so far.

 This gist explains the functionality: https://gist.github.com/benjeffery/e7c68bab9839259dbab9d888d2458fa3

Left to do:

- [x] Complete tests
- [x] Method docs
- [x] Changelog