### PR TITLE
Allow mixture of known and unknown as long as they are on different sites

### DIFF
--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -3800,7 +3800,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret = tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
-    /* A mixture of known and unknown times fails */
+    /* A mixture of known and unknown times on a site fails */
     ret = tsk_mutation_table_clear(&tables.mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_mutation_table_add_row(
@@ -3809,8 +3809,20 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN);
+
+    /* But on different sites, passes */
+    ret = tsk_mutation_table_clear(&tables.mutations);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_mutation_table_add_row(
+        &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_mutation_table_add_row(
+        &tables.mutations, 1, 0, TSK_NULL, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -303,7 +303,7 @@ tsk_strerror_internal(int err)
             break;
         case TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN:
             ret = "Mutation times must either be all marked 'unknown', or all be known "
-                  "values";
+                  "values for any single site.";
             break;
 
         /* Sample errors */

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -6701,13 +6701,6 @@ tsk_table_collection_check_mutation_integrity(
                 goto out;
             }
         }
-        /* Check known/unknown times are not both present */
-        if (unknown_time) {
-            unknown_times_seen = true;
-        } else if (unknown_times_seen) {
-            ret = TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN;
-            goto out;
-        }
 
         if (check_mutation_ordering) {
             /* Check site ordering and reset time check if needed*/
@@ -6718,7 +6711,16 @@ tsk_table_collection_check_mutation_integrity(
                 }
                 if (mutations.site[j - 1] != mutations.site[j]) {
                     last_known_time = INFINITY;
+                    unknown_times_seen = false;
                 }
+            }
+
+            /* Check known/unknown times are not both present on a site*/
+            if (unknown_time) {
+                unknown_times_seen = true;
+            } else if (unknown_times_seen) {
+                ret = TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN;
+                goto out;
             }
 
             /* Check the mutation parents for ordering */

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -638,8 +638,8 @@ requirements for a valid set of mutations are:
   the time is unknown) or be a finite value which is greater or equal to the
   mutation ``node``'s ``time``, less than the ``node`` above the mutation's
   ``time`` and equal to or less than the ``time`` of the ``parent`` mutation
-  if this mutation has one. If one mutation has UNKNOWN_TIME then all mutations
-  must, a mixture of known and unknown is not valid.
+  if this mutation has one. If one mutation on a site has UNKNOWN_TIME then all mutations
+  at that site must, a mixture of known and unknown is not valid.
 - ``parent`` must either be the null ID (-1) or a valid mutation ID within the
   current table
 


### PR DESCRIPTION
FIxes #748 by relaxing the constraint on mutation times to allow mixtures of known/unknown as long as they are on different sites.