### PR TITLE
Remove gsl

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -180,9 +180,6 @@ jobs:
         run: |
           docker run --rm -v `pwd`:/project -w /project quay.io/pypa/manylinux2010_x86_64 bash .github/workflows/docker/buildwheel.sh
 
-      - name: Install libgsl
-        run: sudo apt-get install libgsl-dev
-
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/c/examples/Makefile
+++ b/c/examples/Makefile
@@ -31,9 +31,8 @@ tree_traversal: tree_traversal.c
 streaming: streaming.c
 	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
 
-# This needs GSL
 haploid_wright_fisher: haploid_wright_fisher.c
-	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lgsl -lgslcblas -lm
+	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
 
 clean:
 	rm -f haploid_wright_fisher tree_iteration

--- a/c/meson.build
+++ b/c/meson.build
@@ -103,13 +103,8 @@ if not meson.is_subproject()
         sources: ['examples/streaming.c'], link_with: [tskit_lib], dependencies: lib_deps)
     executable('cpp_sorting_example',
         sources: ['examples/cpp_sorting_example.cpp'], link_with: [tskit_lib], dependencies: lib_deps)
-
-    gsl_dep = dependency('gsl', required: false)
-    if gsl_dep.found()
-        executable('haploid_wright_fisher',
-            sources: ['examples/haploid_wright_fisher.c'], link_with: [tskit_lib],
-            dependencies: [gsl_dep, lib_deps])
-    endif
+     executable('haploid_wright_fisher',
+        sources: ['examples/haploid_wright_fisher.c'], link_with: [tskit_lib], dependencies: lib_deps)
 endif
 
 # TMP: until we've ported all the tests, keep this compilable.

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -460,6 +460,24 @@ haploid Wright-Fisher simulator. Because this simple example
 repeatedly sorts the edge data, it is quite inefficient and
 should not be used as the basis of a large-scale simulator.
 
+.. note::
+
+   This example uses the C function ``rand`` and constant
+   ``RAND_MAX`` for random number generation.  These methods
+   are used for example purposes only and a high-quality
+   random number library should be preferred for code
+   used for research.  Examples include, but are not
+   limited to:
+
+   1. The `GNU Scientific Library <https://www.gnu.org/software/gsl>`_,
+      which is licensed under the GNU General Public License, version
+      3 (`GPL3+ <https://www.gnu.org/licenses/gpl-3.0.en.html>`_.
+   2. For C++ projects using C++11 or later,
+      the built-in `random <https://en.cppreference.com/w/cpp/numeric/random>`_
+      number library.
+   3. The `numpy C API <https://numpy.org/devdocs/reference/random/c-api.html>`_
+      may be useful for those writing Python extension modules in C/C++.
+
 .. todo::
     Give a pointer to an example that caches and flushes edge data efficiently.
     Probably using the C++ API?


### PR DESCRIPTION
The haploid WF example simulation uses the GSL, which is a GPL3+ library.  It seems possible, even likely, that this means tskit needs to be distributed under the GPL3+.  This PR removes all GSL dependencies, and uses vanilla C random number generation instead.