### PR TITLE
Mergify: configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,10 +8,10 @@ pull_request_rules:
       - status-success=lint-c
       - status-success=pre-commit
       - "status-success=ci/circleci: build"
-      - status-success=codecov/patch
-      - status-success=codecov/project/c-tests
-      - status-success=codecov/project/python-c-tests
-      - status-success=codecov/project/python-tests
+      #- status-success=codecov/patch
+      #- status-success=codecov/project/c-tests
+      #- status-success=codecov/project/python-c-tests
+      #- status-success=codecov/project/python-tests
       - status-success=continuous-integration/appveyor/pr
       - status-success=continuous-integration/travis-ci/pr
     actions:


### PR DESCRIPTION
This takes out codecov as it is flakey and often we merge when "patch" is red.

This change has been made by @benjeffery from https://mergify.io simulator.

---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://doc.mergify.io/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
