### PR TITLE
Use attr instead of namedtuples

### DIFF
--- a/python/requirements/CI/requirements.txt
+++ b/python/requirements/CI/requirements.txt
@@ -1,3 +1,4 @@
+attrs==19.3.0
 biopython==1.76
 black==19.10b0
 breathe==4.14.2

--- a/python/requirements/conda-minimal.txt
+++ b/python/requirements/conda-minimal.txt
@@ -1,3 +1,4 @@
+attrs>=19.1.0 #Pinned as we need kw_args support
 numpy
 nose
 h5py

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -1,3 +1,4 @@
+attrs>=19.1.0 #Pinned as we need kw_args support
 biopython
 black
 breathe==4.14.2 #Pinned as next version needs sphinx 3 (see below)

--- a/python/setup.py
+++ b/python/setup.py
@@ -96,7 +96,7 @@ setup(
     packages=["tskit"],
     include_package_data=True,
     ext_modules=[_tskit_module],
-    install_requires=[numpy_ver, "h5py", "svgwrite", "jsonschema"],
+    install_requires=[numpy_ver, "h5py", "svgwrite", "jsonschema", "attrs>=19.1.0"],
     entry_points={"console_scripts": ["tskit=tskit.cli:tskit_main"]},
     project_urls={
         "Bug Reports": "https://github.com/tskit-dev/tskit/issues",

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -31,6 +31,7 @@ import random
 import unittest
 import warnings
 
+import attr
 import msprime
 import numpy as np
 
@@ -369,7 +370,7 @@ class CommonTestsMixin:
                 self.assertTrue(np.all(input_array == output_array))
             t2 = self.table_class()
             for row in list(t1):
-                t2.add_row(**row._asdict())
+                t2.add_row(**attr.asdict(row))
             self.assertEqual(t1, t2)
 
     def test_set_columns_data(self):
@@ -782,8 +783,8 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, 0, b"123"))
-        self.assertEqual(t[1], (1, 2, 3, 1, b"\xf0"))
+        self.assertEqual(attr.astuple(t[0]), (0, 1, 2, 0, b"123"))
+        self.assertEqual(attr.astuple(t[1]), (1, 2, 3, 1, b"\xf0"))
         self.assertEqual(t[0].flags, 0)
         self.assertEqual(t[0].time, 1)
         self.assertEqual(t[0].population, 2)
@@ -860,8 +861,8 @@ class TestEdgeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         t.add_row(left=0, right=1, parent=2, child=3, metadata=b"123")
         t.add_row(1, 2, 3, 4, b"\xf0")
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, 3, b"123"))
-        self.assertEqual(t[1], (1, 2, 3, 4, b"\xf0"))
+        self.assertEqual(attr.astuple(t[0]), (0, 1, 2, 3, b"123"))
+        self.assertEqual(attr.astuple(t[1]), (1, 2, 3, 4, b"\xf0"))
         self.assertEqual(t[0].left, 0)
         self.assertEqual(t[0].right, 1)
         self.assertEqual(t[0].parent, 2)
@@ -906,8 +907,8 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, "1", b"2"))
-        self.assertEqual(t[1], (1, "2", b"\xf0"))
+        self.assertEqual(attr.astuple(t[0]), (0, "1", b"2"))
+        self.assertEqual(attr.astuple(t[1]), (1, "2", b"\xf0"))
         self.assertEqual(t[0].position, 0)
         self.assertEqual(t[0].ancestral_state, "1")
         self.assertEqual(t[0].metadata, b"2")
@@ -965,8 +966,8 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin)
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, "2", 3, b"4"))
-        self.assertEqual(t[1], (1, 2, "3", 4, b"\xf0"))
+        self.assertEqual(attr.astuple(t[0]), (0, 1, "2", 3, b"4"))
+        self.assertEqual(attr.astuple(t[1]), (1, 2, "3", 4, b"\xf0"))
         self.assertEqual(t[0].site, 0)
         self.assertEqual(t[0].node, 1)
         self.assertEqual(t[0].derived_state, "2")
@@ -1025,8 +1026,8 @@ class TestMigrationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin
         t.add_row(left=0, right=1, node=2, source=3, dest=4, time=5, metadata=b"123")
         t.add_row(1, 2, 3, 4, 5, 6, b"\xf0")
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, 3, 4, 5, b"123"))
-        self.assertEqual(t[1], (1, 2, 3, 4, 5, 6, b"\xf0"))
+        self.assertEqual(attr.astuple(t[0]), (0, 1, 2, 3, 4, 5, b"123"))
+        self.assertEqual(attr.astuple(t[1]), (1, 2, 3, 4, 5, 6, b"\xf0"))
         self.assertEqual(t[0].left, 0)
         self.assertEqual(t[0].right, 1)
         self.assertEqual(t[0].node, 2)
@@ -1071,8 +1072,8 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
         t.add_row(timestamp="0", record="1")
         t.add_row("2", "1")  # The orders are reversed for default timestamp.
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], ("0", "1"))
-        self.assertEqual(t[1], ("1", "2"))
+        self.assertEqual(attr.astuple(t[0]), ("0", "1"))
+        self.assertEqual(attr.astuple(t[1]), ("1", "2"))
         self.assertEqual(t[0].timestamp, "0")
         self.assertEqual(t[0].record, "1")
         self.assertEqual(t[0], t[-2])
@@ -1120,9 +1121,9 @@ class TestPopulationTable(unittest.TestCase, CommonTestsMixin):
         s = str(t)
         self.assertGreater(len(s), 0)
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (b"\xf0",))
+        self.assertEqual(attr.astuple(t[0]), (b"\xf0",))
         self.assertEqual(t[0].metadata, b"\xf0")
-        self.assertEqual(t[1], (b"1",))
+        self.assertEqual(attr.astuple(t[1]), (b"1",))
         self.assertRaises(IndexError, t.__getitem__, -3)
 
     def test_add_row_bad_data(self):

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -24,11 +24,11 @@
 Tree sequence IO via the tables API.
 """
 import base64
-import collections
 import datetime
 import json
 import warnings
 
+import attr
 import numpy as np
 
 import _tskit
@@ -36,43 +36,70 @@ import tskit
 import tskit.provenance as provenance
 import tskit.util as util
 
-
-IndividualTableRow = collections.namedtuple(
-    "IndividualTableRow", ["flags", "location", "metadata"]
-)
+attr_options = {"slots": True, "frozen": True, "auto_attribs": True}
 
 
-NodeTableRow = collections.namedtuple(
-    "NodeTableRow", ["flags", "time", "population", "individual", "metadata"]
-)
+@attr.s(**attr_options)
+class IndividualTableRow:
+    flags: int
+    location: np.ndarray
+    metadata: bytes
 
 
-EdgeTableRow = collections.namedtuple(
-    "EdgeTableRow", ["left", "right", "parent", "child", "metadata"]
-)
+@attr.s(**attr_options)
+class NodeTableRow:
+    flags: int
+    time: float
+    population: int
+    individual: int
+    metadata: bytes
 
 
-MigrationTableRow = collections.namedtuple(
-    "MigrationTableRow", ["left", "right", "node", "source", "dest", "time", "metadata"]
-)
+@attr.s(**attr_options)
+class EdgeTableRow:
+    left: float
+    right: float
+    parent: int
+    child: int
+    metadata: bytes
 
 
-SiteTableRow = collections.namedtuple(
-    "SiteTableRow", ["position", "ancestral_state", "metadata"]
-)
+@attr.s(**attr_options)
+class MigrationTableRow:
+    left: float
+    right: float
+    node: int
+    source: int
+    dest: int
+    time: float
+    metadata: bytes
 
 
-MutationTableRow = collections.namedtuple(
-    "MutationTableRow", ["site", "node", "derived_state", "parent", "metadata"]
-)
+@attr.s(**attr_options)
+class SiteTableRow:
+    position: float
+    ancestral_state: str
+    metadata: bytes
 
 
-PopulationTableRow = collections.namedtuple("PopulationTableRow", ["metadata"])
+@attr.s(**attr_options)
+class MutationTableRow:
+    site: int
+    node: int
+    derived_state: str
+    parent: int
+    metadata: bytes
 
 
-ProvenanceTableRow = collections.namedtuple(
-    "ProvenanceTableRow", ["timestamp", "record"]
-)
+@attr.s(**attr_options)
+class PopulationTableRow:
+    metadata: bytes
+
+
+@attr.s(**attr_options)
+class ProvenanceTableRow:
+    timestamp: str
+    record: str
 
 
 def keep_with_offset(keep, data, offset):


### PR DESCRIPTION
Using `attrs` gives better `repr` and user introspection for these classes. Type hints mean user IDEs will tell them what they are getting out of tskit, and help with future static error checking.