### PR TITLE
compare indiv table rows and test

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -580,16 +580,21 @@ class CommonTestsMixin:
                 t2.set_columns(**input_data_copy)
                 self.assertEqual(t1, t2)
                 self.assertFalse(t1 != t2)
+                self.assertEqual(t1[0], t2[0])
                 col_copy += 1
                 t2.set_columns(**input_data_copy)
                 self.assertNotEqual(t1, t2)
                 self.assertNotEqual(t2, t1)
+                self.assertNotEqual(t1[0], t2[0])
+                self.assertTrue(t1[0] != t2[0])
+                self.assertTrue(t1[0] != [])
             for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value + 1
                 t2.set_columns(**input_data_copy)
                 self.assertNotEqual(t1, t2)
+                self.assertNotEqual(t1[0], t2[0])
                 value = list_col.get_input(num_rows + 1)
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value
@@ -600,6 +605,7 @@ class CommonTestsMixin:
                 t2.set_columns(**input_data_copy)
                 self.assertNotEqual(t1, t2)
                 self.assertNotEqual(t2, t1)
+                self.assertNotEqual(t1[-1], t2[-1])
             # Different types should always be unequal.
             self.assertNotEqual(t1, None)
             self.assertNotEqual(t1, [])

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -39,11 +39,27 @@ import tskit.util as util
 attr_options = {"slots": True, "frozen": True, "auto_attribs": True}
 
 
-@attr.s(**attr_options)
+# note: soon attrs will deprecate cmp; we just need to change this argument to eq
+@attr.s(cmp=False, **attr_options)
 class IndividualTableRow:
     flags: int
     location: np.ndarray
     metadata: bytes
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+        else:
+            return all(
+                (
+                    self.flags == other.flags,
+                    np.array_equal(self.location, other.location),
+                    self.metadata == other.metadata,
+                )
+            )
+
+    def __neq__(self, other):
+        return not self.__eq__(other)
 
 
 @attr.s(**attr_options)


### PR DESCRIPTION
@mufernando noticed that we can't compare IndividualTableRows because of the numpy arrays. And, it turned out this wasn't being tested anywhere. There is [discussion about the right way to do this](https://github.com/python-attrs/attrs/issues/435) in attrs, but currently we just have to implement ``__eq__``. The precise way to do this will [change soon](https://www.attrs.org/en/stable/changelog.html), but no big deal.