### PR TITLE
Fix type in documentation for tskit.Mutation

### DIFF
--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -348,7 +348,7 @@ class Mutation(SimpleContainerWithMetadata):
         :meth:`TreeSequence.node`.
     :vartype node: int
     :ivar time: The occurrence time of this mutation.
-    :vartype node: float
+    :vartype time: float
     :ivar derived_state: The derived state for this mutation. This is the state
         inherited by nodes in the subtree rooted at this mutation's node, unless
         another mutation occurs.


### PR DESCRIPTION
Currently in the [documentation](https://tskit.readthedocs.io/en/latest/python-api.html#tskit.Mutation), the type of node shows up as float and the type of time is absent. It surprised me that node would be a float and it turned out to be a typo in the documentation.