### PR TITLE
more general error on fail to write

### DIFF
--- a/c/tests/test_file_format.c
+++ b/c/tests/test_file_format.c
@@ -810,7 +810,8 @@ test_dump_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_IO);
     str = tsk_strerror(ret);
     CU_ASSERT_TRUE(strlen(str) > 0);
-    CU_ASSERT_STRING_EQUAL(str, strerror(EACCES));
+    CU_ASSERT_TRUE(
+        (strcmp(str, strerror(EACCES)) == 0) || (strcmp(str, strerror(EPERM)) == 0));
 
     /* open a file in the wrong mode */
     f = fopen(_tmp_file_name, "r");


### PR DESCRIPTION
@mufernando discovered that on his system (macOS), this test actually returns "Operation not permitted" instead of "Permission denied". This should cover that situation as well.  @mufernando, can you see if it passes that test, now?