### PR TITLE
Add summary tables to Tree and TreeSequence docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,6 +124,7 @@ extensions = [
     "breathe",
     "sphinxarg.ext",
     "sphinx_issues",
+    "autodocsumm",
 ]
 
 # Github repo

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -27,6 +27,7 @@ The ``TreeSequence`` class
 ++++++++++++++++++++++++++
 
 .. autoclass:: tskit.TreeSequence()
+    :autosummary:
     :members:
 
 
@@ -42,6 +43,7 @@ class which provides methods, for example, to access information
 about particular nodes in the tree.
 
 .. autoclass:: tskit.Tree()
+    :autosummary:
     :members:
 
 

--- a/python/requirements/CI/requirements.txt
+++ b/python/requirements/CI/requirements.txt
@@ -1,4 +1,5 @@
 attrs==19.3.0
+autodocsumm==0.1.13
 biopython==1.77
 black==19.10b0
 breathe==4.14.2

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -1,4 +1,5 @@
 attrs>=19.1.0 #Pinned as we need kw_args support
+autodocsumm
 biopython
 black
 breathe==4.14.2 #Pinned as next version needs sphinx 3 (see below)


### PR DESCRIPTION
I often find myself forgetting the name of a `Tree` or `TreeSequence` method/attribute, or to which class it belongs. And as both classes have many methods, simply finding the correct place in the docs is more time consuming than it needs to be. So this change inserts `Methods` and `Attributes` summary tables at the top of each of these classes.

![autodocsumm](https://user-images.githubusercontent.com/8665077/86259583-7c303000-bbbc-11ea-967f-a9ad7b288cef.png)
