### PR TITLE
Add macs conversion from msp

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -118,6 +118,9 @@ SVG drawing improvements and many others.
 - Add ``tree.as_dict_of_dicts()`` function to enable use with networkx. See
   :ref:`sec_tutorial_networkx` (:user:`winni2k`, :pr:`457`).
 
+- Add ``tree_sequence.to_macs()`` function to convert tree sequence to MACS
+  format (:user:`winni2k`, :pr:`727`)
+
 **Bugfixes**
 
 - :issue:`453` - Fix LibraryError when ``tree.newick()`` is called with large node time

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4302,6 +4302,25 @@ class TreeSequence:
         s += "END;\n"
         return s
 
+    def to_macs(self):
+        """
+        Return a `macs encoding <https://github.com/gchen98/macs>`_
+        of this tree sequence.
+
+        :return: The macs representation of this TreeSequence as a string.
+        :rtype: str
+        """
+        n = self.get_sample_size()
+        m = self.get_sequence_length()
+        output = [f"COMMAND:\tnot_macs {n} {m}"]
+        output.append("SEED:\tASEED")
+        for variant in self.variants(as_bytes=True):
+            output.append(
+                f"SITE:\t{variant.index}\t{variant.position / m}\t0.0\t"
+                f"{variant.genotypes.decode()}"
+            )
+        return "\n".join(output) + "\n"
+
     def simplify(
         self,
         samples=None,


### PR DESCRIPTION
Move the macs and newick CLI commands over from msprime. See https://github.com/tskit-dev/msprime/pull/1124. This closes https://github.com/tskit-dev/msprime/issues/1120.