### PR TITLE
Pin msgpack.

### DIFF
--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -8,7 +8,7 @@ flake8
 h5py
 jsonschema
 kastore
-msgpack
+msgpack>=1.0.0
 msprime
 networkx
 newick


### PR DESCRIPTION
An older version of msgpack (0.5.6) led to test failures.