### PR TITLE
Produce better error message when running kc without sample_lists

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -4751,7 +4751,7 @@ test_no_sample_lists_kc(void)
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     ret = tsk_tree_kc_distance(&t, &t, 9, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSUPPORTED_OPERATION);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NO_SAMPLE_LISTS);
 
     tsk_treeseq_free(&ts);
     tsk_tree_free(&t);

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -402,6 +402,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_SEQUENCE_LENGTH_MISMATCH:
             ret = "Sequence lengths must be identical to compare.";
             break;
+        case TSK_ERR_NO_SAMPLE_LISTS:
+            ret = "The sample_lists option must be enabled to perform this operation.";
+            break;
 
         /* Haplotype matching errors */
         case TSK_ERR_NULL_VITERBI_MATRIX:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -245,6 +245,7 @@ not found in the file.
 #define TSK_ERR_MULTIPLE_ROOTS                                     -1203
 #define TSK_ERR_UNARY_NODES                                        -1204
 #define TSK_ERR_SEQUENCE_LENGTH_MISMATCH                           -1205
+#define TSK_ERR_NO_SAMPLE_LISTS                                    -1206
 
 /* Haplotype matching errors */
 #define TSK_ERR_NULL_VITERBI_MATRIX                                -1300

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4667,7 +4667,7 @@ check_kc_distance_tree_inputs(tsk_tree_t *self)
         goto out;
     }
     if (!tsk_tree_has_sample_lists(self)) {
-        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        ret = TSK_ERR_NO_SAMPLE_LISTS;
         goto out;
     }
 


### PR DESCRIPTION
The unsupported operation error I had used previously was pretty opaque and not helpful.