### PR TITLE
Struct codec

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -35,6 +35,8 @@ Note that the C API simply provides byte-array binary access to the metadata and
 leaves encoding and decoding to the user. The same can be achieved with the Python
 API, see :ref:`sec_tutorial_metadata_binary`.
 
+.. _sec_metadata_codecs:
+
 ******
 Codecs
 ******
@@ -44,20 +46,89 @@ As the underlying metadata is in raw binary (see
 must be encoded and decoded, in the case of the Python API to Python objects.
 The method for doing this is specified in the top-level schema property ``codec``.
 Currently the Python API supports the ``json`` codec which encodes metadata as
-`JSON <https://www.json.org/json-en.html>`_. We plan to support more codecs soon, such
-as an efficient binary encoding (see :issue:`535`). It is possible to define a custom
-codec using :meth:`tskit.register_metadata_codec`, however this should only be used
-when necessary as downstream users of the metadata will not be able to decode it
-without the custom codec. For an example see :ref:`sec_tutorial_metadata_custom_codec`
+`JSON <https://www.json.org/json-en.html>`_, and the ``struct`` codec which encodes
+metadata in an efficient schema-defined binary format using :py:func:`struct.pack` .
+It is possible to define a custom codec using :meth:`tskit.register_metadata_codec`,
+however this should only be used when necessary as downstream users of the metadata
+will not be able to decode it without the custom codec. For an example see
+:ref:`sec_tutorial_metadata_custom_codec`.
+
+----
+JSON
+----
+
+When ``json`` is specified as the ``codec`` in the schema the metadata is encoded in
+the human readable `JSON <https://www.json.org/json-en.html>`_ format. As this format
+is human readable and encodes numbers as text it uses more bytes than the ``struct``
+format. However it is simpler to configure as it doesn't require any format specifiers
+in the schema.
+
+------
+struct
+------
+
+When ``struct`` is specifed as the ``codec`` in the schema the metadata is encoded
+using :py:func:`struct.pack` which results in a compact binary representation. This
+codec places extra restrictions on the schema:
+
+#. Each property must have a ``binaryFormat`` entry.
+    This describes the encoding for that property using ``struct``
+    `format characters <https://docs.python.org/3/library/struct.html#format-characters>`_.
+    For example an unsigned 8-byte integer can be specifed with::
+
+        {'type': 'number', 'binaryFormat':'Q'}
+
+    And a length 10 string with::
+
+        {'type': 'string', 'binaryFormat':'10p'}
+
+    * Endian-ness is fixed at little endian so cannot be specified.
+    * Not all formats are supported - ``binaryFormat`` must match
+      ``^[cbB\?hHiIlLqQfd]|\d*[spx]$``.
+    * It is recommended to use ``p`` for strings, as ``s`` doesn't store where
+      the string ends. Note that ``5p`` can only store a string that when encoded is 4
+      bytes or less. If using ``s``, set ``nullTerminated`` to ``true`` if you are
+      sure your strings do not have null characters in. This will remove the spare
+      bytes at the end of the string.
+    * Strings that are longer than the specified length will be silently truncated,
+      note that the length is in bytes, not characters.
+    * To insert padding bytes use ``null`` for ``type`` and ``x`` for ``binaryFormat``.
+    * For ``array`` types the format of the length of the array can be chosen with
+      ``arrayLengthFormat`` which must be one of ``B``, ``H``, ``I``, ``L`` or ``Q``
+      which is the default. For dealing with legacy encodings that do not store the
+      length of the array setting ``noLengthEncodingExhaustBuffer`` to true will read
+      the buffer to exhaustion. As such an array with this encoding must be the last type
+      in the encoded struct.
+    * For strings, the encoding can be set with ``stringEncoding`` which defaults to
+      ``utf-8``.
+
+#. All metadata objects must have fixed properties.
+    This means that they can have no missing properties and have no additional
+    properties not listed in the schema.
+
+#. Arrays must be lists of homogeneous objects.
+    This is not valid::
+
+    {"type": "array", "items": [{"type": "number"}, {"type": "string"}]}
+
+#. Types must be singular and not unions.
+    This is not valid::
+
+    {"type": ["number", "string"]}
+
+#. The order that properties are encoded is by default alphabetically by name.
+    The order can be overridden by setting an optional numerical ``index`` on each
+    property.
+
 
 .. _sec_metadata_example:
 
-*******
-Example
-*******
+********
+Examples
+********
 
 
-As an example here is a schema using the ``json`` codec which could apply, for example,
+As an example here is a schema using the ``struct`` codec which could apply, for example,
 to the individuals in a tree sequence:
 
 .. code-block:: json
@@ -66,11 +137,12 @@ to the individuals in a tree sequence:
       "codec": "json",
       "type": "object",
       "properties": {
-        "accession_number": {"type": "number"},
+        "accession_number": {"type": "number", "binaryFormat": "i"},
         "collection_date": {
           "name": "Collection date",
           "description": "Date of sample collection in ISO format",
           "type": "string",
+          "binaryFormat": "10p",
           "pattern": "^([1-9][0-9]{3})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])?$"
         },
       },
@@ -80,7 +152,8 @@ to the individuals in a tree sequence:
 
 This schema states that the metadata for the each row of the table
 is an object consisting of two properties. Property ``accession_number`` is a number
-which must be specified (it is included in the ``required`` list).
+(stored as a 4-byte int) which must be specified (it is included in the ``required``
+list).
 Property ``collection_date`` is an optional string which must satisfy a regex,
 which checks it is a valid `ISO8601 <https://www.iso.org/iso-8601-date-and-time-format
 .html>`_ date.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -764,7 +764,7 @@ Here's a simple example schema, which we'll apply to the individuals table:
     }
 
 The ``codec`` entry in the schema specifies how the metadata should be stored.
-Currently only ``json`` is supported, others are planned (:issue:`535`). This schema
+See :ref:`sec_metadata_codecs` for details on the supported codecs. This schema
 defines two properties, both of which are mandatory as they are in the ``required``
 list. To avoid errors we set ``additionalProperties`` to false, as this causes any
 unexpected properties in the metadata to fail validation.

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -21,7 +21,7 @@ In development
 - Tables with a metadata column now have a ``metadata_schema`` that is used to
   validate and encode metadata that is passed to ``add_row`` and decode metadata
   on calls to ``table[j]`` and e.g. ``tree_sequence.node(j)`` See :ref:`sec_metadata`.
-  (:user:`benjeffery`, :pr:`491`, :pr:`542`, :pr:`543`)
+  (:user:`benjeffery`, :pr:`491`, :pr:`542`, :pr:`543`, :pr:`601`)
 
 - Add classes to SVG drawings to allow easy adjustment and styling, and document the new
   ``tskit.Tree.draw_svg()`` and ``tskit.TreeSequence.draw_svg()`` methods. This also fixes

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -23,9 +23,13 @@
 Classes for metadata decoding, encoding and validation
 """
 import abc
+import collections
 import copy
 import json
+import struct
+from itertools import islice
 from typing import Any
+from typing import Mapping
 from typing import Optional
 from typing import Type
 
@@ -46,18 +50,18 @@ def replace_root_refs(obj):
         return obj
 
 
-class TSKITMetadataSchemaValidator(jsonschema.validators.Draft7Validator):
-    """
-    Our schema is the Draft7Validator schema with added codec information.
-    """
-
-    META_SCHEMA: dict = copy.deepcopy(jsonschema.validators.Draft7Validator.META_SCHEMA)
-    # We need a top-level only required property so we need to rewite any reference
-    # to the top-level schema to a copy in a definition.
-    META_SCHEMA = replace_root_refs(META_SCHEMA)
-    META_SCHEMA["definitions"]["root"] = copy.deepcopy(META_SCHEMA)
-    META_SCHEMA["codec"] = {"type": "string"}
-    META_SCHEMA["required"] = ["codec"]
+# Our schema is the Draft7Validator schema with added codec information.
+TSKITMetadataSchemaValidator = jsonschema.validators.extend(
+    jsonschema.validators.Draft7Validator
+)
+META_SCHEMA: Mapping[str, Any] = copy.deepcopy(TSKITMetadataSchemaValidator.META_SCHEMA)
+# We need a top-level only required property so we need to rewite any reference
+# to the top-level schema to a copy in a definition.
+META_SCHEMA = replace_root_refs(META_SCHEMA)
+META_SCHEMA["definitions"]["root"] = copy.deepcopy(META_SCHEMA)
+META_SCHEMA["codec"] = {"type": "string"}
+META_SCHEMA["required"] = ["codec"]
+TSKITMetadataSchemaValidator.META_SCHEMA = META_SCHEMA
 
 
 class AbstractMetadataCodec(metaclass=abc.ABCMeta):
@@ -65,8 +69,12 @@ class AbstractMetadataCodec(metaclass=abc.ABCMeta):
     Superclass of all MetadataCodecs.
     """
 
-    def __init__(self, schema: dict) -> None:
+    def __init__(self, schema: Mapping[str, Any]) -> None:
         raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def modify_schema(self, schema: Mapping) -> Mapping:
+        return schema
 
     @abc.abstractmethod
     def encode(self, obj: Any) -> bytes:
@@ -96,7 +104,7 @@ def register_metadata_codec(
 
 
 class JSONCodec(AbstractMetadataCodec):
-    def __init__(self, schema: dict) -> None:
+    def __init__(self, schema: Mapping[str, Any]) -> None:
         pass
 
     def encode(self, obj: Any) -> bytes:
@@ -110,7 +118,7 @@ register_metadata_codec(JSONCodec, "json")
 
 
 class NOOPCodec(AbstractMetadataCodec):
-    def __init__(self, schema: dict) -> None:
+    def __init__(self, schema: Mapping[str, Any]) -> None:
         pass
 
     def encode(self, data: bytes) -> bytes:
@@ -118,6 +126,310 @@ class NOOPCodec(AbstractMetadataCodec):
 
     def decode(self, data: bytes) -> bytes:
         return data
+
+
+def binary_format_validator(validator, types, instance, schema):
+    # We're hooking into jsonschemas validaiton code here, which works by creating
+    # generators of exceptions, hence the yielding
+
+    # Make sure the normal type validation gets done
+    yield from jsonschema._validators.type(validator, types, instance, schema)
+
+    # Non-composite types must have a binaryFormat
+    if (
+        validator.is_type(instance, "object")
+        and (instance.get("type") not in (None, "object", "array", "null"))
+        and "binaryFormat" not in instance
+    ):
+        yield jsonschema.ValidationError(
+            f"{instance['type']} type must have binaryFormat set"
+        )
+    # null type must be padding
+    if (
+        validator.is_type(instance, "object")
+        and instance.get("type") == "null"
+        and "binaryFormat" in instance
+        and instance["binaryFormat"][-1] != "x"
+    ):
+        yield jsonschema.ValidationError(
+            f'null type binaryFormat must be padding ("x") if set'
+        )
+
+
+StructCodecSchemaValidator = jsonschema.validators.extend(
+    TSKITMetadataSchemaValidator, {"type": binary_format_validator}
+)
+META_SCHEMA: Mapping[str, Any] = copy.deepcopy(StructCodecSchemaValidator.META_SCHEMA)
+# No union types
+META_SCHEMA["properties"]["type"] = {"$ref": "#/definitions/simpleTypes"}
+META_SCHEMA["definitions"]["root"]["properties"]["type"] = META_SCHEMA["properties"][
+    "type"
+]
+# No hetrogeneous arrays
+META_SCHEMA["properties"]["items"] = {"$ref": "#/definitions/root"}
+META_SCHEMA["definitions"]["root"]["properties"]["items"] = META_SCHEMA["properties"][
+    "items"
+]
+# binaryFormat matches regex
+META_SCHEMA["properties"]["binaryFormat"] = {
+    "type": "string",
+    "pattern": r"^([cbB\?hHiIlLqQfd]|\d*[spx])$",
+}
+META_SCHEMA["definitions"]["root"]["properties"]["binaryFormat"] = META_SCHEMA[
+    "properties"
+]["binaryFormat"]
+# arrayLengthFormat matches regex and has default
+META_SCHEMA["properties"]["arrayLengthFormat"] = {
+    "type": "string",
+    "pattern": r"^[BHILQ]$",
+    "default": "L",
+}
+META_SCHEMA["definitions"]["root"]["properties"]["arrayLengthFormat"] = META_SCHEMA[
+    "properties"
+]["arrayLengthFormat"]
+# index is numeric
+META_SCHEMA["properties"]["index"] = {"type": "number"}
+META_SCHEMA["definitions"]["root"]["properties"]["index"] = META_SCHEMA["properties"][
+    "index"
+]
+# stringEncoding is string and has default
+META_SCHEMA["properties"]["stringEncoding"] = {"type": "string", "default": "utf-8"}
+META_SCHEMA["definitions"]["root"]["properties"]["stringEncoding"] = META_SCHEMA[
+    "properties"
+]["stringEncoding"]
+# nullTerminated is a boolean
+META_SCHEMA["properties"]["nullTerminated"] = {"type": "boolean"}
+META_SCHEMA["definitions"]["root"]["properties"]["nullTerminated"] = META_SCHEMA[
+    "properties"
+]["index"]
+# noLengthEncodingExhaustBuffer is a boolean
+META_SCHEMA["properties"]["noLengthEncodingExhaustBuffer"] = {"type": "boolean"}
+META_SCHEMA["definitions"]["root"]["properties"][
+    "noLengthEncodingExhaustBuffer"
+] = META_SCHEMA["properties"]["index"]
+StructCodecSchemaValidator.META_SCHEMA = META_SCHEMA
+
+
+class StructCodec(AbstractMetadataCodec):
+    """
+    Codec that encodes data using struct. Note that this codec has extra restrictions
+    Namely that object keys must be fixed (all present and no extra); each entry should
+    have a binaryFormat; that arrays are homogeneous and that types are not unions.
+    """
+
+    @classmethod
+    def order_by_index(cls, obj, do_sort=False):
+        """
+        Take a schema and recursively convert any dict that is under the key
+        name ``properties`` to an OrderedDict.
+        """
+        if isinstance(obj, collections.abc.Mapping):
+            items = obj.items()
+            if do_sort:
+                # Python sort is stable so we can do the sorts in reverse priority
+                items = sorted(items, key=lambda k_v: k_v[0])
+                items = sorted(items, key=lambda k_v: k_v[1].get("index", 0))
+            items = ((k, cls.order_by_index(v, k == "properties")) for k, v in items)
+            if do_sort:
+                return collections.OrderedDict(items)
+            else:
+                return dict(items)
+        elif isinstance(obj, list) or isinstance(obj, tuple):
+            return [cls.order_by_index(v, False) for v in obj]
+        else:
+            return obj
+
+    @classmethod
+    def make_decode(cls, sub_schema):
+        """
+        Create a function that can decode objects of this schema
+        """
+        return {
+            "array": StructCodec.make_array_decode,
+            "object": StructCodec.make_object_decode,
+            "string": StructCodec.make_string_decode,
+            "null": StructCodec.make_null_decode,
+            "number": StructCodec.make_numeric_decode,
+            "integer": StructCodec.make_numeric_decode,
+            "boolean": StructCodec.make_numeric_decode,
+        }[sub_schema["type"]](sub_schema)
+
+    @classmethod
+    def make_array_decode(cls, sub_schema):
+        element_decoder = StructCodec.make_decode(sub_schema["items"])
+        array_length_f = "<" + sub_schema.get("arrayLengthFormat", "L")
+        array_length_size = struct.calcsize(array_length_f)
+        exhaust_buffer = sub_schema.get("noLengthEncodingExhaustBuffer", False)
+
+        def array_decode(buffer):
+            print(array_length_f)
+            array_length = struct.unpack(
+                array_length_f, bytes(islice(buffer, array_length_size))
+            )[0]
+            return [element_decoder(buffer) for _ in range(array_length)]
+
+        def array_decode_exhaust(buffer):
+            ret = []
+            while True:
+                try:
+                    ret.append(element_decoder(buffer))
+                except struct.error as e:
+                    if "unpack requires a buffer" in str(e):
+                        break
+                    else:
+                        raise e
+            return ret
+
+        if exhaust_buffer:
+            return array_decode_exhaust
+        else:
+            return array_decode
+
+    @classmethod
+    def make_object_decode(cls, sub_schema):
+        sub_decoders = {
+            key: StructCodec.make_decode(prop)
+            for key, prop in sub_schema["properties"].items()
+        }
+        return lambda buffer: {
+            key: sub_decoder(buffer) for key, sub_decoder in sub_decoders.items()
+        }
+
+    @classmethod
+    def make_string_decode(cls, sub_schema):
+        f = "<" + sub_schema["binaryFormat"]
+        size = struct.calcsize(f)
+        encoding = sub_schema.get("stringEncoding", "utf-8")
+        null_terminated = sub_schema.get("nullTerminated", False)
+        if not null_terminated:
+            return lambda buffer: struct.unpack(f, bytes(islice(buffer, size)))[
+                0
+            ].decode(encoding)
+        else:
+
+            def decode_string(buffer):
+                s = struct.unpack(f, bytes(islice(buffer, size)))[0].decode(encoding)
+                i = s.find("\x00")
+                if i == -1:
+                    return s
+                return s[:i]
+
+            return decode_string
+
+    @classmethod
+    def make_null_decode(cls, sub_schema):
+        if sub_schema.get("binaryFormat") is not None:
+            f = sub_schema["binaryFormat"]
+            size = struct.calcsize(f)
+
+            def padding_decode(buffer):
+                struct.unpack(f, bytes(islice(buffer, size)))
+
+            return padding_decode
+        else:
+            return lambda _: None
+
+    @classmethod
+    def make_numeric_decode(cls, sub_schema):
+        f = "<" + sub_schema["binaryFormat"]
+        size = struct.calcsize(f)
+        return lambda buffer: struct.unpack(f, bytes(islice(buffer, size)))[0]
+
+    @classmethod
+    def make_encode(cls, sub_schema):
+        """
+        Create a function that can encode objects of this schema
+        """
+        return {
+            "array": StructCodec.make_array_encode,
+            "object": StructCodec.make_object_encode,
+            "string": StructCodec.make_string_encode,
+            "null": StructCodec.make_null_encode,
+            "number": StructCodec.make_numeric_encode,
+            "integer": StructCodec.make_numeric_encode,
+            "boolean": StructCodec.make_numeric_encode,
+        }[sub_schema["type"]](sub_schema)
+
+    @classmethod
+    def make_array_encode(cls, sub_schema):
+        array_length_f = "<" + sub_schema.get("arrayLengthFormat", "L")
+        element_encoder = StructCodec.make_encode(sub_schema["items"])
+        exhaust_buffer = sub_schema.get("noLengthEncodingExhaustBuffer", False)
+        if exhaust_buffer:
+            return lambda array: b"".join(element_encoder(ele) for ele in array)
+        else:
+            return lambda array: struct.pack(array_length_f, len(array)) + b"".join(
+                element_encoder(ele) for ele in array
+            )
+
+    @classmethod
+    def make_object_encode(cls, sub_schema):
+        sub_encoders = {
+            key: StructCodec.make_encode(prop)
+            for key, prop in sub_schema["properties"].items()
+        }
+        return lambda obj: b"".join(
+            sub_encoder(obj[key]) for key, sub_encoder in sub_encoders.items()
+        )
+
+    @classmethod
+    def make_string_encode(cls, sub_schema):
+        encoding = sub_schema.get("stringEncoding", "utf-8")
+        return lambda string: struct.pack(
+            "<" + sub_schema["binaryFormat"], string.encode(encoding)
+        )
+
+    @classmethod
+    def make_null_encode(cls, sub_schema):
+        return lambda _: struct.pack(sub_schema.get("binaryFormat", "0x"))
+
+    @classmethod
+    def make_numeric_encode(cls, sub_schema):
+        return struct.Struct("<" + sub_schema["binaryFormat"]).pack
+
+    @classmethod
+    def modify_schema(cls, schema: Mapping) -> Mapping:
+        # This codec requires that all properties are required and additional ones
+        # not allowed. Rather than get schema authors to repeat that everywhere
+        # we add it here, sadly we can't do this in the metaschema as "default" isn't
+        # used by the validator.
+        def enforce_fixed_properties(obj):
+            if type(obj) == list:
+                return [enforce_fixed_properties(j) for j in obj]
+            elif type(obj) == dict:
+                ret = {k: enforce_fixed_properties(v) for k, v in obj.items()}
+                if ret.get("type") == "object":
+                    ret["required"] = list(ret.get("properties", {}).keys())
+                    ret["additionalProperties"] = False
+                return ret
+            else:
+                return obj
+
+        schema = enforce_fixed_properties(schema)
+
+        # We also give the schema an explicit ordering
+        return StructCodec.order_by_index(schema)
+
+    def __init__(self, schema: Mapping[str, Any]) -> None:
+        try:
+            StructCodecSchemaValidator.check_schema(schema)
+        except jsonschema.exceptions.SchemaError as ve:
+            raise exceptions.MetadataSchemaValidationError(str(ve)) from ve
+
+        self.encode = StructCodec.make_encode(schema)
+        decoder = StructCodec.make_decode(schema)
+        self.decode = lambda buffer: decoder(iter(buffer))
+
+    def encode(self, obj: Any) -> bytes:
+        # Set by __init__
+        pass  # pragma: nocover
+
+    def decode(self, encoded: bytes) -> Any:
+        # Set by __init__
+        pass  # pragma: nocover
+
+
+register_metadata_codec(StructCodec, "struct")
 
 
 def validate_bytes(data: Optional[bytes]) -> None:
@@ -134,7 +446,7 @@ class MetadataSchema:
     :param dict schema: A dict containing a valid JSONSchema object.
     """
 
-    def __init__(self, schema: Optional[dict]) -> None:
+    def __init__(self, schema: Optional[Mapping[str, Any]]) -> None:
         self._schema = schema
 
         if schema is None:
@@ -146,15 +458,18 @@ class MetadataSchema:
             try:
                 TSKITMetadataSchemaValidator.check_schema(schema)
             except jsonschema.exceptions.SchemaError as ve:
-                raise exceptions.MetadataSchemaValidationError from ve
-            codec = schema["codec"]
+                raise exceptions.MetadataSchemaValidationError(str(ve)) from ve
             try:
-                codec_instance = codec_registry[codec](schema)
+                codec_cls = codec_registry[schema["codec"]]
             except KeyError:
                 raise exceptions.MetadataSchemaValidationError(
                     f"Unrecognised metadata codec '{schema['codec']}'. "
                     f"Valid options are {str(list(codec_registry.keys()))}."
                 )
+            # Codecs can modify the schema, for example to set defaults as the validator
+            # does not.
+            schema = codec_cls.modify_schema(schema)
+            codec_instance = codec_cls(schema)
             self._string = json.dumps(schema)
             self._validate_row = TSKITMetadataSchemaValidator(schema).validate
             self.encode_row = codec_instance.encode
@@ -164,7 +479,7 @@ class MetadataSchema:
         return self._string
 
     @property
-    def schema(self) -> Optional[dict]:
+    def schema(self) -> Optional[Mapping[str, Any]]:
         # Make schema read-only
         return self._schema
 
@@ -176,7 +491,7 @@ class MetadataSchema:
         try:
             self._validate_row(row)
         except jsonschema.exceptions.ValidationError as ve:
-            raise exceptions.MetadataValidationError from ve
+            raise exceptions.MetadataValidationError(str(ve)) from ve
         return self.encode_row(row)
 
     def decode_row(self, row: bytes) -> Any:


### PR DESCRIPTION
Implementation of the `struct` codec for metadata. Supports encoding an arbitrary nesting of variable-length arrays and fixed-key-set objects up to the python stack depth. Only overhead is array length as keys and types are not stored in the encoded bytes but read from the schema.

TODOs:
- [x] Schema: Enforce all object keys must be required and no additional
- [x] Schema: Enforce `binaryFormat` strings by regex
- [x] ~~Schema: Enforce `index` to be unique and numeric~~
- [x] Schema: No union types
- [x] JSONSchema `null` type handling
- [x] Investigate replacing `index` with alphabetic key sort
- [x] ~~`array` type in JSONSchema allows heterogeneous arrays, support?~~ (No! Forbid in schema)
- [x] Force endian-ness
- [x] ~~Support variable length strings?~~ Deferring to another PR if wanted. #613 
- [x] ~~Perf pass~~ deferring to another PR #614 
- [x] Docs
- [x] Use iterator in decode
- [x] Support padding
- [x] Reinstate index as an optional parameter
- [x] Allow specifying array length format
- [x] Add string encoding parameter
- [x] Test with SLiM metadata
- [x] Extract encode/decode functions and test individually
- [x] Don't catch all types, but error on unsupported.
- [x] Add note about `p` type needing an extra byte
- [ ] File issues about numpy encoding, variable length strings, efficient `enum` encoding, bytes, and compression.