### PR TITLE
Make tests run on all CI cores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,9 @@ install:
   - pip install -e python
 
 script:
-  - nosetests -vs tests
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      nosetests -vs --processes=`sysctl -n hw.ncpu` --process-timeout=5000 tests;
+    else
+      nosetests -vs --processes=`nproc` --process-timeout=5000 tests;
+    fi
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 init:
   - cmd: SET PYTHON=C:\\Miniconda37-x64
   - cmd: ECHO Using %PYTHON%
+  - cmd: ECHO Cores %NUMBER_OF_PROCESSORS%
 
 install:
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
@@ -28,7 +29,7 @@ build_script:
   - cmd: python -m pip install newick
   - cmd: python -m pip install python_jsonschema_objects
   - cmd: python -m pip install xmlunittest
-  - cmd: python -m nose -vs
+  - cmd: python -m nose -vs --processes=%NUMBER_OF_PROCESSORS% --process-timeout=5000
 
 after_test:
   - cmd: python setup.py bdist_wheel


### PR DESCRIPTION
All our CI providers are dual-core. This PR runs tests on both cores to halve testing time. Sadly, we can't do that while measuring coverage though.