### PR TITLE
update subset docs - no support for migration table

### DIFF
--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -2424,9 +2424,8 @@ each of the tables as follows:
 3. Edges: if both parent and child are retained nodes.
 4. Mutations: if the mutation's node is a retained node.
 5. Sites: if any mutations remain at the site after removing mutations.
-6. Migrations: if the migration's node is a retained node.
 
-Retained edges, mutations, sites, and migrations appear in the same
+Retained edges, mutations, and sites appear in the same
 order as in the original tables.
 
 If ``nodes`` is the entire list of nodes in the tables, then the

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4483,9 +4483,8 @@ class TreeSequence:
         3. Edges: if both parent and child are retained nodes.
         4. Mutations: if the mutation's node is a retained node.
         5. Sites: if any mutations remain at the site after removing mutations.
-        6. Migrations: if the migration's node is a retained node.
 
-        Retained edges, mutations, sites, and migrations appear in the same
+        Retained edges, mutations, and sites appear in the same
         order as in the original tables.
 
         If ``nodes`` is the entire list of nodes in the tables, then the


### PR DESCRIPTION
I forgot to update the documentation after I removed the support for subsetting the Migration Table in #663. I followed the same that was done for `TableCollection.simplify()` -- that is added a note (it was there already) in the C API and removed any mentions of migration in the Python API.