### PR TITLE
Implement incremental KC Distance on tree sequences

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -4353,6 +4353,9 @@ test_isolated_node_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, single_leaf, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -4364,6 +4367,8 @@ test_isolated_node_kc(void)
     tsk_tree_free(&t);
 
     tsk_treeseq_from_text(&ts, 1, single_internal, edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_ROOTS);
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -4385,6 +4390,13 @@ test_single_tree_kc(void)
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
         NULL, NULL, NULL);
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 1, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -4396,12 +4408,14 @@ test_single_tree_kc(void)
     ret = tsk_tree_copy(&t, &other_t, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     check_trees_identical(&t, &other_t);
+
     ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result, 0);
     ret = tsk_tree_kc_distance(&t, &other_t, 1, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result, 0);
+
     tsk_treeseq_free(&ts);
     tsk_tree_free(&t);
     tsk_tree_free(&other_t);
@@ -4434,15 +4448,26 @@ test_two_trees_kc(void)
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     tsk_treeseq_from_text(
         &other_ts, 1, nodes_other, edges, NULL, NULL, NULL, NULL, NULL);
+
+    ret = tsk_treeseq_kc_distance(&ts, &other_ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+    ret = tsk_treeseq_kc_distance(&ts, &other_ts, 1, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 4.243, 1e-2);
+
     ret = tsk_tree_init(&other_t, &other_ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
+
     ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result, 0);
     ret = tsk_tree_kc_distance(&t, &other_t, 1, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 4.243, 1e-2);
+
     tsk_treeseq_free(&ts);
     tsk_treeseq_free(&other_ts);
     tsk_tree_free(&t);
@@ -4469,6 +4494,9 @@ test_empty_tree_kc(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     verify_empty_tree_sequence(&ts, 1.0);
+
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_ROOTS);
 
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4502,6 +4530,10 @@ test_nonbinary_tree_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+
+    tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -4526,6 +4558,11 @@ test_nonzero_samples_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0);
+
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -4550,6 +4587,12 @@ test_internal_samples_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+
+    /* Permitted in tree sequences */
+    ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(result, 0.0);
+
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -4580,16 +4623,22 @@ test_unequal_sample_size_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(
+        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+
+    ret = tsk_treeseq_kc_distance(&ts, &other_ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SAMPLE_SIZE_MISMATCH);
+
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    tsk_treeseq_from_text(
-        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+
     ret = tsk_tree_init(&other_t, &other_ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
+
     ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SAMPLE_SIZE_MISMATCH);
     tsk_treeseq_free(&ts);
@@ -4622,18 +4671,25 @@ test_unequal_samples_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(
+        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+
+    ret = tsk_treeseq_kc_distance(&ts, &other_ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SAMPLES_NOT_EQUAL);
+
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    tsk_treeseq_from_text(
-        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+
     ret = tsk_tree_init(&other_t, &other_ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&other_t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
+
     ret = tsk_tree_kc_distance(&t, &other_t, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SAMPLES_NOT_EQUAL);
+
     tsk_treeseq_free(&ts);
     tsk_treeseq_free(&other_ts);
     tsk_tree_free(&t);
@@ -4661,8 +4717,186 @@ test_unary_nodes_kc(void)
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     ret = tsk_tree_kc_distance(&t, &t, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNARY_NODES);
+
     tsk_treeseq_free(&ts);
     tsk_tree_free(&t);
+}
+
+static void
+test_no_sample_lists_kc(void)
+{
+    tsk_treeseq_t ts;
+    tsk_tree_t t;
+    int ret = 0;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
+        NULL, NULL, NULL);
+
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&t);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = tsk_tree_kc_distance(&t, &t, 9, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSUPPORTED_OPERATION);
+
+    tsk_treeseq_free(&ts);
+    tsk_tree_free(&t);
+}
+
+static void
+test_unequal_sequence_lengths_kc(void)
+{
+    const char *nodes = "1  0   0\n"
+                        "1  0   0\n"
+                        "1  0   0\n"
+                        "0  2   0\n"
+                        "0  3   0\n";
+    const char *edges_1 = "0 1  3 0,1\n"
+                          "0 1  4 2,3\n";
+    const char *edges_2 = "0 2  3 0,1\n"
+                          "0 2  4 2,3\n";
+
+    tsk_treeseq_t ts, other;
+    int ret;
+    double result = 0;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, edges_1, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&other, 2, nodes, edges_2, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_kc_distance(&ts, &other, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SEQUENCE_LENGTH_MISMATCH);
+
+    tsk_treeseq_free(&ts);
+    tsk_treeseq_free(&other);
+}
+
+static void
+test_different_number_trees_kc(void)
+{
+    const char *nodes = "1  0   0\n"
+                        "1  0   0\n"
+                        "1  0   0\n"
+                        "1  0   0\n"
+                        "1  0   0\n"
+                        "0  1   0\n"
+                        "0  2   0\n"
+                        "0  3   0\n"
+                        "0  4   0\n"
+                        "0  5   0\n";
+    const char *edges = "0 10  5 0,1\n"
+                        "0 10  6 3,4\n"
+                        "5 10  7 2,5\n"
+                        "0 5   8 2\n"
+                        "0 10  8 6\n"
+                        "5 10  8 7\n"
+                        "0 5   9 5,8\n";
+
+    const char *other_nodes = "1  0   0\n"
+                              "1  0   0\n"
+                              "1  0   0\n"
+                              "1  0   0\n"
+                              "1  0   0\n"
+                              "0  1   0\n"
+                              "0  2   0\n"
+                              "0  3   0\n"
+                              "0  4   0\n";
+    const char *other_edges = "0 10  5 0,1\n"
+                              "0 10  6 2,3\n"
+                              "0 10  7 4,5\n"
+                              "0 10  8 6,7\n";
+    tsk_treeseq_t ts, other;
+    double result, expected;
+    int ret = 0;
+
+    tsk_treeseq_from_text(&ts, 10, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(
+        &other, 10, other_nodes, other_edges, NULL, NULL, NULL, NULL, NULL);
+    ret = tsk_treeseq_kc_distance(&ts, &other, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    expected = (sqrt(8.0) * 5.0 + sqrt(6.0) * 5.0) / 10.0;
+    CU_ASSERT_DOUBLE_EQUAL_FATAL(result, expected, 1e-2);
+
+    tsk_treeseq_free(&ts);
+    tsk_treeseq_free(&other);
+}
+
+static void
+test_offset_trees_with_errors_kc(void)
+{
+    const char *nodes = "1  0   0\n"
+                        "1  0   0\n"
+                        "1  0   0\n"
+                        "1  0   0\n"
+                        "0  2   0\n"
+                        "0  3   0\n"
+                        "0  4   0\n";
+    const char *edges = "0 10  4 0,1\n"
+                        "0 10  5 2,3\n"
+                        "0 10  6 4,5\n";
+    tsk_treeseq_t ts, other;
+    double result;
+    int ret = 0;
+
+    tsk_treeseq_from_text(
+        &ts, 10, unary_ex_nodes, unary_ex_edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&other, 10, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 10);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&other), 10);
+
+    ret = tsk_treeseq_kc_distance(&ts, &other, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNARY_NODES);
+
+    ret = tsk_treeseq_kc_distance(&other, &ts, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNARY_NODES);
+
+    tsk_treeseq_free(&ts);
+    tsk_treeseq_free(&other);
+}
+
+static void
+test_invalid_first_tree_errors_kc(void)
+{
+    const char *nodes = "1  0   -1\n"
+                        "1  0   -1\n"
+                        "0  1   -1\n";
+    const char *edges = "0  1   2   0\n"
+                        "0  1   2   1\n";
+
+    const char *bad_nodes = "1  0   -1\n"
+                            "1  1   -1\n"
+                            "0  1   -1\n";
+    const char *bad_edges = "0  1   1   0\n"
+                            "0  1   2   0\n";
+    tsk_treeseq_t ts, other;
+    tsk_table_collection_t tables;
+    double result;
+    int ret;
+    tsk_flags_t load_flags = TSK_BUILD_INDEXES;
+
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    parse_nodes(bad_nodes, &tables.nodes);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.num_rows, 3);
+    parse_edges(bad_edges, &tables.edges);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.num_rows, 2);
+    tables.sequence_length = 1.0;
+
+    ret = tsk_treeseq_init(&other, &tables, load_flags);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    ret = tsk_treeseq_kc_distance(&ts, &other, 0, &result);
+    CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN);
+
+    ret = tsk_treeseq_kc_distance(&other, &ts, 0, &result);
+    CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN);
+
+    tsk_treeseq_free(&ts);
+    tsk_treeseq_free(&other);
+    tsk_table_collection_free(&tables);
 }
 
 /*=======================================================
@@ -5367,7 +5601,7 @@ main(int argc, char **argv)
         { "test_nonbinary_sample_sets", test_nonbinary_sample_sets },
         { "test_internal_sample_sample_sets", test_internal_sample_sample_sets },
 
-        /*KC distance tests */
+        /* KC distance tests */
         { "test_single_tree_kc", test_single_tree_kc },
         { "test_isolated_node_kc", test_isolated_node_kc },
         { "test_two_trees_kc", test_two_trees_kc },
@@ -5378,6 +5612,11 @@ main(int argc, char **argv)
         { "test_unequal_sample_size_kc", test_unequal_sample_size_kc },
         { "test_unequal_samples_kc", test_unequal_samples_kc },
         { "test_unary_nodes_kc", test_unary_nodes_kc },
+        { "test_no_sample_lists_kc", test_no_sample_lists_kc },
+        { "test_unequal_sequence_lengths_kc", test_unequal_sequence_lengths_kc },
+        { "test_different_number_trees_kc", test_different_number_trees_kc },
+        { "test_offset_trees_with_errors_kc", test_offset_trees_with_errors_kc },
+        { "test_invalid_first_tree_errors_kc", test_invalid_first_tree_errors_kc },
 
         /* Misc */
         { "test_tree_errors", test_tree_errors },

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -399,6 +399,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_UNARY_NODES:
             ret = "Unsimplified trees with unary nodes are not supported.";
             break;
+        case TSK_ERR_SEQUENCE_LENGTH_MISMATCH:
+            ret = "Sequence lengths must be identical to compare.";
+            break;
 
         /* Haplotype matching errors */
         case TSK_ERR_NULL_VITERBI_MATRIX:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -244,6 +244,7 @@ not found in the file.
 #define TSK_ERR_INTERNAL_SAMPLES                                   -1202
 #define TSK_ERR_MULTIPLE_ROOTS                                     -1203
 #define TSK_ERR_UNARY_NODES                                        -1204
+#define TSK_ERR_SEQUENCE_LENGTH_MISMATCH                           -1205
 
 /* Haplotype matching errors */
 #define TSK_ERR_NULL_VITERBI_MATRIX                                -1300

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -260,6 +260,9 @@ int tsk_treeseq_get_individual(
 int tsk_treeseq_simplify(tsk_treeseq_t *self, tsk_id_t *samples, tsk_size_t num_samples,
     tsk_flags_t options, tsk_treeseq_t *output, tsk_id_t *node_map);
 
+int tsk_treeseq_kc_distance(
+    tsk_treeseq_t *self, tsk_treeseq_t *other, double lambda_, double *result);
+
 /* TODO do these belong in trees or stats? They should probably be in stats.
  * Keep them here for now until we figure out the correct interface.
  */

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,6 +6,10 @@ In development
 
 **New features**
 
+- Add extension of Kendall-Colijn tree distance metric for tree sequences
+  computed by ``TreeSequence.kc_distance``
+  (:user:`daniel-goldstein`, :pr:`548`)
+
 - Add an optional node traversal order in ``tskit.Tree`` that uses the minimum
   lexicographic order of leaf nodes visited. This ordering (``"minlex_postorder"``)
   adds more determinism because it constraints the order in which children of

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7113,6 +7113,36 @@ out:
     return ret;
 }
 
+/* Forward Declaration */
+static PyTypeObject TreeSequenceType;
+
+static PyObject *
+TreeSequence_get_kc_distance(TreeSequence *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *ret = NULL;
+    TreeSequence *other = NULL;
+    static char *kwlist[] = {"other", "lambda_", NULL};
+    double lambda = 0;
+    double result = 0;
+    int err;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!d", kwlist,
+                &TreeSequenceType, &other, &lambda)) {
+        goto out;
+    }
+    if (TreeSequence_check_tree_sequence(self) != 0) {
+        goto out;
+    }
+    err = tsk_treeseq_kc_distance(self->tree_sequence, other->tree_sequence, lambda, &result);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("d", result);
+out:
+    return ret;
+}
+
 static PyObject *
 TreeSequence_mean_descendants(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
@@ -8150,6 +8180,9 @@ static PyMethodDef TreeSequence_methods[] = {
     {"genealogical_nearest_neighbours",
         (PyCFunction) TreeSequence_genealogical_nearest_neighbours,
         METH_VARARGS|METH_KEYWORDS, "Returns the genealogical nearest neighbours statistic." },
+    {"get_kc_distance", (PyCFunction) TreeSequence_get_kc_distance,
+        METH_VARARGS|METH_KEYWORDS,
+        "Returns the KC distance between this tree sequence and another." },
     {"mean_descendants",
         (PyCFunction) TreeSequence_mean_descendants,
         METH_VARARGS|METH_KEYWORDS, "Returns the mean number of nodes descending from each node." },

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5370,6 +5370,20 @@ class TreeSequence:
                 arrays = pool.map(worker, splits)
             return np.vstack(list(arrays))
 
+    def kc_distance(self, other, lambda_=0.0):
+        """
+        Returns the average :meth:`Tree.kc_distance` between pairs of trees along
+        the sequence whose intervals overlap. The average is weighted by the
+        fraction of the sequence on which each pair of trees overlap.
+
+        :param TreeSequence other: The other tree sequence to compare to.
+        :param float lambda_: The KC metric lambda parameter determining the
+            relative weight of topology and branch length.
+        :return: The computed KC distance between this tree sequence and other.
+        :rtype: float
+        """
+        return self._ll_tree_sequence.get_kc_distance(other._ll_tree_sequence, lambda_)
+
     ############################################
     #
     # Deprecated APIs. These are either already unsupported, or will be unsupported in a


### PR DESCRIPTION
A high-level implementation of the KC distance on Tree sequences. The tree sequence extension of KC walks a long both tree sequences, taking the KC distance between corresponding trees. The distance is the sum of the individual tree KC distances weighted by the fraction of the sequence spanned by the pair of trees.

The KC distance focuses on pairs of leaves, specifically the depth and time-from-root for the mrca of a given pair of leaves. To maintain the depth and time vectors used in KC incrementally, for each edge `e`, we must do an upward and downward traversal. While traversing up toward the root, we update the pairs of leaves where one leaf is in the subtree affected by `e` and one is not. Traversing down from `e`, we update all pairs of leaves where both leaves are in the subtree. Pairs where both leaves are outside of the subtree under `e` haven't been affected by the insertion/removal of that edge.