### PR TITLE
Union of tree sequences

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -44,6 +44,12 @@ In development.
 
 **New features**
 
+- New methods to perform set operations on table collections.
+  ``tsk_table_collection_subset`` subsets and reorders table collections by nodes
+  (:user:`mufernando`, :user:`petrelharp`, :pr:`663`, :pr:`690`). 
+  ``tsk_table_collection_union`` forms the node-wise union of two table collections
+  (:user:`mufernando`, :user:`petrelharp`, :issue:`381`, :pr:`623`).
+
 - Mutations now have an optional double-precision floating-point ``time`` column.
   If not specified, this defaults to a particular NaN value (``TSK_UNKNOWN_TIME``)
   indicating that the time is unknown. For a tree sequence to be considered valid

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -3803,7 +3803,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret = tsk_mutation_table_clear(&tables.mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+        &tables.mutations, 0, 0, TSK_NULL, NAN, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_NONFINITE);

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -3803,7 +3803,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret = tsk_mutation_table_clear(&tables.mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 0, 0, TSK_NULL, NAN, NULL, 0, NULL, 0);
+        &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_NONFINITE);
@@ -3986,10 +3986,10 @@ test_table_collection_subset_with_options(tsk_flags_t options)
     // four nodes from two diploids; the first is from pop 0
     ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 1.0, 0, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, 1, NULL, 0);
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 2.0, TSK_NULL, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, 1, NULL, 0);
@@ -4009,13 +4009,16 @@ test_table_collection_subset_with_options(tsk_flags_t options)
     ret = tsk_site_table_add_row(&tables.sites, 0.4, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 0, 0, TSK_NULL, NAN, NULL, 0, NULL, 0);
-    CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_mutation_table_add_row(&tables.mutations, 0, 0, 0, NAN, NULL, 0, NULL, 0);
+        &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 1, 1, TSK_NULL, NAN, NULL, 0, NULL, 0);
+        &tables.mutations, 0, 0, 0, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_mutation_table_add_row(
+        &tables.mutations, 1, 1, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_build_index(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     // empty nodes should get empty tables
     ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT | options);
@@ -4069,16 +4072,17 @@ test_table_collection_subset_errors(void)
 
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
     ret = tsk_table_collection_init(&tables_copy, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     // four nodes from two diploids; the first is from pop 0
     ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 1.0, 0, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, 1, NULL, 0);
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 2.0, TSK_NULL, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, 1, NULL, 0);
@@ -4091,6 +4095,8 @@ test_table_collection_subset_errors(void)
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 1, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_build_index(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Migrations are not supported */
     ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
@@ -4101,15 +4107,248 @@ test_table_collection_subset_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MIGRATIONS_NOT_SUPPORTED);
 
     // test out of bounds nodes
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     nodes[0] = -1;
-    ret = tsk_table_collection_subset(&tables, nodes, 4);
+    ret = tsk_table_collection_subset(&tables_copy, nodes, 4);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     nodes[0] = 6;
-    ret = tsk_table_collection_subset(&tables, nodes, 4);
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_subset(&tables_copy, nodes, 4);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+
+    // check integrity
+    nodes[0] = 0;
+    nodes[1] = 1;
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_node_table_truncate(&tables_copy.nodes, 3);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_node_table_add_row(
+        &tables_copy.nodes, TSK_NODE_IS_SAMPLE, 0.0, -2, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_subset(&tables_copy, nodes, 4);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
 
     tsk_table_collection_free(&tables);
     tsk_table_collection_free(&tables_copy);
+}
+
+static void
+test_table_collection_union(void)
+{
+    int ret;
+    tsk_table_collection_t tables;
+    tsk_table_collection_t tables_empty;
+    tsk_table_collection_t tables_copy;
+    tsk_id_t node_mapping[3];
+
+    memset(node_mapping, 0xff, sizeof(node_mapping));
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
+    ret = tsk_table_collection_init(&tables_empty, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables_empty.sequence_length = 1;
+    ret = tsk_table_collection_init(&tables_copy, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    // does not error on empty tables
+    ret = tsk_table_collection_union(
+        &tables, &tables_empty, node_mapping, TSK_UNION_NO_CHECK_SHARED);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    // three nodes, two pop, three ind, two edge, two site, two mut
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 1, 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.5, 1, 2, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_individual_table_add_row(&tables.individuals, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_individual_table_add_row(&tables.individuals, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_individual_table_add_row(&tables.individuals, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_population_table_add_row(&tables.populations, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_population_table_add_row(&tables.populations, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 2, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 2, 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_site_table_add_row(&tables.sites, 0.4, "T", 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_site_table_add_row(&tables.sites, 0.2, "A", 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_mutation_table_add_row(
+        &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    ret = tsk_mutation_table_add_row(
+        &tables.mutations, 1, 1, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_build_index(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_sort(&tables, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    // union with empty should not change
+    // other is empty
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_union(
+        &tables_copy, &tables_empty, node_mapping, TSK_UNION_NO_CHECK_SHARED);
+    CU_ASSERT_FATAL(tsk_table_collection_equals(&tables, &tables_copy));
+    // self is empty
+    ret = tsk_table_collection_clear(&tables_copy);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_union(
+        &tables_copy, &tables, node_mapping, TSK_UNION_NO_CHECK_SHARED);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_FATAL(tsk_table_collection_equals(&tables, &tables_copy));
+
+    // union all shared nodes + subset original nodes = original table
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_union(
+        &tables_copy, &tables, node_mapping, TSK_UNION_NO_CHECK_SHARED);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    node_mapping[0] = 0;
+    node_mapping[1] = 1;
+    node_mapping[2] = 2;
+    ret = tsk_table_collection_subset(&tables_copy, node_mapping, 3);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_FATAL(tsk_table_collection_equals(&tables, &tables_copy));
+
+    // union with one shared node
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    node_mapping[0] = TSK_NULL;
+    node_mapping[1] = TSK_NULL;
+    node_mapping[2] = 2;
+    ret = tsk_table_collection_union(&tables_copy, &tables, node_mapping, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(
+        tables_copy.populations.num_rows, tables.populations.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(
+        tables_copy.individuals.num_rows, tables.individuals.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.nodes.num_rows, tables.nodes.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.edges.num_rows, tables.edges.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.sites.num_rows, tables.sites.num_rows);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.mutations.num_rows, tables.mutations.num_rows + 2);
+
+    // union with one shared node, but no add pop
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    node_mapping[0] = TSK_NULL;
+    node_mapping[1] = TSK_NULL;
+    node_mapping[2] = 2;
+    ret = tsk_table_collection_union(
+        &tables_copy, &tables, node_mapping, TSK_UNION_NO_ADD_POP);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.populations.num_rows, tables.populations.num_rows);
+    CU_ASSERT_EQUAL_FATAL(
+        tables_copy.individuals.num_rows, tables.individuals.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.nodes.num_rows, tables.nodes.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.edges.num_rows, tables.edges.num_rows + 2);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.sites.num_rows, tables.sites.num_rows);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.mutations.num_rows, tables.mutations.num_rows + 2);
+
+    tsk_table_collection_free(&tables_copy);
+    tsk_table_collection_free(&tables_empty);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_table_collection_union_errors(void)
+{
+    int ret;
+    tsk_table_collection_t tables;
+    tsk_table_collection_t tables_copy;
+    tsk_id_t node_mapping[] = { 0, 1 };
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
+    ret = tsk_table_collection_init(&tables_copy, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    // two nodes, two pop, two ind, one edge, one site, one mut
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.5, 1, 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_individual_table_add_row(&tables.individuals, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_individual_table_add_row(&tables.individuals, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_population_table_add_row(&tables.populations, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_population_table_add_row(&tables.populations, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 1, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_site_table_add_row(&tables.sites, 0.2, "A", 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_mutation_table_add_row(
+        &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+
+    // trigger diff histories error
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_mutation_table_add_row(
+        &tables_copy.mutations, 0, 1, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_union(&tables_copy, &tables, node_mapping, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNION_DIFF_HISTORIES);
+
+    // Migrations are not supported
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tsk_migration_table_add_row(&tables_copy.migrations, 0, 1, 0, 0, 0, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(tables_copy.migrations.num_rows, 1);
+    ret = tsk_table_collection_union(
+        &tables_copy, &tables, node_mapping, TSK_UNION_NO_CHECK_SHARED);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MIGRATIONS_NOT_SUPPORTED);
+
+    // unsuported union - child shared parent not shared
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    node_mapping[0] = 0;
+    node_mapping[1] = TSK_NULL;
+    ret = tsk_table_collection_union(
+        &tables_copy, &tables, node_mapping, TSK_UNION_NO_ADD_POP);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNION_NOT_SUPPORTED);
+
+    // test out of bounds node_mapping
+    node_mapping[0] = -4;
+    node_mapping[1] = 6;
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_union(&tables_copy, &tables, node_mapping, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNION_BAD_MAP);
+
+    // check integrity
+    node_mapping[0] = 0;
+    node_mapping[1] = 1;
+    ret = tsk_node_table_add_row(
+        &tables_copy.nodes, TSK_NODE_IS_SAMPLE, 0.0, -2, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_union(&tables_copy, &tables, node_mapping, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
+    ret = tsk_table_collection_copy(&tables, &tables_copy, TSK_NO_INIT);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, -2, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_union(&tables, &tables_copy, node_mapping, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
+
+    tsk_table_collection_free(&tables_copy);
+    tsk_table_collection_free(&tables);
 }
 
 int
@@ -4168,6 +4407,8 @@ main(int argc, char **argv)
             test_table_collection_check_integrity_no_populations },
         { "test_table_collection_subset", test_table_collection_subset },
         { "test_table_collection_subset_errors", test_table_collection_subset_errors },
+        { "test_table_collection_union", test_table_collection_union },
+        { "test_table_collection_union_errors", test_table_collection_union_errors },
         { NULL, NULL },
     };
 

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -352,6 +352,10 @@ tsk_strerror_internal(int err)
         case TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED:
             ret = "Only binary mutations are supported for this operation";
             break;
+        case TSK_ERR_UNION_NOT_SUPPORTED:
+            ret = "Union is not supported for cases where there is non-shared"
+                  "history older than the shared history of the two Table Collections";
+            break;
 
         /* Stats errors */
         case TSK_ERR_BAD_NUM_WINDOWS:
@@ -441,6 +445,16 @@ tsk_strerror_internal(int err)
         case TSK_ERR_TOO_MANY_VALUES:
             ret = "Too many values to compress";
             break;
+
+        /* Union errors */
+        case TSK_ERR_UNION_BAD_MAP:
+            ret = "Node map contains an entry of a node not present in this table "
+                  "collection.";
+            break;
+        case TSK_ERR_UNION_DIFF_HISTORIES:
+            // histories could be equivalent, because subset does not reorder
+            // edges (if not sorted) or mutations.
+            ret = "Shared portions of the tree sequences are not equal.";
     }
     return ret;
 }

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -267,6 +267,7 @@ not found in the file.
 #define TSK_ERR_SORT_OFFSET_NOT_SUPPORTED                           -803
 #define TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -804
 #define TSK_ERR_MIGRATIONS_NOT_SUPPORTED                            -805
+#define TSK_ERR_UNION_NOT_SUPPORTED                                 -806
 
 /* Stats errors */
 #define TSK_ERR_BAD_NUM_WINDOWS                                     -900
@@ -303,6 +304,11 @@ not found in the file.
 #define TSK_ERR_MATCH_IMPOSSIBLE                                   -1301
 #define TSK_ERR_BAD_COMPRESSED_MATRIX_NODE                         -1302
 #define TSK_ERR_TOO_MANY_VALUES                                    -1303
+
+/* Union errors */
+#define TSK_ERR_UNION_BAD_MAP                                      -1400
+#define TSK_ERR_UNION_DIFF_HISTORIES                               -1401
+
 // clang-format on
 
 /* This bit is 0 for any errors originating from kastore */

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -21,6 +21,12 @@ In development
 
 **New features**
 
+- New methods to perform set operations on TableCollections and TreeSequences.
+  ``TableCollection.subset`` subsets and reorders table collections by nodes
+  (:user:`mufernando`, :user:`petrelharp`, :pr:`663`, :pr:`690`). 
+  ``TableCollection.union`` forms the node-wise union of two table collections
+  (:user:`mufernando`, :user:`petrelharp`, :issue:`381` :pr:`623`).
+
 - Mutations now have an optional double-precision floating-point ``time`` column.
   If not specified, this defaults to a particular NaN value (``tskit.UNKNOWN_TIME``)
   indicating that the time is unknown. For a tree sequence to be considered valid

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -277,6 +277,28 @@ class TestTableCollection(LowLevelTestCase):
         with self.assertRaises(_tskit.LibraryError):
             tc.subset(np.array([100, 200], dtype="int32"))
 
+    def test_union_bad_args(self):
+        ts = msprime.simulate(10, random_seed=1)
+        tc = ts.tables.ll_tables
+        tc2 = tc
+        with self.assertRaises(TypeError):
+            tc.union(tc2, np.array(["a"]))
+        with self.assertRaises(ValueError):
+            tc.union(tc2, np.array([0], dtype="int32"))
+        with self.assertRaises(TypeError):
+            tc.union(tc2)
+        with self.assertRaises(TypeError):
+            tc.union()
+        node_mapping = np.arange(ts.num_nodes, dtype="int32")
+        node_mapping[0] = 1200
+        with self.assertRaises(_tskit.LibraryError):
+            tc.union(tc2, node_mapping)
+        node_mapping = np.array(
+            [node_mapping.tolist(), node_mapping.tolist()], dtype="int32"
+        )
+        with self.assertRaises(ValueError):
+            tc.union(tc2, np.array([[1], [2]], dtype="int32"))
+
 
 class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
     """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4549,6 +4549,62 @@ class TreeSequence:
         tables.subset(nodes, record_provenance)
         return tables.tree_sequence()
 
+    def union(
+        self,
+        other,
+        node_mapping,
+        check_shared_equality=True,
+        add_populations=True,
+        record_provenance=True,
+    ):
+        """
+        Returns an expanded tree sequence which contains the node-wise union of
+        ``self`` and ``other``, obtained by adding the non-shared portions of
+        ``other`` onto ``self``. The "shared" portions are specified using a
+        map that specifies which nodes in ``other`` are equivalent to those in
+        ``self``: the ``node_mapping`` argument should be an array of length
+        equal to the number of nodes in ``other`` and whose entries are the ID
+        of the matching node in ``self``, or ``tskit.NULL`` if there is no
+        matching node. Those nodes in ``other`` that map to ``tskit.NULL`` will
+        be added to ``self``, along with:
+
+        1. Individuals whose nodes are new to ``self``.
+        2. Edges whose parent or child are new to ``self``.
+        3. Mutations whose nodes are new to ``self``.
+        4. Sites which were not present in ``self``, if the site contains a newly
+           added mutation.
+
+        By default, populations of newly added nodes are assumed to be new
+        populations, and added to the population table as well.
+
+        Note that this operation also sorts the resulting tables, so the
+        resulting tree sequence may not be equal to ``self`` even if nothing
+        new was added (although it would differ only in ordering of the tables).
+
+        :param TableCollection other: Another table collection.
+        :param list node_mapping: An array of node IDs that relate nodes in
+            ``other`` to nodes in ``self``.
+        :param bool check_shared_equality: If True, the shared portions of the
+            tree sequences will be checked for equality. It does so by
+            subsetting both ``self`` and ``other`` on the equivalent nodes
+            specified in ``node_mapping``, and then checking for equality of
+            the subsets.
+        :param bool add_populations: If True, nodes new to ``self`` will be
+            assigned new population IDs.
+        :param bool record_provenance: Whether to record a provenance entry
+            in the provenance table for this operation.
+        """
+        tables = self.dump_tables()
+        other_tables = other.dump_tables()
+        tables.union(
+            other_tables,
+            node_mapping,
+            check_shared_equality=check_shared_equality,
+            add_populations=add_populations,
+            record_provenance=record_provenance,
+        )
+        return tables.tree_sequence()
+
     def draw_svg(
         self,
         path=None,


### PR DESCRIPTION
If we have two tree sequences which share part of their past histories, we might want to graft them together (also see #381). One use case could be that one population split into two and you might want to simulate their branches independently as a way of parallelising the simulations.

Here, @petrelharp and I implemented a method to `graft` two tables, a **base** table and its **sister** (details of dev process can be found in [this repo](https://github.com/mufernando/graft)). The main rationale is:

- First, identify which nodes are shared between tables, and encode them in a `node_map`;
- If the tree sequences for a different number of generations (e.g., in a forward simulator) , it is possible the times along the nodes in the `node_map` don't match. For that reason, we also implemented a method to `add_time` to the node times and migration times of a Table Collection;
- Now, we can copy the **base** as a **new** table and start adding the non-shared bits of the **sister** table to it;
- All the nodes of the **sister** table not in the `node_map` are added to **new** -- these are the target nodes;
    - These nodes are assigned new individuals;
    - The population of all target nodes are considered new, and are added to **new** population table;
- Edges connecting target nodes are added to **new**;
- Mutations falling in any of the target nodes are also added;
    - At first pass all these mutations are assigned new sites, which are later deduplicated;
    - We do not assign a parent mutation, but late recompute them;
- Migrations within **base** are kept, and migrations within **sister** are added, with nodes and populations being remapped;
- A new row is added to the provenance table -- the way it's currently done is NOT final;
- At last, we can sort, deduplicate sites, and compute the parent mutations;

We implemented some tests, which rely on simplification. The idea is that if you simulate a history of one population splitting into two, simplify independently on the nodes of population 0 and 1, and graft them together you should get equivalent TreeSequences. 

The implementation is not finalised, this is a slow -- but likely correct -- solution to the problem. 

We would like any input on implementation/interface, but most importantly there are two points of improvement:

- We cannot currently test how the MigrationTable is grafted, because our tests rely on simplification and MigrationTables are not dealt with by `simplify` (see [here](https://github.com/tskit-dev/tskit/issues/20))
- We need help figuring out how to deal with the ProvenanceTable of the grafted tree sequence.
