### PR TITLE
Background svg shading

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -12,6 +12,9 @@ In development
 
 **New features**
 
+- Add background shading to SVG tree sequences to reflect tree position along the
+  sequence (:user:`hyanwong`, :pr:`563`)
+
 - Tables with a metadata column now have a ``metadata_schema`` that is used to
   validate and encode metadata that is passed to ``add_row`` and decode metadata
   on calls to ``table[j]`` and e.g. ``tree_sequence.node(j)`` See :ref:`sec_metadata`.

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -1,38 +1,42 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="1000" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="1000">
   <defs>
-    <style type="text/css">
-<![CDATA[.edges {stroke: blue}]]>    </style>
+    <style type="text/css"><![CDATA[.edges {stroke: blue}]]></style>
   </defs>
   <g class="tree-sequence">
+    <g class="background">
+      <polygon fill="#F1F1F1" points="20,185 20,180 20,160 20,0 212.0,0 212.0,160 77.3623328,180 77.3623328,185"/>
+      <polygon fill="#F1F1F1" points="780.8827328000001,185 780.8827328000001,180 404.0,160 404.0,0 596.0,0 596.0,160 890.090816,180 890.090816,185"/>
+      <polygon fill="#F1F1F1" points="893.8825760000001,185 893.8825760000001,180 788.0,160 788.0,0 980.0,0 980.0,160 980.0,180 980.0,185"/>
+    </g>
     <g class="trees">
-      <g class="tree t0" transform="translate(20 15)">
+      <g class="tree t0" transform="translate(20 30)">
         <g class="edges" fill="none" stroke="black">
-          <path class="p9 c4" d="M 61.599999999999994 139.70389833418668 V 30.0 H 95.99999999999999"/>
-          <path class="p4 c0" d="M 44.4 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p4 c1" d="M 78.8 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p9 c5" d="M 130.39999999999998 138.6596223256533 V 30.0 H 95.99999999999999"/>
-          <path class="p5 c2" d="M 113.19999999999999 140.0 V 138.6596223256533 H 130.39999999999998"/>
-          <path class="p5 c3" d="M 147.6 140.0 V 138.6596223256533 H 130.39999999999998"/>
+          <path class="p9 c4" d="M 61.599999999999994 109.78465333395394 V 30.0 H 95.99999999999999"/>
+          <path class="p4 c0" d="M 44.4 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p4 c1" d="M 78.8 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p9 c5" d="M 130.39999999999998 109.02517987320238 V 30.0 H 95.99999999999999"/>
+          <path class="p5 c2" d="M 113.19999999999999 110.0 V 109.02517987320238 H 130.39999999999998"/>
+          <path class="p5 c3" d="M 147.6 110.0 V 109.02517987320238 H 130.39999999999998"/>
         </g>
         <g class="symbols">
           <g class="nodes">
             <circle class="n9" cx="95.99999999999999" cy="30.0" r="3"/>
-            <circle class="n4" cx="61.599999999999994" cy="139.70389833418668" r="3"/>
-            <circle class="n0 sample" cx="44.4" cy="140.0" r="3"/>
-            <circle class="n1 sample" cx="78.8" cy="140.0" r="3"/>
-            <circle class="n5" cx="130.39999999999998" cy="138.6596223256533" r="3"/>
-            <circle class="n2 sample" cx="113.19999999999999" cy="140.0" r="3"/>
-            <circle class="n3 sample" cx="147.6" cy="140.0" r="3"/>
+            <circle class="n4" cx="61.599999999999994" cy="109.78465333395394" r="3"/>
+            <circle class="n0 sample" cx="44.4" cy="110.0" r="3"/>
+            <circle class="n1 sample" cx="78.8" cy="110.0" r="3"/>
+            <circle class="n5" cx="130.39999999999998" cy="109.02517987320238" r="3"/>
+            <circle class="n2 sample" cx="113.19999999999999" cy="110.0" r="3"/>
+            <circle class="n3 sample" cx="147.6" cy="110.0" r="3"/>
           </g>
           <g class="mutations" fill="red">
-            <rect class="m0 s0 n4" height="6" transform="translate(-3 -3)" width="6" x="61.599999999999994" y="84.85194916709334"/>
+            <rect class="m0 s0 n4" height="6" transform="translate(-3 -3)" width="6" x="61.599999999999994" y="69.89232666697697"/>
           </g>
         </g>
         <g class="labels" dominant-baseline="middle" font-size="14">
           <g class="nodes">
             <g text-anchor="start">
-              <g transform="translate(135.39999999999998, 133.6596223256533)">
+              <g transform="translate(135.39999999999998, 104.02517987320238)">
                 <text class="n5">5</text>
               </g>
             </g>
@@ -40,21 +44,21 @@
               <g transform="translate(95.99999999999999, 25.0)">
                 <text class="n9">9</text>
               </g>
-              <g transform="translate(44.4, 160.0)">
+              <g transform="translate(44.4, 130.0)">
                 <text class="n0 sample">0</text>
               </g>
-              <g transform="translate(78.8, 160.0)">
+              <g transform="translate(78.8, 130.0)">
                 <text class="n1 sample">1</text>
               </g>
-              <g transform="translate(113.19999999999999, 160.0)">
+              <g transform="translate(113.19999999999999, 130.0)">
                 <text class="n2 sample">2</text>
               </g>
-              <g transform="translate(147.6, 160.0)">
+              <g transform="translate(147.6, 130.0)">
                 <text class="n3 sample">3</text>
               </g>
             </g>
             <g text-anchor="end">
-              <g transform="translate(56.599999999999994, 134.70389833418668)">
+              <g transform="translate(56.599999999999994, 104.78465333395394)">
                 <text class="n4">4</text>
               </g>
             </g>
@@ -62,60 +66,60 @@
           <g class="mutations" font-style="italic">
             <g text-anchor="start"/>
             <g text-anchor="end">
-              <g transform="translate(56.599999999999994, 88.85194916709334)">
+              <g transform="translate(56.599999999999994, 73.89232666697697)">
                 <text class="m0 s0 n4">0</text>
               </g>
             </g>
           </g>
         </g>
       </g>
-      <g class="tree t1" transform="translate(212.0 15)">
+      <g class="tree t1" transform="translate(212.0 30)">
         <g class="edges" fill="none" stroke="black">
-          <path class="p7 c4" d="M 61.599999999999994 139.70389833418668 V 112.01678495513357 H 95.99999999999999"/>
-          <path class="p4 c0" d="M 44.4 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p4 c1" d="M 78.8 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p7 c5" d="M 130.39999999999998 138.6596223256533 V 112.01678495513357 H 95.99999999999999"/>
-          <path class="p5 c2" d="M 113.19999999999999 140.0 V 138.6596223256533 H 130.39999999999998"/>
-          <path class="p5 c3" d="M 147.6 140.0 V 138.6596223256533 H 130.39999999999998"/>
+          <path class="p7 c4" d="M 61.599999999999994 109.78465333395394 V 89.64857087646077 H 95.99999999999999"/>
+          <path class="p4 c0" d="M 44.4 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p4 c1" d="M 78.8 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p7 c5" d="M 130.39999999999998 109.02517987320238 V 89.64857087646077 H 95.99999999999999"/>
+          <path class="p5 c2" d="M 113.19999999999999 110.0 V 109.02517987320238 H 130.39999999999998"/>
+          <path class="p5 c3" d="M 147.6 110.0 V 109.02517987320238 H 130.39999999999998"/>
         </g>
         <g class="symbols">
           <g class="nodes">
-            <circle class="n7" cx="95.99999999999999" cy="112.01678495513357" r="3"/>
-            <circle class="n4" cx="61.599999999999994" cy="139.70389833418668" r="3"/>
-            <circle class="n0 sample" cx="44.4" cy="140.0" r="3"/>
-            <circle class="n1 sample" cx="78.8" cy="140.0" r="3"/>
-            <circle class="n5" cx="130.39999999999998" cy="138.6596223256533" r="3"/>
-            <circle class="n2 sample" cx="113.19999999999999" cy="140.0" r="3"/>
-            <circle class="n3 sample" cx="147.6" cy="140.0" r="3"/>
+            <circle class="n7" cx="95.99999999999999" cy="89.64857087646077" r="3"/>
+            <circle class="n4" cx="61.599999999999994" cy="109.78465333395394" r="3"/>
+            <circle class="n0 sample" cx="44.4" cy="110.0" r="3"/>
+            <circle class="n1 sample" cx="78.8" cy="110.0" r="3"/>
+            <circle class="n5" cx="130.39999999999998" cy="109.02517987320238" r="3"/>
+            <circle class="n2 sample" cx="113.19999999999999" cy="110.0" r="3"/>
+            <circle class="n3 sample" cx="147.6" cy="110.0" r="3"/>
           </g>
           <g class="mutations" fill="red"/>
         </g>
         <g class="labels" dominant-baseline="middle" font-size="14">
           <g class="nodes">
             <g text-anchor="start">
-              <g transform="translate(135.39999999999998, 133.6596223256533)">
+              <g transform="translate(135.39999999999998, 104.02517987320238)">
                 <text class="n5">5</text>
               </g>
             </g>
             <g text-anchor="middle">
-              <g transform="translate(95.99999999999999, 107.01678495513357)">
+              <g transform="translate(95.99999999999999, 84.64857087646077)">
                 <text class="n7">7</text>
               </g>
-              <g transform="translate(44.4, 160.0)">
+              <g transform="translate(44.4, 130.0)">
                 <text class="n0 sample">0</text>
               </g>
-              <g transform="translate(78.8, 160.0)">
+              <g transform="translate(78.8, 130.0)">
                 <text class="n1 sample">1</text>
               </g>
-              <g transform="translate(113.19999999999999, 160.0)">
+              <g transform="translate(113.19999999999999, 130.0)">
                 <text class="n2 sample">2</text>
               </g>
-              <g transform="translate(147.6, 160.0)">
+              <g transform="translate(147.6, 130.0)">
                 <text class="n3 sample">3</text>
               </g>
             </g>
             <g text-anchor="end">
-              <g transform="translate(56.599999999999994, 134.70389833418668)">
+              <g transform="translate(56.599999999999994, 104.78465333395394)">
                 <text class="n4">4</text>
               </g>
             </g>
@@ -126,53 +130,53 @@
           </g>
         </g>
       </g>
-      <g class="tree t2" transform="translate(404.0 15)">
+      <g class="tree t2" transform="translate(404.0 30)">
         <g class="edges" fill="none" stroke="black">
-          <path class="p6 c4" d="M 61.599999999999994 139.70389833418668 V 118.8061198904806 H 95.99999999999999"/>
-          <path class="p4 c0" d="M 44.4 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p4 c1" d="M 78.8 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p6 c5" d="M 130.39999999999998 138.6596223256533 V 118.8061198904806 H 95.99999999999999"/>
-          <path class="p5 c2" d="M 113.19999999999999 140.0 V 138.6596223256533 H 130.39999999999998"/>
-          <path class="p5 c3" d="M 147.6 140.0 V 138.6596223256533 H 130.39999999999998"/>
+          <path class="p6 c4" d="M 61.599999999999994 109.78465333395394 V 94.58626901125862 H 95.99999999999999"/>
+          <path class="p4 c0" d="M 44.4 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p4 c1" d="M 78.8 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p6 c5" d="M 130.39999999999998 109.02517987320238 V 94.58626901125862 H 95.99999999999999"/>
+          <path class="p5 c2" d="M 113.19999999999999 110.0 V 109.02517987320238 H 130.39999999999998"/>
+          <path class="p5 c3" d="M 147.6 110.0 V 109.02517987320238 H 130.39999999999998"/>
         </g>
         <g class="symbols">
           <g class="nodes">
-            <circle class="n6" cx="95.99999999999999" cy="118.8061198904806" r="3"/>
-            <circle class="n4" cx="61.599999999999994" cy="139.70389833418668" r="3"/>
-            <circle class="n0 sample" cx="44.4" cy="140.0" r="3"/>
-            <circle class="n1 sample" cx="78.8" cy="140.0" r="3"/>
-            <circle class="n5" cx="130.39999999999998" cy="138.6596223256533" r="3"/>
-            <circle class="n2 sample" cx="113.19999999999999" cy="140.0" r="3"/>
-            <circle class="n3 sample" cx="147.6" cy="140.0" r="3"/>
+            <circle class="n6" cx="95.99999999999999" cy="94.58626901125862" r="3"/>
+            <circle class="n4" cx="61.599999999999994" cy="109.78465333395394" r="3"/>
+            <circle class="n0 sample" cx="44.4" cy="110.0" r="3"/>
+            <circle class="n1 sample" cx="78.8" cy="110.0" r="3"/>
+            <circle class="n5" cx="130.39999999999998" cy="109.02517987320238" r="3"/>
+            <circle class="n2 sample" cx="113.19999999999999" cy="110.0" r="3"/>
+            <circle class="n3 sample" cx="147.6" cy="110.0" r="3"/>
           </g>
           <g class="mutations" fill="red"/>
         </g>
         <g class="labels" dominant-baseline="middle" font-size="14">
           <g class="nodes">
             <g text-anchor="start">
-              <g transform="translate(135.39999999999998, 133.6596223256533)">
+              <g transform="translate(135.39999999999998, 104.02517987320238)">
                 <text class="n5">5</text>
               </g>
             </g>
             <g text-anchor="middle">
-              <g transform="translate(95.99999999999999, 113.8061198904806)">
+              <g transform="translate(95.99999999999999, 89.58626901125862)">
                 <text class="n6">6</text>
               </g>
-              <g transform="translate(44.4, 160.0)">
+              <g transform="translate(44.4, 130.0)">
                 <text class="n0 sample">0</text>
               </g>
-              <g transform="translate(78.8, 160.0)">
+              <g transform="translate(78.8, 130.0)">
                 <text class="n1 sample">1</text>
               </g>
-              <g transform="translate(113.19999999999999, 160.0)">
+              <g transform="translate(113.19999999999999, 130.0)">
                 <text class="n2 sample">2</text>
               </g>
-              <g transform="translate(147.6, 160.0)">
+              <g transform="translate(147.6, 130.0)">
                 <text class="n3 sample">3</text>
               </g>
             </g>
             <g text-anchor="end">
-              <g transform="translate(56.599999999999994, 134.70389833418668)">
+              <g transform="translate(56.599999999999994, 104.78465333395394)">
                 <text class="n4">4</text>
               </g>
             </g>
@@ -183,53 +187,53 @@
           </g>
         </g>
       </g>
-      <g class="tree t3" transform="translate(596.0 15)">
+      <g class="tree t3" transform="translate(596.0 30)">
         <g class="edges" fill="none" stroke="black">
-          <path class="p7 c4" d="M 61.599999999999994 139.70389833418668 V 112.01678495513357 H 95.99999999999999"/>
-          <path class="p4 c0" d="M 44.4 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p4 c1" d="M 78.8 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p7 c5" d="M 130.39999999999998 138.6596223256533 V 112.01678495513357 H 95.99999999999999"/>
-          <path class="p5 c2" d="M 113.19999999999999 140.0 V 138.6596223256533 H 130.39999999999998"/>
-          <path class="p5 c3" d="M 147.6 140.0 V 138.6596223256533 H 130.39999999999998"/>
+          <path class="p7 c4" d="M 61.599999999999994 109.78465333395394 V 89.64857087646077 H 95.99999999999999"/>
+          <path class="p4 c0" d="M 44.4 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p4 c1" d="M 78.8 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p7 c5" d="M 130.39999999999998 109.02517987320238 V 89.64857087646077 H 95.99999999999999"/>
+          <path class="p5 c2" d="M 113.19999999999999 110.0 V 109.02517987320238 H 130.39999999999998"/>
+          <path class="p5 c3" d="M 147.6 110.0 V 109.02517987320238 H 130.39999999999998"/>
         </g>
         <g class="symbols">
           <g class="nodes">
-            <circle class="n7" cx="95.99999999999999" cy="112.01678495513357" r="3"/>
-            <circle class="n4" cx="61.599999999999994" cy="139.70389833418668" r="3"/>
-            <circle class="n0 sample" cx="44.4" cy="140.0" r="3"/>
-            <circle class="n1 sample" cx="78.8" cy="140.0" r="3"/>
-            <circle class="n5" cx="130.39999999999998" cy="138.6596223256533" r="3"/>
-            <circle class="n2 sample" cx="113.19999999999999" cy="140.0" r="3"/>
-            <circle class="n3 sample" cx="147.6" cy="140.0" r="3"/>
+            <circle class="n7" cx="95.99999999999999" cy="89.64857087646077" r="3"/>
+            <circle class="n4" cx="61.599999999999994" cy="109.78465333395394" r="3"/>
+            <circle class="n0 sample" cx="44.4" cy="110.0" r="3"/>
+            <circle class="n1 sample" cx="78.8" cy="110.0" r="3"/>
+            <circle class="n5" cx="130.39999999999998" cy="109.02517987320238" r="3"/>
+            <circle class="n2 sample" cx="113.19999999999999" cy="110.0" r="3"/>
+            <circle class="n3 sample" cx="147.6" cy="110.0" r="3"/>
           </g>
           <g class="mutations" fill="red"/>
         </g>
         <g class="labels" dominant-baseline="middle" font-size="14">
           <g class="nodes">
             <g text-anchor="start">
-              <g transform="translate(135.39999999999998, 133.6596223256533)">
+              <g transform="translate(135.39999999999998, 104.02517987320238)">
                 <text class="n5">5</text>
               </g>
             </g>
             <g text-anchor="middle">
-              <g transform="translate(95.99999999999999, 107.01678495513357)">
+              <g transform="translate(95.99999999999999, 84.64857087646077)">
                 <text class="n7">7</text>
               </g>
-              <g transform="translate(44.4, 160.0)">
+              <g transform="translate(44.4, 130.0)">
                 <text class="n0 sample">0</text>
               </g>
-              <g transform="translate(78.8, 160.0)">
+              <g transform="translate(78.8, 130.0)">
                 <text class="n1 sample">1</text>
               </g>
-              <g transform="translate(113.19999999999999, 160.0)">
+              <g transform="translate(113.19999999999999, 130.0)">
                 <text class="n2 sample">2</text>
               </g>
-              <g transform="translate(147.6, 160.0)">
+              <g transform="translate(147.6, 130.0)">
                 <text class="n3 sample">3</text>
               </g>
             </g>
             <g text-anchor="end">
-              <g transform="translate(56.599999999999994, 134.70389833418668)">
+              <g transform="translate(56.599999999999994, 104.78465333395394)">
                 <text class="n4">4</text>
               </g>
             </g>
@@ -240,53 +244,53 @@
           </g>
         </g>
       </g>
-      <g class="tree t4" transform="translate(788.0 15)">
+      <g class="tree t4" transform="translate(788.0 30)">
         <g class="edges" fill="none" stroke="black">
-          <path class="p8 c4" d="M 61.599999999999994 139.70389833418668 V 96.72565330282865 H 95.99999999999999"/>
-          <path class="p4 c0" d="M 44.4 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p4 c1" d="M 78.8 140.0 V 139.70389833418668 H 61.599999999999994"/>
-          <path class="p8 c5" d="M 130.39999999999998 138.6596223256533 V 96.72565330282865 H 95.99999999999999"/>
-          <path class="p5 c2" d="M 113.19999999999999 140.0 V 138.6596223256533 H 130.39999999999998"/>
-          <path class="p5 c3" d="M 147.6 140.0 V 138.6596223256533 H 130.39999999999998"/>
+          <path class="p8 c4" d="M 61.599999999999994 109.78465333395394 V 78.52774785660264 H 95.99999999999999"/>
+          <path class="p4 c0" d="M 44.4 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p4 c1" d="M 78.8 110.0 V 109.78465333395394 H 61.599999999999994"/>
+          <path class="p8 c5" d="M 130.39999999999998 109.02517987320238 V 78.52774785660264 H 95.99999999999999"/>
+          <path class="p5 c2" d="M 113.19999999999999 110.0 V 109.02517987320238 H 130.39999999999998"/>
+          <path class="p5 c3" d="M 147.6 110.0 V 109.02517987320238 H 130.39999999999998"/>
         </g>
         <g class="symbols">
           <g class="nodes">
-            <circle class="n8" cx="95.99999999999999" cy="96.72565330282865" r="3"/>
-            <circle class="n4" cx="61.599999999999994" cy="139.70389833418668" r="3"/>
-            <circle class="n0 sample" cx="44.4" cy="140.0" r="3"/>
-            <circle class="n1 sample" cx="78.8" cy="140.0" r="3"/>
-            <circle class="n5" cx="130.39999999999998" cy="138.6596223256533" r="3"/>
-            <circle class="n2 sample" cx="113.19999999999999" cy="140.0" r="3"/>
-            <circle class="n3 sample" cx="147.6" cy="140.0" r="3"/>
+            <circle class="n8" cx="95.99999999999999" cy="78.52774785660264" r="3"/>
+            <circle class="n4" cx="61.599999999999994" cy="109.78465333395394" r="3"/>
+            <circle class="n0 sample" cx="44.4" cy="110.0" r="3"/>
+            <circle class="n1 sample" cx="78.8" cy="110.0" r="3"/>
+            <circle class="n5" cx="130.39999999999998" cy="109.02517987320238" r="3"/>
+            <circle class="n2 sample" cx="113.19999999999999" cy="110.0" r="3"/>
+            <circle class="n3 sample" cx="147.6" cy="110.0" r="3"/>
           </g>
           <g class="mutations" fill="red"/>
         </g>
         <g class="labels" dominant-baseline="middle" font-size="14">
           <g class="nodes">
             <g text-anchor="start">
-              <g transform="translate(135.39999999999998, 133.6596223256533)">
+              <g transform="translate(135.39999999999998, 104.02517987320238)">
                 <text class="n5">5</text>
               </g>
             </g>
             <g text-anchor="middle">
-              <g transform="translate(95.99999999999999, 91.72565330282865)">
+              <g transform="translate(95.99999999999999, 73.52774785660264)">
                 <text class="n8">8</text>
               </g>
-              <g transform="translate(44.4, 160.0)">
+              <g transform="translate(44.4, 130.0)">
                 <text class="n0 sample">0</text>
               </g>
-              <g transform="translate(78.8, 160.0)">
+              <g transform="translate(78.8, 130.0)">
                 <text class="n1 sample">1</text>
               </g>
-              <g transform="translate(113.19999999999999, 160.0)">
+              <g transform="translate(113.19999999999999, 130.0)">
                 <text class="n2 sample">2</text>
               </g>
-              <g transform="translate(147.6, 160.0)">
+              <g transform="translate(147.6, 130.0)">
                 <text class="n3 sample">3</text>
               </g>
             </g>
             <g text-anchor="end">
-              <g transform="translate(56.599999999999994, 134.70389833418668)">
+              <g transform="translate(56.599999999999994, 104.78465333395394)">
                 <text class="n4">4</text>
               </g>
             </g>
@@ -300,27 +304,27 @@
     </g>
     <g class="axis">
       <line stroke="black" x1="20" x2="980" y1="180" y2="180"/>
-      <line stroke="black" x1="20" x2="20" y1="175" y2="185"/>
+      <line stroke="black" x1="20" x2="20" y1="180" y2="185"/>
       <g transform="translate(20, 200)">
         <text font-size="14" font-weight="bold" text-anchor="middle">0.00</text>
       </g>
-      <line stroke="black" x1="212.0" x2="212.0" y1="175" y2="185"/>
-      <g transform="translate(212.0, 200)">
+      <line stroke="black" x1="77.3623328" x2="77.3623328" y1="180" y2="185"/>
+      <g transform="translate(77.3623328, 200)">
         <text font-size="14" font-weight="bold" text-anchor="middle">0.06</text>
       </g>
-      <line stroke="black" x1="404.0" x2="404.0" y1="175" y2="185"/>
-      <g transform="translate(404.0, 200)">
+      <line stroke="black" x1="780.8827328000001" x2="780.8827328000001" y1="180" y2="185"/>
+      <g transform="translate(780.8827328000001, 200)">
         <text font-size="14" font-weight="bold" text-anchor="middle">0.79</text>
       </g>
-      <line stroke="black" x1="596.0" x2="596.0" y1="175" y2="185"/>
-      <g transform="translate(596.0, 200)">
+      <line stroke="black" x1="890.090816" x2="890.090816" y1="180" y2="185"/>
+      <g transform="translate(890.090816, 200)">
         <text font-size="14" font-weight="bold" text-anchor="middle">0.91</text>
       </g>
-      <line stroke="black" x1="788.0" x2="788.0" y1="175" y2="185"/>
-      <g transform="translate(788.0, 200)">
+      <line stroke="black" x1="893.8825760000001" x2="893.8825760000001" y1="180" y2="185"/>
+      <g transform="translate(893.8825760000001, 200)">
         <text font-size="14" font-weight="bold" text-anchor="middle">0.91</text>
       </g>
-      <line stroke="black" x1="980.0" x2="980.0" y1="175" y2="185"/>
+      <line stroke="black" x1="980.0" x2="980.0" y1="180" y2="185"/>
       <g transform="translate(980.0, 200)">
         <text font-size="14" font-weight="bold" text-anchor="middle">1.00</text>
       </g>

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4367,6 +4367,7 @@ class TreeSequence:
         path=None,
         *,
         size=None,
+        x_scale=None,
         tree_height_scale=None,
         node_labels=None,
         mutation_labels=None,
@@ -4405,6 +4406,12 @@ class TreeSequence:
             produced SVG drawing in abstract user units (usually interpreted as pixels on
             display).
         :type size: tuple(int, int)
+        :param str x_scale: Control how the X axis is drawn. If "physical" (the default)
+            the axis scales linearly with physical distance along the sequence, and
+            background shading is used to indicate the position of the trees along the
+            sequence. If "treewise", each axis tick corresponds to a tree boundary, which
+            are positioned evenly along the axis, so that the X axis is of variable scale
+            and no background scaling is required.
         :param str tree_height_scale: Control how height values for nodes are computed.
             If this is equal to ``"time"``, node heights are proportional to their time
             values (this is the default). If this is equal to ``"log_time"``, node
@@ -4429,6 +4436,7 @@ class TreeSequence:
         draw = drawing.SvgTreeSequence(
             self,
             size,
+            x_scale=x_scale,
             tree_height_scale=tree_height_scale,
             node_labels=node_labels,
             mutation_labels=mutation_labels,


### PR DESCRIPTION
To be considered after #555 (on which this is based - the only new stuff is in the last commit in this PR). New (default) behaviour is equivalent to `ts.draw_svg(x_scale="physical")`, old behaviour is gained by `ts.draw_svg(x_scale="treewise")`. `x_scale="physical"` produces tree sequence SVG plots like the one below. There are some hard-coded margin values etc that could probably be improved, and suggestions as to better parameter nomenclature welcome.

![Screenshot 2020-04-28 at 22 49 05](https://user-images.githubusercontent.com/4699014/80541108-7e9ac180-89a2-11ea-9a2e-1b5c84e02cef.png)


