### PR TITLE
Make edge lists in diff iterator doubly linked

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -357,7 +357,8 @@ verify_tree_diffs(tsk_treeseq_t *ts)
     int ret;
     tsk_diff_iter_t iter;
     tsk_tree_t tree;
-    tsk_edge_list_t *record, *records_out, *records_in;
+    tsk_edge_list_node_t *record;
+    tsk_edge_list_t records_out, records_in;
     size_t num_nodes = tsk_treeseq_get_num_nodes(ts);
     size_t j, num_trees;
     double left, right;
@@ -386,10 +387,22 @@ verify_tree_diffs(tsk_treeseq_t *ts)
            == 1) {
         tsk_diff_iter_print_state(&iter, _devnull);
         num_trees++;
-        for (record = records_out; record != NULL; record = record->next) {
+        /* Update forwards */
+        for (record = records_out.head; record != NULL; record = record->next) {
             parent[record->edge.child] = TSK_NULL;
         }
-        for (record = records_in; record != NULL; record = record->next) {
+        for (record = records_in.head; record != NULL; record = record->next) {
+            parent[record->edge.child] = record->edge.parent;
+        }
+        /* Now check against the sparse tree iterator. */
+        for (j = 0; j < num_nodes; j++) {
+            CU_ASSERT_EQUAL(parent[j], tree.parent[j]);
+        }
+        /* Update backwards */
+        for (record = records_out.tail; record != NULL; record = record->prev) {
+            parent[record->edge.child] = TSK_NULL;
+        }
+        for (record = records_in.tail; record != NULL; record = record->prev) {
             parent[record->edge.child] = record->edge.parent;
         }
         /* Now check against the sparse tree iterator. */

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -297,7 +297,8 @@ tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
     tsk_id_t *restrict parent = self->parent;
     tsk_id_t *restrict T_index = self->transition_index;
     tsk_value_transition_t *restrict T = self->transitions;
-    tsk_edge_list_t *record, *records_out, *records_in;
+    tsk_edge_list_node_t *record;
+    tsk_edge_list_t records_out, records_in;
     tsk_edge_t edge;
     double left, right;
     tsk_id_t u;
@@ -308,7 +309,7 @@ tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
         goto out;
     }
 
-    for (record = records_out; record != NULL; record = record->next) {
+    for (record = records_out.head; record != NULL; record = record->next) {
         u = record->edge.child;
         if (T_index[u] == TSK_NULL) {
             /* Ensure the subtree we're detaching has a transition at the root */
@@ -325,7 +326,7 @@ tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
         parent[record->edge.child] = TSK_NULL;
     }
 
-    for (record = records_in; record != NULL; record = record->next) {
+    for (record = records_in.head; record != NULL; record = record->next) {
         edge = record->edge;
         parent[edge.child] = edge.parent;
         u = edge.parent;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -189,9 +189,15 @@ typedef struct {
 
 /* Diff iterator. TODO Not sure if we want to keep this, as it's not used
  * very much in the C code. */
-typedef struct _tsk_edge_list_t {
+typedef struct _tsk_edge_list_node_t {
     tsk_edge_t edge;
-    struct _tsk_edge_list_t *next;
+    struct _tsk_edge_list_node_t *next;
+    struct _tsk_edge_list_node_t *prev;
+} tsk_edge_list_node_t;
+
+typedef struct {
+    tsk_edge_list_node_t *head;
+    tsk_edge_list_node_t *tail;
 } tsk_edge_list_t;
 
 typedef struct {
@@ -202,7 +208,7 @@ typedef struct {
     size_t insertion_index;
     size_t removal_index;
     size_t tree_index;
-    tsk_edge_list_t *edge_list_nodes;
+    tsk_edge_list_node_t *edge_list_nodes;
 } tsk_diff_iter_t;
 
 /****************************************************************************/
@@ -406,7 +412,7 @@ int tsk_tree_kc_distance(
 int tsk_diff_iter_init(tsk_diff_iter_t *self, tsk_treeseq_t *tree_sequence);
 int tsk_diff_iter_free(tsk_diff_iter_t *self);
 int tsk_diff_iter_next(tsk_diff_iter_t *self, double *left, double *right,
-    tsk_edge_list_t **edges_out, tsk_edge_list_t **edges_in);
+    tsk_edge_list_t *edges_out, tsk_edge_list_t *edges_in);
 void tsk_diff_iter_print_state(tsk_diff_iter_t *self, FILE *out);
 
 #ifdef __cplusplus

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9420,7 +9420,8 @@ TreeDiffIterator_next(TreeDiffIterator  *self)
     int err;
     double left, right;
     size_t list_size, j;
-    tsk_edge_list_t *records_out, *records_in, *record;
+    tsk_edge_list_node_t *record;
+    tsk_edge_list_t records_out, records_in;
 
     if (TreeDiffIterator_check_state(self) != 0) {
         goto out;
@@ -9433,7 +9434,7 @@ TreeDiffIterator_next(TreeDiffIterator  *self)
     }
     if (err == 1) {
         /* out records */
-        record = records_out;
+        record = records_out.head;
         list_size = 0;
         while (record != NULL) {
             list_size++;
@@ -9443,7 +9444,7 @@ TreeDiffIterator_next(TreeDiffIterator  *self)
         if (out_list == NULL) {
             goto out;
         }
-        record = records_out;
+        record = records_out.head;
         j = 0;
         while (record != NULL) {
             value = make_edge(&record->edge, true);
@@ -9455,7 +9456,7 @@ TreeDiffIterator_next(TreeDiffIterator  *self)
             j++;
         }
         /* in records */
-        record = records_in;
+        record = records_in.head;
         list_size = 0;
         while (record != NULL) {
             list_size++;
@@ -9465,7 +9466,7 @@ TreeDiffIterator_next(TreeDiffIterator  *self)
         if (in_list == NULL) {
             goto out;
         }
-        record = records_in;
+        record = records_in.head;
         j = 0;
         while (record != NULL) {
             value = make_edge(&record->edge, true);


### PR DESCRIPTION
Added backward pointers to nodes in the edge diffs lists. Also changed the edge list struct definition to hold pointers to the head and tail of the edge list nodes. This will allow us to easily and efficiently iterate over the individual edge diff lists in leaf -> root order (forward) or root ->leaf order (backward)