### PR TITLE
Change diff iter types to tsk_ equivalents

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -175,7 +175,7 @@ verify_individual_nodes(tsk_treeseq_t *ts)
 }
 
 static void
-verify_trees(tsk_treeseq_t *ts, uint32_t num_trees, tsk_id_t *parents)
+verify_trees(tsk_treeseq_t *ts, tsk_size_t num_trees, tsk_id_t *parents)
 {
     int ret;
     tsk_id_t u, j, v;

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4383,7 +4383,7 @@ tsk_diff_iter_init(tsk_diff_iter_t *self, tsk_treeseq_t *tree_sequence)
     self->insertion_index = 0;
     self->removal_index = 0;
     self->tree_left = 0;
-    self->tree_index = (size_t) -1;
+    self->tree_index = -1;
     self->edge_list_nodes = malloc(self->num_edges * sizeof(*self->edge_list_nodes));
     if (self->edge_list_nodes == NULL) {
         ret = TSK_ERR_NO_MEMORY;
@@ -4420,7 +4420,7 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
     const double sequence_length = self->tree_sequence->tables->sequence_length;
     double left = self->tree_left;
     double right = sequence_length;
-    size_t next_edge_list_node = 0;
+    tsk_size_t next_edge_list_node = 0;
     tsk_treeseq_t *s = self->tree_sequence;
     tsk_edge_list_node_t *out_head = NULL;
     tsk_edge_list_node_t *out_tail = NULL;
@@ -4429,7 +4429,7 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
     tsk_edge_list_node_t *w = NULL;
     tsk_edge_list_t edges_out;
     tsk_edge_list_t edges_in;
-    size_t num_trees = tsk_treeseq_get_num_trees(s);
+    tsk_size_t num_trees = tsk_treeseq_get_num_trees(s);
     const tsk_edge_table_t *edges = &s->tables->edges;
     const tsk_id_t *insertion_order = s->tables->indexes.edge_insertion_order;
     const tsk_id_t *removal_order = s->tables->indexes.edge_removal_order;
@@ -4437,9 +4437,9 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
     memset(&edges_out, 0, sizeof(edges_out));
     memset(&edges_in, 0, sizeof(edges_in));
 
-    if (self->tree_index + 1 < num_trees) {
+    if (self->tree_index + 1 < (tsk_id_t) num_trees) {
         /* First we remove the stale records */
-        while (self->removal_index < self->num_edges
+        while (self->removal_index < (tsk_id_t) self->num_edges
                && left == edges->right[removal_order[self->removal_index]]) {
             k = removal_order[self->removal_index];
             assert(next_edge_list_node < self->num_edges);
@@ -4469,7 +4469,7 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
         edges_out.tail = out_tail;
 
         /* Now insert the new records */
-        while (self->insertion_index < self->num_edges
+        while (self->insertion_index < (tsk_id_t) self->num_edges
                && left == edges->left[insertion_order[self->insertion_index]]) {
             k = insertion_order[self->insertion_index];
             assert(next_edge_list_node < self->num_edges);
@@ -4499,10 +4499,10 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
         edges_in.tail = in_tail;
 
         right = sequence_length;
-        if (self->insertion_index < self->num_edges) {
+        if (self->insertion_index < (tsk_id_t) self->num_edges) {
             right = TSK_MIN(right, edges->left[insertion_order[self->insertion_index]]);
         }
-        if (self->removal_index < self->num_edges) {
+        if (self->removal_index < (tsk_id_t) self->num_edges) {
             right = TSK_MIN(right, edges->right[removal_order[self->removal_index]]);
         }
         self->tree_index++;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -198,13 +198,13 @@ typedef struct {
 } tsk_edge_list_t;
 
 typedef struct {
-    size_t num_nodes;
-    size_t num_edges;
+    tsk_size_t num_nodes;
+    tsk_size_t num_edges;
     double tree_left;
     tsk_treeseq_t *tree_sequence;
-    size_t insertion_index;
-    size_t removal_index;
-    size_t tree_index;
+    tsk_id_t insertion_index;
+    tsk_id_t removal_index;
+    tsk_id_t tree_index;
     tsk_edge_list_node_t *edge_list_nodes;
 } tsk_diff_iter_t;
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9888,7 +9888,7 @@ TreeDiffIterator_next(TreeDiffIterator  *self)
     PyObject *value = NULL;
     int err;
     double left, right;
-    size_t list_size, j;
+    tsk_size_t list_size, j;
     tsk_edge_list_node_t *record;
     tsk_edge_list_t records_out, records_in;
 


### PR DESCRIPTION
As discussed on slack. I don't think any of these are exposed to Python, so conversion to/from python equivalents shouldn't catch us out here.