### PR TITLE
Dump/load from file objects

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -55,6 +55,9 @@ In development.
 - Tables loaded from a file can now be edited in the same way as any other
   table collection (:user:`jeromekelleher`, :issue:`536`, :pr:`530`.
 
+- Support for reading/writing to arbitrary file streams with the loadf/dumpf
+  variants for tree sequence and table collection load/dump
+  (:user:`jeromekelleher`, :user:`grahamgower`, :issue:`565`, :pr:`599`).
 
 **Deprecated**
 

--- a/c/examples/Makefile
+++ b/c/examples/Makefile
@@ -1,5 +1,5 @@
 # Simple Makefile for building examples.
-# This will build the examples in the current directory by compiling in the 
+# This will build the examples in the current directory by compiling in the
 # full tskit source into each of the examples. This is *not* recommended for
 # real projects!
 #
@@ -8,28 +8,31 @@
 #
 # **Note**: This repo uses git submodules, and these must be checked out
 # correctly for this makefile to work, e.g.:
-# 
+#
 # $ git clone git@github.com:tskit-dev/tskit.git --recurse-submodules
-# 
+#
 # See the documentation (https://tskit.readthedocs.io/en/stable/c-api.html)
-# for more details on how to use the C API, and the tskit build examples 
-# repo (https://github.com/tskit-dev/tskit-build-examples) for examples 
+# for more details on how to use the C API, and the tskit build examples
+# repo (https://github.com/tskit-dev/tskit-build-examples) for examples
 # of how to set up a production-ready build with tskit.
 #
 
 CFLAGS=-I../ -I../subprojects/kastore
 TSKIT_SOURCE=../tskit/*.c ../subprojects/kastore/kastore.c
 
-all: tree_iteration haploid_wright_fisher tree_traversal
+all: tree_iteration haploid_wright_fisher tree_traversal streaming
 
-tree_iteration: tree_iteration.c 
+tree_iteration: tree_iteration.c
 	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
 
-tree_traversal: tree_traversal.c 
+tree_traversal: tree_traversal.c
+	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
+
+streaming: streaming.c
 	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
 
 # This needs GSL
-haploid_wright_fisher: haploid_wright_fisher.c 
+haploid_wright_fisher: haploid_wright_fisher.c
 	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lgsl -lgslcblas -lm
 
 clean:

--- a/c/examples/streaming.c
+++ b/c/examples/streaming.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <tskit/tables.h>
+
+#define check_tsk_error(val)                                                            \
+    if (val < 0) {                                                                      \
+        fprintf(stderr, "Error: line %d: %s\n", __LINE__, tsk_strerror(val));           \
+        exit(EXIT_FAILURE);                                                             \
+    }
+
+int
+main(int argc, char **argv)
+{
+    int ret;
+    int j = 0;
+    tsk_table_collection_t tables;
+
+    ret = tsk_table_collection_init(&tables, 0);
+    check_tsk_error(ret);
+
+    while (true) {
+        ret = tsk_table_collection_loadf(&tables, stdin, TSK_NO_INIT);
+        if (ret == TSK_ERR_EOF) {
+            break;
+        }
+        check_tsk_error(ret);
+        fprintf(stderr, "Tree sequence %d had %d mutations\n", j,
+            (int) tables.mutations.num_rows);
+        ret = tsk_mutation_table_truncate(&tables.mutations, 0);
+        check_tsk_error(ret);
+        ret = tsk_table_collection_dumpf(&tables, stdout, 0);
+        check_tsk_error(ret);
+        j++;
+    }
+    tsk_table_collection_free(&tables);
+    return EXIT_SUCCESS;
+}

--- a/c/meson.build
+++ b/c/meson.build
@@ -99,6 +99,8 @@ if not meson.is_subproject()
         sources: ['examples/tree_iteration.c'], link_with: [tskit_lib], dependencies: lib_deps)
     executable('tree_traversal',
         sources: ['examples/tree_traversal.c'], link_with: [tskit_lib], dependencies: lib_deps)
+    executable('streaming',
+        sources: ['examples/streaming.c'], link_with: [tskit_lib], dependencies: lib_deps)
 
     gsl_dep = dependency('gsl', required: false)
     if gsl_dep.found()

--- a/c/tests/meson-subproject/example.c
+++ b/c/tests/meson-subproject/example.c
@@ -52,7 +52,7 @@ test_load_error()
     printf("test_open_error\n");
     tsk_treeseq_t ts;
     int ret = tsk_treeseq_load(&ts, "no such file", 0);
-    assert(tsk_is_kas_error(ret));
+    assert(ret == TSK_ERR_IO);
     tsk_treeseq_free(&ts);
 }
 

--- a/c/tests/test_core.c
+++ b/c/tests/test_core.c
@@ -47,7 +47,7 @@ test_strerror(void)
 static void
 test_strerror_kastore(void)
 {
-    int kastore_errors[] = { KAS_ERR_NO_MEMORY, KAS_ERR_IO, KAS_ERR_KEY_NOT_FOUND };
+    int kastore_errors[] = { KAS_ERR_NO_MEMORY, KAS_ERR_KEY_NOT_FOUND };
     size_t j;
     int err;
 

--- a/c/tests/test_minimal_cpp.cpp
+++ b/c/tests/test_minimal_cpp.cpp
@@ -57,7 +57,7 @@ test_load_error()
     std::cout << "test_open_error" << endl;
     tsk_treeseq_t ts;
     int ret = tsk_treeseq_load(&ts, "no such file", 0);
-    assert(tsk_is_kas_error(ret));
+    assert(ret == TSK_ERR_IO);
     tsk_treeseq_free(&ts);
 }
 

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -154,6 +154,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_GENERATE_UUID:
             ret = "Error generating UUID";
             break;
+        case TSK_ERR_EOF:
+            ret = "End of file";
+            break;
 
         /* File format errors */
         case TSK_ERR_FILE_FORMAT:
@@ -423,8 +426,14 @@ tsk_strerror_internal(int err)
 int
 tsk_set_kas_error(int err)
 {
-    /* Flip this bit. As the error is negative, this sets the bit to 0 */
-    return err ^ (1 << TSK_KAS_ERR_BIT);
+    if (err == KAS_ERR_IO) {
+        /* If we've detected an IO error, report it as TSK_ERR_IO so that we have
+         * a consistent error code covering these situtations */
+        return TSK_ERR_IO;
+    } else {
+        /* Flip this bit. As the error is negative, this sets the bit to 0 */
+        return err ^ (1 << TSK_KAS_ERR_BIT);
+    }
 }
 
 bool

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -119,6 +119,10 @@ An IO error occured.
 #define TSK_ERR_BUFFER_OVERFLOW                                     -5
 #define TSK_ERR_UNSUPPORTED_OPERATION                               -6
 #define TSK_ERR_GENERATE_UUID                                       -7
+/**
+The file stream ended after reading zero bytes.
+*/
+#define TSK_ERR_EOF                                                 -8
 /** @} */
 
 /**

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -220,8 +220,10 @@ int tsk_treeseq_init(
     tsk_treeseq_t *self, tsk_table_collection_t *tables, tsk_flags_t options);
 
 int tsk_treeseq_load(tsk_treeseq_t *self, const char *filename, tsk_flags_t options);
+int tsk_treeseq_loadf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options);
 
 int tsk_treeseq_dump(tsk_treeseq_t *self, const char *filename, tsk_flags_t options);
+int tsk_treeseq_dumpf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options);
 int tsk_treeseq_copy_tables(
     tsk_treeseq_t *self, tsk_table_collection_t *tables, tsk_flags_t options);
 int tsk_treeseq_free(tsk_treeseq_t *self);

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -442,3 +442,37 @@ tree in three different ways:
 .. literalinclude:: ../c/examples/tree_traversal.c
     :language: c
 
+.. _sec_c_api_examples_file_streaming:
+
+--------------
+File streaming
+--------------
+
+It is often useful to read tree sequence files from a stream rather than
+from a fixed filename. This example shows how to do this using the
+:c:func:`tsk_table_collection_loadf` and
+:c:func:`tsk_table_collection_dumpf` functions. Here, we sequentially
+load table collections from the ``stdin`` stream and write them
+back out to ``stdout`` with their mutations removed.
+
+.. literalinclude:: ../c/examples/streaming.c
+    :language: c
+
+Note that we use the value :c:macro:`TSK_ERR_EOF` to detect when the stream
+ends, as we don't know how many tree sequences to expect on the input.
+In this case, :c:macro:`TSK_ERR_EOF` is not considered an error and we exit
+normally.
+
+Running this program on some tree sequence files we might get::
+
+    $ cat tmp1.trees tmp2.trees | ./build/streaming > no_mutations.trees
+    Tree sequence 0 had 38 mutations
+    Tree sequence 1 had 132 mutations
+
+Then, running this program again on the output of the previous command,
+we see that we now have two tree sequences with their mutations removed
+stored in the file ``no_mutations.trees``::
+
+    $ ./build/streaming < no_mutations.trees > /dev/null
+    Tree sequence 0 had 0 mutations
+    Tree sequence 1 had 0 mutations

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -10,6 +10,10 @@ In development
   (see below) to stabilise the node ordering and to make trees more readily
   comparable. The old behaviour is still available with ``order="tree"``.
 
+- File system operations such as dump/load now raise an appropriate OSError
+  instead of tskit.FileFormatError. Loading from an empty file now raises
+  and EOFError.
+
 **New features**
 
 - Add support for trees with internal samples for the Kendall-Colijn tree distance

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -219,6 +219,12 @@ handle_library_error(int err)
             case TSK_ERR_FILE_FORMAT:
                 PyErr_SetString(TskitFileFormatError, tsk_strerror(err));
                 break;
+            case TSK_ERR_IO:
+                PyErr_SetFromErrno(PyExc_OSError);
+                break;
+            case TSK_ERR_EOF:
+                PyErr_Format(PyExc_EOFError, "End of file");
+                break;
             default:
                 PyErr_SetString(TskitLibraryError, tsk_strerror(err));
         }

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -553,7 +553,9 @@ class TestBadFile(unittest.TestCase):
         with mock.patch("sys.exit", side_effect=TestException) as mocked_exit:
             with self.assertRaises(TestException):
                 capture_output(cli.tskit_main, ["info", "/no/such/file"])
-            mocked_exit.assert_called_once_with("Load error: No such file or directory")
+            mocked_exit.assert_called_once_with(
+                "Load error: [Errno 2] No such file or directory"
+            )
 
     def test_info(self):
         self.verify("info")

--- a/python/tests/test_file_format.py
+++ b/python/tests/test_file_format.py
@@ -983,8 +983,8 @@ class TestFileFormatErrors(TestFileFormat):
 
     def test_load_bad_formats(self):
         # try loading a bunch of files in various formats.
-        # First, check the emtpy file.
-        self.assertRaises(exceptions.FileFormatError, tskit.load, self.temp_file)
+        # First, check the empty file.
+        self.assertRaises(EOFError, tskit.load, self.temp_file)
         # Now some ascii text
         with open(self.temp_file, "wb") as f:
             f.write(b"Some ASCII text")

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -260,21 +260,19 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
                 self.assertRaises(TypeError, func, bad_type)
             # Try to dump/load files we don't have access to or don't exist.
             for f in ["/", "/test.trees", "/dir_does_not_exist/x.trees"]:
-                self.assertRaises(_tskit.FileFormatError, func, f)
+                self.assertRaises(OSError, func, f)
                 try:
                     func(f)
-                except _tskit.FileFormatError as e:
+                except OSError as e:
                     message = str(e)
                     self.assertGreater(len(message), 0)
-            # use a long filename and make sure we don't overflow error
-            # buffers
             f = "/" + 4000 * "x"
-            self.assertRaises(_tskit.FileFormatError, func, f)
+            self.assertRaises(OSError, func, f)
             try:
                 func(f)
-            except _tskit.FileFormatError as e:
+            except OSError as e:
                 message = str(e)
-                self.assertLess(len(message), 1024)
+            self.assertTrue(message.endswith("File name too long"))
 
     def test_initial_state(self):
         # Check the initial state to make sure that it is empty.

--- a/python/tskit/cli.py
+++ b/python/tskit/cli.py
@@ -46,7 +46,7 @@ def sys_exit(message):
 def load_tree_sequence(path):
     try:
         return tskit.load(path)
-    except tskit.FileFormatError as e:
+    except OSError as e:
         sys_exit(f"Load error: {e}")
 
 


### PR DESCRIPTION
Support loading/dumping tree sequences to real files rather than just paths.

See #565 for background.

Not for merging - this temporarily pulls in kastore, but needs rebasing when we bring in kastore 2.0 properly as noted in the first commit.