### PR TITLE
Add python 3.8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ language: python
 matrix:
   include:
     - os: linux
+      python: 3.8
+    - os: linux
       python: 3.7
     - os: osx
       language: generic
@@ -41,7 +43,7 @@ install:
       conda install -c conda-forge gxx_linux-64;
     fi
   - conda install --yes --file=python/requirements/conda-minimal.txt
-  - conda install -c bioconda --yes pysam
+  #- conda install -c bioconda --yes pysam
   # codecov requires a more recent version of certifi, but we can't uninstall the old one
   # see https://github.com/tskit-dev/tskit/issues/366
   - pip install --ignore-installed certifi

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1320,7 +1320,7 @@ class TestSortTables(unittest.TestCase):
         tables2 = ts2.dump_tables()
         tables2.edges.set_columns(**tables1.edges.asdict())
         # The edges in tables2 will refer to nodes that don't exist.
-        self.assertRaises(_tskit.LibraryError, tables1.sort())
+        self.assertRaises(_tskit.LibraryError, tables2.sort)
 
     def test_incompatible_sites(self):
         ts1 = msprime.simulate(10, random_seed=self.random_seed)


### PR DESCRIPTION
I have a local test failure when using 3.8. Seeing if the CI also hits this. We should test 3.8 on at least one of the CI's anyway.