### PR TITLE
Expose sorting API and test C++ implementation.

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -71,6 +71,9 @@ In development.
   variants for tree sequence and table collection load/dump
   (:user:`jeromekelleher`, :user:`grahamgower`, :issue:`565`, :pr:`599`).
 
+- Add low-level sorting API and ``TSK_NO_CHECK_INTEGRITY`` flag
+  (:user:`jeromekelleher`, :pr:`627`, :issue:`626`).
+
 **Deprecated**
 
 - The ``TSK_SAMPLE_COUNTS`` options is now ignored and  will print out a warning

--- a/c/tests/test_minimal_cpp.cpp
+++ b/c/tests/test_minimal_cpp.cpp
@@ -1,7 +1,6 @@
-/*
- * MIT License
+/* * MIT License
  *
- * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2019-2020 Tskit Developers
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +27,9 @@
 #include <iostream>
 #include <cassert>
 #include <sstream>
+#include <vector>
+#include <algorithm>
+#include <cstring>
 
 #include <tskit.h>
 
@@ -78,6 +80,177 @@ test_table_basics()
     tsk_table_collection_free(&tables);
 }
 
+/* A definition of sort_edges that uses C++ std::sort and inlining of the
+ * comparison function to achieve significantly better performance than
+ * the builtin method in tskit.
+ */
+int
+cpp_sort_edges(tsk_table_sorter_t *sorter, tsk_size_t start)
+{
+    struct _edge {
+        double left, right;
+        tsk_id_t parent, child;
+
+        _edge(double l, double r, tsk_id_t p, tsk_id_t c)
+            : left{ l }, right{ r }, parent{ p }, child{ c }
+        {
+        }
+    };
+    tsk_edge_table_t *edges = &sorter->tables->edges;
+    const double *node_time = sorter->tables->nodes.time;
+    std::vector<_edge> sorted_edges;
+    size_t num_edges = edges->num_rows;
+    size_t j;
+
+    /* This is the comparison function.  We cannot define an
+     * operator < for _edge because we need to bind the node times
+     * so we have to use a functional method. This is a copy of the cmp
+     * from fwdpp.  Only difference is the final time comparison
+     * (fwdpp table times go forwards). */
+    const auto cmp = [&node_time](const _edge &lhs, const _edge &rhs) {
+        auto tl = node_time[lhs.parent];
+        auto tr = node_time[rhs.parent];
+        if (tl == tr) {
+            if (lhs.parent == rhs.parent) {
+                if (lhs.child == rhs.child) {
+                    return lhs.left < rhs.left;
+                }
+                return lhs.child < rhs.child;
+            }
+            return lhs.parent < rhs.parent;
+        }
+        return tl < tr;
+    };
+
+    assert(start == 0);
+    /* Let's not bother with metadata */
+    assert(edges->metadata_length == 0);
+
+    sorted_edges.reserve(num_edges);
+    for (j = 0; j < num_edges; j++) {
+        sorted_edges.emplace_back(
+            edges->left[j], edges->right[j], edges->parent[j], edges->child[j]);
+    }
+
+    std::sort(begin(sorted_edges), end(sorted_edges), cmp);
+
+    for (j = 0; j < num_edges; j++) {
+        edges->left[j] = sorted_edges[j].left;
+        edges->right[j] = sorted_edges[j].right;
+        edges->parent[j] = sorted_edges[j].parent;
+        edges->child[j] = sorted_edges[j].child;
+    }
+    return 0;
+}
+
+void
+test_edge_sorting()
+{
+    std::cout << "test_edge_sorting" << endl;
+    tsk_table_collection_t tables;
+    tsk_id_t n = 10;
+    tsk_id_t j;
+    tsk_id_t ret = tsk_table_collection_init(&tables, 0);
+    assert(ret == 0);
+
+    tables.sequence_length = 1.0;
+    /* Make a stick tree */
+    /* Add nodes and edges */
+    for (j = 0; j < n; j++) {
+        ret = tsk_node_table_add_row(
+            &tables.nodes, TSK_NODE_IS_SAMPLE, j + 1, TSK_NULL, TSK_NULL, NULL, 0);
+        assert(ret == j);
+    }
+    for (j = n - 1; j > 0; j--) {
+        tsk_edge_table_add_row(&tables.edges, 0, 1, j, j - 1, NULL, 0);
+    }
+    assert(tables.nodes.num_rows == (tsk_size_t) n);
+    assert(tables.edges.num_rows == (tsk_size_t) n - 1);
+
+    /* Make sure the edges are unsorted */
+    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_EDGE_ORDERING);
+    assert(ret == TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME);
+
+    /* Sort the tables */
+    tsk_table_sorter_t sorter;
+    ret = tsk_table_sorter_init(&sorter, &tables, 0);
+    assert(ret == 0);
+    /* Set the sort_edges to our local C++ version. We could also set some
+     * persistent state in sorter.params if we wanted to. */
+    sorter.sort_edges = cpp_sort_edges;
+    ret = tsk_table_sorter_run(&sorter, NULL);
+    assert(ret == 0);
+    tsk_table_sorter_free(&sorter);
+
+    /* Make sure the edges are now sorted */
+    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_EDGE_ORDERING);
+    assert(ret == 0);
+
+    tsk_table_collection_free(&tables);
+}
+
+int
+sort_edges_raises_exception(tsk_table_sorter_t *sorter, tsk_size_t start)
+{
+    throw std::exception();
+    return 0;
+}
+
+int
+sort_edges_raises_non_exception(tsk_table_sorter_t *sorter, tsk_size_t start)
+{
+    throw 42;
+    return 0;
+}
+
+int
+safe_sort_edges(tsk_table_sorter_t *sorter, tsk_size_t start)
+{
+    int ret = 0;
+    if (sorter->user_data == NULL) {
+        try {
+            ret = sort_edges_raises_exception(sorter, start);
+        } catch (...) {
+            ret = -12345;
+        }
+    } else {
+        try {
+            ret = sort_edges_raises_non_exception(sorter, start);
+        } catch (...) {
+            ret = -123456;
+        }
+    }
+    return ret;
+}
+
+void
+test_edge_sorting_errors()
+{
+    std::cout << "test_edge_sorting_errors" << endl;
+    tsk_table_collection_t tables;
+    tsk_table_sorter_t sorter;
+    tsk_id_t ret = tsk_table_collection_init(&tables, 0);
+
+    assert(ret == 0);
+    tables.sequence_length = 1.0;
+
+    ret = tsk_table_sorter_init(&sorter, &tables, 0);
+    assert(ret == 0);
+    sorter.sort_edges = safe_sort_edges;
+    ret = tsk_table_sorter_run(&sorter, NULL);
+    assert(ret == -12345);
+
+    /* Use the user_data as a way to communicate with the sorter
+     * function. Here, we want to try out two different types
+     * of exception that get thrown. */
+    sorter.user_data = &tables;
+    ret = tsk_table_sorter_run(&sorter, NULL);
+    assert(ret == -123456);
+
+    tsk_table_sorter_free(&sorter);
+    tsk_table_collection_free(&tables);
+}
+
 int
 main()
 {
@@ -85,5 +258,7 @@ main()
     test_strerror();
     test_load_error();
     test_table_basics();
+    test_edge_sorting();
+    test_edge_sorting_errors();
     return 0;
 }

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -341,6 +341,34 @@ Trees
 .. doxygengroup:: TREE_API_GROUP
     :content-only:
 
+
+.. _sec_c_api_low_level_sorting:
+
+*****************
+Low-level sorting
+*****************
+
+In some highly performance sensitive cases it can be useful to
+have more control over the process of sorting tables. This low-level
+API allows a user to provide their own edge sorting function.
+This can be useful, for example, to use parallel sorting algorithms,
+or to take advantage of the more efficient sorting procedures
+available in C++. It is the user's responsibility to ensure that the
+edge sorting requirements are fulfilled by this function.
+
+.. todo::
+    Create an idiomatic C++11 example where we load a table collection
+    file from argv[1], and sort the edges  using std::sort, based
+    on the example in tests/test_minimal_cpp.cpp. We can include
+    this in the examples below, and link to it here.
+
+.. doxygenstruct:: _tsk_table_sorter_t
+    :members:
+
+.. doxygengroup:: TABLE_SORTER_API_GROUP
+    :content-only:
+
+
 ***********************
 Miscellaneous functions
 ***********************


### PR DESCRIPTION
Closes #616

Here's an initial proposal @molpopgen and @bhaller. I've tested out basic C++ linkage by stealing @molpopgen's nice code, which should hopefully make the proposal clear.

Basically, in C++ code we'd have
```c

    tsk_table_sorter_t sorter;
    ret = tsk_table_sorter_init(&sorter, &tables, 0);
    check_error(ret);
    /* Set the sort_edges to our local C++ version. We could also set some
     * persistent state in sorter.params if we wanted to. */
    sorter.sort_edges = sort_edges;
    ret = tsk_table_sorter_run(&sorter, NULL);
    check_error(ret);
    tsk_table_sorter_free(&sorter);
```

One thing I'm a little bit uneasy about is what happens if ``std::sort`` throws an exception within the ``sort_edges`` function. The C code is expecting ``sort_edges`` to return an error if something bad happens, so what'll happen if an exception occurs? Will it all just work out, or will things explode? 

I guess we should test it. (If anyone has ideas for less lame ways than ``assert(something)`` for defining the C++ tests that doesn't involve an annoying dependency, I'd love to hear it!)