### PR TITLE
Move fix for clang bug to C file.

### DIFF
--- a/c/tests/testlib.h
+++ b/c/tests/testlib.h
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 
 #include <CUnit/Basic.h>
+#define _TSK_WORKAROUND_FALSE_CLANG_WARNING
 #include <tskit/trees.h>
 
 /* Global variables used in the test suite */

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -39,9 +39,13 @@ extern "C" {
 #include <stdint.h>
 #include <limits.h>
 
-#if defined(__clang__) && !defined(__cplusplus)
+#if defined(_TSK_WORKAROUND_FALSE_CLANG_WARNING) && defined(__clang__)
 /* Work around bug in clang >= 6.0, https://github.com/tskit-dev/tskit/issues/721
  * (note: fixed in clang January 2019)
+ * This workaround does some nasty fiddling with builtins and is only intended to
+ * be used within the library. To turn it on, make sure
+ * _TSK_WORKAROUND_FALSE_CLANG_WARNING is defined before including any tskit
+ * headers.
  */
 #if __has_builtin(__builtin_isnan)
 #undef isnan

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -32,6 +32,7 @@
 #include <float.h>
 #include <math.h>
 
+#define _TSK_WORKAROUND_FALSE_CLANG_WARNING
 #include <tskit/tables.h>
 
 #define DEFAULT_SIZE_INCREMENT 1024


### PR DESCRIPTION
This moves the workaround for the clang bug (#721) from the header file to a C file, to address very good points made by @bhaller. The fix is now local to C code, so we don't need to check for C++ any more, and library users will no longer have this workaround foisted on them unwittingly.

@molpopgen, do you see any problems with doing this?