### PR TITLE
Implement algorithm for calculating species tree topology distributions.

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -502,6 +502,8 @@ See :ref:`sec_combinatorics` for details.
 
 .. autofunction:: tskit.all_tree_labellings
 
+.. autoclass:: tskit.TopologyCounter
+
 **********************
 Linkage disequilibrium
 **********************

--- a/python/tskit/__init__.py
+++ b/python/tskit/__init__.py
@@ -56,6 +56,7 @@ from tskit.combinatorics import (  # NOQA
     all_trees,
     all_tree_shapes,
     all_tree_labellings,
+    TopologyCounter,
 )
 from tskit.exceptions import *  # NOQA
 from tskit.util import *  # NOQA


### PR DESCRIPTION
This implements both per-tree and incremental algorithms for computing exact tree topology distributions on tree sequences.

As discussed in my talk last week, this uses a DP approach to compute all possible species topology distributions at each node in the tree, starting from leaves up to roots. The `TopologyTree` class is used to store topology distributions at each node. This approach does not support internal samples, and enforces that samples be a subset of leaves (leaves that are not samples are ignored). This does, nicely, support multiply-rooted trees. As there can't be species topologies that span different roots, we compute the topologies for each root using `TopologyTree` and "add" the resulting distributions together.

Since this approach needs only a single upward traversal, the incremental algorithm is straightforward. We maintain a reference to the `TopologyTree` for each node and reconstruct those `TopologyTree`s on the upward traversals when inserting/removing edge diffs.

Should we follow the pattern of adding wrapper methods on `Tree` and `TreeSequence` (and move the docstrings over) to not have to expose the combinatorics module? If so, should we lift the functions over entirely or make the `Tree{Sequence}` methods one-liners?

cc @jeromekelleher @hyanwong 