### PR TITLE
Fix edge metadata sorting and prevent processing edge metadata in other functions.

### DIFF
--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -757,6 +757,7 @@ test_edge_table_copy_semantics(void)
     int ret;
     tsk_treeseq_t ts;
     tsk_table_collection_t t1, t2;
+    tsk_edge_table_t edges;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
         NULL, NULL, NULL, 0);
@@ -790,6 +791,12 @@ test_edge_table_copy_semantics(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&t1, &t2));
     tsk_table_collection_free(&t2);
+
+    /* Try copying into a table directly */
+    ret = tsk_edge_table_copy(&t1.edges, &edges, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_edge_table_equals(&t1.edges, &edges));
+    tsk_edge_table_free(&edges);
 
     tsk_table_collection_free(&t1);
     tsk_treeseq_free(&ts);
@@ -2334,6 +2341,205 @@ test_provenance_table(void)
 }
 
 static void
+test_table_size_increments(void)
+{
+    int ret;
+    tsk_table_collection_t tables;
+    tsk_size_t default_size = 1024;
+    tsk_size_t new_size;
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    CU_ASSERT_EQUAL_FATAL(tables.individuals.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.individuals.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.individuals.max_location_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.sites.max_ancestral_state_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.mutations.max_derived_state_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.migrations.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.migrations.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.populations.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.populations.max_metadata_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_rows_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.provenances.max_timestamp_length_increment, default_size);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_record_length_increment, default_size);
+
+    /* Setting to zero sets to the default size */
+    new_size = 0;
+    ret = tsk_individual_table_set_max_rows_increment(&tables.individuals, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.individuals.max_rows_increment, default_size);
+    ret = tsk_individual_table_set_max_metadata_length_increment(
+        &tables.individuals, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.individuals.max_metadata_length_increment, default_size);
+    ret = tsk_individual_table_set_max_location_length_increment(
+        &tables.individuals, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.individuals.max_location_length_increment, default_size);
+
+    ret = tsk_node_table_set_max_rows_increment(&tables.nodes, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.max_rows_increment, default_size);
+    ret = tsk_node_table_set_max_metadata_length_increment(&tables.nodes, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.max_metadata_length_increment, default_size);
+
+    ret = tsk_edge_table_set_max_rows_increment(&tables.edges, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.max_rows_increment, default_size);
+    ret = tsk_edge_table_set_max_metadata_length_increment(&tables.edges, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.max_metadata_length_increment, default_size);
+
+    ret = tsk_site_table_set_max_rows_increment(&tables.sites, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_rows_increment, default_size);
+    ret = tsk_site_table_set_max_metadata_length_increment(&tables.sites, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_metadata_length_increment, default_size);
+    ret = tsk_site_table_set_max_ancestral_state_length_increment(
+        &tables.sites, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.sites.max_ancestral_state_length_increment, default_size);
+
+    ret = tsk_mutation_table_set_max_rows_increment(&tables.mutations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_rows_increment, default_size);
+    ret = tsk_mutation_table_set_max_metadata_length_increment(
+        &tables.mutations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_metadata_length_increment, default_size);
+    ret = tsk_mutation_table_set_max_derived_state_length_increment(
+        &tables.mutations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.mutations.max_derived_state_length_increment, default_size);
+
+    ret = tsk_migration_table_set_max_rows_increment(&tables.migrations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.migrations.max_rows_increment, default_size);
+    ret = tsk_migration_table_set_max_metadata_length_increment(
+        &tables.migrations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.migrations.max_metadata_length_increment, default_size);
+
+    ret = tsk_population_table_set_max_rows_increment(&tables.populations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.populations.max_rows_increment, default_size);
+    ret = tsk_population_table_set_max_metadata_length_increment(
+        &tables.populations, new_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.populations.max_metadata_length_increment, default_size);
+
+    ret = tsk_provenance_table_set_max_rows_increment(&tables.provenances, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_rows_increment, default_size);
+    ret = tsk_provenance_table_set_max_timestamp_length_increment(
+        &tables.provenances, new_size);
+    CU_ASSERT_EQUAL_FATAL(
+        tables.provenances.max_timestamp_length_increment, default_size);
+    ret = tsk_provenance_table_set_max_record_length_increment(
+        &tables.provenances, new_size);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_record_length_increment, default_size);
+
+    /* Setting to non-zero sets to thatsize */
+    new_size = 1;
+    ret = tsk_individual_table_set_max_rows_increment(&tables.individuals, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.individuals.max_rows_increment, new_size);
+    ret = tsk_individual_table_set_max_metadata_length_increment(
+        &tables.individuals, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.individuals.max_metadata_length_increment, new_size);
+    ret = tsk_individual_table_set_max_location_length_increment(
+        &tables.individuals, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.individuals.max_location_length_increment, new_size);
+
+    ret = tsk_node_table_set_max_rows_increment(&tables.nodes, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.max_rows_increment, new_size);
+    ret = tsk_node_table_set_max_metadata_length_increment(&tables.nodes, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.nodes.max_metadata_length_increment, new_size);
+
+    ret = tsk_edge_table_set_max_rows_increment(&tables.edges, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.max_rows_increment, new_size);
+    ret = tsk_edge_table_set_max_metadata_length_increment(&tables.edges, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.edges.max_metadata_length_increment, new_size);
+
+    ret = tsk_site_table_set_max_rows_increment(&tables.sites, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_rows_increment, new_size);
+    ret = tsk_site_table_set_max_metadata_length_increment(&tables.sites, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_metadata_length_increment, new_size);
+    ret = tsk_site_table_set_max_ancestral_state_length_increment(
+        &tables.sites, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites.max_ancestral_state_length_increment, new_size);
+
+    ret = tsk_mutation_table_set_max_rows_increment(&tables.mutations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_rows_increment, new_size);
+    ret = tsk_mutation_table_set_max_metadata_length_increment(
+        &tables.mutations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_metadata_length_increment, new_size);
+    ret = tsk_mutation_table_set_max_derived_state_length_increment(
+        &tables.mutations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.mutations.max_derived_state_length_increment, new_size);
+
+    ret = tsk_migration_table_set_max_rows_increment(&tables.migrations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.migrations.max_rows_increment, new_size);
+    ret = tsk_migration_table_set_max_metadata_length_increment(
+        &tables.migrations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.migrations.max_metadata_length_increment, new_size);
+
+    ret = tsk_population_table_set_max_rows_increment(&tables.populations, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.populations.max_rows_increment, new_size);
+    ret = tsk_population_table_set_max_metadata_length_increment(
+        &tables.populations, new_size);
+    CU_ASSERT_EQUAL_FATAL(tables.populations.max_metadata_length_increment, new_size);
+
+    ret = tsk_provenance_table_set_max_rows_increment(&tables.provenances, new_size);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_rows_increment, new_size);
+    ret = tsk_provenance_table_set_max_timestamp_length_increment(
+        &tables.provenances, new_size);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_timestamp_length_increment, new_size);
+    ret = tsk_provenance_table_set_max_record_length_increment(
+        &tables.provenances, new_size);
+    CU_ASSERT_EQUAL_FATAL(tables.provenances.max_record_length_increment, new_size);
+
+    tsk_table_collection_free(&tables);
+}
+
+static void
 test_link_ancestors_input_errors(void)
 {
     int ret;
@@ -3832,6 +4038,7 @@ main(int argc, char **argv)
         { "test_individual_table", test_individual_table },
         { "test_population_table", test_population_table },
         { "test_provenance_table", test_provenance_table },
+        { "test_table_size_increments", test_table_size_increments },
         { "test_table_collection_simplify_errors",
             test_table_collection_simplify_errors },
         { "test_table_collection_metadata", test_table_collection_metadata },

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -723,7 +723,6 @@ test_edge_table_squash(void)
      / \
     0   1
     */
-
     /* Squashing doesn't support metadata */
     ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -769,7 +768,7 @@ test_edge_table_squash_multiple_parents(void)
                / \     / \
               0   1   2   3
     */
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 10;
 
@@ -824,8 +823,7 @@ test_edge_table_squash_single_edge(void)
     const char *nodes_ex = "1  0   -1   -1\n"
                            "0  0   -1   -1\n";
     const char *edges_ex = "0  1   1   0\n";
-
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
@@ -852,7 +850,7 @@ test_edge_table_squash_bad_intervals(void)
     const char *edges_ex = "0  0.6   1   0\n"
                            "0.4  1   1   0\n";
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
@@ -2261,6 +2259,19 @@ test_link_ancestors_input_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&result, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_link_ancestors(
+        &tables, NULL, 2, ancestors, 2, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA);
+    tsk_table_collection_free(&tables);
+    tsk_treeseq_free(&ts);
+    tsk_edge_table_free(&result);
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_edge_table_init(&result, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_table_collection_link_ancestors(
         &tables, NULL, 2, ancestors, 2, 0, &result);
@@ -2314,7 +2325,7 @@ test_link_ancestors_single_tree(void)
     double res_right = 1;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&result, 0);
@@ -2351,7 +2362,7 @@ test_link_ancestors_no_edges(void)
     tsk_id_t ancestors[] = { 4 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&result, 0);
@@ -2377,7 +2388,7 @@ test_link_ancestors_samples_and_ancestors_overlap(void)
     tsk_id_t ancestors[] = { 4 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&result, 0);
@@ -2388,6 +2399,7 @@ test_link_ancestors_samples_and_ancestors_overlap(void)
 
     // tsk_edge_table_print_state(&result, stdout);
 
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     // Check we get the right result.
     CU_ASSERT_EQUAL(result.num_rows, 2);
     size_t i;
@@ -2418,7 +2430,7 @@ test_link_ancestors_paper(void)
     tsk_id_t ancestors[] = { 5, 6, 7 };
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL, 0);
+        paper_ex_mutations, paper_ex_individuals, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&result, 0);
@@ -2459,7 +2471,7 @@ test_link_ancestors_multiple_to_single_tree(void)
     tsk_id_t ancestors[] = { 5 };
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
-        paper_ex_mutations, paper_ex_individuals, NULL, 0);
+        paper_ex_mutations, paper_ex_individuals, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&result, 0);
@@ -2498,7 +2510,7 @@ test_simplify_tables_drops_indexes(void)
     tsk_id_t samples[] = { 0, 1 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -2530,15 +2542,31 @@ test_simplify_empty_tables(void)
 }
 
 static void
-test_sort_tables_drops_indexes(void)
+test_simplify_metadata(void)
+{
+    int ret;
+    tsk_table_collection_t tables;
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 10;
+    tsk_edge_table_add_row(&tables.edges, 0, 0, 1, 1, "metadata", 8);
+    ret = tsk_table_collection_simplify(&tables, NULL, 0, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA);
+
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_sort_tables_drops_indexes_with_options(tsk_flags_t tc_options)
 {
     int ret;
     tsk_treeseq_t ts;
     tsk_table_collection_t tables;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
-    ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
+        NULL, NULL, NULL, tc_options);
+    ret = tsk_treeseq_copy_tables(&ts, &tables, tc_options);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     CU_ASSERT_TRUE(tsk_table_collection_has_index(&tables, 0))
@@ -2548,6 +2576,13 @@ test_sort_tables_drops_indexes(void)
 
     tsk_table_collection_free(&tables);
     tsk_treeseq_free(&ts);
+}
+
+static void
+test_sort_tables_drops_indexes(void)
+{
+    test_sort_tables_drops_indexes_with_options(0);
+    test_sort_tables_drops_indexes_with_options(TSK_NO_EDGE_METADATA);
 }
 
 static void
@@ -3664,6 +3699,7 @@ main(int argc, char **argv)
         { "test_table_collection_metadata", test_table_collection_metadata },
         { "test_simplify_tables_drops_indexes", test_simplify_tables_drops_indexes },
         { "test_simplify_empty_tables", test_simplify_empty_tables },
+        { "test_simplify_metadata", test_simplify_metadata },
         { "test_link_ancestors_no_edges", test_link_ancestors_no_edges },
         { "test_link_ancestors_input_errors", test_link_ancestors_input_errors },
         { "test_link_ancestors_single_tree", test_link_ancestors_single_tree },

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -910,8 +910,7 @@ test_simplest_records(void)
     tsk_id_t sample_ids[] = { 0, 1 };
     int ret;
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -944,8 +943,7 @@ test_simplest_nonbinary_records(void)
     tsk_id_t sample_ids[] = { 0, 1, 2, 3 };
     int ret;
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -980,8 +978,7 @@ test_simplest_unary_records(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1030,8 +1027,7 @@ test_simplest_non_sample_leaf_records(void)
     tsk_vargen_t vargen;
     tsk_variant_t *var;
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1099,8 +1095,7 @@ test_simplest_degenerate_multiple_root_records(void)
     tsk_tree_t t;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 4);
@@ -1147,8 +1142,7 @@ test_simplest_multiple_root_records(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1, 2, 3 };
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 6);
@@ -1314,8 +1308,7 @@ test_simplest_root_mutations(void)
     tsk_id_t sample_ids[] = { 0, 1 };
     tsk_treeseq_t ts, simplified;
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1397,8 +1390,7 @@ test_simplest_general_samples(void)
 
     tsk_treeseq_t ts, simplified;
 
-    tsk_treeseq_from_text(
-        &ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1443,8 +1435,8 @@ test_simplest_holey_tree_sequence(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt,
-        NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(
+        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1534,8 +1526,7 @@ test_simplest_initial_gap_tree_sequence(void)
     tsk_size_t num_trees = 2;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(
-        &ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
+    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -2409,7 +2400,7 @@ test_simplest_overlapping_edges_simplify(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 3;
@@ -2457,7 +2448,7 @@ test_simplest_overlapping_unary_edges_simplify(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 3;
@@ -2500,7 +2491,7 @@ test_simplest_overlapping_unary_edges_internal_samples_simplify(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 3;
@@ -2548,7 +2539,7 @@ test_simplest_reduce_site_topology(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 2;
@@ -3660,8 +3651,7 @@ test_single_tree_simplify(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL,
-        TSK_NO_EDGE_METADATA);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
     verify_simplify(&ts);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3718,7 +3708,7 @@ test_single_tree_simplify_no_sample_nodes(void)
     tsk_id_t samples[] = { 0, 1, 2, 3 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+        NULL, NULL, NULL, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t2, 0);
@@ -3746,7 +3736,7 @@ test_single_tree_simplify_null_samples(void)
     tsk_table_collection_t t1, t2;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
+        NULL, NULL, NULL, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t2, 0);
@@ -4263,8 +4253,7 @@ test_internal_sample_simplified_multi_tree(void)
     uint32_t num_trees = 3;
 
     tsk_treeseq_from_text(&ts, 10, internal_sample_ex_nodes, internal_sample_ex_edges,
-        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL,
-        TSK_NO_EDGE_METADATA);
+        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL, 0);
     ret = tsk_treeseq_simplify(&ts, samples, 3, 0, &simplified, node_map);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(node_map[2], 0);
@@ -4435,24 +4424,18 @@ test_tsk_treeseq_bad_records(void)
  *======================================================*/
 
 static void
-test_simple_diff_iter_with_options(tsk_flags_t tc_options)
+test_simple_diff_iter(void)
 {
     int ret;
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
-        paper_ex_individuals, NULL, tc_options);
+        paper_ex_individuals, NULL, 0);
+
     verify_tree_diffs(&ts);
 
     ret = tsk_treeseq_free(&ts);
     CU_ASSERT_EQUAL(ret, 0);
-}
-
-static void
-test_simple_diff_iter(void)
-{
-    test_simple_diff_iter_with_options(0);
-    test_simple_diff_iter_with_options(TSK_NO_EDGE_METADATA);
 }
 
 static void

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -910,7 +910,8 @@ test_simplest_records(void)
     tsk_id_t sample_ids[] = { 0, 1 };
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -943,7 +944,8 @@ test_simplest_nonbinary_records(void)
     tsk_id_t sample_ids[] = { 0, 1, 2, 3 };
     int ret;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -978,7 +980,8 @@ test_simplest_unary_records(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1027,7 +1030,8 @@ test_simplest_non_sample_leaf_records(void)
     tsk_vargen_t vargen;
     tsk_variant_t *var;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 5);
@@ -1095,7 +1099,8 @@ test_simplest_degenerate_multiple_root_records(void)
     tsk_tree_t t;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 4);
@@ -1142,7 +1147,8 @@ test_simplest_multiple_root_records(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1, 2, 3 };
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 4);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 6);
@@ -1308,7 +1314,8 @@ test_simplest_root_mutations(void)
     tsk_id_t sample_ids[] = { 0, 1 };
     tsk_treeseq_t ts, simplified;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1390,7 +1397,8 @@ test_simplest_general_samples(void)
 
     tsk_treeseq_t ts, simplified;
 
-    tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 1, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 1.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1435,8 +1443,8 @@ test_simplest_holey_tree_sequence(void)
     tsk_treeseq_t ts, simplified;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(
-        &ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt, NULL, NULL, 0);
+    tsk_treeseq_from_text(&ts, 3, nodes_txt, edges_txt, NULL, sites_txt, mutations_txt,
+        NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -1526,7 +1534,8 @@ test_simplest_initial_gap_tree_sequence(void)
     tsk_size_t num_trees = 2;
     tsk_id_t sample_ids[] = { 0, 1 };
 
-    tsk_treeseq_from_text(&ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 3, nodes, edges, NULL, sites, mutations, NULL, NULL, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
     CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 3.0);
     CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
@@ -2400,7 +2409,7 @@ test_simplest_overlapping_edges_simplify(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 3;
@@ -2448,7 +2457,7 @@ test_simplest_overlapping_unary_edges_simplify(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 3;
@@ -2491,7 +2500,7 @@ test_simplest_overlapping_unary_edges_internal_samples_simplify(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 3;
@@ -2539,7 +2548,7 @@ test_simplest_reduce_site_topology(void)
     tsk_table_collection_t tables;
     int ret;
 
-    ret = tsk_table_collection_init(&tables, 0);
+    ret = tsk_table_collection_init(&tables, TSK_NO_EDGE_METADATA);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tables.sequence_length = 2;
@@ -3651,7 +3660,8 @@ test_single_tree_simplify(void)
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,
-        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL, 0);
+        single_tree_ex_sites, single_tree_ex_mutations, NULL, NULL,
+        TSK_NO_EDGE_METADATA);
     verify_simplify(&ts);
     ret = tsk_treeseq_copy_tables(&ts, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3708,7 +3718,7 @@ test_single_tree_simplify_no_sample_nodes(void)
     tsk_id_t samples[] = { 0, 1, 2, 3 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &t1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t2, 0);
@@ -3736,7 +3746,7 @@ test_single_tree_simplify_null_samples(void)
     tsk_table_collection_t t1, t2;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
-        NULL, NULL, NULL, 0);
+        NULL, NULL, NULL, TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_copy_tables(&ts, &t1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_copy_tables(&ts, &t2, 0);
@@ -4253,7 +4263,8 @@ test_internal_sample_simplified_multi_tree(void)
     uint32_t num_trees = 3;
 
     tsk_treeseq_from_text(&ts, 10, internal_sample_ex_nodes, internal_sample_ex_edges,
-        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL, 0);
+        NULL, internal_sample_ex_sites, internal_sample_ex_mutations, NULL, NULL,
+        TSK_NO_EDGE_METADATA);
     ret = tsk_treeseq_simplify(&ts, samples, 3, 0, &simplified, node_map);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(node_map[2], 0);

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -270,13 +270,6 @@ parse_edges(const char *text, tsk_edge_table_t *edge_table)
     double left, right;
     tsk_id_t parent, child;
     uint32_t num_children;
-    char *metadata_str = malloc(255 * sizeof(char));
-
-    if (metadata_str == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
-        goto out;
-    }
-    memset(metadata_str, 0, 255 * sizeof(char));
 
     c = 0;
     while (text[c] != '\0') {
@@ -319,22 +312,13 @@ parse_edges(const char *text, tsk_edge_table_t *edge_table)
         for (k = 0; k < num_children; k++) {
             CU_ASSERT_FATAL(q != NULL);
             child = atoi(q);
-            if (edge_table->options & TSK_NO_METADATA) {
-                ret = tsk_edge_table_add_row(
-                    edge_table, left, right, parent, child, NULL, 0);
-            } else {
-                /* Add some unique metadata to each edge */
-                sprintf(metadata_str, "m%ld_%ld", c, k);
-                ret = tsk_edge_table_add_row(edge_table, left, right, parent, child,
-                    (const char *) metadata_str, 255);
-            }
+            ret = tsk_edge_table_add_row(
+                edge_table, left, right, parent, child, NULL, 0);
             CU_ASSERT_FATAL(ret >= 0);
             q = strtok(NULL, ",");
         }
         CU_ASSERT_FATAL(q == NULL);
     }
-out:
-    tsk_safe_free(metadata_str);
 }
 
 void

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -270,6 +270,13 @@ parse_edges(const char *text, tsk_edge_table_t *edge_table)
     double left, right;
     tsk_id_t parent, child;
     uint32_t num_children;
+    char *metadata_str = malloc(255 * sizeof(char));
+
+    if (metadata_str == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(metadata_str, 0, 255 * sizeof(char));
 
     c = 0;
     while (text[c] != '\0') {
@@ -312,13 +319,22 @@ parse_edges(const char *text, tsk_edge_table_t *edge_table)
         for (k = 0; k < num_children; k++) {
             CU_ASSERT_FATAL(q != NULL);
             child = atoi(q);
-            ret = tsk_edge_table_add_row(
-                edge_table, left, right, parent, child, NULL, 0);
+            if (edge_table->options & TSK_NO_METADATA) {
+                ret = tsk_edge_table_add_row(
+                    edge_table, left, right, parent, child, NULL, 0);
+            } else {
+                /* Add some unique metadata to each edge */
+                sprintf(metadata_str, "m%ld_%ld", c, k);
+                ret = tsk_edge_table_add_row(edge_table, left, right, parent, child,
+                    (const char *) metadata_str, 255);
+            }
             CU_ASSERT_FATAL(ret >= 0);
             q = strtok(NULL, ",");
         }
         CU_ASSERT_FATAL(q == NULL);
     }
+out:
+    tsk_safe_free(metadata_str);
 }
 
 void

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -257,7 +257,8 @@ tsk_strerror_internal(int err)
                   "an interval";
             break;
         case TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA:
-            ret = "Can't squash or flush edges that have non-empty metadata";
+            ret = "Can't squash, flush, simplify or link ancestors with edges that have "
+                  "non-empty metadata";
             break;
 
         /* Site errors */

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -1367,7 +1367,7 @@ tsk_edge_table_init(tsk_edge_table_t *self, tsk_flags_t options)
 {
     int ret = 0;
 
-    memset(self, 0, sizeof(tsk_edge_table_t));
+    memset(self, 0, sizeof(*self));
     self->options = options;
 
     /* Allocate space for one row initially, ensuring we always have valid
@@ -1435,6 +1435,8 @@ int TSK_WARN_UNUSED
 tsk_edge_table_copy(tsk_edge_table_t *self, tsk_edge_table_t *dest, tsk_flags_t options)
 {
     int ret = 0;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
 
     if (!(options & TSK_NO_INIT)) {
         ret = tsk_edge_table_init(dest, options);
@@ -1443,21 +1445,19 @@ tsk_edge_table_copy(tsk_edge_table_t *self, tsk_edge_table_t *dest, tsk_flags_t 
         }
     }
 
-    /* We can't change to use metadata if it was disabled when the dest table was init'd
+    /* We can't use TSK_NO_METADATA in dest if metadata_length is non-zero.
+     * This also captures the case where TSK_NO_METADATA is set on this table.
      */
-    if (!tsk_edge_table_has_metadata(dest) && !(options & TSK_NO_METADATA)) {
+    if (self->metadata_length > 0 && !tsk_edge_table_has_metadata(dest)) {
         ret = TSK_ERR_METADATA_DISABLED;
         goto out;
     }
-    dest->options = options;
-
     if (tsk_edge_table_has_metadata(dest)) {
-        ret = tsk_edge_table_set_columns(dest, self->num_rows, self->left, self->right,
-            self->parent, self->child, self->metadata, self->metadata_offset);
-    } else {
-        ret = tsk_edge_table_set_columns(dest, self->num_rows, self->left, self->right,
-            self->parent, self->child, NULL, NULL);
+        metadata = self->metadata;
+        metadata_offset = self->metadata_offset;
     }
+    ret = tsk_edge_table_set_columns(dest, self->num_rows, self->left, self->right,
+        self->parent, self->child, metadata, metadata_offset);
     if (ret != 0) {
         goto out;
     }
@@ -1588,7 +1588,8 @@ tsk_edge_table_print_state(tsk_edge_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "edge_table: %p:\n", (void *) self);
-    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
+    fprintf(out, "options         = 0x%X\n", self->options);
+    fprintf(out, "num_rows        = %d\tmax= %d\tincrement = %d)\n",
         (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
     fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
         (int) self->metadata_length, (int) self->max_metadata_length,
@@ -4350,6 +4351,11 @@ typedef struct {
     tsk_id_t parent;
     tsk_id_t child;
     double time;
+    /* It would be a little bit more convenient to store a pointer to the
+     * metadata here in the struct rather than an offset back into the
+     * original array. However, this would increase the size of the struct
+     * from 40 bytes to 48 and we will allocate very large numbers of these.
+     */
     tsk_size_t metadata_offset;
     tsk_size_t metadata_length;
 } edge_sort_t;
@@ -4419,7 +4425,8 @@ tsk_table_sorter_sort_edges(tsk_table_sorter_t *self, tsk_size_t start)
     tsk_size_t j, k, metadata_offset;
     tsk_size_t n = edges->num_rows - start;
     edge_sort_t *sorted_edges = malloc(n * sizeof(*sorted_edges));
-    char *old_metadata = malloc(edges->metadata_length + sizeof(char));
+    char *old_metadata = malloc(edges->metadata_length);
+    bool has_metadata = tsk_edge_table_has_metadata(edges);
 
     if (sorted_edges == NULL || old_metadata == NULL) {
         ret = TSK_ERR_NO_MEMORY;
@@ -4434,7 +4441,7 @@ tsk_table_sorter_sort_edges(tsk_table_sorter_t *self, tsk_size_t start)
         e->parent = edges->parent[k];
         e->child = edges->child[k];
         e->time = node_time[e->parent];
-        if (tsk_edge_table_has_metadata(edges)) {
+        if (has_metadata) {
             e->metadata_offset = edges->metadata_offset[k];
             e->metadata_length
                 = edges->metadata_offset[k + 1] - edges->metadata_offset[k];
@@ -4450,7 +4457,7 @@ tsk_table_sorter_sort_edges(tsk_table_sorter_t *self, tsk_size_t start)
         edges->right[k] = e->right;
         edges->parent[k] = e->parent;
         edges->child[k] = e->child;
-        if (tsk_edge_table_has_metadata(edges)) {
+        if (has_metadata) {
             memcpy(edges->metadata + metadata_offset, old_metadata + e->metadata_offset,
                 e->metadata_length);
             edges->metadata_offset[k] = metadata_offset;
@@ -6864,17 +6871,17 @@ int TSK_WARN_UNUSED
 tsk_table_collection_init(tsk_table_collection_t *self, tsk_flags_t options)
 {
     int ret = 0;
+    tsk_flags_t edge_options = 0;
+
     memset(self, 0, sizeof(*self));
-    /* Allocate all the tables with their default increments */
+    if (options & TSK_NO_EDGE_METADATA) {
+        edge_options |= TSK_NO_METADATA;
+    }
     ret = tsk_node_table_init(&self->nodes, 0);
     if (ret != 0) {
         goto out;
     }
-    if (options & TSK_NO_EDGE_METADATA) {
-        ret = tsk_edge_table_init(&self->edges, TSK_NO_METADATA);
-    } else {
-        ret = tsk_edge_table_init(&self->edges, 0);
-    }
+    ret = tsk_edge_table_init(&self->edges, edge_options);
     if (ret != 0) {
         goto out;
     }
@@ -7085,12 +7092,7 @@ tsk_table_collection_copy(
     if (ret != 0) {
         goto out;
     }
-    if (options & TSK_NO_EDGE_METADATA) {
-        ret = tsk_edge_table_copy(
-            &self->edges, &dest->edges, TSK_NO_INIT | TSK_NO_METADATA);
-    } else {
-        ret = tsk_edge_table_copy(&self->edges, &dest->edges, TSK_NO_INIT);
-    }
+    ret = tsk_edge_table_copy(&self->edges, &dest->edges, TSK_NO_INIT);
     if (ret != 0) {
         goto out;
     }
@@ -7602,6 +7604,8 @@ tsk_table_collection_simplify(tsk_table_collection_t *self, tsk_id_t *samples,
     /* Avoid calling to simplifier_free with uninit'd memory on error branches */
     memset(&simplifier, 0, sizeof(simplifier_t));
 
+    /* For now we don't bother with edge metadata, but it can easily be
+     * implemented. */
     if (self->edges.metadata_length > 0) {
         ret = TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA;
         goto out;

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -205,6 +205,16 @@ out:
     return ret;
 }
 
+static int
+write_metadata_schema_header(
+    FILE *out, char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    const char *fmt = "#metadata_schema#\n"
+                      "%.*s\n"
+                      "#end#metadata_schema\n";
+    return fprintf(out, fmt, metadata_schema_length, metadata_schema);
+}
+
 /*************************
  * individual table
  *************************/
@@ -569,9 +579,8 @@ tsk_individual_table_print_state(tsk_individual_table_t *self, FILE *out)
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here because we want to output
      * the offset columns. */
-    fprintf(out, "#metadata_schema#\n");
-    fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    fprintf(out, "#end#metadata_schema\n");
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "id\tflags\tlocation_offset\tlocation\t");
     fprintf(out, "metadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
@@ -634,15 +643,8 @@ tsk_individual_table_dump_text(tsk_individual_table_t *self, FILE *out)
     tsk_size_t metadata_len;
     int err;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     if (err < 0) {
         goto out;
     }
@@ -1085,9 +1087,8 @@ tsk_node_table_print_state(tsk_node_table_t *self, FILE *out)
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here for simplicity because we want to output
      * the flags column directly. */
-    fprintf(out, "#metadata_schema#\n");
-    fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    fprintf(out, "#end#metadata_schema\n");
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "id\tflags\ttime\tpopulation\tindividual\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t%f\t%d\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
@@ -1117,15 +1118,8 @@ tsk_node_table_dump_text(tsk_node_table_t *self, FILE *out)
     tsk_size_t metadata_len;
     int err;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     if (err < 0) {
         goto out;
     }
@@ -1615,15 +1609,8 @@ tsk_edge_table_dump_text(tsk_edge_table_t *self, FILE *out)
     tsk_edge_t row;
     int err;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     if (err < 0) {
         goto out;
     }
@@ -2274,15 +2261,8 @@ tsk_site_table_dump_text(tsk_site_table_t *self, FILE *out)
     int err;
     tsk_size_t ancestral_state_len, metadata_len;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     if (err < 0) {
         goto out;
     }
@@ -2855,15 +2835,8 @@ tsk_mutation_table_dump_text(tsk_mutation_table_t *self, FILE *out)
     int err;
     tsk_size_t j, derived_state_len, metadata_len;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     if (err < 0) {
         goto out;
     }
@@ -3323,15 +3296,8 @@ tsk_migration_table_dump_text(tsk_migration_table_t *self, FILE *out)
     tsk_size_t metadata_len;
     int err;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     if (err < 0) {
         goto out;
     }
@@ -3715,9 +3681,8 @@ tsk_population_table_print_state(tsk_population_table_t *self, FILE *out)
         (int) self->metadata_length, (int) self->max_metadata_length,
         (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
-    fprintf(out, "#metadata_schema#\n");
-    fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    fprintf(out, "#end#metadata_schema\n");
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "index\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t", (int) j, self->metadata_offset[j]);
@@ -3764,16 +3729,9 @@ tsk_population_table_dump_text(tsk_population_table_t *self, FILE *out)
     tsk_size_t j;
     tsk_size_t metadata_len;
 
-    err = fprintf(out, "#metadata_schema#\n");
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    if (err < 0) {
-        goto out;
-    }
-    err = fprintf(out, "#end#metadata_schema\n");
-    if (err < 0) {
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err != 0) {
         goto out;
     }
     err = fprintf(out, "metadata\n");
@@ -6851,9 +6809,9 @@ tsk_table_collection_print_state(tsk_table_collection_t *self, FILE *out)
 {
     fprintf(out, "Table collection state\n");
     fprintf(out, "sequence_length = %f\n", self->sequence_length);
-    fprintf(out, "#metadata_schema#\n");
-    fprintf(out, "%.*s\n", self->metadata_schema_length, self->metadata_schema);
-    fprintf(out, "#end#metadata_schema\n");
+
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "#metadata#\n");
     fprintf(out, "%.*s\n", self->metadata_length, self->metadata);
     fprintf(out, "#end#metadata\n");

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -648,7 +648,7 @@ typedef struct _tsk_table_sorter_t {
 #define TSK_NO_INIT (1u << 30)
 
 /** @brief Do not run integrity checks before performing an operation. */
-#define TSK_NO_CHECK_INTEGRITY (1u << 30)
+#define TSK_NO_CHECK_INTEGRITY (1u << 29)
 
 /**@} */
 
@@ -680,10 +680,10 @@ typedef struct _tsk_table_sorter_t {
 /* Flags for load tables */
 #define TSK_BUILD_INDEXES (1 << 0)
 
-/* Flags for init table collection */
+/* Flags for table collection init */
 #define TSK_NO_EDGE_METADATA (1 << 0)
 
-/* Flags for init tables */
+/* Flags for table init. */
 #define TSK_NO_METADATA (1 << 0)
 
 /****************************************************************************/
@@ -1043,6 +1043,17 @@ int tsk_node_table_dump_text(tsk_node_table_t *self, FILE *out);
 This must be called before any operations are performed on the table.
 See the :ref:`sec_c_api_overview_structure` for details on how objects
 are initialised and freed.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_METADATA
+    Do not allocate space to store metadata in this table. Operations
+    attempting to add non-empty metadata to the table will fail
+    with error TSK_ERR_METADATA_DISABLED.
+
 @endrst
 
 @param self A pointer to an uninitialised tsk_edge_table_t object.
@@ -2050,6 +2061,17 @@ int tsk_provenance_table_get_row(
 This must be called before any operations are performed on the table
 collection. See the :ref:`sec_c_api_overview_structure` for details on how objects
 are initialised and freed.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_EDGE_METADATA
+    Do not allocate space to store metadata in the edge table. Operations
+    attempting to add non-empty metadata to the edge table will fail
+    with error TSK_ERR_METADATA_DISABLED.
+
 @endrst
 
 @param self A pointer to an uninitialised tsk_table_collection_t object.


### PR DESCRIPTION
Fixes #708 

Note that this is stacked on #712 so the diff looks bigger than it is.

To test I have made `parse_edges` return metadata by default. This is a little odd - but as one row is many edges in parse edges there doesn't seem to be a clean way to specify per-edge metadata there anyway.