### PR TITLE
Update KC metric to work on samples not leaves

### DIFF
--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -390,9 +390,6 @@ tsk_strerror_internal(int err)
         case TSK_ERR_SAMPLES_NOT_EQUAL:
             ret = "Samples must be identical in trees to compare.";
             break;
-        case TSK_ERR_INTERNAL_SAMPLES:
-            ret = "Internal samples are not supported.";
-            break;
         case TSK_ERR_MULTIPLE_ROOTS:
             ret = "Trees with multiple roots not supported.";
             break;

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -241,11 +241,10 @@ not found in the file.
 /* Distance metric errors */
 #define TSK_ERR_SAMPLE_SIZE_MISMATCH                               -1200
 #define TSK_ERR_SAMPLES_NOT_EQUAL                                  -1201
-#define TSK_ERR_INTERNAL_SAMPLES                                   -1202
-#define TSK_ERR_MULTIPLE_ROOTS                                     -1203
-#define TSK_ERR_UNARY_NODES                                        -1204
-#define TSK_ERR_SEQUENCE_LENGTH_MISMATCH                           -1205
-#define TSK_ERR_NO_SAMPLE_LISTS                                    -1206
+#define TSK_ERR_MULTIPLE_ROOTS                                     -1202
+#define TSK_ERR_UNARY_NODES                                        -1203
+#define TSK_ERR_SEQUENCE_LENGTH_MISMATCH                           -1204
+#define TSK_ERR_NO_SAMPLE_LISTS                                    -1205
 
 /* Haplotype matching errors */
 #define TSK_ERR_NULL_VITERBI_MATRIX                                -1300

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -12,6 +12,9 @@ In development
 
 **New features**
 
+- Add support for trees with internal samples for the Kendall-Colijn tree distance
+  metric. (:user:`daniel-goldstein`, :pr:`610`)
+
 - Add background shading to SVG tree sequences to reflect tree position along the
   sequence (:user:`hyanwong`, :pr:`563`)
 

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1976,8 +1976,7 @@ class TestTree(LowLevelTestCase):
         t2 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)
         # If we don't seek to a specific tree, it has multiple roots (i.e., it's
         # in the null state). This fails because we don't accept multiple roots.
-        with self.assertRaises(_tskit.LibraryError):
-            t1.get_kc_distance(t2, 0)
+        self.verify_kc_library_error(t2, t2)
 
         # Different numbers of samples fail.
         ts2 = self.get_example_tree_sequence(11)
@@ -1991,7 +1990,7 @@ class TestTree(LowLevelTestCase):
         t2.first()
         self.verify_kc_library_error(t1, t2)
 
-        # Internal samples cause errors.
+        # Unary nodes cause errors.
         tables = _tskit.TableCollection(1.0)
         tables.nodes.add_row(flags=1)
         tables.nodes.add_row(flags=1, time=1)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2163,7 +2163,9 @@ class Tree:
         <https://academic.oup.com/mbe/article/33/10/2735/2925548>`_ for details.
 
         The trees we are comparing to must have identical lists of sample
-        nodes (i.e., the same IDs in the same order).
+        nodes (i.e., the same IDs in the same order). The metric operates on
+        samples, not leaves, so internal samples are treated identically to
+        sample tips. Subtrees with no samples do not contribute to the metric.
 
         :param Tree other: The other tree to compare to.
         :param float lambda_: The KC metric lambda parameter determining the


### PR DESCRIPTION
KC distance previously assumed that samples == leaves. However, the metric should measure the similarities of trees based on the relationships between the samples. This changes the metric to exclusively consider samples, not leaves. This means that internal samples no longer throw an exception and subtrees without any samples in them do not contribute to the KC distance.

It also makes more sense to focus on solely samples because the set of leaves is not consistent across trees in a tree sequence. Internal nodes that are roots in some trees and not in others affect how many leaves there are per tree. The sample set, however, is consistent across the sequence.

Resolves #575 #598 