### PR TITLE
omit math.h under cpp

### DIFF
--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -39,8 +39,9 @@ extern "C" {
 #include <stdint.h>
 #include <limits.h>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__cplusplus)
 /* Work around bug in clang >= 6.0, https://github.com/tskit-dev/tskit/issues/721
+ * (note: fixed in clang January 2019)
  */
 #if __has_builtin(__builtin_isnan)
 #undef isnan


### PR DESCRIPTION
Thanks to @molpopgen, this seems to fix problems that prevent including the C files in C++ (see https://github.com/MesserLab/SLiM/pull/101#issuecomment-670539013). I have no idea if there's a better way to do this.