### PR TITLE
test for time with keep_roots

### DIFF
--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -6458,7 +6458,8 @@ simplifier_insert_input_roots(simplifier_t *self)
                     if (ret != 0) {
                         goto out;
                     }
-                    simplifier_map_mutations(self, input_id, x->left, x->right, x->node);
+                    simplifier_map_mutations(
+                        self, input_id, x->left, x->right, output_id);
                 }
                 x = x->next;
             }

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -482,7 +482,7 @@ class Simplifier:
                 while x is not None:
                     if x.node != output_id:
                         self.record_edge(x.left, x.right, output_id, x.node)
-                        self.map_mutations(x.left, x.right, input_id, x.node)
+                        self.map_mutations(x.left, x.right, input_id, output_id)
                     x = x.next
                 self.flush_edges()
                 root_time = self.tables.nodes.time[output_id]

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -111,27 +111,26 @@ def insert_branch_mutations(ts, mutations_per_branch=1):
     for tree in ts.trees():
         site = tables.sites.add_row(position=tree.interval[0], ancestral_state="0")
         for root in tree.roots:
-            state = {root: 0}
-            mutation = {root: -1}
+            state = {tskit.NULL: 0}
+            mutation = {tskit.NULL: -1}
             stack = [root]
             while len(stack) > 0:
                 u = stack.pop()
                 stack.extend(tree.children(u))
                 v = tree.parent(u)
-                if v != tskit.NULL:
-                    state[u] = state[v]
-                    parent = mutation[v]
-                    for _ in range(mutations_per_branch):
-                        state[u] = (state[u] + 1) % 2
-                        metadata = f"{len(tables.mutations)}".encode()
-                        mutation[u] = tables.mutations.add_row(
-                            site=site,
-                            node=u,
-                            derived_state=str(state[u]),
-                            parent=parent,
-                            metadata=metadata,
-                        )
-                        parent = mutation[u]
+                state[u] = state[v]
+                parent = mutation[v]
+                for _ in range(mutations_per_branch):
+                    state[u] = (state[u] + 1) % 2
+                    metadata = f"{len(tables.mutations)}".encode()
+                    mutation[u] = tables.mutations.add_row(
+                        site=site,
+                        node=u,
+                        derived_state=str(state[u]),
+                        parent=parent,
+                        metadata=metadata,
+                    )
+                    parent = mutation[u]
     add_provenance(tables.provenances, "insert_branch_mutations")
     return tables.tree_sequence()
 


### PR DESCRIPTION
There appears to be a bug related to mutation times and `simplify(keep_input_roots=True)`. This PR modifies a test so that it triggers the problem: simplify changes the node the mutation is on, if that node is retained as an input root.  Here's a simple example:
```
import tskit

t = tskit.TableCollection(sequence_length=1)
t.nodes.add_row(time=0, flags=1)
t.nodes.add_row(time=1, flags=0)
t.nodes.add_row(time=2, flags=0)
t.edges.add_row(parent=1, child=0, left=0, right=1)
t.edges.add_row(parent=2, child=1, left=0, right=1)
t.sites.add_row(position=0, ancestral_state='0')
t.mutations.add_row(site=0, derived_state='1', time=2, node=2)

print(t.mutations)
# id	site	node	time	derived_state	parent	metadata
# 0	0	2	2.0	1	-1	

t.simplify(keep_input_roots=True)
print(t.mutations)
# id	site	node	time	derived_state	parent	metadata
# 0	0	0	2.0	1	-1	
```
The `node` should be `1` afterwards, not `0`, and doing `t.tree_sequence()` throws
```
_tskit.LibraryError: A mutation's time must be < the parent node of the edge on which it occurs, or be marked as 'unknown'
```

I'll see if I can track this down now...