### PR TITLE
Implement get_left_child

### DIFF
--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -252,6 +252,7 @@ class TestClosestLeftNode(TestTreeDraw):
 
         m1 = drawing.get_left_neighbour(tree, "minlex_postorder")
         m2 = get_left_neighbour(tree, "minlex_postorder")
+        np.testing.assert_array_equal(m1, m2)
 
     def test_2_binary(self):
         ts = msprime.simulate(2, random_seed=2)
@@ -280,6 +281,24 @@ class TestClosestLeftNode(TestTreeDraw):
 
     def test_multiroot(self):
         self.verify(self.get_multiroot_tree())
+
+    def test_left_child(self):
+        t = self.get_nonbinary_tree()
+        left_child = drawing.get_left_child(t, "postorder")
+        for u in t.nodes(order="postorder"):
+            if t.num_children(u) > 0:
+                self.assertEqual(left_child[u], t.children(u)[0])
+
+    def test_null_node_left_child(self):
+        t = self.get_nonbinary_tree()
+        left_child = drawing.get_left_child(t, "minlex_postorder")
+        self.assertEqual(left_child[tskit.NULL], tskit.NULL)
+
+    def test_leaf_node_left_child(self):
+        t = self.get_nonbinary_tree()
+        left_child = drawing.get_left_child(t, "minlex_postorder")
+        for u in t.samples():
+            self.assertEqual(left_child[u], tskit.NULL)
 
 
 class TestOrder(TestTreeDraw):

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -612,6 +612,7 @@ class SvgTree:
         node_x_coord_map = self.node_x_coord_map
         node_y_coord_map = self.node_y_coord_map
         tree = self.tree
+        left_child = get_left_child(tree, self.traversal_order)
 
         # Iterate over nodes, adding groups to reflect the tree heirarchy
         stack = []
@@ -658,7 +659,7 @@ class SvgTree:
             curr_svg_group.add(dwg.circle(**self.node_attrs[u]))
             # Labels
             if not tree.is_leaf(u) and tree.parent(u) != NULL:
-                if tree.left_sib(u) == NULL:
+                if u == left_child[tree.parent(u)]:
                     self.add_class(self.node_label_attrs[u], "rgt")
                 else:
                     self.add_class(self.node_label_attrs[u], "lft")
@@ -677,7 +678,7 @@ class SvgTree:
                 # Symbols
                 mut_group.add(dwg.rect(insert=o, **self.mutation_attrs[mutation.id]))
                 # Labels
-                if tree.left_sib(mutation.node) == NULL:
+                if mutation.node == left_child[tree.parent(mutation.node)]:
                     mut_label_class = "rgt"
                 else:
                     mut_label_class = "lft"
@@ -803,6 +804,20 @@ def get_left_neighbour(tree, traversal_order):
     find_neighbours(-1, -1)
 
     return left_neighbour[:-1]
+
+
+def get_left_child(tree, traversal_order):
+    """
+    Returns the left-most child of each node in the tree according to the
+    specified traversal order. If a node has no children or NULL is passed
+    in, return NULL.
+    """
+    left_child = np.full(tree.num_nodes + 1, NULL, dtype=int)
+    for u in tree.nodes(order=traversal_order):
+        parent = tree.parent(u)
+        if parent != NULL and left_child[parent] == NULL:
+            left_child[parent] = u
+    return left_child
 
 
 def node_time_depth(tree, min_branch_length=None, max_tree_height="tree"):


### PR DESCRIPTION
Fixes #615. It was logically easier (and probably more generally useful) for me to implement a get_left_child rather than a get_left_sib method, so to position labels we just check to see if a node is the left child of its parent.

Will stick a test in if you think this is a reasonable approach, @jeromekelleher .