### PR TITLE
check equality for missing times in mutation table rows

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -197,7 +197,9 @@ To include the changes that the hooks made, ``git add`` any
 files that were modified and run ``git commit`` (or, use ``git commit -a``
 to commit all changed files.)
 
-If you would like to run the checks without committing, use ``pre-commit run``.
+If you would like to run the checks without committing, use ``pre-commit run``
+(but, note that this will *only* check changes that have been *staged*;
+do ``pre-commit run --all`` to check unstaged changes as well).
 To bypass the checks (to save or get feedback on work-in-progress) use
 ``git commit --no-verify``
 

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -103,7 +103,7 @@ class SiteTableRow:
     metadata: bytes
 
 
-@attr.s(**attr_options)
+@attr.s(eq=False, **attr_options)
 class MutationTableRow:
     site: int
     node: int
@@ -111,6 +111,22 @@ class MutationTableRow:
     parent: int
     metadata: bytes
     time: float
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, MutationTableRow)
+            and self.site == other.site
+            and self.node == other.node
+            and self.derived_state == other.derived_state
+            and self.parent == other.parent
+            and self.metadata == other.metadata
+            and (
+                self.time == other.time
+                or (
+                    util.is_unknown_time(self.time) and util.is_unknown_time(other.time)
+                )
+            )
+        )
 
 
 @attr.s(**attr_options)


### PR DESCRIPTION
Closes #821, although not in the most elegant way.