### PR TITLE
Use same root branch for ts

### DIFF
--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -195,7 +195,6 @@ class SvgTreeSequence:
         root_svg_attributes=None,
         style=None,
     ):
-        self.ts = ts
         if size is None:
             size = (200 * ts.num_trees, 200)
         if root_svg_attributes is None:
@@ -208,7 +207,8 @@ class SvgTreeSequence:
         )
         if style is not None:
             self.drawing.defs.add(self.drawing.style(style))
-        self.node_labels = {u: str(u) for u in range(ts.num_nodes)}
+        if node_labels is None:
+            node_labels = {u: str(u) for u in range(ts.num_nodes)}
         # TODO add general padding arguments following matplotlib's terminology.
         self.axes_x_offset = 15
         self.axes_y_offset = 10


### PR DESCRIPTION
When plotting a single tree, I do not think we should show a root branch in a tree unless there is a mutation above the root in that tree. At the moment we show a root branch if there is a mutation above the branch in any tree in the ts (which also means we have to iterate through the entire ts when plotting a single tree)

For a whole ts, however, we should plot the root branch for all trees if any tree has a mutation above the root. This minor change does that too.