### PR TITLE
Remove __iter__ protocol from TableCollection

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -19,11 +19,18 @@ In development
   children on an interval. Previously an error was thrown when some operation
   building the trees was attempted. (:user:`jeromekelleher`, :pr:`709`).
 
+- The TableCollection object no longer implements the iterator protocol.
+  Previously ``list(tables)`` returned a sequence of (table_name, table_instance)
+  tuples. This has been replaced with the more intuitive and future-proof
+  TableCollection.name_map and TreeSequence.tables_dict attributes, which
+  perform the same function. (:user:`jeromekelleher`, :issue:`500`,
+  :pr:`694`)
+
 **New features**
 
 - New methods to perform set operations on TableCollections and TreeSequences.
   ``TableCollection.subset`` subsets and reorders table collections by nodes
-  (:user:`mufernando`, :user:`petrelharp`, :pr:`663`, :pr:`690`). 
+  (:user:`mufernando`, :user:`petrelharp`, :pr:`663`, :pr:`690`).
   ``TableCollection.union`` forms the node-wise union of two table collections
   (:user:`mufernando`, :user:`petrelharp`, :issue:`381` :pr:`623`).
 

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1328,7 +1328,7 @@ class TestTreeSequence(HighLevelTestCase):
 
     def test_sequence_iteration(self):
         for ts in get_example_tree_sequences():
-            for table_name, _ in ts.tables:
+            for table_name in ts.tables_dict.keys():
                 sequence = getattr(ts, table_name)()
                 length = getattr(ts, "num_" + table_name)
                 # Test __iter__

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -53,8 +53,12 @@ def tables_equal(table_collection_1, table_collection_2, compare_provenances=Tru
     """
     Check equality of tables, ignoring provenance timestamps (but not contents)
     """
-    for (_, table_1), (_, table_2) in zip(table_collection_1, table_collection_2):
-        if isinstance(table_1, tskit.ProvenanceTable):
+    tc_dict_1 = table_collection_1.name_map
+    tc_dict_2 = table_collection_2.name_map
+    for table_name in tc_dict_1.keys():
+        table_1 = tc_dict_1[table_name]
+        table_2 = tc_dict_2[table_name]
+        if table_name == "provenances":
             if compare_provenances:
                 if np.any(table_1.record != table_2.record):
                     return False

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1966,7 +1966,7 @@ class TableCollection:
         """
         Returns a dictionary representation of this TableCollection.
 
-        Note: the semantics of this method changed at tskit 1.0.0. Previously a
+        Note: the semantics of this method changed at tskit 0.1.0. Previously a
         map of table names to the tables themselves was returned.
         """
         return {
@@ -1984,6 +1984,24 @@ class TableCollection:
             "provenances": self.provenances.asdict(),
         }
 
+    @property
+    def name_map(self):
+        """
+        Returns a dictionary mapping table names to the corresponding
+        table instances. For example, the returned dictionary will contain the
+        key "edges" that maps to an :class:`.EdgeTable` instance.
+        """
+        return {
+            "edges": self.edges,
+            "individuals": self.individuals,
+            "migrations": self.migrations,
+            "mutations": self.mutations,
+            "nodes": self.nodes,
+            "populations": self.populations,
+            "provenances": self.provenances,
+            "sites": self.sites,
+        }
+
     def __banner(self, title):
         width = 60
         line = "#" * width
@@ -1991,20 +2009,6 @@ class TableCollection:
         title_line += " " * (width - len(title_line) - 1)
         title_line += "#"
         return line + "\n" + title_line + "\n" + line + "\n"
-
-    def __iter__(self):
-        """
-        Iterate over all the tables in this TableCollection, ordered by table name
-        (i.e. deterministically), returning a tuple of (table_name, table_object)
-        """
-        yield "edges", self.edges
-        yield "individuals", self.individuals
-        yield "migrations", self.migrations
-        yield "mutations", self.mutations
-        yield "nodes", self.nodes
-        yield "populations", self.populations
-        yield "provenances", self.provenances
-        yield "sites", self.sites
 
     def __str__(self):
         s = self.__banner("Individuals")

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2941,6 +2941,15 @@ class TreeSequence:
         self._ll_tree_sequence.dump(str(path))
 
     @property
+    def tables_dict(self):
+        """
+        Returns a dictionary mapping names to tables in the
+        underlying :class:`.TableCollection`. Equivalent to calling
+        ``ts.tables.name_map``.
+        """
+        return self.tables.name_map
+
+    @property
     def tables(self):
         """
         A copy of the tables underlying this tree sequence. See also


### PR DESCRIPTION
Closes #500

This removes the ``__iter__`` protocol from TableCollection and replaces it with two properties on TableCollection and TreeSequence which do the same thing, more directly. This was done for a couple of reasons:

- Implementing ``__iter__`` without also implementing ``__getitem__``, ``__len__`` etc isn't a great practise. We will probably want to implement ``__getitem__`` at some point, and it would probably not be compatible with this definition of iter, so we don't want to be constrained by that.
- A list of (key, value) tuples is more naturally a dict, so it makes sense to be explicity about this.

The behaviour was undocumented, so I don't think we're doing to break much code with this change.

The names of the new attributes could probably be improved, so open to ideas there. You could also argue that they should be methods rather than properties - I don't have a strong opinion here.

@hyanwong, I think you're the main user of this - is it going to affect you much?