### PR TITLE
Fix versions in rtd requirements

### DIFF
--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -3,7 +3,7 @@ numpy
 svgwrite
 jsonschema
 h5py
-breathe
-sphinx
+breathe>=4.20.0
+sphinx>=3.2.1
 sphinx-issues
 sphinx-argparse


### PR DESCRIPTION
RTD installs a specific version of sphinx before running the install of our requirements, so we need to be specific.