### PR TITLE
method to subset and reorder table collection

### DIFF
--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -323,6 +323,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_SORT_MIGRATIONS_NOT_SUPPORTED:
             ret = "Migrations not currently supported by sort";
             break;
+        case TSK_ERR_MIGRATIONS_NOT_SUPPORTED:
+            ret = "Migrations not currently supported by this operation";
+            break;
         case TSK_ERR_SORT_OFFSET_NOT_SUPPORTED:
             ret = "Specifying position for mutation, sites or migrations is not "
                   "supported";

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -225,6 +225,7 @@ not found in the file.
 #define TSK_ERR_SORT_MIGRATIONS_NOT_SUPPORTED                       -802
 #define TSK_ERR_SORT_OFFSET_NOT_SUPPORTED                           -803
 #define TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -804
+#define TSK_ERR_MIGRATIONS_NOT_SUPPORTED                            -805
 
 /* Stats errors */
 #define TSK_ERR_BAD_NUM_WINDOWS                                     -900

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -2410,6 +2410,43 @@ int tsk_table_collection_simplify(tsk_table_collection_t *self, tsk_id_t *sample
     tsk_size_t num_samples, tsk_flags_t options, tsk_id_t *node_map);
 
 /**
+@brief Subsets and reorders a table collection according to an array of nodes.
+
+@rst
+Reduces the table collection to contain only the entries referring to
+the provided list of nodes, with nodes reordered according to the order
+they appear in the ``nodes`` argument. Specifically, this subsets and reorders
+each of the tables as follows:
+
+1. Nodes: if in the list of nodes, and in the order provided.
+2. Individuals and Populations: if referred to by a retained node,
+   and in the order first seen when traversing the list of retained nodes.
+3. Edges: if both parent and child are retained nodes.
+4. Mutations: if the mutation's node is a retained node.
+5. Sites: if any mutations remain at the site after removing mutations.
+6. Migrations: if the migration's node is a retained node.
+
+Retained edges, mutations, sites, and migrations appear in the same
+order as in the original tables.
+
+If ``nodes`` is the entire list of nodes in the tables, then the
+resulting tables will be identical to the original tables, but with
+nodes (and individuals and populations) reordered.
+
+.. note:: Migrations are currently not supported by susbset, and an error will
+    be raised if we attempt call subset on a table collection with greater
+    than zero migrations.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param nodes An array of num_nodes valid node IDs.
+@param num_nodes The number of node IDs in the input nodes array.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_subset(
+    tsk_table_collection_t *self, tsk_id_t *nodes, tsk_size_t num_nodes);
+
+/**
 @brief Set the metadata
 @rst
 Copies the metadata string to this table collection, replacing any existing.

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -265,6 +265,18 @@ class TestTableCollection(LowLevelTestCase):
         del edges
         self.assertEqual(tc.edges.num_rows, 2)
 
+    def test_subset_bad_args(self):
+        ts = msprime.simulate(10, random_seed=1)
+        tc = ts.tables.ll_tables
+        with self.assertRaises(TypeError):
+            tc.subset(np.array(["a"]))
+        with self.assertRaises(ValueError):
+            tc.subset(np.array([[1], [2]], dtype="int32"))
+        with self.assertRaises(TypeError):
+            tc.subset()
+        with self.assertRaises(_tskit.LibraryError):
+            tc.subset(np.array([100, 200], dtype="int32"))
+
 
 class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
     """

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2494,3 +2494,23 @@ class TableCollection:
         currently indexed this method has no effect.
         """
         self.ll_tables.drop_index()
+
+    def subset(self, nodes, record_provenance=True):
+        """
+        Modifies the tables in place to contain only the entries referring to
+        the provided list of nodes, with nodes reordered according to the order
+        they appear in the list. See :meth:`TreeSequence.subset` for a more
+        detailed description.
+
+        :param list nodes: The list of nodes for which to retain information. This
+            may be a numpy array (or array-like) object (dtype=np.int32).
+        :param bool record_provenance: Whether to record a provenance entry
+            in the provenance table for this operation.
+        """
+        nodes = util.safe_np_int_cast(nodes, np.int32)
+        self.ll_tables.subset(nodes)
+        if record_provenance:
+            parameters = {"command": "subset", "nodes": nodes.tolist()}
+            self.provenances.add_row(
+                record=json.dumps(provenance.get_provenance_dict(parameters))
+            )

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4470,6 +4470,45 @@ class TreeSequence:
         tables.trim(record_provenance)
         return tables.tree_sequence()
 
+    def subset(self, nodes, record_provenance=True):
+        """
+        Returns a tree sequence modified to contain only the entries referring to
+        the provided list of nodes, with nodes reordered according to the order
+        they appear in the ``nodes`` argument. Specifically, this subsets and reorders
+        each of the tables as follows:
+
+        1. Nodes: if in the list of nodes, and in the order provided.
+        2. Individuals and Populations: if referred to by a retained node,
+           and in the order first seen when traversing the list of retained nodes.
+        3. Edges: if both parent and child are retained nodes.
+        4. Mutations: if the mutation's node is a retained node.
+        5. Sites: if any mutations remain at the site after removing mutations.
+        6. Migrations: if the migration's node is a retained node.
+
+        Retained edges, mutations, sites, and migrations appear in the same
+        order as in the original tables.
+
+        If ``nodes`` is the entire list of nodes in the tables, then the
+        resulting tables will be identical to the original tables, but with
+        nodes (and individuals and populations) reordered.
+
+        To instead subset the tables to a given portion of the *genome*, see
+        :meth:`.keep_intervals`.
+
+        **Note:** This is quite different from :meth:`.simplify`: the resulting
+        tables contain only the nodes given, not ancestral ones as well, and
+        does not simplify the relationships in any way.
+
+        :param list nodes: The list of nodes for which to retain information. This
+            may be a numpy array (or array-like) object (dtype=np.int32).
+        :param bool record_provenance: If True, add details of this operation to the
+            provenance information of the returned tree sequence. (Default: True).
+        :rtype: .TreeSequence
+        """
+        tables = self.dump_tables()
+        tables.subset(nodes, record_provenance)
+        return tables.tree_sequence()
+
     def draw_svg(
         self,
         path=None,


### PR DESCRIPTION
Here I implemented a numpy version of a method to subset a table collection.

There are probably many uses for this, but most importantly:

- If you subset on a permutation of all existing nodes, you can reorder the Nodes, Individuals, and Populations Tables to your liking. I think @hyanwong was interested in this use?
- For the new `graft` method we need a better way of checking for equivalency between Table Collections, and now we can quickly do so by subsetting.
    - We now can get the non-overlapping bits of two tree sequences using this method, so it could be used to rethink the way `graft` works.

@petrelharp described the motivation and approach [here](https://github.com/tskit-dev/tskit/pull/623#issuecomment-631655756):

The proposed subset-and-reorder method is: tables.subset_nodes(nodes) modifies the tables to retain exactly those:

- nodes that are listed in nodes and in the order listed
- mutations whose node entry is in nodes
- sites with remaining mutations
- edges whose parent and child entries are in nodes
- individuals referred to by the nodes in nodes, and in the order encountered in nodes
- only populations referred to by nodes in nodes, and in the order encountered in nodes
- migrations whose nodes are in nodes

I also implemented a new function to `subset_ragged_col` that subsets ragged cols based on a list of indices (or boolean mask). I added it to `util.py` but not sure that is the right place.