### PR TITLE
Add TSK_NO_EDGE_METADATA option, which disables the metadata column on edges

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -25,8 +25,9 @@ In development.
 
 - Edges can now have metadata. Hence edge methods now take two extra arguments:
   metadata and metadata length. The file format has also changed to accommodate this,
-  but is backwards compatible.
-  (:user:`benjeffery`, :pr:`496`)
+  but is backwards compatible. Edge metadata can be disabled for a table collection with
+  the TSK_NO_EDGE_METADATA flag.
+  (:user:`benjeffery`, :pr:`496`, :pr:`712`)
 
 - Migrations can now have metadata. Hence migration methods now take two extra arguments:
   metadata and metadata length. The file format has also changed to accommodate this,

--- a/c/tests/old_tests.c
+++ b/c/tests/old_tests.c
@@ -1468,7 +1468,7 @@ test_node_metadata(void)
     int ret;
     tsk_node_t node;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
 

--- a/c/tests/test_convert.c
+++ b/c/tests/test_convert.c
@@ -38,7 +38,7 @@ test_single_tree_newick(void)
     char newick[buffer_size];
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
 
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0)
@@ -74,7 +74,7 @@ test_single_tree_newick_errors(void)
     char newick[buffer_size];
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
 
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0)

--- a/c/tests/test_genotypes.c
+++ b/c/tests/test_genotypes.c
@@ -39,7 +39,7 @@ test_simplest_missing_data(void)
     tsk_variant_t *var;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, "", NULL, sites, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, "", NULL, sites, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 1);
 
@@ -94,7 +94,7 @@ test_simplest_missing_data_user_alleles(void)
     const char *alleles[] = { "A", NULL };
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, "", NULL, sites, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, "", NULL, sites, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 1);
 
@@ -159,7 +159,7 @@ test_single_tree_user_alleles(void)
     const char *alleles[] = { "A", "C", "G", "T", NULL };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        sites, mutations, NULL, NULL);
+        sites, mutations, NULL, NULL, 0);
     ret = tsk_vargen_init(&vargen, &ts, NULL, 0, alleles, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -265,7 +265,7 @@ test_single_tree_char_alphabet(void)
     tsk_variant_t *var;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        sites, mutations, NULL, NULL);
+        sites, mutations, NULL, NULL, 0);
     ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -345,7 +345,7 @@ test_single_tree_binary_alphabet(void)
     tsk_variant_t *var;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
@@ -405,7 +405,7 @@ test_single_tree_non_samples(void)
     tsk_id_t samples[] = { 4, 5 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     /* It's an error to hand in non-samples without imputation turned on */
     ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUST_IMPUTE_NON_SAMPLES);
@@ -462,7 +462,7 @@ test_single_tree_errors(void)
     tsk_id_t samples[] = { 0, 3 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_free(&vargen);
@@ -503,7 +503,7 @@ test_single_tree_user_alleles_errors(void)
     tsk_id_t samples[] = { 0, 3 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     /* these are 0/1 alleles */
     ret = tsk_vargen_init(&vargen, &ts, samples, 2, acct_alleles, 0);
@@ -545,7 +545,7 @@ test_single_tree_subsample(void)
     tsk_id_t samples[] = { 0, 3 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
@@ -638,7 +638,7 @@ test_single_tree_many_alleles(void)
     tsk_table_collection_t tables;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_FATAL(ret == 0);
     tsk_treeseq_free(&ts);
@@ -706,7 +706,7 @@ test_single_tree_inconsistent_mutations(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        sites, mutations, NULL, NULL);
+        sites, mutations, NULL, NULL, 0);
 
     for (s = 0; s < 2; s++) {
         for (f = 0; f < sizeof(options) / sizeof(*options); f++) {

--- a/c/tests/test_haplotype_matching.c
+++ b/c/tests/test_haplotype_matching.c
@@ -82,7 +82,7 @@ test_single_tree_missing_alleles(void)
     int8_t h[] = { 0, 0, 0, 0 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_ls_hmm_init(&ls_hmm, &ts, rho, mu, TSK_ALLELES_ACGT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -114,7 +114,7 @@ test_single_tree_exact_match(void)
     unsigned int precision;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_ls_hmm_init(&ls_hmm, &ts, rho, mu, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -172,7 +172,7 @@ test_single_tree_missing_haplotype_data(void)
     double decoded_compressed_matrix[12];
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_ls_hmm_init(&ls_hmm, &ts, rho, mu, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -214,7 +214,7 @@ test_single_tree_match_impossible(void)
     int8_t h[] = { 0, 0, 0 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_ls_hmm_init(&ls_hmm, &ts, rho, mu, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -250,7 +250,7 @@ test_single_tree_errors(void)
     int8_t h[] = { 0, 0, 0 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_viterbi_matrix_init(&viterbi, &ts, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -312,7 +312,7 @@ test_single_tree_compressed_matrix(void)
     int8_t h[] = { 0, 0, 0 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_compressed_matrix_init(&matrix, &ts, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -380,7 +380,7 @@ test_single_tree_viterbi_matrix(void)
     int j;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     ret = tsk_viterbi_matrix_init(&viterbi, &ts, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -454,7 +454,7 @@ test_multi_tree_exact_match(void)
     unsigned int precision;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_ls_hmm_init(&ls_hmm, &ts, rho, mu, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -506,7 +506,7 @@ test_multi_tree_errors(void)
     double decoded[3][4];
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_compressed_matrix_init(&forward, &ts, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -874,7 +874,7 @@ test_general_stat_input_errors(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
 
     /* Bad input dimensions */
     ret = tsk_treeseq_general_stat(
@@ -905,7 +905,7 @@ test_empty_ts_ld(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(
-        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL);
+        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL, 0);
 
     verify_ld(&ts);
     tsk_treeseq_free(&ts);
@@ -917,7 +917,7 @@ test_empty_ts_mean_descendants(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(
-        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL);
+        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL, 0);
     verify_mean_descendants(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -928,7 +928,7 @@ test_empty_ts_genealogical_nearest_neighbours(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(
-        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL);
+        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL, 0);
     verify_genealogical_nearest_neighbours(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -939,7 +939,7 @@ test_empty_ts_general_stat(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(
-        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL);
+        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL, 0);
     verify_branch_general_stat_identity(&ts);
     verify_default_general_stat(&ts);
     verify_general_stat(&ts, TSK_STAT_BRANCH);
@@ -954,7 +954,7 @@ test_empty_ts_afs(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(
-        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL);
+        &ts, 1, single_tree_ex_nodes, "", NULL, NULL, NULL, NULL, NULL, 0);
     verify_afs(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -965,7 +965,7 @@ test_single_tree_ld(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_ld(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -976,7 +976,7 @@ test_single_tree_mean_descendants(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_mean_descendants(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -987,7 +987,7 @@ test_single_tree_genealogical_nearest_neighbours(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_genealogical_nearest_neighbours(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -998,7 +998,7 @@ test_single_tree_general_stat(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_branch_general_stat_identity(&ts);
     verify_default_general_stat(&ts);
     verify_general_stat(&ts, TSK_STAT_BRANCH);
@@ -1013,7 +1013,7 @@ test_single_tree_general_stat_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_branch_general_stat_errors(&ts);
     verify_site_general_stat_errors(&ts);
     verify_node_general_stat_errors(&ts);
@@ -1026,7 +1026,7 @@ test_paper_ex_ld(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_ld(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -1037,7 +1037,7 @@ test_paper_ex_mean_descendants(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_mean_descendants(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -1048,7 +1048,7 @@ test_paper_ex_genealogical_nearest_neighbours(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_genealogical_nearest_neighbours(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -1059,7 +1059,7 @@ test_paper_ex_general_stat(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_branch_general_stat_identity(&ts);
     verify_default_general_stat(&ts);
     verify_general_stat(&ts, TSK_STAT_BRANCH);
@@ -1074,7 +1074,7 @@ test_paper_ex_general_stat_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_branch_general_stat_errors(&ts);
     verify_site_general_stat_errors(&ts);
     verify_node_general_stat_errors(&ts);
@@ -1087,7 +1087,7 @@ test_paper_ex_diversity_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_one_way_stat_func_errors(&ts, tsk_treeseq_diversity);
     tsk_treeseq_free(&ts);
 }
@@ -1102,7 +1102,7 @@ test_paper_ex_diversity(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_diversity(
         &ts, 1, &sample_set_sizes, samples, 0, NULL, &pi, TSK_STAT_SITE);
@@ -1125,7 +1125,7 @@ test_paper_ex_trait_covariance_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_one_way_weighted_func_errors(&ts, tsk_treeseq_trait_covariance);
     tsk_treeseq_free(&ts);
 }
@@ -1140,7 +1140,7 @@ test_paper_ex_trait_covariance(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     weights = malloc(4 * sizeof(double));
     weights[0] = weights[1] = 0.0;
     weights[2] = weights[3] = 1.0;
@@ -1167,7 +1167,7 @@ test_paper_ex_trait_correlation_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_one_way_weighted_func_errors(&ts, tsk_treeseq_trait_correlation);
     tsk_treeseq_free(&ts);
 }
@@ -1181,7 +1181,7 @@ test_paper_ex_trait_correlation(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     weights = malloc(4 * sizeof(double));
     weights[0] = weights[1] = 0.0;
     weights[2] = weights[3] = 1.0;
@@ -1201,7 +1201,7 @@ test_paper_ex_trait_regression_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_one_way_weighted_covariate_func_errors(&ts, tsk_treeseq_trait_regression);
     tsk_treeseq_free(&ts);
 }
@@ -1216,7 +1216,7 @@ test_paper_ex_trait_regression(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     weights = malloc(4 * sizeof(double));
     covariates = malloc(8 * sizeof(double));
     weights[0] = weights[1] = 0.0;
@@ -1242,7 +1242,7 @@ test_paper_ex_segregating_sites_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_one_way_stat_func_errors(&ts, tsk_treeseq_segregating_sites);
     tsk_treeseq_free(&ts);
 }
@@ -1257,7 +1257,7 @@ test_paper_ex_segregating_sites(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_segregating_sites(
         &ts, 1, &sample_set_sizes, samples, 0, NULL, &segsites, TSK_STAT_SITE);
@@ -1280,7 +1280,7 @@ test_paper_ex_Y1_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_one_way_stat_func_errors(&ts, tsk_treeseq_Y1);
     tsk_treeseq_free(&ts);
 }
@@ -1295,7 +1295,7 @@ test_paper_ex_Y1(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_Y1(&ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1315,7 +1315,7 @@ test_paper_ex_divergence_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_two_way_stat_func_errors(&ts, tsk_treeseq_divergence);
     tsk_treeseq_free(&ts);
 }
@@ -1331,7 +1331,7 @@ test_paper_ex_divergence(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_divergence(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0,
         NULL, &result, TSK_STAT_SITE);
@@ -1354,7 +1354,7 @@ test_paper_ex_Y2_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_two_way_stat_func_errors(&ts, tsk_treeseq_Y2);
     tsk_treeseq_free(&ts);
 }
@@ -1370,7 +1370,7 @@ test_paper_ex_Y2(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_Y2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         &result, TSK_STAT_SITE);
@@ -1392,7 +1392,7 @@ test_paper_ex_f2_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_two_way_stat_func_errors(&ts, tsk_treeseq_f2);
     tsk_treeseq_free(&ts);
 }
@@ -1408,7 +1408,7 @@ test_paper_ex_f2(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_f2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         &result, TSK_STAT_SITE);
@@ -1438,7 +1438,7 @@ test_paper_ex_Y3_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_three_way_stat_func_errors(&ts, tsk_treeseq_Y3);
     tsk_treeseq_free(&ts);
 }
@@ -1454,7 +1454,7 @@ test_paper_ex_Y3(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_Y3(&ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         &result, TSK_STAT_SITE);
@@ -1469,7 +1469,7 @@ test_paper_ex_f3_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_three_way_stat_func_errors(&ts, tsk_treeseq_f3);
     tsk_treeseq_free(&ts);
 }
@@ -1485,7 +1485,7 @@ test_paper_ex_f3(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_f3(&ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         &result, TSK_STAT_SITE);
@@ -1507,7 +1507,7 @@ test_paper_ex_f4_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_four_way_stat_func_errors(&ts, tsk_treeseq_f4);
     tsk_treeseq_free(&ts);
 }
@@ -1523,7 +1523,7 @@ test_paper_ex_f4(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_f4(&ts, 4, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         &result, TSK_STAT_SITE);
@@ -1541,7 +1541,7 @@ test_paper_ex_afs_errors(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     verify_one_way_stat_func_errors(&ts, tsk_treeseq_allele_frequency_spectrum);
 
@@ -1566,7 +1566,7 @@ test_paper_ex_afs(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     /* we have two singletons and one tripleton */
 
     ret = tsk_treeseq_allele_frequency_spectrum(
@@ -1595,7 +1595,7 @@ test_nonbinary_ex_ld(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
-        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL);
+        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL, 0);
     verify_ld(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -1606,7 +1606,7 @@ test_nonbinary_ex_mean_descendants(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
-        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL);
+        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL, 0);
     verify_mean_descendants(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -1617,7 +1617,7 @@ test_nonbinary_ex_genealogical_nearest_neighbours(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
-        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL);
+        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL, 0);
     verify_genealogical_nearest_neighbours(&ts);
     tsk_treeseq_free(&ts);
 }
@@ -1628,7 +1628,7 @@ test_nonbinary_ex_general_stat(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
-        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL);
+        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL, 0);
     verify_branch_general_stat_identity(&ts);
     verify_default_general_stat(&ts);
     verify_general_stat(&ts, TSK_STAT_BRANCH);
@@ -1643,7 +1643,7 @@ test_nonbinary_ex_general_stat_errors(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
-        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL);
+        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL, 0);
     verify_branch_general_stat_errors(&ts);
     verify_site_general_stat_errors(&ts);
     verify_node_general_stat_errors(&ts);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -910,7 +910,7 @@ test_simplest_records(void)
     tsk_id_t sample_ids[] = { 0, 1 };
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -943,7 +943,7 @@ test_simplest_nonbinary_records(void)
     tsk_id_t sample_ids[] = { 0, 1, 2, 3 };
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -978,7 +978,7 @@ test_simplest_unary_records(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1027,7 +1027,7 @@ test_simplest_non_sample_leaf_records(void)
     tsk_vargen_t vargen;
     tsk_variant_t *var;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1095,7 +1095,7 @@ test_simplest_degenerate_multiple_root_records(void)
     tsk_tree_t t;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 4);
@@ -1142,7 +1142,7 @@ test_simplest_multiple_root_records(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1, 2, 3 };
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 6);
@@ -1185,7 +1185,7 @@ test_simplest_zero_root_tree(void)
     tsk_treeseq_t ts;
     tsk_tree_t t;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 6);
@@ -1217,7 +1217,7 @@ test_simplest_multi_root_tree(void)
     tsk_treeseq_t ts;
     tsk_tree_t t;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 3);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 4);
@@ -1308,7 +1308,7 @@ test_simplest_root_mutations(void)
     tsk_id_t sample_ids[] = { 0, 1 };
     tsk_treeseq_t ts, simplified;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1347,7 +1347,7 @@ test_simplest_back_mutations(void)
     tsk_vargen_t vargen;
     tsk_variant_t *var;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 3);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1390,7 +1390,7 @@ test_simplest_general_samples(void)
 
     tsk_treeseq_t ts, simplified;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1436,7 +1436,7 @@ test_simplest_holey_tree_sequence(void)
     tsk_id_t sample_ids[] = { 0, 1 };
 
     tsk_treeseq_from_text(
-        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL);
+        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1481,7 +1481,7 @@ test_simplest_holey_tsk_treeseq_mutation_parents(void)
     int ret;
 
     tsk_treeseq_from_text(
-        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL);
+        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 6);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 3);
@@ -1526,7 +1526,7 @@ test_simplest_initial_gap_tree_sequence(void)
     tsk_size_t num_trees = 2;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1570,7 +1570,7 @@ test_simplest_initial_gap_zero_roots(void)
     uint32_t num_trees = 2;
     tsk_tree_t tree;
 
-    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1622,7 +1622,7 @@ test_simplest_holey_tsk_treeseq_zero_roots(void)
     uint32_t num_trees = 3;
     tsk_tree_t tree;
 
-    tsk_treeseq_from_text(&ts, 3, nodes_txt, edges_txt, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 3, nodes_txt, edges_txt, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 0);
@@ -1677,7 +1677,7 @@ test_simplest_initial_gap_tsk_treeseq_mutation_parents(void)
     int ret;
 
     tsk_treeseq_from_text(
-        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL);
+        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 6);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 2);
@@ -1720,7 +1720,7 @@ test_simplest_final_gap_tree_sequence(void)
     };
     uint32_t num_trees = 2;
 
-    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1753,7 +1753,7 @@ test_simplest_final_gap_tsk_treeseq_mutation_parents(void)
     int ret;
 
     tsk_treeseq_from_text(
-        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL);
+        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_mutations(&ts), 6);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 2);
@@ -2659,7 +2659,7 @@ test_simplest_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -2724,7 +2724,7 @@ test_simplest_nonbinary_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -2770,7 +2770,7 @@ test_simplest_unary_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -2814,7 +2814,7 @@ test_simplest_non_sample_leaf_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -2856,7 +2856,7 @@ test_simplest_internal_sample_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -2913,7 +2913,7 @@ test_simplest_multiple_root_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -2970,7 +2970,7 @@ test_simplest_chained_map_mutations(void)
     int8_t ancestral_state;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_tree_next(&t));
@@ -3010,7 +3010,7 @@ test_single_tree_good_records(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 7);
@@ -3037,7 +3037,7 @@ test_single_nonbinary_tree_good_records(void)
                         "0 1 9 6,7,8";
     tsk_treeseq_t ts;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 7);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 10);
@@ -3108,7 +3108,7 @@ test_single_tree_good_mutations(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 7);
@@ -3357,7 +3357,7 @@ test_single_tree_iter(void)
     size_t num_samples;
     uint32_t num_nodes = 7;
 
-    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
@@ -3420,7 +3420,7 @@ test_single_nonbinary_tree_iter(void)
     size_t num_nodes = 10;
     size_t total_samples = 7;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
@@ -3508,7 +3508,7 @@ test_single_tree_general_samples_iter(void)
     size_t num_samples;
     uint32_t num_nodes = 7;
 
-    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     samples = tsk_treeseq_get_samples(&ts);
     CU_ASSERT_EQUAL(samples[0], 3);
     CU_ASSERT_EQUAL(samples[1], 4);
@@ -3573,7 +3573,7 @@ test_single_tree_iter_times(void)
     tsk_id_t u, v;
     uint32_t num_nodes = 7;
 
-    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_tree_first(&tree);
@@ -3618,7 +3618,7 @@ test_single_tree_iter_depths(void)
     tsk_id_t u;
     uint32_t num_nodes = 7;
 
-    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_tree_first(&tree);
@@ -3651,7 +3651,7 @@ test_single_tree_simplify(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_simplify(&ts);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3708,7 +3708,7 @@ test_single_tree_simplify_no_sample_nodes(void)
     tsk_id_t samples[] = { 0, 1, 2, 3 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t2, 0);
@@ -3736,7 +3736,7 @@ test_single_tree_simplify_null_samples(void)
     tsk_table_collection_t t1, t2;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t2, 0);
@@ -3985,7 +3985,7 @@ test_single_tree_is_descendant(void)
     tsk_tree_t tree;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&tree);
@@ -4029,7 +4029,7 @@ test_single_tree_map_mutations(void)
     int8_t ancestral_state, j;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4156,7 +4156,7 @@ test_single_tree_map_mutations_internal_samples(void)
     tsk_state_transition_t *transitions;
     int8_t ancestral_state;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 5);
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4191,7 +4191,7 @@ test_simple_multi_tree(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL);
+        paper_ex_mutations, paper_ex_individuals, NULL, 0);
     verify_trees(&ts, num_trees, parents);
     tsk_treeseq_free(&ts);
 }
@@ -4210,7 +4210,7 @@ test_unary_multi_tree(void)
     uint32_t num_trees = 3;
 
     tsk_treeseq_from_text(&ts, 10, unary_ex_nodes, unary_ex_edges, NULL, unary_ex_sites,
-        unary_ex_mutations, NULL, NULL);
+        unary_ex_mutations, NULL, NULL, 0);
     verify_trees(&ts, num_trees, parents);
     tsk_treeseq_free(&ts);
 }
@@ -4229,7 +4229,7 @@ test_internal_sample_multi_tree(void)
     uint32_t num_trees = 3;
 
     tsk_treeseq_from_text(&ts, 10, internal_sample_ex_nodes, internal_sample_ex_edges,
-        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL);
+        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL, 0);
     verify_trees(&ts, num_trees, parents);
     tsk_treeseq_free(&ts);
 }
@@ -4253,7 +4253,7 @@ test_internal_sample_simplified_multi_tree(void)
     uint32_t num_trees = 3;
 
     tsk_treeseq_from_text(&ts, 10, internal_sample_ex_nodes, internal_sample_ex_edges,
-        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL);
+        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL, 0);
     ret = tsk_treeseq_simplify(&ts, samples, 3, 0, &simplified, node_map);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(node_map[2], 0);
@@ -4280,7 +4280,7 @@ test_nonbinary_multi_tree(void)
     uint32_t num_trees = 2;
 
     tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL,
-        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL);
+        nonbinary_ex_sites, nonbinary_ex_mutations, NULL, NULL, 0);
     verify_trees(&ts, num_trees, parents);
     tsk_treeseq_free(&ts);
 }
@@ -4322,7 +4322,7 @@ test_left_to_right_multi_tree(void)
     tsk_treeseq_t ts;
     uint32_t num_trees = 3;
 
-    tsk_treeseq_from_text(&ts, 10, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 10, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     verify_trees(&ts, num_trees, parents);
     verify_tree_next_prev(&ts);
     tsk_treeseq_free(&ts);
@@ -4367,7 +4367,7 @@ test_gappy_multi_tree(void)
     tsk_treeseq_t ts;
     uint32_t num_trees = 6;
 
-    tsk_treeseq_from_text(&ts, 12, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 12, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     verify_trees(&ts, num_trees, parents);
     verify_tree_next_prev(&ts);
     tsk_treeseq_free(&ts);
@@ -4424,17 +4424,24 @@ test_tsk_treeseq_bad_records(void)
  *======================================================*/
 
 static void
-test_simple_diff_iter(void)
+test_simple_diff_iter_with_options(tsk_flags_t tc_options)
 {
     int ret;
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
-        paper_ex_individuals, NULL);
+        paper_ex_individuals, NULL, tc_options);
     verify_tree_diffs(&ts);
 
     ret = tsk_treeseq_free(&ts);
     CU_ASSERT_EQUAL(ret, 0);
+}
+
+static void
+test_simple_diff_iter(void)
+{
+    test_simple_diff_iter_with_options(0);
+    test_simple_diff_iter_with_options(TSK_NO_EDGE_METADATA);
 }
 
 static void
@@ -4443,8 +4450,8 @@ test_nonbinary_diff_iter(void)
     int ret;
     tsk_treeseq_t ts;
 
-    tsk_treeseq_from_text(
-        &ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL, NULL,
+        NULL, NULL, NULL, 0);
     verify_tree_diffs(&ts);
 
     ret = tsk_treeseq_free(&ts);
@@ -4458,7 +4465,7 @@ test_unary_diff_iter(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(
-        &ts, 10, unary_ex_nodes, unary_ex_edges, NULL, NULL, NULL, NULL, NULL);
+        &ts, 10, unary_ex_nodes, unary_ex_edges, NULL, NULL, NULL, NULL, NULL, 0);
     verify_tree_diffs(&ts);
 
     ret = tsk_treeseq_free(&ts);
@@ -4472,7 +4479,7 @@ test_internal_sample_diff_iter(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, internal_sample_ex_nodes, internal_sample_ex_edges,
-        NULL, NULL, NULL, NULL, NULL);
+        NULL, NULL, NULL, NULL, NULL, 0);
     verify_tree_diffs(&ts);
 
     ret = tsk_treeseq_free(&ts);
@@ -4495,7 +4502,7 @@ test_simple_sample_sets(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
-        paper_ex_individuals, NULL);
+        paper_ex_individuals, NULL, 0);
     verify_sample_counts(&ts, num_tests, tests);
     verify_sample_sets(&ts);
 
@@ -4513,8 +4520,8 @@ test_nonbinary_sample_sets(void)
     uint32_t num_tests = 8;
     tsk_treeseq_t ts;
 
-    tsk_treeseq_from_text(
-        &ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 100, nonbinary_ex_nodes, nonbinary_ex_edges, NULL, NULL,
+        NULL, NULL, NULL, 0);
     verify_sample_counts(&ts, num_tests, tests);
     verify_sample_sets(&ts);
 
@@ -4534,7 +4541,7 @@ test_internal_sample_sample_sets(void)
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, internal_sample_ex_nodes, internal_sample_ex_edges,
-        NULL, NULL, NULL, NULL, NULL);
+        NULL, NULL, NULL, NULL, NULL, 0);
     verify_sample_counts(&ts, num_tests, tests);
     verify_sample_sets(&ts);
 
@@ -4558,7 +4565,7 @@ test_non_sample_leaf_sample_lists(void)
     tsk_id_t i;
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4594,7 +4601,7 @@ test_isolated_node_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, single_leaf, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, single_leaf, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result, 0);
@@ -4608,7 +4615,8 @@ test_isolated_node_kc(void)
     tsk_treeseq_free(&ts);
     tsk_tree_free(&t);
 
-    tsk_treeseq_from_text(&ts, 1, single_internal, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(
+        &ts, 1, single_internal, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_ROOTS);
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
@@ -4631,7 +4639,7 @@ test_single_tree_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result, 0);
@@ -4683,13 +4691,13 @@ test_two_trees_kc(void)
     tsk_tree_t t, other_t;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     tsk_treeseq_from_text(
-        &other_ts, 1, nodes_other, edges, NULL, NULL, NULL, NULL, NULL);
+        &other_ts, 1, nodes_other, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_treeseq_kc_distance(&ts, &other_ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4726,7 +4734,7 @@ test_empty_tree_kc(void)
     int ret;
     double result = 0;
 
-    ret = tsk_table_collection_init(&tables, TSK_SAMPLE_LISTS);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES | TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SEQUENCE_LENGTH);
@@ -4771,7 +4779,7 @@ test_nonbinary_tree_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(result, 0);
@@ -4799,7 +4807,7 @@ test_nonzero_samples_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4828,7 +4836,7 @@ test_internal_samples_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     /* Permitted in tree sequences */
     ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
@@ -4857,7 +4865,7 @@ test_non_sample_leaf_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_treeseq_kc_distance(&ts, &ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4894,9 +4902,9 @@ test_unequal_sample_size_kc(void)
     tsk_tree_t t, other_t;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     tsk_treeseq_from_text(
-        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_treeseq_kc_distance(&ts, &other_ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SAMPLE_SIZE_MISMATCH);
@@ -4942,9 +4950,9 @@ test_unequal_samples_kc(void)
     tsk_tree_t t, other_t;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     tsk_treeseq_from_text(
-        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL);
+        &other_ts, 1, nodes_other, edges_other, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_treeseq_kc_distance(&ts, &other_ts, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SAMPLES_NOT_EQUAL);
@@ -4982,7 +4990,7 @@ test_unary_nodes_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&t, &ts, TSK_SAMPLE_LISTS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
@@ -5003,7 +5011,7 @@ test_no_sample_lists_kc(void)
     double result = 0;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
 
     ret = tsk_tree_init(&t, &ts, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5033,8 +5041,8 @@ test_unequal_sequence_lengths_kc(void)
     int ret;
     double result = 0;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges_1, NULL, NULL, NULL, NULL, NULL);
-    tsk_treeseq_from_text(&other, 2, nodes, edges_2, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges_1, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(&other, 2, nodes, edges_2, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_treeseq_kc_distance(&ts, &other, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SEQUENCE_LENGTH_MISMATCH);
 
@@ -5080,9 +5088,9 @@ test_different_number_trees_kc(void)
     double result, expected;
     int ret = 0;
 
-    tsk_treeseq_from_text(&ts, 10, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 10, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     tsk_treeseq_from_text(
-        &other, 10, other_nodes, other_edges, NULL, NULL, NULL, NULL, NULL);
+        &other, 10, other_nodes, other_edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_treeseq_kc_distance(&ts, &other, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -5111,8 +5119,8 @@ test_offset_trees_with_errors_kc(void)
     int ret = 0;
 
     tsk_treeseq_from_text(
-        &ts, 10, unary_ex_nodes, unary_ex_edges, NULL, NULL, NULL, NULL, NULL);
-    tsk_treeseq_from_text(&other, 10, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+        &ts, 10, unary_ex_nodes, unary_ex_edges, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(&other, 10, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 10);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&other), 10);
 
@@ -5146,7 +5154,7 @@ test_invalid_first_tree_errors_kc(void)
     int ret;
     tsk_flags_t load_flags = TSK_BUILD_INDEXES;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
 
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5189,7 +5197,7 @@ test_genealogical_nearest_neighbours_errors(void)
     CU_ASSERT_FATAL(A != NULL);
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 1);
 
@@ -5281,7 +5289,7 @@ test_tree_errors(void)
     tsk_id_t tracked_samples[] = { 0, 0, 0 };
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
-        paper_ex_individuals, NULL);
+        paper_ex_individuals, NULL, 0);
 
     ret = tsk_tree_init(&t, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_PARAM_VALUE);
@@ -5324,7 +5332,7 @@ test_tree_errors(void)
     CU_ASSERT_EQUAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
 
     tsk_treeseq_from_text(&other_ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL,
-        NULL, paper_ex_individuals, NULL);
+        NULL, paper_ex_individuals, NULL, 0);
 
     ret = tsk_tree_init(&other_t, &other_ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -5358,7 +5366,7 @@ test_tree_copy_flags(void)
         TSK_NO_SAMPLE_COUNTS | TSK_SAMPLE_LISTS };
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
-        paper_ex_individuals, NULL);
+        paper_ex_individuals, NULL, 0);
 
     for (j = 0; j < sizeof(options) / sizeof(*options); j++) {
         ret = tsk_tree_init(&t, &ts, options[j]);
@@ -5686,7 +5694,7 @@ test_zero_edges(void)
     };
     int ret;
 
-    tsk_treeseq_from_text(&ts, 2, nodes, edges, NULL, sites, mutations, NULL, NULL);
+    tsk_treeseq_from_text(&ts, 2, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 2.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 2);
@@ -5750,7 +5758,7 @@ test_sample_counts_deprecated(void)
     FILE *tmp = stderr;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
 
     stderr = f;

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -479,7 +479,7 @@ parse_individuals(const char *text, tsk_individual_table_t *individual_table)
 void
 tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nodes,
     const char *edges, const char *migrations, const char *sites, const char *mutations,
-    const char *individuals, const char *provenance)
+    const char *individuals, const char *provenance, tsk_flags_t tc_options)
 {
     int ret;
     tsk_table_collection_t tables;
@@ -492,7 +492,7 @@ tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nod
     /* Not supporting provenance here for now */
     CU_ASSERT_FATAL(provenance == NULL);
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, tc_options);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = sequence_length;
     parse_nodes(nodes, &tables.nodes);
@@ -547,7 +547,7 @@ caterpillar_tree(tsk_size_t n, tsk_size_t num_sites, tsk_size_t num_mutations)
     const char *prov_record = "Produced by caterpillar_tree for testing purposes";
 
     CU_ASSERT_FATAL(ts != NULL);
-    ret = tsk_table_collection_init(&tables, 1.0);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     CU_ASSERT_FATAL(num_sites > 0 && num_mutations < n - 1);

--- a/c/tests/testlib.h
+++ b/c/tests/testlib.h
@@ -42,7 +42,7 @@ int test_main(CU_TestInfo *tests, int argc, char **argv);
 
 void tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nodes,
     const char *edges, const char *migrations, const char *sites, const char *mutations,
-    const char *individuals, const char *provenance);
+    const char *individuals, const char *provenance, tsk_flags_t tc_options);
 tsk_treeseq_t *caterpillar_tree(
     tsk_size_t num_samples, tsk_size_t num_sites, tsk_size_t num_mutations);
 

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -324,6 +324,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_COLUMN_OVERFLOW:
             ret = "Table column too large; cannot be more than 2**32 bytes.";
             break;
+        case TSK_ERR_METADATA_DISABLED:
+            ret = "Metadata is disabled for this table, so cannot be set";
+            break;
 
         /* Limitations */
         case TSK_ERR_ONLY_INFINITE_SITES:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -240,7 +240,7 @@ not found in the file.
 #define TSK_ERR_TABLES_NOT_INDEXED                                  -702
 #define TSK_ERR_TABLE_OVERFLOW                                      -703
 #define TSK_ERR_COLUMN_OVERFLOW                                     -704
-
+#define TSK_ERR_METADATA_DISABLED                                   -705
 /* Limitations */
 #define TSK_ERR_ONLY_INFINITE_SITES                                 -800
 #define TSK_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED                   -801

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -382,6 +382,8 @@ typedef struct {
     tsk_size_t *metadata_offset;
     /** @brief The metadata schema */
     char *metadata_schema;
+    /** @brief Flags for this table */
+    tsk_flags_t options;
 } tsk_edge_table_t;
 
 /**
@@ -677,6 +679,12 @@ typedef struct _tsk_table_sorter_t {
 
 /* Flags for load tables */
 #define TSK_BUILD_INDEXES (1 << 0)
+
+/* Flags for init table collection */
+#define TSK_NO_EDGE_METADATA (1 << 0)
+
+/* Flags for init tables */
+#define TSK_NO_METADATA (1 << 0)
 
 /****************************************************************************/
 /* Function signatures */

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -407,7 +407,11 @@ tsk_treeseq_init(
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
+
+    /* Note that this copy reinstates metadata for a table collection with
+     * TSK_NO_EDGE_METADATA a table without metadata will crash tsk_diff_iter_next*/
     ret = tsk_table_collection_copy(tables, self->tables, 0);
+
     if (ret != 0) {
         goto out;
     }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -409,7 +409,10 @@ tsk_treeseq_init(
     }
 
     /* Note that this copy reinstates metadata for a table collection with
-     * TSK_NO_EDGE_METADATA a table without metadata will crash tsk_diff_iter_next*/
+     * TSK_NO_EDGE_METADATA. Otherwise a table without metadata would
+     * crash tsk_diff_iter_next. This is something we will need to
+     * watch out for when we take a read-only view of the input table
+     * rather than a copy. */
     ret = tsk_table_collection_copy(tables, self->tables, 0);
 
     if (ret != 0) {


### PR DESCRIPTION
Closes #585 

I've got far enough with this that feedback would be useful. The big decision is to add `options` to `tsk_edge_table_t`. This seems cleaner and more preferable to using `metadata==NULL` to tell if the table has metadata. 

Currently when an edge table with `TSK_NO_METADATA`  is dumped the metadata columns are absent from the kastore. This is fine as those are optional. When the table is re-loaded, however metadata will be re-enabled. If we stored `options` in the kastore we could load a table with metadata disabled.

I've also opted to error if you try to set metadata on the table.

There are probably a few more tests needed. I've started work on #708, but in doing that realised it would be nice to have this done first.
