### PR TITLE
fix to minor print_locs bug

### DIFF
--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -337,7 +337,7 @@ class IndividualTable(BaseTable, MetadataMixin):
         rows = []
         for j in range(self.num_rows):
             md = base64.b64encode(metadata[j]).decode("utf8")
-            location_str = ",".join(map(str, location))
+            location_str = ",".join(map(str, location[j]))
             rows.append(
                 "{}\t{}\t{}\t{}".format(j, flags[j], location_str, md).split("\t")
             )


### PR DESCRIPTION
Currently, printing an individual table prints *all* individual locations with *every* line, like so:
```
>>> print(ts.tables.individuals)
id	flags	location	metadata
0	65536	[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.]	WgAAAAAAAAD/////AQAAAP////8AAAAA
1	65536	[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.],[0. 0. 0.]	WwAAAAAAAAD/////AQAAAP////8AAAAA
```
... which was caused by missing out a `[j]` in the relevant loop. Whoops!