### PR TITLE
canonical sorting

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1233,6 +1233,13 @@ class TestSortTables(unittest.TestCase):
 
     random_seed = 12345
 
+    def verify_sort_equality(self, ts, seed):
+        tables = tsutil.disorder_ts(ts, seed)
+        copy = tables.copy()
+        tables.sort()
+        tsutil.py_sort(copy)
+        self.assertEqual(tables, copy)
+
     def verify_randomise_tables(self, ts):
         tables = ts.dump_tables()
 
@@ -1318,40 +1325,47 @@ class TestSortTables(unittest.TestCase):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
+        self.verify_sort_equality(ts, 432)
 
     def test_single_tree_no_mutations_metadata(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         ts = tsutil.add_random_metadata(ts, self.random_seed)
         self.verify_randomise_tables(ts)
+        self.verify_sort_equality(ts, 12)
 
     def test_many_trees_no_mutations(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
         self.assertGreater(ts.num_trees, 2)
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
+        self.verify_sort_equality(ts, 31)
 
     def test_single_tree_mutations(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
+        self.verify_sort_equality(ts, 83)
 
     def test_single_tree_mutations_metadata(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
         self.assertGreater(ts.num_sites, 2)
         ts = tsutil.add_random_metadata(ts, self.random_seed)
         self.verify_randomise_tables(ts)
+        self.verify_sort_equality(ts, 923)
 
     def test_single_tree_multichar_mutations(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         ts = tsutil.insert_multichar_mutations(ts, self.random_seed)
         self.verify_randomise_tables(ts)
+        self.verify_sort_equality(ts, 35)
 
     def test_single_tree_multichar_mutations_metadata(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         ts = tsutil.insert_multichar_mutations(ts, self.random_seed)
         ts = tsutil.add_random_metadata(ts, self.random_seed)
         self.verify_randomise_tables(ts)
+        self.verify_sort_equality(ts, 2175)
 
     def test_many_trees_mutations(self):
         ts = msprime.simulate(
@@ -1361,12 +1375,14 @@ class TestSortTables(unittest.TestCase):
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
+        self.verify_sort_equality(ts, 173)
 
     def test_many_trees_multichar_mutations(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
         self.assertGreater(ts.num_trees, 2)
         ts = tsutil.insert_multichar_mutations(ts, self.random_seed)
         self.verify_randomise_tables(ts)
+        self.verify_sort_equality(ts, 16)
 
     def test_many_trees_multichar_mutations_metadata(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
@@ -1374,6 +1390,7 @@ class TestSortTables(unittest.TestCase):
         ts = tsutil.insert_multichar_mutations(ts, self.random_seed)
         ts = tsutil.add_random_metadata(ts, self.random_seed)
         self.verify_randomise_tables(ts)
+        self.verify_sort_equality(ts, 91)
 
     def get_nonbinary_example(self, mutation_rate):
         ts = msprime.simulate(
@@ -1399,6 +1416,7 @@ class TestSortTables(unittest.TestCase):
         self.assertGreater(ts.num_trees, 2)
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
+        self.verify_sort_equality(ts, 9182)
 
     def test_nonbinary_trees_mutations(self):
         ts = self.get_nonbinary_example(mutation_rate=2)
@@ -1406,6 +1424,7 @@ class TestSortTables(unittest.TestCase):
         self.assertGreater(ts.num_sites, 2)
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
+        self.verify_sort_equality(ts, 44)
 
     def test_incompatible_edges(self):
         ts1 = msprime.simulate(10, random_seed=self.random_seed)

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -730,7 +730,7 @@ def orig_site_keys(i, tables):
     return tables.sites.position[i]
 
 
-def orig_mut_keys(i, tables, sorted_sites):
+def orig_mut_keys(i, tables, sorted_sites, **kwargs):
     orig_site = tables.mutations.site[i]
     return sorted_sites.index(orig_site)
 

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -715,7 +715,7 @@ def disorder_ts(ts, seed):
             derived_state=m.derived_state,
             parent=m.parent,
             metadata=m.metadata,
-            # time=m.time,
+            time=m.time,
         )
     return tables
 
@@ -735,10 +735,12 @@ def orig_mut_keys(i, tables, sorted_sites):
     return sorted_sites.index(orig_site)
 
 
-def new_mut_keys(i, tables, sorted_sites):
+def new_mut_keys(i, tables, sorted_sites, time_in_key):
     orig_site = tables.mutations.site[i]
+    time = tables.mutations.time[i] if time_in_key else 0
     return (
         sorted_sites.index(orig_site),
+        time,
         tables.mutations.parent[i],
         tables.mutations.node[i],
     )
@@ -751,6 +753,7 @@ def py_sort(
     tables.edges.clear()
     tables.sites.clear()
     tables.mutations.clear()
+    time_in_key = np.all(~np.isnan(copy.mutations.time))
     sorted_edges = sorted(
         range(copy.edges.num_rows), key=lambda x: edge_keys(x, tables=copy)
     )
@@ -759,7 +762,9 @@ def py_sort(
     )
     sorted_muts = sorted(
         range(copy.mutations.num_rows),
-        key=lambda x: mut_keys(x, tables=copy, sorted_sites=sorted_sites),
+        key=lambda x: mut_keys(
+            x, tables=copy, sorted_sites=sorted_sites, time_in_key=time_in_key
+        ),
     )
     for edge_id in sorted_edges:
         tables.edges.add_row(
@@ -781,7 +786,7 @@ def py_sort(
             copy.mutations[mut_id].derived_state,
             copy.mutations[mut_id].parent,
             copy.mutations[mut_id].metadata,
-            # copy.mutations[mut_id].time,
+            copy.mutations[mut_id].time,
         )
 
 


### PR DESCRIPTION
Currently, sort does not put a Table Collection in canonical form (given the order of nodes) -- see #705 .

Here I am working on adding mutation time, mutation parent and node to the mutation sorting key.

(still very early, working on a python impl of sort first!)