### PR TITLE
Update pre-commit packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
@@ -8,18 +8,18 @@ repos:
       - id: check-case-conflict
       - id: check-yaml
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.2.0
+    rev: v2.3.5
     hooks:
       - id: reorder-python-imports
         args: [--application-directories=python,
                --unclassifiable-application-module=_tskit]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.2.1
+    rev: v2.7.2
     hooks:
       - id: pyupgrade
         args: [--py3-plus, --py36-plus]
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3
@@ -27,16 +27,16 @@ repos:
         # loop that throws an error before black excludes it
         args: [python/tskit, python/setup.py, python/stress_lowlevel.py]
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
       - id: flake8
         args: [--config=python/.flake8]
         additional_dependencies: ["flake8-bugbear==20.1.4", "flake8-builtins==1.5.2"]
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.7.0
+    rev: v1.8.0
     hooks:
       - id: blacken-docs
         args: [--skip-errors]
-        additional_dependencies: [black==19.10b0]
+        additional_dependencies: [black==20.8b1]
         language_version: python3
 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -83,35 +83,35 @@ class PythonTree:
             v = self.right_sib[v]
         return ret
 
-    def _preorder_nodes(self, u, l):
-        l.append(u)
+    def _preorder_nodes(self, u, node_ist):
+        node_ist.append(u)
         for c in self.children(u):
-            self._preorder_nodes(c, l)
+            self._preorder_nodes(c, node_ist)
 
-    def _postorder_nodes(self, u, l):
+    def _postorder_nodes(self, u, node_ist):
         for c in self.children(u):
-            self._postorder_nodes(c, l)
-        l.append(u)
+            self._postorder_nodes(c, node_ist)
+        node_ist.append(u)
 
-    def _inorder_nodes(self, u, l):
+    def _inorder_nodes(self, u, node_ist):
         children = self.children(u)
         if len(children) > 0:
             mid = len(children) // 2
             for v in children[:mid]:
-                self._inorder_nodes(v, l)
-            l.append(u)
+                self._inorder_nodes(v, node_ist)
+            node_ist.append(u)
             for v in children[mid:]:
-                self._inorder_nodes(v, l)
+                self._inorder_nodes(v, node_ist)
         else:
-            l.append(u)
+            node_ist.append(u)
 
-    def _levelorder_nodes(self, u, l, level):
-        l[level].append(u) if level < len(l) else l.append([u])
+    def _levelorder_nodes(self, u, node_ist, level):
+        node_ist[level].append(u) if level < len(node_ist) else node_ist.append([u])
         for c in self.children(u):
-            self._levelorder_nodes(c, l, level + 1)
+            self._levelorder_nodes(c, node_ist, level + 1)
 
-    def _minlex_postorder_nodes(self, u, l):
-        l.extend(self._minlex_postorder_nodes_helper(u)[1])
+    def _minlex_postorder_nodes(self, u, node_ist):
+        node_ist.extend(self._minlex_postorder_nodes_helper(u)[1])
 
     def _minlex_postorder_nodes_helper(self, u):
         """

--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -352,7 +352,7 @@ class IbdFinder:
                     # IBD relationship.
                     if right - left > self.min_length:
                         self.add_ibd_segments(
-                            index, Segment(left, right, current_parent),
+                            index, Segment(left, right, current_parent)
                         )
                     seg1 = seg1.next
                 seg0 = seg0.next

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -1902,7 +1902,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
     def test_known_svg_ts(self):
         ts = self.get_simple_ts()
         svg = ts.draw_svg(
-            root_svg_attributes={"id": "XYZ"}, style=".edge {stroke: blue}",
+            root_svg_attributes={"id": "XYZ"}, style=".edge {stroke: blue}"
         )
         # Prettify the SVG code for easy inspection
         svg = xml.dom.minidom.parseString(svg).toprettyxml()

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1524,7 +1524,7 @@ class TestTreeSequenceMetadata(unittest.TestCase):
             # Check via tree-sequence API
             new_ts = tskit.TreeSequence.load_tables(tables)
             self.assertEqual(
-                str(getattr(new_ts.table_metadata_schemas, table)), str(schema),
+                str(getattr(new_ts.table_metadata_schemas, table)), str(schema)
             )
             for other_table in self.metadata_tables:
                 if other_table != table:
@@ -2078,7 +2078,7 @@ class TestTree(HighLevelTestCase):
         5       0.00000000      1.00000000      6       5
         """
         )
-        ts = tskit.load_text(nodes, edges, sequence_length=1, strict=False,)
+        ts = tskit.load_text(nodes, edges, sequence_length=1, strict=False)
         tree = ts.first()
         for precision in range(17):
             newick_c = tree.newick(precision=precision)

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -156,8 +156,8 @@ def subtrees_are_equal(tree1, pdict0, root):
     if root not in pdict0.values() or root not in pdict1.values():
         return False
     leaves1 = set(tree1.leaves(root))
-    for l in leaves1:
-        node = l
+    for leaf in leaves1:
+        node = leaf
         while node != root:
             p1 = pdict1[node]
             if p1 not in pdict0.values():
@@ -294,7 +294,7 @@ class TestIbdSingleBinaryTree(unittest.TestCase):
 
     # Basic test
     def test_defaults(self):
-        ibd_segs = find_ibd(self.ts, sample_pairs=[(0, 1), (0, 2), (1, 2)],)
+        ibd_segs = find_ibd(self.ts, sample_pairs=[(0, 1), (0, 2), (1, 2)])
         true_segs = {
             (0, 1): [ibd.Segment(0.0, 1.0, 3)],
             (0, 2): [ibd.Segment(0.0, 1.0, 4)],
@@ -315,7 +315,7 @@ class TestIbdSingleBinaryTree(unittest.TestCase):
     # Min length = 2
     def test_length(self):
         ibd_segs = find_ibd(
-            self.ts, sample_pairs=[(0, 1), (0, 2), (1, 2)], min_length=2,
+            self.ts, sample_pairs=[(0, 1), (0, 2), (1, 2)], min_length=2
         )
         true_segs = {(0, 1): [], (0, 2): [], (1, 2): []}
         assert ibd_is_equal(ibd_segs, true_segs)
@@ -484,7 +484,7 @@ class TestIbdSamplesAreDescendants(unittest.TestCase):
 
     def test_basic(self):
         ibd_segs = find_ibd(
-            self.ts, sample_pairs=[(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            self.ts, sample_pairs=[(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
         )
         true_segs = {
             (0, 1): [],
@@ -675,7 +675,7 @@ class TestIbdPolytomies(unittest.TestCase):
 
     def test_defaults(self):
         ibd_segs = find_ibd(
-            self.ts, sample_pairs=[(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            self.ts, sample_pairs=[(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
         )
         true_segs = {
             (0, 1): [ibd.Segment(0, 1, 4)],

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -837,9 +837,7 @@ class TestStructCodec(unittest.TestCase):
             metadata.StructCodec.make_array_decode(schema)(5)
 
     def test_make_object_encode_and_decode(self):
-        self.encode_decode(
-            "make_object", {"type": "object", "properties": {}}, {}, b"",
-        )
+        self.encode_decode("make_object", {"type": "object", "properties": {}}, {}, b"")
         self.encode_decode(
             "make_object",
             {
@@ -968,7 +966,7 @@ class TestStructCodec(unittest.TestCase):
             b"a\xb2)B",
         )
         self.encode_decode(
-            "make_numeric", {"type": "integer", "binaryFormat": "b"}, 42, b"*",
+            "make_numeric", {"type": "integer", "binaryFormat": "b"}, 42, b"*"
         )
 
     def test_null_union_top_level(self):
@@ -1224,12 +1222,8 @@ class TestStructCodecRoundTrip(unittest.TestCase):
             },
         }
         self.round_trip(schema, {"array": []})
-        self.round_trip(
-            schema, {"array": [1]},
-        )
-        self.round_trip(
-            schema, {"array": list(range(255))},
-        )
+        self.round_trip(schema, {"array": [1]})
+        self.round_trip(schema, {"array": list(range(255))})
 
     def test_string_encoding(self):
         schema = {
@@ -1381,7 +1375,7 @@ class TestStructCodecErrors(unittest.TestCase):
             "properties": {"array": {"type": "array", "arrayLengthFormat": "b"}},
         }
         with self.assertRaisesRegex(
-            exceptions.MetadataSchemaValidationError, "does not match",
+            exceptions.MetadataSchemaValidationError, "does not match"
         ):
             metadata.MetadataSchema(schema)
 
@@ -1410,7 +1404,7 @@ class TestStructCodecErrors(unittest.TestCase):
             },
         }
         with self.assertRaisesRegex(
-            exceptions.MetadataSchemaValidationError, "is not of type",
+            exceptions.MetadataSchemaValidationError, "is not of type"
         ):
             metadata.MetadataSchema(schema)
 
@@ -1427,7 +1421,7 @@ class TestStructCodecErrors(unittest.TestCase):
             },
         }
         with self.assertRaisesRegex(
-            exceptions.MetadataSchemaValidationError, "is not of type",
+            exceptions.MetadataSchemaValidationError, "is not of type"
         ):
             metadata.MetadataSchema(schema)
 
@@ -1444,7 +1438,7 @@ class TestStructCodecErrors(unittest.TestCase):
             },
         }
         with self.assertRaisesRegex(
-            exceptions.MetadataSchemaValidationError, "is not of type",
+            exceptions.MetadataSchemaValidationError, "is not of type"
         ):
             metadata.MetadataSchema(schema)
 
@@ -1774,9 +1768,9 @@ class TestTableCollectionEquality(unittest.TestCase):
         # Set with low-level to emulate loading.
         tables._ll_tables.metadata_schema = json.dumps(schema)
         self.assertNotEqual(
-            tables._ll_tables.metadata_schema, tskit.canonical_json(schema),
+            tables._ll_tables.metadata_schema, tskit.canonical_json(schema)
         )
         tables.metadata_schema = tables.metadata_schema
         self.assertEqual(
-            tables._ll_tables.metadata_schema, tskit.canonical_json(schema),
+            tables._ll_tables.metadata_schema, tskit.canonical_json(schema)
         )

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -2688,7 +2688,7 @@ class TestDeduplicateSites(unittest.TestCase):
             tables.sites.add_row(position=site.position, ancestral_state="0")
             for mutation in site.mutations:
                 tables.mutations.add_row(
-                    site=site_id, node=mutation.node, derived_state="T" * site.id,
+                    site=site_id, node=mutation.node, derived_state="T" * site.id
                 )
         tables.deduplicate_sites()
         new_ts = tables.tree_sequence()

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -203,7 +203,7 @@ def fill_kc_vectors(tree, kc_vecs):
                 c2 = tree.right_sib(c1)
                 while c2 != tskit.NULL:
                     update_kc_vectors_all_pairs(
-                        tree, kc_vecs, c1, c2, depth, tree.time(root) - tree.time(u),
+                        tree, kc_vecs, c1, c2, depth, tree.time(root) - tree.time(u)
                     )
                     c2 = tree.right_sib(c2)
                 c1 = tree.right_sib(c1)
@@ -512,9 +512,9 @@ class TestKCMetric(unittest.TestCase):
         pv = [3, 3, 4, 4]
         cv = [0, 1, 2, 3]
 
-        for l, r, p, c in zip(lv, rv, pv, cv):
-            tables_1.edges.add_row(left=l, right=r, parent=p, child=c)
-            tables_2.edges.add_row(left=l, right=r, parent=p, child=c)
+        for left, right, p, c in zip(lv, rv, pv, cv):
+            tables_1.edges.add_row(left=left, right=right, parent=p, child=c)
+            tables_2.edges.add_row(left=left, right=right, parent=p, child=c)
 
         tree_1 = next(tables_1.tree_sequence().trees(sample_lists=True))
         tree_2 = next(tables_2.tree_sequence().trees(sample_lists=True))
@@ -1239,13 +1239,13 @@ class TestKCSequenceMetric(unittest.TestCase):
         rv = [1.0, 1.0, 1.0, 1.0]
         pv1 = [3, 3, 4, 4]
         cv1 = [0, 1, 2, 3]
-        for l, r, p, c in zip(lv, rv, pv1, cv1):
-            tables_1.edges.add_row(left=l, right=r, parent=p, child=c)
+        for left, right, p, c in zip(lv, rv, pv1, cv1):
+            tables_1.edges.add_row(left=left, right=right, parent=p, child=c)
 
         pv2 = [2, 2, 3, 3]
         cv2 = [0, 1, 2, 4]
-        for l, r, p, c in zip(lv, rv, pv2, cv2):
-            tables_2.edges.add_row(left=l, right=r, parent=p, child=c)
+        for left, right, p, c in zip(lv, rv, pv2, cv2):
+            tables_2.edges.add_row(left=left, right=right, parent=p, child=c)
 
         ts1 = tables_1.tree_sequence()
         ts2 = tables_2.tree_sequence()
@@ -1269,8 +1269,8 @@ class TestKCSequenceMetric(unittest.TestCase):
         rv = [1.0, 1.0, 1.0]
         pv = [1, 2]
         cv = [0, 1]
-        for l, r, p, c in zip(lv, rv, pv, cv):
-            tables.edges.add_row(left=l, right=r, parent=p, child=c)
+        for left, right, p, c in zip(lv, rv, pv, cv):
+            tables.edges.add_row(left=left, right=right, parent=p, child=c)
 
         ts = tables.tree_sequence()
         self.verify_errors(ts, ts)
@@ -1399,10 +1399,10 @@ class TestKCSequenceMetric(unittest.TestCase):
         lv2 = [0, 0, 0, 0, 0, 0, 1, 1]
         rv2 = [2, 2, 1, 2, 1, 2, 2, 2]
 
-        for l, r, p, c in zip(lv1, rv1, pv1, cv1):
-            tables_1.edges.add_row(left=l, right=r, parent=p, child=c)
-        for l, r, p, c in zip(lv2, rv2, pv2, cv2):
-            tables_2.edges.add_row(left=l, right=r, parent=p, child=c)
+        for left, right, p, c in zip(lv1, rv1, pv1, cv1):
+            tables_1.edges.add_row(left=left, right=right, parent=p, child=c)
+        for left, right, p, c in zip(lv2, rv2, pv2, cv2):
+            tables_2.edges.add_row(left=left, right=right, parent=p, child=c)
 
         tables_1.sort()
         tables_2.sort()
@@ -1430,9 +1430,9 @@ class TestKCSequenceMetric(unittest.TestCase):
         pv = [3, 3, 4, 4]
         cv = [0, 1, 2, 3]
 
-        for l, r, p, c in zip(lv, rv, pv, cv):
-            tables_1.edges.add_row(left=l, right=r, parent=p, child=c)
-            tables_2.edges.add_row(left=l, right=r, parent=p, child=c)
+        for left, right, p, c in zip(lv, rv, pv, cv):
+            tables_1.edges.add_row(left=left, right=right, parent=p, child=c)
+            tables_2.edges.add_row(left=left, right=right, parent=p, child=c)
 
         ts_1 = tables_1.tree_sequence()
         ts_2 = tables_2.tree_sequence()
@@ -6368,7 +6368,7 @@ class TestMutationTime(unittest.TestCase):
         """
         )
         ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False,
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
         # ts.dump_text(mutations=sys.stdout)
         # self.assertFalse(True)

--- a/python/tskit/cli.py
+++ b/python/tskit/cli.py
@@ -162,7 +162,7 @@ def get_tskit_parser():
         prog="python3 -m tskit", description="Command line interface for tskit."
     )
     top_parser.add_argument(
-        "-V", "--version", action="version", version=f"%(prog)s {tskit.__version__}",
+        "-V", "--version", action="version", version=f"%(prog)s {tskit.__version__}"
     )
     subparsers = top_parser.add_subparsers(dest="subcommand")
     subparsers.required = True

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -643,7 +643,7 @@ class RankTree:
         return self.labels[0]
 
     def labelled(self):
-        return all(l is not None for l in self.labels)
+        return all(label is not None for label in self.labels)
 
     def min_label(self):
         return self.labels[0]

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -158,7 +158,7 @@ def binary_format_validator(validator, types, instance, schema):
         and instance["binaryFormat"][-1] != "x"
     ):
         yield jsonschema.ValidationError(
-            f'null type binaryFormat must be padding ("x") if set'
+            'null type binaryFormat must be padding ("x") if set'
         )
 
 

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -357,7 +357,7 @@ class MetadataMixin:
     @property
     def metadata_schema(self) -> metadata.MetadataSchema:
         """
-            The :class:`tskit.MetadataSchema` for this table.
+        The :class:`tskit.MetadataSchema` for this table.
         """
         return self._metadata_schema_cache
 
@@ -611,7 +611,7 @@ class NodeTable(BaseTable, MetadataMixin):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     :ivar metadata_schema: The metadata schema for this table's metadata column
     :vartype metadata_schema: tskit.MetadataSchema
-"""
+    """
 
     column_names = [
         "time",
@@ -808,7 +808,7 @@ class EdgeTable(BaseTable, MetadataMixin):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     :ivar metadata_schema: The metadata schema for this table's metadata column
     :vartype metadata_schema: tskit.MetadataSchema
-"""
+    """
 
     column_names = [
         "left",
@@ -923,7 +923,7 @@ class EdgeTable(BaseTable, MetadataMixin):
         )
 
     def append_columns(
-        self, left, right, parent, child, metadata=None, metadata_offset=None,
+        self, left, right, parent, child, metadata=None, metadata_offset=None
     ):
         """
         Appends the specified arrays to the end of the columns of this
@@ -1016,7 +1016,7 @@ class MigrationTable(BaseTable, MetadataMixin):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     :ivar metadata_schema: The metadata schema for this table's metadata column
     :vartype metadata_schema: tskit.MetadataSchema
-"""
+    """
 
     column_names = [
         "left",
@@ -1232,7 +1232,7 @@ class SiteTable(BaseTable, MetadataMixin):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     :ivar metadata_schema: The metadata schema for this table's metadata column
     :vartype metadata_schema: tskit.MetadataSchema
-"""
+    """
 
     column_names = [
         "position",
@@ -1449,7 +1449,7 @@ class MutationTable(BaseTable, MetadataMixin):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     :ivar metadata_schema: The metadata schema for this table's metadata column
     :vartype metadata_schema: tskit.MetadataSchema
-"""
+    """
 
     column_names = [
         "site",
@@ -1498,9 +1498,7 @@ class MutationTable(BaseTable, MetadataMixin):
                 )
         return headers, rows
 
-    def add_row(
-        self, site, node, derived_state, parent=-1, metadata=None, time=None,
-    ):
+    def add_row(self, site, node, derived_state, parent=-1, metadata=None, time=None):
         """
         Adds a new row to this :class:`MutationTable` and returns the ID of the
         corresponding mutation. Metadata, if specified, will be validated and encoded
@@ -1699,7 +1697,7 @@ class PopulationTable(BaseTable, MetadataMixin):
     :vartype metadata_offset: numpy.ndarray, dtype=np.uint32
     :ivar metadata_schema: The metadata schema for this table's metadata column
     :vartype metadata_schema: tskit.MetadataSchema
-"""
+    """
 
     column_names = ["metadata", "metadata_offset"]
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -85,8 +85,8 @@ class SimpleContainerWithMetadata(SimpleContainer):
 
     class CachedMetadata:
         """
-            If we had python>=3.8 we could just use @functools.cached_property here. We
-            don't so we implement it similarly using a descriptor
+        If we had python>=3.8 we could just use @functools.cached_property here. We
+        don't so we implement it similarly using a descriptor
         """
 
         def __get__(self, container: "SimpleContainerWithMetadata", owner: type):
@@ -484,7 +484,7 @@ class Population(SimpleContainerWithMetadata):
     """
 
     def __init__(
-        self, id_, encoded_metadata=b"", metadata_decoder=lambda metadata: metadata,
+        self, id_, encoded_metadata=b"", metadata_decoder=lambda metadata: metadata
     ):
         self.id = id_
         self._encoded_metadata = encoded_metadata

--- a/python/tskit/vcf.py
+++ b/python/tskit/vcf.py
@@ -134,7 +134,7 @@ class VcfWriter:
         print(f"##source=tskit {provenance.__version__}", file=output)
         print('##FILTER=<ID=PASS,Description="All filters passed">', file=output)
         print(
-            f"##contig=<ID={self.contig_id},length={self.contig_length}>", file=output,
+            f"##contig=<ID={self.contig_id},length={self.contig_length}>", file=output
         )
         print(
             '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">', file=output


### PR DESCRIPTION
Whilst looking at #820 I updated our pre-commit dependencies. 

- Black now formats docstrings :+1: and behaviour round trailing commas has been improved.  
- flake8 has new errors about visually ambiguous variable names. It wasn't a lot of changes so changed the code instead of disabling the error.