### PR TITLE
Deprecate impute_missing_data and TSK_IMPUTE_MISSING_DATA

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -1,4 +1,12 @@
 ---------------------
+[0.99.5] - 2020-08-27
+---------------------
+
+**Breaking changes**
+
+- The macro ``TSK_IMPUTE_MISSING_DATA`` is renamed to ``TSK_ISOLATED_NOT_MISSING``
+
+---------------------
 [0.99.4] - 2020-08-12
 ---------------------
 
@@ -9,7 +17,7 @@
 
 **Changes**
 
-- Mutation times can be a mixture of known and unkown as long as for each
+- Mutation times can be a mixture of known and unknown as long as for each
   individual site  they are either all known or all unknown (:user:`benjeffery`, :pr:`761`).
 
 **Bugfixes**

--- a/c/tests/test_genotypes.c
+++ b/c/tests/test_genotypes.c
@@ -67,7 +67,7 @@ test_simplest_missing_data(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_free(&vargen);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_IMPUTE_MISSING_DATA);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_ISOLATED_NOT_MISSING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_vargen_next(&vargen, &var);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -122,7 +122,7 @@ test_simplest_missing_data_user_alleles(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_free(&vargen);
 
-    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_IMPUTE_MISSING_DATA);
+    ret = tsk_vargen_init(&vargen, &ts, NULL, 0, NULL, TSK_ISOLATED_NOT_MISSING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_vargen_next(&vargen, &var);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
@@ -411,7 +411,7 @@ test_single_tree_non_samples(void)
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUST_IMPUTE_NON_SAMPLES);
     tsk_vargen_free(&vargen);
 
-    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, TSK_IMPUTE_MISSING_DATA);
+    ret = tsk_vargen_init(&vargen, &ts, samples, 2, NULL, TSK_ISOLATED_NOT_MISSING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_vargen_print_state(&vargen, _devnull);
 

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -478,7 +478,7 @@ verify_simplify_genotypes(
     ret = tsk_vargen_init(&vargen, ts, NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_vargen_init(
-        &subset_vargen, subset, NULL, 0, NULL, TSK_IMPUTE_MISSING_DATA);
+        &subset_vargen, subset, NULL, 0, NULL, TSK_ISOLATED_NOT_MISSING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(m, tsk_treeseq_get_num_sites(subset));
 

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -107,7 +107,7 @@ tsk_vargen_init(tsk_vargen_t *self, tsk_treeseq_t *tree_sequence, tsk_id_t *samp
     tsk_flags_t tree_options;
     const tsk_flags_t *flags = tree_sequence->tables->nodes.flags;
     size_t j, num_nodes, num_samples_alloc, max_alleles_limit;
-    bool impute_missing = !!(options & TSK_IMPUTE_MISSING_DATA);
+    bool impute_missing = !!(options & TSK_ISOLATED_NOT_MISSING);
     tsk_size_t max_alleles;
     tsk_id_t u;
 
@@ -504,7 +504,7 @@ tsk_vargen_update_site(tsk_vargen_t *self)
     tsk_site_t *site = var->site;
     tsk_mutation_t mutation;
     bool genotypes16 = !!(self->options & TSK_16_BIT_GENOTYPES);
-    bool impute_missing = !!(self->options & TSK_IMPUTE_MISSING_DATA);
+    bool impute_missing = !!(self->options & TSK_ISOLATED_NOT_MISSING);
     bool by_traversal = self->samples != NULL;
     int (*update_genotypes)(tsk_vargen_t *, tsk_id_t, tsk_id_t);
     bool (*mark_missing)(tsk_vargen_t *);

--- a/c/tskit/genotypes.h
+++ b/c/tskit/genotypes.h
@@ -33,7 +33,7 @@ extern "C" {
 #include <tskit/trees.h>
 
 #define TSK_16_BIT_GENOTYPES (1 << 0)
-#define TSK_IMPUTE_MISSING_DATA (1 << 1)
+#define TSK_ISOLATED_NOT_MISSING (1 << 1)
 
 typedef struct {
     tsk_site_t *site;

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -27,6 +27,11 @@ SVG drawing improvements and many others.
   perform the same function (:user:`jeromekelleher`, :issue:`500`,
   :pr:`694`).
 
+- The arguments to ``TreeSequence.genotype_matrix``, ``TreeSequence.haplotypes``
+  and ``TreeSequence.variants`` must now be keyword arguments, not positional. This
+  is to support the change from ``impute_missing_data`` to ``isolated_as_missing``
+  in the arguments to these methods
+
 **New features**
 
 - New methods to perform set operations on TableCollections and TreeSequences.
@@ -98,7 +103,7 @@ SVG drawing improvements and many others.
 
 - Allow sites with missing data to be output by the ``haplotypes`` method, by
   default replacing with ``-``. Errors are no longer raised for missing data
-  with ``impute_missing_data=False``; the error types returned for bad alleles
+  with ``isolated_as_missing=True``; the error types returned for bad alleles
   (e.g. multiletter or non-ascii) have also changed from ``_tskit.LibraryError``
   to TypeError, or ValueError if the missing data character clashes
   (:user:`hyanwong`, :pr:`426`).
@@ -131,6 +136,10 @@ SVG drawing improvements and many others.
 - The ``sample_counts`` feature has been deprecated and is now
   ignored. Sample counts are now always computed.
 
+- For ``TreeSequence.genotype_matrix``, ``TreeSequence.haplotypes``
+  and ``TreeSequence.variants`` the ``impute_missing_data`` argument is deprecated
+  and replaced with ``isolated_as_missing``. Note that to get the same behaviour
+  ``impute_missing_data=True`` should be replaced with ``isolated_as_missing=False``.
 
 --------------------
 [0.2.3] - 2019-11-22

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -8494,7 +8494,7 @@ static PyObject *
 TreeSequence_get_genotype_matrix(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     PyObject *ret = NULL;
-    static char *kwlist[] = {"impute_missing_data", "alleles", NULL};
+    static char *kwlist[] = {"isolated_as_missing", "alleles", NULL};
     int err;
     size_t num_sites;
     size_t num_samples;
@@ -8505,7 +8505,7 @@ TreeSequence_get_genotype_matrix(TreeSequence *self, PyObject *args, PyObject *k
     char *V;
     tsk_variant_t *variant;
     size_t j;
-    int impute_missing_data = 0;
+    int isolated_as_missing = 1;
     const char **alleles = NULL;
     tsk_flags_t options = 0;
 
@@ -8515,11 +8515,11 @@ TreeSequence_get_genotype_matrix(TreeSequence *self, PyObject *args, PyObject *k
 
     /* TODO add option for 16 bit genotypes */
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO", kwlist,
-                &impute_missing_data, &py_alleles)) {
+                &isolated_as_missing, &py_alleles)) {
         goto out;
     }
-    if (impute_missing_data) {
-        options |= TSK_IMPUTE_MISSING_DATA;
+    if (!isolated_as_missing) {
+        options |= TSK_ISOLATED_NOT_MISSING;
     }
 
     if (py_alleles != Py_None) {
@@ -10035,7 +10035,7 @@ VariantGenerator_init(VariantGenerator *self, PyObject *args, PyObject *kwds)
 {
     int ret = -1;
     int err;
-    static char *kwlist[] = {"tree_sequence", "samples", "impute_missing_data",
+    static char *kwlist[] = {"tree_sequence", "samples", "isolated_as_missing",
         "alleles", NULL};
     TreeSequence *tree_sequence = NULL;
     PyObject *samples_input = Py_None;
@@ -10043,7 +10043,7 @@ VariantGenerator_init(VariantGenerator *self, PyObject *args, PyObject *kwds)
     PyArrayObject *samples_array = NULL;
     tsk_id_t *samples = NULL;
     size_t num_samples = 0;
-    int impute_missing_data = 0;
+    int isolated_as_missing = 1;
     const char **alleles = NULL;
     npy_intp *shape;
     tsk_flags_t options = 0;
@@ -10053,11 +10053,11 @@ VariantGenerator_init(VariantGenerator *self, PyObject *args, PyObject *kwds)
     self->tree_sequence = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|OiO", kwlist,
             &TreeSequenceType, &tree_sequence, &samples_input,
-            &impute_missing_data, &py_alleles)) {
+            &isolated_as_missing, &py_alleles)) {
         goto out;
     }
-    if (impute_missing_data) {
-        options |= TSK_IMPUTE_MISSING_DATA;
+    if (!isolated_as_missing) {
+        options |= TSK_ISOLATED_NOT_MISSING;
     }
     self->tree_sequence = tree_sequence;
     Py_INCREF(self->tree_sequence);

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -602,7 +602,7 @@ class TestTreeSequence(HighLevelTestCase):
             self.verify_mutations(ts)
 
     def verify_pairwise_diversity(self, ts):
-        haplotypes = ts.genotype_matrix(impute_missing_data=True).T
+        haplotypes = ts.genotype_matrix(isolated_as_missing=False).T
         pi1 = ts.get_pairwise_diversity()
         pi2 = simple_get_pairwise_diversity(haplotypes)
         self.assertAlmostEqual(pi1, pi2)
@@ -1067,10 +1067,10 @@ class TestTreeSequence(HighLevelTestCase):
         s = np.array([sample_map[u] for u in sample])
         # Build a map of genotypes by position
         full_genotypes = {}
-        for variant in ts.variants(impute_missing_data=True):
+        for variant in ts.variants(isolated_as_missing=False):
             alleles = [variant.alleles[g] for g in variant.genotypes]
             full_genotypes[variant.position] = alleles
-        for variant in subset.variants(impute_missing_data=True):
+        for variant in subset.variants(isolated_as_missing=False):
             if variant.position in full_genotypes:
                 a1 = [full_genotypes[variant.position][u] for u in s]
                 a2 = [variant.alleles[g] for g in variant.genotypes]

--- a/python/tests/test_parsimony.py
+++ b/python/tests/test_parsimony.py
@@ -384,7 +384,7 @@ class TestFitchParsimonyDistance(unittest.TestCase):
         self.assertEqual(ts.num_trees, 1)
         self.assertGreater(ts.num_sites, 3)
         tree = ts.first()
-        for variant in ts.variants(impute_missing_data=True):
+        for variant in ts.variants(isolated_as_missing=False):
             score = fitch_score(tree, variant.genotypes)
             bp_score = bp_fitch_score(tree, variant.genotypes)
             self.assertEqual(bp_score, score)
@@ -468,7 +468,7 @@ class TestParsimonyRoundTrip(TestParsimonyBase):
         tables = ts.dump_tables()
         tables.sites.clear()
         tables.mutations.clear()
-        G = ts.genotype_matrix(impute_missing_data=True)
+        G = ts.genotype_matrix(isolated_as_missing=False)
         alleles = [v.alleles for v in ts.variants()]
         for tree in ts.trees():
             for site in tree.sites():
@@ -490,8 +490,8 @@ class TestParsimonyRoundTrip(TestParsimonyBase):
                     )
         other_ts = tables.tree_sequence()
         for h1, h2 in zip(
-            ts.haplotypes(impute_missing_data=True),
-            other_ts.haplotypes(impute_missing_data=True),
+            ts.haplotypes(isolated_as_missing=False),
+            other_ts.haplotypes(isolated_as_missing=False),
         ):
             self.assertEqual(h1, h2)
 
@@ -500,7 +500,7 @@ class TestParsimonyRoundTrip(TestParsimonyBase):
         tables2 = ts.dump_tables()
         tables2.sites.clear()
         tables2.mutations.clear()
-        G = ts.genotype_matrix(impute_missing_data=True)
+        G = ts.genotype_matrix(isolated_as_missing=False)
         alleles = [v.alleles for v in ts.variants()]
         for tree in ts.trees():
             for site in tree.sites():
@@ -600,7 +600,7 @@ class TestParsimonyRoundTripMissingData(TestParsimonyRoundTrip):
         tables = ts.dump_tables()
         tables.sites.clear()
         tables.mutations.clear()
-        G = ts.genotype_matrix(impute_missing_data=True)
+        G = ts.genotype_matrix(isolated_as_missing=False)
         # Set the first sample to missing data everywhere
         G[:, 0] = -1
         alleles = [v.alleles for v in ts.variants()]
@@ -624,8 +624,8 @@ class TestParsimonyRoundTripMissingData(TestParsimonyRoundTrip):
                     )
         other_ts = tables.tree_sequence()
         self.assertEqual(ts.num_samples, other_ts.num_samples)
-        H1 = list(ts.haplotypes(impute_missing_data=True))
-        H2 = list(other_ts.haplotypes(impute_missing_data=True))
+        H1 = list(ts.haplotypes(isolated_as_missing=False))
+        H2 = list(other_ts.haplotypes(isolated_as_missing=False))
         # All samples except 0 should be reproduced exactly.
         self.assertEqual(H1[1:], H2[1:])
 

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -1801,7 +1801,7 @@ class TestEmptyTreeSequences(TopologyTestCase):
         self.assertEqual(t.root, 0)
         self.assertEqual(t.parent_dict, {})
         self.assertEqual(list(t.nodes()), [0])
-        self.assertEqual(list(ts.haplotypes(impute_missing_data=True)), [""])
+        self.assertEqual(list(ts.haplotypes(isolated_as_missing=False)), [""])
         self.assertEqual(list(ts.variants()), [])
         methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
         for method in methods:
@@ -1833,7 +1833,7 @@ class TestEmptyTreeSequences(TopologyTestCase):
         self.assertEqual(t.root, 0)
         self.assertEqual(t.parent_dict, {})
         self.assertEqual(list(t.nodes()), [0])
-        self.assertEqual(list(ts.haplotypes(impute_missing_data=True)), ["1"])
+        self.assertEqual(list(ts.haplotypes(isolated_as_missing=False)), ["1"])
         self.assertEqual(len(list(ts.variants())), 1)
         methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
         for method in methods:
@@ -3268,9 +3268,12 @@ class TestMultipleRoots(TopologyTestCase):
         t = next(ts.trees())
         self.assertEqual(t.parent_dict, {})
         self.assertEqual(sorted(t.roots), [0, 1])
-        self.assertEqual(list(ts.haplotypes(impute_missing_data=True)), ["10", "01"])
+        self.assertEqual(list(ts.haplotypes(isolated_as_missing=False)), ["10", "01"])
         self.assertEqual(
-            [v.genotypes for v in ts.variants(as_bytes=True, impute_missing_data=True)],
+            [
+                v.genotypes
+                for v in ts.variants(as_bytes=True, isolated_as_missing=False)
+            ],
             [b"10", b"01"],
         )
         simplified = ts.simplify()
@@ -3533,13 +3536,15 @@ class TestMultipleRoots(TopologyTestCase):
         self.assertEqual([v.genotypes for v in ts.variants(as_bytes=True)], variants)
         ts_simplified = ts.simplify(filter_sites=False)
         self.assertEqual(
-            list(ts_simplified.haplotypes(impute_missing_data=True)), haplotypes
+            list(ts_simplified.haplotypes(isolated_as_missing=False)), haplotypes
         )
         self.assertEqual(
             variants,
             [
                 v.genotypes
-                for v in ts_simplified.variants(as_bytes=True, impute_missing_data=True)
+                for v in ts_simplified.variants(
+                    as_bytes=True, isolated_as_missing=False
+                )
             ],
         )
 
@@ -5130,7 +5135,7 @@ class TestSimplify(unittest.TestCase):
             tss, node_map = self.do_simplify(ts, keep_unary=keep)
             self.assertEqual(tss.num_sites, 1)
             self.assertEqual(tss.num_mutations, 2)
-            self.assertEqual(list(tss.haplotypes(impute_missing_data=True)), ["0"])
+            self.assertEqual(list(tss.haplotypes(isolated_as_missing=False)), ["0"])
 
     def test_many_mutations_over_single_sample_derived_state(self):
         nodes = io.StringIO(
@@ -5171,7 +5176,7 @@ class TestSimplify(unittest.TestCase):
             tss, node_map = self.do_simplify(ts, keep_unary=keep)
             self.assertEqual(tss.num_sites, 1)
             self.assertEqual(tss.num_mutations, 3)
-            self.assertEqual(list(tss.haplotypes(impute_missing_data=True)), ["1"])
+            self.assertEqual(list(tss.haplotypes(isolated_as_missing=False)), ["1"])
 
     def test_many_trees_filter_zero_mutations(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
@@ -5342,10 +5347,10 @@ class TestSimplify(unittest.TestCase):
             ts, samples, filter_sites=False, keep_unary=keep_unary
         )
         self.assertEqual(ts.num_sites, sub_ts.num_sites)
-        sub_haplotypes = list(sub_ts.haplotypes(impute_missing_data=True))
+        sub_haplotypes = list(sub_ts.haplotypes(isolated_as_missing=False))
         all_samples = list(ts.samples())
         k = 0
-        for j, h in enumerate(ts.haplotypes(impute_missing_data=True)):
+        for j, h in enumerate(ts.haplotypes(isolated_as_missing=False)):
             if k == len(samples):
                 break
             if samples[k] == all_samples[j]:

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -1117,7 +1117,7 @@ def site_diversity(ts, sample_sets, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True).T
+        haps = ts.genotype_matrix(isolated_as_missing=False).T
         site_positions = [x.position for x in ts.sites()]
         for i, X in enumerate(sample_sets):
             S = 0
@@ -1254,7 +1254,7 @@ def site_segregating_sites(ts, sample_sets, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True)
+        haps = ts.genotype_matrix(isolated_as_missing=False)
         site_positions = [x.position for x in ts.sites()]
         for i, X in enumerate(sample_sets):
             X_index = np.where(np.in1d(samples, X))[0]
@@ -1398,7 +1398,7 @@ def site_tajimas_d(ts, sample_sets, windows=None):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True)
+        haps = ts.genotype_matrix(isolated_as_missing=False)
         site_positions = [x.position for x in ts.sites()]
         n = np.array([len(X) for X in sample_sets])
         for i, X in enumerate(sample_sets):
@@ -1521,7 +1521,7 @@ def site_Y1(ts, sample_sets, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True).T
+        haps = ts.genotype_matrix(isolated_as_missing=False).T
         site_positions = [x.position for x in ts.sites()]
         for i, X in enumerate(sample_sets):
             S = 0
@@ -1627,7 +1627,7 @@ def site_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True)
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True).T
+        haps = ts.genotype_matrix(isolated_as_missing=False).T
         site_positions = [x.position for x in ts.sites()]
         for i, (ix, iy) in enumerate(indexes):
             X = sample_sets[ix]
@@ -1785,7 +1785,7 @@ def single_site_Fst(ts, sample_sets, indexes):
     out = np.zeros((ts.num_sites, len(indexes)))
     samples = ts.samples()
     # TODO deal with missing data properly.
-    for j, v in enumerate(ts.variants(impute_missing_data=True)):
+    for j, v in enumerate(ts.variants(isolated_as_missing=False)):
         for i, (ix, iy) in enumerate(indexes):
             g = v.genotypes
             X = sample_sets[ix]
@@ -1923,7 +1923,7 @@ def site_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True).T
+        haps = ts.genotype_matrix(isolated_as_missing=False).T
         site_positions = [x.position for x in ts.sites()]
         for i, (ix, iy) in enumerate(indexes):
             X = sample_sets[ix]
@@ -2085,7 +2085,7 @@ def branch_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
 def site_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(indexes)))
-    haps = ts.genotype_matrix(impute_missing_data=True).T
+    haps = ts.genotype_matrix(isolated_as_missing=False).T
     site_positions = ts.tables.sites.position
     samples = ts.samples()
     for j in range(len(windows) - 1):
@@ -2246,7 +2246,7 @@ def site_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(indexes)))
     samples = ts.samples()
-    haps = ts.genotype_matrix(impute_missing_data=True).T
+    haps = ts.genotype_matrix(isolated_as_missing=False).T
     site_positions = ts.tables.sites.position
     for j in range(len(windows) - 1):
         begin = windows[j]
@@ -2420,7 +2420,7 @@ def site_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(indexes)))
     samples = ts.samples()
-    haps = ts.genotype_matrix(impute_missing_data=True).T
+    haps = ts.genotype_matrix(isolated_as_missing=False).T
     site_positions = ts.tables.sites.position
     for j in range(len(windows) - 1):
         begin = windows[j]
@@ -2605,7 +2605,7 @@ def branch_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
 def site_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
     windows = ts.parse_windows(windows)
     samples = ts.samples()
-    haps = ts.genotype_matrix(impute_missing_data=True).T
+    haps = ts.genotype_matrix(isolated_as_missing=False).T
     site_positions = ts.tables.sites.position
     out = np.zeros((len(windows) - 1, len(indexes)))
     for j in range(len(windows) - 1):
@@ -2835,7 +2835,7 @@ def naive_site_allele_frequency_spectrum(
     num_windows = len(windows) - 1
     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
     out = np.zeros([num_windows] + out_dim)
-    G = ts.genotype_matrix(impute_missing_data=True)
+    G = ts.genotype_matrix(isolated_as_missing=False)
     samples = ts.samples()
     # Indexes of the samples within the sample sets into the samples array.
     sample_set_indexes = [
@@ -3889,7 +3889,7 @@ def site_trait_covariance(ts, W, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True)
+        haps = ts.genotype_matrix(isolated_as_missing=False)
         site_positions = [x.position for x in ts.sites()]
         for i in range(K):
             w = W[:, i].copy()
@@ -4092,7 +4092,7 @@ def site_trait_correlation(ts, W, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True)
+        haps = ts.genotype_matrix(isolated_as_missing=False)
         site_positions = [x.position for x in ts.sites()]
         for i in range(K):
             w = W[:, i].copy()
@@ -4335,7 +4335,7 @@ def site_trait_regression(ts, W, Z, windows=None, span_normalise=True):
     for j in range(len(windows) - 1):
         begin = windows[j]
         end = windows[j + 1]
-        haps = ts.genotype_matrix(impute_missing_data=True)
+        haps = ts.genotype_matrix(isolated_as_missing=False)
         site_positions = [x.position for x in ts.sites()]
         for i in range(K):
             w = W[:, i]


### PR DESCRIPTION
Fixes #716 
I have made the arguments to the functions that take the new argument all keyword-only. This didn't break any of our test code and will only break those users that are using the arguments positionally. While this break could be avoided, I think it is best as it allows us to remove the old argument eventually with out more subtle breakage.
