### PR TITLE
Grouped svg mutations

### DIFF
--- a/python/tests/data/svg/mut_tree.svg
+++ b/python/tests/data/svg/mut_tree.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <style type="text/css">
+<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree text {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .edge + * {r: 3px; fill: black; stroke: none}.mut > text.rgt {transform: translateX(0.5em); text-anchor: start}.mut > text.lft {transform: translateX(-0.5em); text-anchor: end}.node > text {transform: translateY(-0.8em)}.node.leaf > text {transform: translateY(1em)}.node > text.rgt {transform: translate(0.5em, -0.5em); text-anchor: start}.node > text.lft {transform: translate(-0.5em, -0.5em); text-anchor: end}.mut > text {fill: red; font-style: italic}.mut > .edge + * {fill: red;}]]>    </style>
+    <style type="text/css">
+<![CDATA[.edges {stroke: blue}]]>    </style>
+  </defs>
+  <g class="tree t0">
+    <g class="n9 root mut m1 s0" transform="translate(100.0 36.666666666666664)">
+      <g class="n9 root mut m0 s0" transform="translate(0 6.666666666666667)">
+        <g class="n9 root node" transform="translate(0 6.666666666666667)">
+          <g class="n4 p9 mut m2 s0" transform="translate(-36.0 59.758837958120594)">
+            <g class="n4 p9 node" transform="translate(0 59.758837958120594)">
+              <g class="n0 p4 node sample leaf" transform="translate(-18.0 0.48232408375881164)">
+                <path class="edge" d="M 0 0 V -0.48232408375881164 H 18.0"/>
+                <circle cx="0" cy="0" r="1"/>
+                <text>0</text>
+              </g>
+              <g class="n1 p4 node sample leaf" transform="translate(18.0 0.48232408375881164)">
+                <path class="edge" d="M 0 0 V -0.48232408375881164 H -18.0"/>
+                <circle cx="0" cy="0" r="1"/>
+                <text>1</text>
+              </g>
+              <path class="edge" d="M 0 0 V -59.758837958120594"/>
+              <circle cx="0" cy="0" r="1"/>
+              <text class="lft">4</text>
+            </g>
+            <path class="edge" d="M 0 0 V -59.758837958120594 H 36.0"/>
+            <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+            <text class="lft">2</text>
+          </g>
+          <g class="n5 p9 node" transform="translate(36.0 117.81664033569598)">
+            <g class="n2 p5 node sample leaf" transform="translate(-18.0 2.183359664304021)">
+              <path class="edge" d="M 0 0 V -2.183359664304021 H 18.0"/>
+              <circle cx="0" cy="0" r="1"/>
+              <text>2</text>
+            </g>
+            <g class="n3 p5 node sample leaf" transform="translate(18.0 2.183359664304021)">
+              <path class="edge" d="M 0 0 V -2.183359664304021 H -18.0"/>
+              <circle cx="0" cy="0" r="1"/>
+              <text>3</text>
+            </g>
+            <path class="edge" d="M 0 0 V -117.81664033569598 H -36.0"/>
+            <circle cx="0" cy="0" r="1"/>
+            <text class="rgt">5</text>
+          </g>
+          <path class="edge" d="M 0 0 V -6.666666666666667"/>
+          <circle cx="0" cy="0" r="1"/>
+          <text class="rgt">9</text>
+        </g>
+        <path class="edge" d="M 0 0 V -6.666666666666667"/>
+        <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+        <text class="lft">0</text>
+      </g>
+      <path class="edge" d="M 0 0 V -6.666666666666667"/>
+      <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+      <text class="lft">1</text>
+    </g>
+  </g>
+</svg>

--- a/python/tests/data/svg/mut_tree.svg
+++ b/python/tests/data/svg/mut_tree.svg
@@ -22,7 +22,7 @@
                 <circle class="sym" cx="0" cy="0" r="1"/>
                 <text class="lab">1</text>
               </g>
-              <path class="edge" d="M 0 0 V -59.8385"/>
+              <path class="edge" d="M 0 0 V -59.8385 H 0"/>
               <circle class="sym" cx="0" cy="0" r="1"/>
               <text class="lab lft">4</text>
             </g>
@@ -45,15 +45,15 @@
             <circle class="sym" cx="0" cy="0" r="1"/>
             <text class="lab rgt">5</text>
           </g>
-          <path class="edge" d="M 0 0 V -6.66667"/>
+          <path class="edge" d="M 0 0 V -6.66667 H 0"/>
           <circle class="sym" cx="0" cy="0" r="1"/>
           <text class="lab rgt">9</text>
         </g>
-        <path class="edge" d="M 0 0 V -6.66667"/>
+        <path class="edge" d="M 0 0 V -6.66667 H 0"/>
         <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
         <text class="lab rgt">0</text>
       </g>
-      <path class="edge" d="M 0 0 V -6.66667"/>
+      <path class="edge" d="M 0 0 V -6.66667 H 0"/>
       <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
       <text class="lab rgt">1</text>
     </g>

--- a/python/tests/data/svg/mut_tree.svg
+++ b/python/tests/data/svg/mut_tree.svg
@@ -22,7 +22,7 @@
                 <circle class="sym" cx="0" cy="0" r="1"/>
                 <text class="lab">1</text>
               </g>
-              <path class="edge" d="M 0 0 V -59.8385 H 0"/>
+              <path class="edge" d="M 0 0 V -119.677 H 36.0"/>
               <circle class="sym" cx="0" cy="0" r="1"/>
               <text class="lab lft">4</text>
             </g>
@@ -45,7 +45,7 @@
             <circle class="sym" cx="0" cy="0" r="1"/>
             <text class="lab rgt">5</text>
           </g>
-          <path class="edge" d="M 0 0 V -6.66667 H 0"/>
+          <path class="edge" d="M 0 0 V -20.0 H 0"/>
           <circle class="sym" cx="0" cy="0" r="1"/>
           <text class="lab rgt">9</text>
         </g>

--- a/python/tests/data/svg/mut_tree.svg
+++ b/python/tests/data/svg/mut_tree.svg
@@ -2,60 +2,60 @@
 <svg baseProfile="full" height="200" id="XYZ" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <style type="text/css">
-<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree text {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .edge + * {r: 3px; fill: black; stroke: none}.mut > text.rgt {transform: translateX(0.5em); text-anchor: start}.mut > text.lft {transform: translateX(-0.5em); text-anchor: end}.node > text {transform: translateY(-0.8em)}.node.leaf > text {transform: translateY(1em)}.node > text.rgt {transform: translate(0.5em, -0.5em); text-anchor: start}.node > text.lft {transform: translate(-0.5em, -0.5em); text-anchor: end}.mut > text {fill: red; font-style: italic}.mut > .edge + * {fill: red;}]]>    </style>
+<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree .lab {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .sym {r: 3px; fill: black; stroke: none}.node > .lab {transform: translateY(-0.8em)}.node.leaf > .lab {transform: translateY(1em)}.tree .lab.rgt {text-anchor: start}.tree .lab.lft {text-anchor: end}.mut > .lab.rgt {transform: translateX(0.5em);}.mut > .lab.lft {transform: translateX(-0.5em);}.node > .lab.rgt {transform: translate(0.35em, -0.5em);}.node > .lab.lft {transform: translate(-0.35em, -0.5em);}.mut > .lab {fill: red; font-style: italic}.mut > .sym {fill: red;}]]>    </style>
     <style type="text/css">
 <![CDATA[.edges {stroke: blue}]]>    </style>
   </defs>
   <g class="tree t0">
-    <g class="n9 root mut m1 s0" transform="translate(100.0 36.666666666666664)">
-      <g class="n9 root mut m0 s0" transform="translate(0 6.666666666666667)">
-        <g class="n9 root node" transform="translate(0 6.666666666666667)">
-          <g class="n4 p9 mut m2 s0" transform="translate(-36.0 59.758837958120594)">
-            <g class="n4 p9 node" transform="translate(0 59.758837958120594)">
-              <g class="n0 p4 node sample leaf" transform="translate(-18.0 0.48232408375881164)">
-                <path class="edge" d="M 0 0 V -0.48232408375881164 H 18.0"/>
-                <circle cx="0" cy="0" r="1"/>
-                <text>0</text>
+    <g class="n9 root mut m1 s0" transform="translate(100.0 36.6667)">
+      <g class="n9 root mut m0 s0" transform="translate(0 6.66667)">
+        <g class="n9 root node p0" transform="translate(0 6.66667)">
+          <g class="n4 a9 mut m2 s0" transform="translate(-36.0 59.8385)">
+            <g class="n4 a9 node p0" transform="translate(0 59.8385)">
+              <g class="n0 a4 node p0 sample leaf" transform="translate(-18.0 0.32302)">
+                <path class="edge" d="M 0 0 V -0.32302 H 18.0"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">0</text>
               </g>
-              <g class="n1 p4 node sample leaf" transform="translate(18.0 0.48232408375881164)">
-                <path class="edge" d="M 0 0 V -0.48232408375881164 H -18.0"/>
-                <circle cx="0" cy="0" r="1"/>
-                <text>1</text>
+              <g class="n1 a4 node p0 sample leaf" transform="translate(18.0 0.32302)">
+                <path class="edge" d="M 0 0 V -0.32302 H -18.0"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">1</text>
               </g>
-              <path class="edge" d="M 0 0 V -59.758837958120594"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text class="lft">4</text>
+              <path class="edge" d="M 0 0 V -59.8385"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab lft">4</text>
             </g>
-            <path class="edge" d="M 0 0 V -59.758837958120594 H 36.0"/>
-            <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
-            <text class="lft">2</text>
+            <path class="edge" d="M 0 0 V -59.8385 H 36.0"/>
+            <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+            <text class="lab lft">2</text>
           </g>
-          <g class="n5 p9 node" transform="translate(36.0 117.81664033569598)">
-            <g class="n2 p5 node sample leaf" transform="translate(-18.0 2.183359664304021)">
-              <path class="edge" d="M 0 0 V -2.183359664304021 H 18.0"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>2</text>
+          <g class="n5 a9 node p0" transform="translate(36.0 118.538)">
+            <g class="n2 a5 node p0 sample leaf" transform="translate(-18.0 1.46223)">
+              <path class="edge" d="M 0 0 V -1.46223 H 18.0"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab">2</text>
             </g>
-            <g class="n3 p5 node sample leaf" transform="translate(18.0 2.183359664304021)">
-              <path class="edge" d="M 0 0 V -2.183359664304021 H -18.0"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>3</text>
+            <g class="n3 a5 node p0 sample leaf" transform="translate(18.0 1.46223)">
+              <path class="edge" d="M 0 0 V -1.46223 H -18.0"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab">3</text>
             </g>
-            <path class="edge" d="M 0 0 V -117.81664033569598 H -36.0"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="rgt">5</text>
+            <path class="edge" d="M 0 0 V -118.538 H -36.0"/>
+            <circle class="sym" cx="0" cy="0" r="1"/>
+            <text class="lab rgt">5</text>
           </g>
-          <path class="edge" d="M 0 0 V -6.666666666666667"/>
-          <circle cx="0" cy="0" r="1"/>
-          <text class="rgt">9</text>
+          <path class="edge" d="M 0 0 V -6.66667"/>
+          <circle class="sym" cx="0" cy="0" r="1"/>
+          <text class="lab rgt">9</text>
         </g>
-        <path class="edge" d="M 0 0 V -6.666666666666667"/>
-        <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
-        <text class="lft">0</text>
+        <path class="edge" d="M 0 0 V -6.66667"/>
+        <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+        <text class="lab rgt">0</text>
       </g>
-      <path class="edge" d="M 0 0 V -6.666666666666667"/>
-      <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
-      <text class="lft">1</text>
+      <path class="edge" d="M 0 0 V -6.66667"/>
+      <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+      <text class="lab rgt">1</text>
     </g>
   </g>
 </svg>

--- a/python/tests/data/svg/tree.svg
+++ b/python/tests/data/svg/tree.svg
@@ -1,47 +1,46 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="200">
+<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
-    <style type="text/css"><![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.edge {stroke: black; fill: none}.node > circle {r: 3px; fill: black; stroke: none}.tree text {dominant-baseline: middle}.mut > text.lft {transform: translateX(0.5em); text-anchor: start}.mut > text.rgt {transform: translateX(-0.5em); text-anchor: end}.root > text {transform: translateY(-0.8em)}.leaf > text {transform: translateY(1em)}.node > text.lft {transform: translate(0.5em, -0.5em); text-anchor: start}.node > text.rgt {transform: translate(-0.5em, -0.5em); text-anchor: end}.mut {fill: red; font-style: italic}]]></style>
-    <style type="text/css"><![CDATA[.edges {stroke: blue}]]></style>
+    <style type="text/css">
+<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree text {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .edge + * {r: 3px; fill: black; stroke: none}.mut > text.rgt {transform: translateX(0.5em); text-anchor: start}.mut > text.lft {transform: translateX(-0.5em); text-anchor: end}.node > text {transform: translateY(-0.8em)}.node.leaf > text {transform: translateY(1em)}.node > text.rgt {transform: translate(0.5em, -0.5em); text-anchor: start}.node > text.lft {transform: translate(-0.5em, -0.5em); text-anchor: end}.mut > text {fill: red; font-style: italic}.mut > .edge + * {fill: red;}]]>    </style>
+    <style type="text/css">
+<![CDATA[.edges {stroke: blue}]]>    </style>
   </defs>
-  <g class="tree t0">
-    <g class="node n9 root" transform="translate(100.0 30.0)">
-      <g class="m0 node n4 p9 s0" transform="translate(-36.0 139.623)">
-        <g class="leaf node n0 p4 sample" transform="translate(-18.0 0.376857)">
-          <path class="edge" d="M 0 0 V -0.376857 H 18.0"/>
+  <g class="tree t1">
+    <g class="n7 root node" transform="translate(100.0 30.0)">
+      <g class="n4 p7 node" transform="translate(-36.0 138.51860362908977)">
+        <g class="n0 p4 node sample leaf" transform="translate(-18.0 1.4813963709102325)">
+          <path class="edge" d="M 0 0 V -1.4813963709102325 H 18.0"/>
           <circle cx="0" cy="0" r="1"/>
           <text>0</text>
         </g>
-        <g class="leaf node n1 p4 sample" transform="translate(18.0 0.376857)">
-          <path class="edge" d="M 0 0 V -0.376857 H -18.0"/>
+        <g class="n1 p4 node sample leaf" transform="translate(18.0 1.4813963709102325)">
+          <path class="edge" d="M 0 0 V -1.4813963709102325 H -18.0"/>
           <circle cx="0" cy="0" r="1"/>
           <text>1</text>
         </g>
-        <path class="edge" d="M 0 0 V -139.623 H 36.0"/>
+        <path class="edge" d="M 0 0 V -138.51860362908977 H 36.0"/>
         <circle cx="0" cy="0" r="1"/>
-        <text class="rgt">4</text>
-        <g class="mut m0 s0" transform="translate(0 -69.8116)">
-          <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
-          <text class="rgt">0</text>
-        </g>
+        <text class="lft">4</text>
       </g>
-      <g class="node n5 p9" transform="translate(36.0 138.294)">
-        <g class="leaf node n2 p5 sample" transform="translate(-18.0 1.70594)">
-          <path class="edge" d="M 0 0 V -1.70594 H 18.0"/>
+      <g class="n5 p7 node" transform="translate(36.0 133.29409168647453)">
+        <g class="n2 p5 node sample leaf" transform="translate(-18.0 6.70590831352547)">
+          <path class="edge" d="M 0 0 V -6.70590831352547 H 18.0"/>
           <circle cx="0" cy="0" r="1"/>
           <text>2</text>
         </g>
-        <g class="leaf node n3 p5 sample" transform="translate(18.0 1.70594)">
-          <path class="edge" d="M 0 0 V -1.70594 H -18.0"/>
+        <g class="n3 p5 node sample leaf" transform="translate(18.0 6.70590831352547)">
+          <path class="edge" d="M 0 0 V -6.70590831352547 H -18.0"/>
           <circle cx="0" cy="0" r="1"/>
           <text>3</text>
         </g>
-        <path class="edge" d="M 0 0 V -138.294 H -36.0"/>
+        <path class="edge" d="M 0 0 V -133.29409168647453 H -36.0"/>
         <circle cx="0" cy="0" r="1"/>
-        <text class="lft">5</text>
+        <text class="rgt">5</text>
       </g>
+      <path class="edge" d="M 0 0"/>
       <circle cx="0" cy="0" r="1"/>
-      <text>9</text>
+      <text>7</text>
     </g>
   </g>
 </svg>

--- a/python/tests/data/svg/tree.svg
+++ b/python/tests/data/svg/tree.svg
@@ -2,45 +2,45 @@
 <svg baseProfile="full" height="200" id="XYZ" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <style type="text/css">
-<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree text {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .edge + * {r: 3px; fill: black; stroke: none}.mut > text.rgt {transform: translateX(0.5em); text-anchor: start}.mut > text.lft {transform: translateX(-0.5em); text-anchor: end}.node > text {transform: translateY(-0.8em)}.node.leaf > text {transform: translateY(1em)}.node > text.rgt {transform: translate(0.5em, -0.5em); text-anchor: start}.node > text.lft {transform: translate(-0.5em, -0.5em); text-anchor: end}.mut > text {fill: red; font-style: italic}.mut > .edge + * {fill: red;}]]>    </style>
+<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree .lab {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .sym {r: 3px; fill: black; stroke: none}.node > .lab {transform: translateY(-0.8em)}.node.leaf > .lab {transform: translateY(1em)}.tree .lab.rgt {text-anchor: start}.tree .lab.lft {text-anchor: end}.mut > .lab.rgt {transform: translateX(0.5em);}.mut > .lab.lft {transform: translateX(-0.5em);}.node > .lab.rgt {transform: translate(0.35em, -0.5em);}.node > .lab.lft {transform: translate(-0.35em, -0.5em);}.mut > .lab {fill: red; font-style: italic}.mut > .sym {fill: red;}]]>    </style>
     <style type="text/css">
 <![CDATA[.edges {stroke: blue}]]>    </style>
   </defs>
   <g class="tree t1">
-    <g class="n7 root node" transform="translate(100.0 30.0)">
-      <g class="n4 p7 node" transform="translate(-36.0 138.51860362908977)">
-        <g class="n0 p4 node sample leaf" transform="translate(-18.0 1.4813963709102325)">
-          <path class="edge" d="M 0 0 V -1.4813963709102325 H 18.0"/>
-          <circle cx="0" cy="0" r="1"/>
-          <text>0</text>
+    <g class="n7 root node p0" transform="translate(100.0 30.0)">
+      <g class="n4 a7 node p0" transform="translate(-36.0 138.519)">
+        <g class="n0 a4 node p0 sample leaf" transform="translate(-18.0 1.4814)">
+          <path class="edge" d="M 0 0 V -1.4814 H 18.0"/>
+          <circle class="sym" cx="0" cy="0" r="1"/>
+          <text class="lab">0</text>
         </g>
-        <g class="n1 p4 node sample leaf" transform="translate(18.0 1.4813963709102325)">
-          <path class="edge" d="M 0 0 V -1.4813963709102325 H -18.0"/>
-          <circle cx="0" cy="0" r="1"/>
-          <text>1</text>
+        <g class="n1 a4 node p0 sample leaf" transform="translate(18.0 1.4814)">
+          <path class="edge" d="M 0 0 V -1.4814 H -18.0"/>
+          <circle class="sym" cx="0" cy="0" r="1"/>
+          <text class="lab">1</text>
         </g>
-        <path class="edge" d="M 0 0 V -138.51860362908977 H 36.0"/>
-        <circle cx="0" cy="0" r="1"/>
-        <text class="lft">4</text>
+        <path class="edge" d="M 0 0 V -138.519 H 36.0"/>
+        <circle class="sym" cx="0" cy="0" r="1"/>
+        <text class="lab lft">4</text>
       </g>
-      <g class="n5 p7 node" transform="translate(36.0 133.29409168647453)">
-        <g class="n2 p5 node sample leaf" transform="translate(-18.0 6.70590831352547)">
-          <path class="edge" d="M 0 0 V -6.70590831352547 H 18.0"/>
-          <circle cx="0" cy="0" r="1"/>
-          <text>2</text>
+      <g class="n5 a7 node p0" transform="translate(36.0 133.294)">
+        <g class="n2 a5 node p0 sample leaf" transform="translate(-18.0 6.70591)">
+          <path class="edge" d="M 0 0 V -6.70591 H 18.0"/>
+          <circle class="sym" cx="0" cy="0" r="1"/>
+          <text class="lab">2</text>
         </g>
-        <g class="n3 p5 node sample leaf" transform="translate(18.0 6.70590831352547)">
-          <path class="edge" d="M 0 0 V -6.70590831352547 H -18.0"/>
-          <circle cx="0" cy="0" r="1"/>
-          <text>3</text>
+        <g class="n3 a5 node p0 sample leaf" transform="translate(18.0 6.70591)">
+          <path class="edge" d="M 0 0 V -6.70591 H -18.0"/>
+          <circle class="sym" cx="0" cy="0" r="1"/>
+          <text class="lab">3</text>
         </g>
-        <path class="edge" d="M 0 0 V -133.29409168647453 H -36.0"/>
-        <circle cx="0" cy="0" r="1"/>
-        <text class="rgt">5</text>
+        <path class="edge" d="M 0 0 V -133.294 H -36.0"/>
+        <circle class="sym" cx="0" cy="0" r="1"/>
+        <text class="lab rgt">5</text>
       </g>
       <path class="edge" d="M 0 0"/>
-      <circle cx="0" cy="0" r="1"/>
-      <text>7</text>
+      <circle class="sym" cx="0" cy="0" r="1"/>
+      <text class="lab">7</text>
     </g>
   </g>
 </svg>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -30,7 +30,7 @@
                       <circle class="sym" cx="0" cy="0" r="1"/>
                       <text class="lab">1</text>
                     </g>
-                    <path class="edge" d="M 0 0 V -32.9112 H 0"/>
+                    <path class="edge" d="M 0 0 V -65.8223 H 34.4"/>
                     <circle class="sym" cx="0" cy="0" r="1"/>
                     <text class="lab lft">4</text>
                   </g>
@@ -53,7 +53,7 @@
                   <circle class="sym" cx="0" cy="0" r="1"/>
                   <text class="lab rgt">5</text>
                 </g>
-                <path class="edge" d="M 0 0 V -4.66667 H 0"/>
+                <path class="edge" d="M 0 0 V -14.0 H 0"/>
                 <circle class="sym" cx="0" cy="0" r="1"/>
                 <text class="lab rgt">9</text>
               </g>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="1000">
+<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="1000" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
-    <style type="text/css"><![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.edge {stroke: black; fill: none}.node > circle {r: 3px; fill: black; stroke: none}.tree text {dominant-baseline: middle}.mut > text.lft {transform: translateX(0.5em); text-anchor: start}.mut > text.rgt {transform: translateX(-0.5em); text-anchor: end}.root > text {transform: translateY(-0.8em)}.leaf > text {transform: translateY(1em)}.node > text.lft {transform: translate(0.5em, -0.5em); text-anchor: start}.node > text.rgt {transform: translate(-0.5em, -0.5em); text-anchor: end}.mut {fill: red; font-style: italic}]]></style>
-    <style type="text/css"><![CDATA[.edges {stroke: blue}]]></style>
+    <style type="text/css">
+<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle;}.tree .lab {dominant-baseline: middle}.edge {stroke: black; fill: none}.node > .sym {r: 3px; fill: black; stroke: none}.node > .lab {transform: translateY(-0.8em)}.node.leaf > .lab {transform: translateY(1em)}.tree .lab.rgt {text-anchor: start}.tree .lab.lft {text-anchor: end}.mut > .lab.rgt {transform: translateX(0.5em);}.mut > .lab.lft {transform: translateX(-0.5em);}.node > .lab.rgt {transform: translate(0.35em, -0.5em);}.node > .lab.lft {transform: translate(-0.35em, -0.5em);}.mut > .lab {fill: red; font-style: italic}.mut > .sym {fill: red;}]]>    </style>
+    <style type="text/css">
+<![CDATA[.edges {stroke: blue}]]>    </style>
   </defs>
   <g class="tree-sequence">
     <g class="background">
@@ -11,188 +13,214 @@
       <polygon fill="#F1F1F1" points="893.883,185 893.883,180 788.0,160 788.0,0 980.0,0 980.0,160 980.0,180 980.0,185"/>
     </g>
     <g class="trees">
-      <g class="tree t0" transform="translate(20 30)">
-        <g class="node n9 root" transform="translate(96.0 30.0)">
-          <g class="m0 node n4 p9 s0" transform="translate(-34.4 79.7847)">
-            <g class="leaf node n0 p4 sample" transform="translate(-17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>0</text>
+      <g class="treebox t0" transform="translate(20 30)">
+        <g class="tree t0">
+          <g class="n9 root mut m1 s0" transform="translate(96.0 34.6667)">
+            <g class="n9 root mut m0 s0" transform="translate(0 4.66667)">
+              <g class="n9 root node p0" transform="translate(0 4.66667)">
+                <g class="n4 a9 mut m2 s0" transform="translate(-34.4 32.9112)">
+                  <g class="n4 a9 node p0" transform="translate(0 32.9112)">
+                    <g class="n0 a4 node p0 sample leaf" transform="translate(-17.2 0.177661)">
+                      <path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+                      <circle class="sym" cx="0" cy="0" r="1"/>
+                      <text class="lab">0</text>
+                    </g>
+                    <g class="n1 a4 node p0 sample leaf" transform="translate(17.2 0.177661)">
+                      <path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+                      <circle class="sym" cx="0" cy="0" r="1"/>
+                      <text class="lab">1</text>
+                    </g>
+                    <path class="edge" d="M 0 0 V -32.9112"/>
+                    <circle class="sym" cx="0" cy="0" r="1"/>
+                    <text class="lab lft">4</text>
+                  </g>
+                  <path class="edge" d="M 0 0 V -32.9112 H 34.4"/>
+                  <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+                  <text class="lab lft">2</text>
+                </g>
+                <g class="n5 a9 node p0" transform="translate(34.4 65.1958)">
+                  <g class="n2 a5 node p0 sample leaf" transform="translate(-17.2 0.804227)">
+                    <path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+                    <circle class="sym" cx="0" cy="0" r="1"/>
+                    <text class="lab">2</text>
+                  </g>
+                  <g class="n3 a5 node p0 sample leaf" transform="translate(17.2 0.804227)">
+                    <path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+                    <circle class="sym" cx="0" cy="0" r="1"/>
+                    <text class="lab">3</text>
+                  </g>
+                  <path class="edge" d="M 0 0 V -65.1958 H -34.4"/>
+                  <circle class="sym" cx="0" cy="0" r="1"/>
+                  <text class="lab rgt">5</text>
+                </g>
+                <path class="edge" d="M 0 0 V -4.66667"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab rgt">9</text>
+              </g>
+              <path class="edge" d="M 0 0 V -4.66667"/>
+              <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+              <text class="lab rgt">0</text>
             </g>
-            <g class="leaf node n1 p4 sample" transform="translate(17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>1</text>
-            </g>
-            <path class="edge" d="M 0 0 V -79.7847 H 34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="rgt">4</text>
-            <g class="mut m0 s0" transform="translate(0 -39.8923)">
-              <rect height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
-              <text class="rgt">0</text>
-            </g>
+            <path class="edge" d="M 0 0 V -4.66667"/>
+            <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+            <text class="lab rgt">1</text>
           </g>
-          <g class="node n5 p9" transform="translate(34.4 79.0252)">
-            <g class="leaf node n2 p5 sample" transform="translate(-17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>2</text>
-            </g>
-            <g class="leaf node n3 p5 sample" transform="translate(17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>3</text>
-            </g>
-            <path class="edge" d="M 0 0 V -79.0252 H -34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="lft">5</text>
-          </g>
-          <circle cx="0" cy="0" r="1"/>
-          <text>9</text>
         </g>
       </g>
-      <g class="tree t1" transform="translate(212.0 30)">
-        <g class="node n7 root" transform="translate(96.0 89.6486)">
-          <g class="node n4 p7" transform="translate(-34.4 20.1361)">
-            <g class="leaf node n0 p4 sample" transform="translate(-17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>0</text>
+      <g class="treebox t1" transform="translate(212.0 30)">
+        <g class="tree t1">
+          <g class="n7 root node p0" transform="translate(96.0 93.2101)">
+            <g class="n4 a7 node p0" transform="translate(-34.4 16.6123)">
+              <g class="n0 a4 node p0 sample leaf" transform="translate(-17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">0</text>
+              </g>
+              <g class="n1 a4 node p0 sample leaf" transform="translate(17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">1</text>
+              </g>
+              <path class="edge" d="M 0 0 V -16.6123 H 34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab lft">4</text>
             </g>
-            <g class="leaf node n1 p4 sample" transform="translate(17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>1</text>
+            <g class="n5 a7 node p0" transform="translate(34.4 15.9857)">
+              <g class="n2 a5 node p0 sample leaf" transform="translate(-17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">2</text>
+              </g>
+              <g class="n3 a5 node p0 sample leaf" transform="translate(17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">3</text>
+              </g>
+              <path class="edge" d="M 0 0 V -15.9857 H -34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -20.1361 H 34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="rgt">4</text>
+            <path class="edge" d="M 0 0 V -14.0"/>
+            <circle class="sym" cx="0" cy="0" r="1"/>
+            <text class="lab rgt">7</text>
           </g>
-          <g class="node n5 p7" transform="translate(34.4 19.3766)">
-            <g class="leaf node n2 p5 sample" transform="translate(-17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>2</text>
-            </g>
-            <g class="leaf node n3 p5 sample" transform="translate(17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>3</text>
-            </g>
-            <path class="edge" d="M 0 0 V -19.3766 H -34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="lft">5</text>
-          </g>
-          <circle cx="0" cy="0" r="1"/>
-          <text>7</text>
         </g>
       </g>
-      <g class="tree t2" transform="translate(404.0 30)">
-        <g class="node n6 root" transform="translate(96.0 94.5863)">
-          <g class="node n4 p6" transform="translate(-34.4 15.1984)">
-            <g class="leaf node n0 p4 sample" transform="translate(-17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>0</text>
+      <g class="treebox t2" transform="translate(404.0 30)">
+        <g class="tree t2">
+          <g class="n6 root node p0" transform="translate(96.0 97.2837)">
+            <g class="n4 a6 node p0" transform="translate(-34.4 12.5387)">
+              <g class="n0 a4 node p0 sample leaf" transform="translate(-17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">0</text>
+              </g>
+              <g class="n1 a4 node p0 sample leaf" transform="translate(17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">1</text>
+              </g>
+              <path class="edge" d="M 0 0 V -12.5387 H 34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab lft">4</text>
             </g>
-            <g class="leaf node n1 p4 sample" transform="translate(17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>1</text>
+            <g class="n5 a6 node p0" transform="translate(34.4 11.9121)">
+              <g class="n2 a5 node p0 sample leaf" transform="translate(-17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">2</text>
+              </g>
+              <g class="n3 a5 node p0 sample leaf" transform="translate(17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">3</text>
+              </g>
+              <path class="edge" d="M 0 0 V -11.9121 H -34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -15.1984 H 34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="rgt">4</text>
+            <path class="edge" d="M 0 0 V -14.0"/>
+            <circle class="sym" cx="0" cy="0" r="1"/>
+            <text class="lab rgt">6</text>
           </g>
-          <g class="node n5 p6" transform="translate(34.4 14.4389)">
-            <g class="leaf node n2 p5 sample" transform="translate(-17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>2</text>
-            </g>
-            <g class="leaf node n3 p5 sample" transform="translate(17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>3</text>
-            </g>
-            <path class="edge" d="M 0 0 V -14.4389 H -34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="lft">5</text>
-          </g>
-          <circle cx="0" cy="0" r="1"/>
-          <text>6</text>
         </g>
       </g>
-      <g class="tree t3" transform="translate(596.0 30)">
-        <g class="node n7 root" transform="translate(96.0 89.6486)">
-          <g class="node n4 p7" transform="translate(-34.4 20.1361)">
-            <g class="leaf node n0 p4 sample" transform="translate(-17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>0</text>
+      <g class="treebox t3" transform="translate(596.0 30)">
+        <g class="tree t3">
+          <g class="n7 root node p0" transform="translate(96.0 93.2101)">
+            <g class="n4 a7 node p0" transform="translate(-34.4 16.6123)">
+              <g class="n0 a4 node p0 sample leaf" transform="translate(-17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">0</text>
+              </g>
+              <g class="n1 a4 node p0 sample leaf" transform="translate(17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">1</text>
+              </g>
+              <path class="edge" d="M 0 0 V -16.6123 H 34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab lft">4</text>
             </g>
-            <g class="leaf node n1 p4 sample" transform="translate(17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>1</text>
+            <g class="n5 a7 node p0" transform="translate(34.4 15.9857)">
+              <g class="n2 a5 node p0 sample leaf" transform="translate(-17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">2</text>
+              </g>
+              <g class="n3 a5 node p0 sample leaf" transform="translate(17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">3</text>
+              </g>
+              <path class="edge" d="M 0 0 V -15.9857 H -34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -20.1361 H 34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="rgt">4</text>
+            <path class="edge" d="M 0 0 V -14.0"/>
+            <circle class="sym" cx="0" cy="0" r="1"/>
+            <text class="lab rgt">7</text>
           </g>
-          <g class="node n5 p7" transform="translate(34.4 19.3766)">
-            <g class="leaf node n2 p5 sample" transform="translate(-17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>2</text>
-            </g>
-            <g class="leaf node n3 p5 sample" transform="translate(17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>3</text>
-            </g>
-            <path class="edge" d="M 0 0 V -19.3766 H -34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="lft">5</text>
-          </g>
-          <circle cx="0" cy="0" r="1"/>
-          <text>7</text>
         </g>
       </g>
-      <g class="tree t4" transform="translate(788.0 30)">
-        <g class="node n8 root" transform="translate(96.0 78.5277)">
-          <g class="node n4 p8" transform="translate(-34.4 31.2569)">
-            <g class="leaf node n0 p4 sample" transform="translate(-17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>0</text>
+      <g class="treebox t4" transform="translate(788.0 30)">
+        <g class="tree t4">
+          <g class="n8 root node p0" transform="translate(96.0 84.0354)">
+            <g class="n4 a8 node p0" transform="translate(-34.4 25.7869)">
+              <g class="n0 a4 node p0 sample leaf" transform="translate(-17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">0</text>
+              </g>
+              <g class="n1 a4 node p0 sample leaf" transform="translate(17.2 0.177661)">
+                <path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">1</text>
+              </g>
+              <path class="edge" d="M 0 0 V -25.7869 H 34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab lft">4</text>
             </g>
-            <g class="leaf node n1 p4 sample" transform="translate(17.2 0.215347)">
-              <path class="edge" d="M 0 0 V -0.215347 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>1</text>
+            <g class="n5 a8 node p0" transform="translate(34.4 25.1604)">
+              <g class="n2 a5 node p0 sample leaf" transform="translate(-17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">2</text>
+              </g>
+              <g class="n3 a5 node p0 sample leaf" transform="translate(17.2 0.804227)">
+                <path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+                <circle class="sym" cx="0" cy="0" r="1"/>
+                <text class="lab">3</text>
+              </g>
+              <path class="edge" d="M 0 0 V -25.1604 H -34.4"/>
+              <circle class="sym" cx="0" cy="0" r="1"/>
+              <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -31.2569 H 34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="rgt">4</text>
+            <path class="edge" d="M 0 0 V -14.0"/>
+            <circle class="sym" cx="0" cy="0" r="1"/>
+            <text class="lab rgt">8</text>
           </g>
-          <g class="node n5 p8" transform="translate(34.4 30.4974)">
-            <g class="leaf node n2 p5 sample" transform="translate(-17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H 17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>2</text>
-            </g>
-            <g class="leaf node n3 p5 sample" transform="translate(17.2 0.97482)">
-              <path class="edge" d="M 0 0 V -0.97482 H -17.2"/>
-              <circle cx="0" cy="0" r="1"/>
-              <text>3</text>
-            </g>
-            <path class="edge" d="M 0 0 V -30.4974 H -34.4"/>
-            <circle cx="0" cy="0" r="1"/>
-            <text class="lft">5</text>
-          </g>
-          <circle cx="0" cy="0" r="1"/>
-          <text>8</text>
         </g>
       </g>
     </g>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -30,7 +30,7 @@
                       <circle class="sym" cx="0" cy="0" r="1"/>
                       <text class="lab">1</text>
                     </g>
-                    <path class="edge" d="M 0 0 V -32.9112"/>
+                    <path class="edge" d="M 0 0 V -32.9112 H 0"/>
                     <circle class="sym" cx="0" cy="0" r="1"/>
                     <text class="lab lft">4</text>
                   </g>
@@ -53,15 +53,15 @@
                   <circle class="sym" cx="0" cy="0" r="1"/>
                   <text class="lab rgt">5</text>
                 </g>
-                <path class="edge" d="M 0 0 V -4.66667"/>
+                <path class="edge" d="M 0 0 V -4.66667 H 0"/>
                 <circle class="sym" cx="0" cy="0" r="1"/>
                 <text class="lab rgt">9</text>
               </g>
-              <path class="edge" d="M 0 0 V -4.66667"/>
+              <path class="edge" d="M 0 0 V -4.66667 H 0"/>
               <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
               <text class="lab rgt">0</text>
             </g>
-            <path class="edge" d="M 0 0 V -4.66667"/>
+            <path class="edge" d="M 0 0 V -4.66667 H 0"/>
             <rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
             <text class="lab rgt">1</text>
           </g>
@@ -100,7 +100,7 @@
               <circle class="sym" cx="0" cy="0" r="1"/>
               <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -14.0"/>
+            <path class="edge" d="M 0 0 V -14.0 H 0"/>
             <circle class="sym" cx="0" cy="0" r="1"/>
             <text class="lab rgt">7</text>
           </g>
@@ -139,7 +139,7 @@
               <circle class="sym" cx="0" cy="0" r="1"/>
               <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -14.0"/>
+            <path class="edge" d="M 0 0 V -14.0 H 0"/>
             <circle class="sym" cx="0" cy="0" r="1"/>
             <text class="lab rgt">6</text>
           </g>
@@ -178,7 +178,7 @@
               <circle class="sym" cx="0" cy="0" r="1"/>
               <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -14.0"/>
+            <path class="edge" d="M 0 0 V -14.0 H 0"/>
             <circle class="sym" cx="0" cy="0" r="1"/>
             <text class="lab rgt">7</text>
           </g>
@@ -217,7 +217,7 @@
               <circle class="sym" cx="0" cy="0" r="1"/>
               <text class="lab rgt">5</text>
             </g>
-            <path class="edge" d="M 0 0 V -14.0"/>
+            <path class="edge" d="M 0 0 V -14.0 H 0"/>
             <circle class="sym" cx="0" cy="0" r="1"/>
             <text class="lab rgt">8</text>
           </g>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -1422,12 +1422,15 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
                     trees = g
                     break
             self.assertIsNotNone(trees)  # Must have found a trees group
-            first_tree = trees.find(prefix + "g")
+            first_treebox = trees.find(prefix + "g")
+            self.assertIn("class", first_treebox.attrib)
+            self.assertRegexpMatches(first_treebox.attrib["class"], r"\btreebox\b")
+            first_tree = first_treebox.find(prefix + "g")
             self.assertIn("class", first_tree.attrib)
             self.assertRegexpMatches(first_tree.attrib["class"], r"\btree\b")
         else:
             first_tree = root_group
-        # Check that we have edges, symbols, and labels groups
+        # Check that the first grouping is labelled as a root
         groups = first_tree.findall(prefix + "g")
         self.assertGreater(len(groups), 0)
         for group in groups:
@@ -1768,13 +1771,14 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         self.verify_basic_svg(svg, width=200 * ts.num_trees)
 
     def test_draw_integer_breaks_ts(self):
-        r_map = msprime.RecombinationMap.uniform_map(1000, 0.001, num_loci=1000)
         r_map = msprime.RecombinationMap.uniform_map(1000, 0.005, num_loci=1000)
         ts = msprime.simulate(5, recombination_map=r_map, random_seed=1)
+        self.assertGreater(ts.num_trees, 2)
         svg = ts.draw_svg()
         self.verify_basic_svg(svg, width=200 * ts.num_trees)
+        axis_pos = svg.find('class="axis"')
         for b in ts.breakpoints():
-            self.assertNotEqual(svg.find(f">{b:.0f}<"), -1)
+            self.assertNotEqual(svg.find(f">{b:.0f}<", axis_pos), -1)
 
     def test_draw_even_height_ts(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=1)

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -473,12 +473,14 @@ class SvgTree:
             self.node_attrs[u] = {}
             if node_attrs is not None and u in node_attrs:
                 self.node_attrs[u].update(node_attrs[u])
+            self.add_class(self.node_attrs[u], "sym")  # class 'sym' for symbol
             label = ""
             if node_labels is None:
                 label = str(u)
             elif u in node_labels:
                 label = str(node_labels[u])
             self.node_label_attrs[u] = {"text": label}
+            self.add_class(self.node_label_attrs[u], "lab")  # class 'lab' for label
             if node_label_attrs is not None and u in node_label_attrs:
                 self.node_label_attrs[u].update(node_label_attrs[u])
 
@@ -494,6 +496,7 @@ class SvgTree:
                 }
                 if mutation_attrs is not None and m in mutation_attrs:
                     self.mutation_attrs[m].update(mutation_attrs[m])
+                self.add_class(self.mutation_attrs[m], "sym")  # class 'sym' for symbol
                 label = ""
                 if mutation_labels is None:
                     label = str(m)
@@ -502,6 +505,7 @@ class SvgTree:
                 self.mutation_label_attrs[m] = {"text": label}
                 if mutation_label_attrs is not None and m in mutation_label_attrs:
                     self.mutation_label_attrs[m].update(mutation_label_attrs[m])
+                self.add_class(self.mutation_label_attrs[m], "lab")
 
         self.draw()
 
@@ -622,7 +626,12 @@ class SvgTree:
             edge_height = dy / (len(self.node_mutations[focal]) + 1)
             offset_y = edge_height
 
-        # Add mutation symbols + labels
+        # Add mut group for each mutation, and give it these classes for css targetting:
+        # "mut"
+        # "nA":           where A == focal node id
+        # "pB" or "root": where B == parent id (or "root" if the focal node is a root)
+        # "mX":           where X == mutation id
+        # "sY":           where Y == site id
         for m in reversed(self.node_mutations[focal]):
             mutation_classes = ["mut", f"m{m.id}", f"s{m.site}"]
             grp = grp.add(
@@ -636,7 +645,7 @@ class SvgTree:
                     g=grp, edge_dxy=(edge_x, edge_height), node=focal, mutation=m.id
                 )
             )
-            # after the first sideways move, all further movements go downwards
+            # after the first sideways line of an edge all further movements go downwards
             offset_x = edge_x = 0
             offset_y = edge_height
 

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -617,11 +617,12 @@ class SvgTree:
         offset_y = dy
         if v == NULL:
             classes.append(f"root")
+            # set the origin of the
+            dx = 0
+            dy = self.root_branch_length
             edge_x = 0
-            edge_height = self.root_branch_length / (
-                len(self.node_mutations[focal]) + 1
-            )
-            offset_y = dy - self.root_branch_length + edge_height
+            edge_height = dy / (len(self.node_mutations[focal]) + 1)
+            offset_y = offset_y - self.root_branch_length + edge_height
         else:
             classes.append(f"a{v}")
             edge_x = offset_x
@@ -674,11 +675,7 @@ class SvgTree:
                 transform=f"translate({rnd(offset_x)} {rnd(offset_y)})",
             )
         )
-        ret.append(
-            SvgGroupInfo(
-                g=grp, edge_dxy=(edge_x, edge_height), node=focal, mutation=None
-            )
-        )
+        ret.append(SvgGroupInfo(g=grp, edge_dxy=(dx, dy), node=focal, mutation=None))
         return ret
 
     def draw(self):


### PR DESCRIPTION
This follows on from #570 and picks up the idea of creating an SVG group for each mutation too (see https://github.com/tskit-dev/tskit/pull/570#issuecomment-624011266 for justification).

It seems like this is a good idea to me. The main thing to sort out is how we assign classes to the groups. At the moment I assign the parent node id (or "root") plus the child node id to all groups, including mutation groups. Mutation groups then have an additional 'mut" class and the mutation number and site number, whereas node groups have a "node" class. An example would be something like this (assuming an example with mutation 0 over a root node id 8 with 2 daughters, id 4 and 5)

```xml
<g class="tree t0">
  <g class="root n8 mut m0 s0">  <!-- a mutation group identifying mutation 0 over node 8 -->  
    <g class="root n8 node">   <!-- a node group identifying node 8-->
      <g class="p8 n4 mut m1 s1">  <!-- a mutation group identifying mutation 1 over child node 4 -->
      ... further mutation or node groups, including the node group for node 4 and descendants
      </g>
      <g class="p8 n5 mut m2 s2">  <!-- a mutation group identifying mutation 2 over child node 5 -->
      ... further mutation or node groups, including the node group for node 5 and descendants
      </g>
      <path class="edge" ...> <!-- the line joining the root node to mutation 0 -->
      <circle ...> <!-- the root node symbol, doesn't strictly need a class, as `edge + *` will do -->
      <text ...> <!-- the root node label, always a text node -->
    </g>
    <path class="edge" ...> <!-- the line above mutation 0 -->
    <rect ...> <!-- the mutation symbol for mutation 0 -->
    <text ...> <!-- the label for mutation 0, always a text node -->
  </g> <!-- close mutation group -->
</g> <!-- close tree group -->
```

This is all quite complicated to describe, but logical. I think it allows us to target anything we might want, but it could be easier to explain if, for instance, the circles and rects are given a class "symbol", rather than targetted because they always follow an element of class "edge".

Probably easiest if I discuss this with someone (e.g. @benjeffery ) on a Jitsi call?