### PR TITLE
Shift language on error and docs to replace 'impute'

### DIFF
--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -411,8 +411,8 @@ tsk_strerror_internal(int err)
             ret = "Must have at least one allele when specifying an allele map";
             break;
         case TSK_ERR_MUST_IMPUTE_NON_SAMPLES:
-            ret = "Cannot generate genotypes for non-samples unless missing data "
-                  "imputation is enabled";
+            ret = "Cannot generate genotypes for non-samples when isolated nodes are "
+                  "considered as missing";
             break;
         case TSK_ERR_ALLELE_NOT_FOUND:
             ret = "An allele was not found in the user-specified allele map";

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -23,7 +23,7 @@ statistics API in use.
 
 .. warning:: :ref:`sec_data_model_missing_data` is not currently
    handled correctly by site statistics defined here, as we always
-   impute missing data to be equal to the ancestral state. Later
+   assign missing data to be equal to the ancestral state. Later
    versions will add this behaviour as an option and will account
    for the presence of missing data by default.
 


### PR DESCRIPTION
Very minor, but I realised our error message still referenced imputation, and would be confusing.