### PR TITLE
Added "order" argument to drawing functions.

### DIFF
--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -59,7 +59,7 @@ individual
 sample
     The focal nodes of a tree sequence, usually thought of as those that we
     have obtained data from. The specification of these affects various
-    methods: (1) :meth:`TreeSequence.variants` and 
+    methods: (1) :meth:`TreeSequence.variants` and
     :meth:`TreeSequence.haplotypes` will output the genotypes of the samples,
     and :attr:`Tree.roots` only return roots ancestral to at least one
     sample. (See the :ref:`node table definitions <sec_node_table_definition>`
@@ -713,7 +713,7 @@ Table transformation methods
 
 In several cases it may be necessary to transform the data stored in a
 :class:`TableCollection`. For example, an application may produce tables
-which, while logically consistent, do not meet all the 
+which, while logically consistent, do not meet all the
 :ref:`requirements <sec_valid_tree_sequence_requirements>` for a valid tree
 sequence, which exist for algorithmic and efficiency reasons; table
 transformation methods can make such a set of tables valid, and thus ready

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,12 @@
 
 In development
 
+**Breaking changes**
+
+- The default display order for tree visualisations has been changed to ``minlex``
+  (see below) to stabilise the node ordering and to make trees more readily
+  comparable. The old behaviour is still available with ``order="tree"``.
+
 **New features**
 
 - Tables with a metadata column now have a ``metadata_schema`` that is used to
@@ -27,6 +33,12 @@ In development
   lexicographic order of leaf nodes visited. This ordering (``"minlex_postorder"``)
   adds more determinism because it constraints the order in which children of
   a node are visited (:user:`brianzhang01`, :pr:`411`).
+
+- Add an ``order`` argument to the tree visualisation functions which supports
+  two node orderings: ``"tree"`` (the previous default) and ``"minlex"``
+  which stabilises the node ordering (making it easier to compare trees).
+  The default node ordering is changed to ``"minlex"``.
+  (:user:`brianzhang01`, :user:`jeromekelleher`, :issue:`389`, :pr:`566`).
 
 - Add ``_repr_html_`` to tables, so that jupyter notebooks render them as
   html tables (:user:`benjeffery`, :pr:`514`)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1462,6 +1462,7 @@ class Tree:
         edge_colours=None,
         tree_height_scale=None,
         max_tree_height=None,
+        order=None,
     ):
         """
         Returns a drawing of this tree.
@@ -1549,6 +1550,13 @@ class Tree:
             that node heights are consistent. If a numeric value, this is used as the
             maximum tree height by which to scale other nodes. This parameter
             is not currently supported for text output.
+        :param str order: The left-to-right ordering of child nodes in the drawn tree.
+            This can be either: ``"minlex"``, which minimises the differences
+            between adjacent trees (see also the ``"minlex_postorder"`` traversal
+            order for the :meth:`.nodes` method); or ``"tree"`` which draws trees
+            in the left-to-right order defined by the
+            :ref:`quintuply linked tree structure <sec_data_model_tree_structure>`.
+            If not specified or None, this defaults to ``"minlex"``.
         :return: A representation of this tree in the requested format.
         :rtype: str
         """
@@ -1564,6 +1572,7 @@ class Tree:
             edge_colours=edge_colours,
             tree_height_scale=tree_height_scale,
             max_tree_height=max_tree_height,
+            order=order,
         )
         if path is not None:
             with open(path, "w") as f:


### PR DESCRIPTION
Add a new ``order`` argument to the various drawing functions that can be either ``tree`` (the natural order arising from the quintuply linked trees) or ``minlex``, the ordering from @brianzhang01's ``minlex_postorder`` tree traversal functions.

Since this is much better, we've changed the **default** ordering, so that people's trees will look different now. The small chance of breakage seems worth it. As this is a breaking change, I've pinged a good few of you for review - feel free to just ignore this or "approve" if you're not bothered.

This ended up being a bit more involved than I had expected, but I think it's good now.

Closes #389