### PR TITLE
Add tsk_bug_assert for production code assertions

### DIFF
--- a/c/dev-tools/dev-cli.c
+++ b/c/dev-tools/dev-cli.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <float.h>

--- a/c/tskit/convert.c
+++ b/c/tskit/convert.c
@@ -25,7 +25,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <math.h>

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <assert.h>
 #include <math.h>
 
 #include <kastore.h>

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -337,6 +337,30 @@ not be freed by client code.
 */
 const char *tsk_strerror(int err);
 
+#ifndef TSK_BUG_ASSERT_MESSAGE
+#define TSK_BUG_ASSERT_MESSAGE                                                          \
+    "If you are using tskit directly please open an issue on"                           \
+    " GitHub, ideally with a reproducible example."                                     \
+    " (https://github.com/tskit-dev/tskit/issues) If you are"                           \
+    " using software that uses tskit, please report an issue"                           \
+    " to that software's issue tracker, at least initially."
+#endif
+
+/**
+We often wish to assert a condition that is unexpected, but using the normal `assert`
+means compiling without NDEBUG. This macro still asserts when NDEBUG is defined.
+If you are using this macro in your own software then please set TSK_BUG_ASSERT_MESSAGE
+to point users to your issue tracker.
+*/
+#define tsk_bug_assert(condition)                                                       \
+    do {                                                                                \
+        if (!(condition)) {                                                             \
+            fprintf(stderr, "Bug detected in %s at line %d. %s\n", __FILE__, __LINE__,  \
+                TSK_BUG_ASSERT_MESSAGE);                                                \
+            abort();                                                                    \
+        }                                                                               \
+    } while (0)
+
 void __tsk_safe_free(void **ptr);
 #define tsk_safe_free(pointer) __tsk_safe_free((void **) &(pointer))
 

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -25,7 +25,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -115,7 +114,7 @@ tsk_vargen_init(tsk_vargen_t *self, tsk_treeseq_t *tree_sequence, tsk_id_t *samp
     tsk_size_t max_alleles;
     tsk_id_t u;
 
-    assert(tree_sequence != NULL);
+    tsk_bug_assert(tree_sequence != NULL);
     memset(self, 0, sizeof(tsk_vargen_t));
 
     if (samples == NULL) {
@@ -299,7 +298,7 @@ tsk_vargen_update_genotypes_i8_sample_list(
     tsk_id_t index, stop;
     int ret = 0;
 
-    assert(derived < INT8_MAX);
+    tsk_bug_assert(derived < INT8_MAX);
 
     index = list_left[node];
     if (index != TSK_NULL) {
@@ -332,7 +331,7 @@ tsk_vargen_update_genotypes_i16_sample_list(
     tsk_id_t index, stop;
     int ret = 0;
 
-    assert(derived < INT16_MAX);
+    tsk_bug_assert(derived < INT16_MAX);
 
     index = list_left[node];
     if (index != TSK_NULL) {
@@ -404,8 +403,8 @@ tsk_vargen_visit_i8(tsk_vargen_t *self, tsk_id_t sample_index, tsk_id_t derived)
     int ret = 0;
     int8_t *restrict genotypes = self->variant.genotypes.i8;
 
-    assert(derived < INT8_MAX);
-    assert(sample_index != -1);
+    tsk_bug_assert(derived < INT8_MAX);
+    tsk_bug_assert(sample_index != -1);
     if (genotypes[sample_index] == (int8_t) derived) {
         ret = TSK_ERR_INCONSISTENT_MUTATIONS;
         goto out;
@@ -422,8 +421,8 @@ tsk_vargen_visit_i16(tsk_vargen_t *self, tsk_id_t sample_index, tsk_id_t derived
     int ret = 0;
     int16_t *restrict genotypes = self->variant.genotypes.i16;
 
-    assert(derived < INT16_MAX);
-    assert(sample_index != -1);
+    tsk_bug_assert(derived < INT16_MAX);
+    tsk_bug_assert(sample_index != -1);
     if (genotypes[sample_index] == (int16_t) derived) {
         ret = TSK_ERR_INCONSISTENT_MUTATIONS;
         goto out;

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <math.h>
 #include <float.h>
 
@@ -64,17 +63,17 @@ tsk_ls_hmm_check_state(tsk_ls_hmm_t *self)
 
     for (j = 0; j < (tsk_id_t) self->num_transitions; j++) {
         if (T[j].tree_node != TSK_NULL) {
-            assert(T_index[T[j].tree_node] == j);
+            tsk_bug_assert(T_index[T[j].tree_node] == j);
         }
     }
-    /* assert(self->num_transitions <= self->num_samples); */
+    /* tsk_bug_assert(self->num_transitions <= self->num_samples); */
 
     if (self->num_transitions > 0) {
         for (j = 0; j < (tsk_id_t) self->num_nodes; j++) {
             if (T_index[j] != TSK_NULL) {
-                assert(T[T_index[j]].tree_node == j);
+                tsk_bug_assert(T[T_index[j]].tree_node == j);
             }
-            assert(self->tree.parent[j] == self->parent[j]);
+            tsk_bug_assert(self->tree.parent[j] == self->parent[j]);
         }
     }
 }
@@ -315,9 +314,9 @@ tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
             /* Ensure the subtree we're detaching has a transition at the root */
             while (T_index[u] == TSK_NULL) {
                 u = parent[u];
-                assert(u != TSK_NULL);
+                tsk_bug_assert(u != TSK_NULL);
             }
-            assert(self->num_transitions < self->max_transitions);
+            tsk_bug_assert(self->num_transitions < self->max_transitions);
             T_index[record->edge.child] = (tsk_id_t) self->num_transitions;
             T[self->num_transitions].tree_node = record->edge.child;
             T[self->num_transitions].value = T[T_index[u]].value;
@@ -334,7 +333,7 @@ tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
             /* Grafting onto a new root. */
             if (T_index[record->edge.parent] == TSK_NULL) {
                 T_index[edge.parent] = (tsk_id_t) self->num_transitions;
-                assert(self->num_transitions < self->max_transitions);
+                tsk_bug_assert(self->num_transitions < self->max_transitions);
                 T[self->num_transitions].tree_node = edge.parent;
                 T[self->num_transitions].value = T[T_index[edge.child]].value;
                 self->num_transitions++;
@@ -344,9 +343,9 @@ tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
             while (T_index[u] == TSK_NULL) {
                 u = parent[u];
             }
-            assert(u != TSK_NULL);
+            tsk_bug_assert(u != TSK_NULL);
         }
-        assert(T_index[u] != -1 && T_index[edge.child] != -1);
+        tsk_bug_assert(T_index[u] != -1 && T_index[edge.child] != -1);
         if (T[T_index[u]].value == T[T_index[edge.child]].value) {
             vt = &T[T_index[edge.child]];
             /* Mark the value transition as unusued */
@@ -422,7 +421,7 @@ tsk_ls_hmm_update_probabilities(
             while (T_index[u] == TSK_NULL) {
                 u = parent[u];
             }
-            assert(self->num_transitions < self->max_transitions);
+            tsk_bug_assert(self->num_transitions < self->max_transitions);
             T_index[mut.node] = (tsk_id_t) self->num_transitions;
             T[self->num_transitions].tree_node = mut.node;
             T[self->num_transitions].value = T[T_index[u]].value;
@@ -437,7 +436,7 @@ tsk_ls_hmm_update_probabilities(
             v = u;
             while (allelic_state[v] == TSK_MISSING_DATA) {
                 v = parent[v];
-                assert(v != -1);
+                tsk_bug_assert(v != -1);
             }
             match = haplotype_state == TSK_MISSING_DATA
                     || haplotype_state == allelic_state[v];
@@ -477,7 +476,7 @@ tsk_ls_hmm_discretise_values(tsk_ls_hmm_t *self)
             num_values++;
         }
     }
-    assert(num_values > 0);
+    tsk_bug_assert(num_values > 0);
 
     qsort(values, num_values, sizeof(double), cmp_double);
 
@@ -494,7 +493,7 @@ tsk_ls_hmm_discretise_values(tsk_ls_hmm_t *self)
         if (T[j].tree_node != TSK_NULL) {
             T[j].value_index
                 = (tsk_id_t) tsk_search_sorted(values, num_values, T[j].value);
-            assert(T[j].value == self->values[T[j].value_index]);
+            tsk_bug_assert(T[j].value == self->values[T[j].value_index]);
         }
     }
     return ret;
@@ -516,7 +515,7 @@ get_smallest_set_bit(uint64_t v)
      */
     uint64_t t = 1;
     tsk_id_t r = 0;
-    assert(v != 0);
+    tsk_bug_assert(v != 0);
 
     while ((v & t) == 0) {
         t <<= 1;
@@ -534,7 +533,7 @@ get_smallest_element(const uint64_t *restrict A, size_t u, size_t num_words)
 
     while (a[j] == 0) {
         j++;
-        assert(j < (tsk_id_t) num_words);
+        tsk_bug_assert(j < (tsk_id_t) num_words);
     }
     return j * 64 + get_smallest_set_bit(a[j]);
 }
@@ -563,7 +562,7 @@ static inline void
 set_fitch(uint64_t *restrict A, const tsk_id_t u, const size_t num_words, tsk_id_t state)
 {
     size_t index = ((size_t) u) * num_words + (size_t)(state / 64);
-    assert(((size_t) state) / 64 < num_words);
+    tsk_bug_assert(((size_t) state) / 64 < num_words);
     A[index] |= 1ULL << (state % 64);
 }
 
@@ -641,7 +640,7 @@ compute_fitch_general(uint64_t *restrict A, const tsk_id_t *restrict left_child,
     const uint64_t state_word = 1ULL << (parent_state % 64);
     int j;
 
-    assert(num_words <= MAX_FITCH_WORDS);
+    tsk_bug_assert(num_words <= MAX_FITCH_WORDS);
 
     memset(a_union, 0, num_words * sizeof(*a_union));
     memset(a_inter, 0xff, num_words * sizeof(*a_inter));
@@ -761,7 +760,7 @@ tsk_ls_hmm_build_fitch_sets(tsk_ls_hmm_t *self)
             if (v != TSK_NULL) {
                 while (T_index[v] == TSK_NULL) {
                     v = parent[v];
-                    assert(v != TSK_NULL);
+                    tsk_bug_assert(v != TSK_NULL);
                 }
                 parent_state = T[T_index[v]].value_index;
                 v = parent[u];
@@ -769,7 +768,7 @@ tsk_ls_hmm_build_fitch_sets(tsk_ls_hmm_t *self)
                     compute_fitch(
                         A, left_child, right_sib, v, parent_state, num_fitch_words);
                     v = parent[v];
-                    assert(v != TSK_NULL);
+                    tsk_bug_assert(v != TSK_NULL);
                 }
             }
         }
@@ -803,12 +802,12 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
     for (root = self->tree.left_root; root != TSK_NULL; root = right_sib[root]) {
         stack[0].tree_node = root;
         stack[0].old_state = T_old[T_index[root]].value_index;
-        /* assert(self->num_fitch_words == 1); */
+        /* tsk_bug_assert(self->num_fitch_words == 1); */
         stack[0].new_state = get_smallest_element(A, (size_t) root, num_fitch_words);
         stack[0].transition_parent = 0;
         stack_top = 0;
 
-        assert(self->num_transitions < self->max_transitions);
+        tsk_bug_assert(self->num_transitions < self->max_transitions);
         T_parent[self->num_transitions] = TSK_NULL;
         T[self->num_transitions].tree_node = stack[0].tree_node;
         T[self->num_transitions].value_index = stack[0].new_state;
@@ -829,7 +828,7 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
                             = get_smallest_element(A, (size_t) v, num_fitch_words);
                         child_s.transition_parent = (tsk_id_t) self->num_transitions;
                         /* Add a new transition */
-                        assert(self->num_transitions < self->max_transitions);
+                        tsk_bug_assert(self->num_transitions < self->max_transitions);
                         T_parent[self->num_transitions] = s.transition_parent;
                         T[self->num_transitions].tree_node = v;
                         T[self->num_transitions].value_index = child_s.new_state;
@@ -840,7 +839,7 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
                 } else {
                     /* Node that we didn't visit when moving up the tree */
                     if (s.old_state != s.new_state) {
-                        assert(self->num_transitions < self->max_transitions);
+                        tsk_bug_assert(self->num_transitions < self->max_transitions);
                         T_parent[self->num_transitions] = s.transition_parent;
                         T[self->num_transitions].tree_node = v;
                         T[self->num_transitions].value_index = s.old_state;
@@ -916,7 +915,7 @@ tsk_ls_hmm_process_site(tsk_ls_hmm_t *self, tsk_site_t *site, int8_t haplotype_s
     if (ret != 0) {
         goto out;
     }
-    assert(self->num_transitions <= self->num_samples);
+    tsk_bug_assert(self->num_transitions <= self->num_samples);
     normalisation_factor = self->compute_normalisation_factor(self);
 
     if (normalisation_factor == 0) {
@@ -924,7 +923,7 @@ tsk_ls_hmm_process_site(tsk_ls_hmm_t *self, tsk_site_t *site, int8_t haplotype_s
         goto out;
     }
     for (j = 0; j < self->num_transitions; j++) {
-        assert(T[j].tree_node != TSK_NULL);
+        tsk_bug_assert(T[j].tree_node != TSK_NULL);
         x = T[j].value / normalisation_factor;
         T[j].value = tsk_round(x, precision);
     }
@@ -999,7 +998,7 @@ tsk_ls_hmm_compute_normalisation_factor_forward(tsk_ls_hmm_t *self)
 
     /* Compute the number of samples directly inheriting from each transition */
     for (j = 0; j < num_transitions; j++) {
-        assert(T[j].tree_node != TSK_NULL);
+        tsk_bug_assert(T[j].tree_node != TSK_NULL);
         N[j] = num_samples[T[j].tree_node];
     }
     for (j = 0; j < num_transitions; j++) {
@@ -1079,9 +1078,9 @@ tsk_ls_hmm_compute_normalisation_factor_viterbi(tsk_ls_hmm_t *self)
 
     max_vt.value = -1;
     max_vt.tree_node = 0; /* keep compiler happy */
-    assert(num_transitions > 0);
+    tsk_bug_assert(num_transitions > 0);
     for (j = 0; j < num_transitions; j++) {
-        assert(T[j].tree_node != TSK_NULL);
+        tsk_bug_assert(T[j].tree_node != TSK_NULL);
         if (T[j].value > max_vt.value) {
             max_vt = T[j];
         }
@@ -1481,7 +1480,7 @@ tsk_viterbi_matrix_choose_sample(
             max_value = transition_values[j];
         }
     }
-    assert(u != TSK_NULL);
+    tsk_bug_assert(u != TSK_NULL);
 
     while (!(node_flags[u] & TSK_NODE_IS_SAMPLE)) {
         found = false;
@@ -1499,7 +1498,7 @@ tsk_viterbi_matrix_choose_sample(
             }
         }
         /* TODO: should remove this once we're sure this is robust */
-        assert(found);
+        tsk_bug_assert(found);
     }
     ret = u;
 out:
@@ -1551,8 +1550,8 @@ tsk_viterbi_matrix_traceback(
                 goto out;
             }
         }
-        assert(tree.left <= site.position);
-        assert(site.position < tree.right);
+        tsk_bug_assert(tree.left <= site.position);
+        tsk_bug_assert(site.position < tree.right);
 
         /* Fill in the recombination tree */
         rr_record_tmp = rr_record;
@@ -1574,7 +1573,7 @@ tsk_viterbi_matrix_traceback(
         while (u != TSK_NULL && recombination_tree[u] == TSK_NULL) {
             u = tree.parent[u];
         }
-        assert(u != TSK_NULL);
+        tsk_bug_assert(u != TSK_NULL);
         if (recombination_tree[u] == 1) {
             /* Switch at the next site */
             current_node = TSK_NULL;

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <math.h>
 
 #include <tskit/stats.h>
@@ -39,15 +38,12 @@ tsk_ld_calc_check_state(tsk_ld_calc_t *self)
     tsk_tree_t *tA = self->outer_tree;
     tsk_tree_t *tB = self->inner_tree;
 
-    /* Suppress unused variable warnings when assert() is a no-op */
-    (void) (tA);
-    (void) (tB);
-    assert(tA->index == tB->index);
+    tsk_bug_assert(tA->index == tB->index);
 
     /* The inner tree's mark values should all be zero. */
     for (u = 0; u < num_nodes; u++) {
-        assert(tA->marked[u] == 0);
-        assert(tB->marked[u] == 0);
+        tsk_bug_assert(tA->marked[u] == 0);
+        tsk_bug_assert(tB->marked[u] == 0);
     }
 }
 
@@ -130,34 +126,34 @@ tsk_ld_calc_position_trees(tsk_ld_calc_t *self, tsk_id_t site_index)
         goto out;
     }
     x = mut.position;
-    assert(tA->index == tB->index);
+    tsk_bug_assert(tA->index == tB->index);
     while (x >= tA->right) {
         ret = tsk_tree_next(tA);
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
         ret = tsk_tree_next(tB);
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
     }
     while (x < tA->left) {
         ret = tsk_tree_prev(tA);
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
         ret = tsk_tree_prev(tB);
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
     }
     ret = 0;
-    assert(x >= tA->left && x < tB->right);
-    assert(tA->index == tB->index);
+    tsk_bug_assert(x >= tA->left && x < tB->right);
+    tsk_bug_assert(tA->index == tB->index);
 out:
     return ret;
 }
@@ -169,8 +165,8 @@ tsk_ld_calc_overlap_within_tree(tsk_ld_calc_t *self, tsk_site_t sA, tsk_site_t s
     const tsk_node_table_t *nodes = &self->tree_sequence->tables->nodes;
     tsk_id_t u, v, nAB;
 
-    assert(sA.mutations_length == 1);
-    assert(sB.mutations_length == 1);
+    tsk_bug_assert(sA.mutations_length == 1);
+    tsk_bug_assert(sB.mutations_length == 1);
     u = sA.mutations[0].node;
     v = sB.mutations[0].node;
     if (nodes->time[u] > nodes->time[v]) {
@@ -193,7 +189,7 @@ tsk_ld_calc_set_tracked_samples(tsk_ld_calc_t *self, tsk_site_t sA)
 {
     int ret = 0;
 
-    assert(sA.mutations_length == 1);
+    tsk_bug_assert(sA.mutations_length == 1);
     ret = tsk_tree_set_tracked_samples_from_sample_list(
         self->inner_tree, self->outer_tree, sA.mutations[0].node);
     return ret;
@@ -223,7 +219,7 @@ tsk_ld_calc_get_r2_array_forward(tsk_ld_calc_t *self, tsk_id_t source_index,
         goto out;
     }
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
-    assert(fA > 0);
+    tsk_bug_assert(fA > 0);
     tB->mark = 1;
     for (j = 0; j < (tsk_id_t) max_sites; j++) {
         if (source_index + j + 1 >= (tsk_id_t) self->num_sites) {
@@ -245,10 +241,10 @@ tsk_ld_calc_get_r2_array_forward(tsk_ld_calc_t *self, tsk_id_t source_index,
             if (ret < 0) {
                 goto out;
             }
-            assert(ret == 1);
+            tsk_bug_assert(ret == 1);
         }
         fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
-        assert(fB > 0);
+        tsk_bug_assert(fB > 0);
         if (sB.position < tA->right) {
             nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
         } else {
@@ -278,7 +274,7 @@ tsk_ld_calc_get_r2_array_forward(tsk_ld_calc_t *self, tsk_id_t source_index,
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
     }
     *num_r2_values = (tsk_size_t) j;
     ret = 0;
@@ -310,7 +306,7 @@ tsk_ld_calc_get_r2_array_reverse(tsk_ld_calc_t *self, tsk_id_t source_index,
         goto out;
     }
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
-    assert(fA > 0);
+    tsk_bug_assert(fA > 0);
     tB->mark = 1;
     for (j = 0; j < (tsk_id_t) max_sites; j++) {
         site_index = source_index - j - 1;
@@ -333,10 +329,10 @@ tsk_ld_calc_get_r2_array_reverse(tsk_ld_calc_t *self, tsk_id_t source_index,
             if (ret < 0) {
                 goto out;
             }
-            assert(ret == 1);
+            tsk_bug_assert(ret == 1);
         }
         fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
-        assert(fB > 0);
+        tsk_bug_assert(fB > 0);
         if (sB.position >= tA->left) {
             nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
         } else {
@@ -366,7 +362,7 @@ tsk_ld_calc_get_r2_array_reverse(tsk_ld_calc_t *self, tsk_id_t source_index,
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
     }
     *num_r2_values = (tsk_size_t) j;
     ret = 0;
@@ -441,10 +437,10 @@ tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2)
         ret = TSK_ERR_ONLY_INFINITE_SITES;
         goto out;
     }
-    assert(sA.mutations_length == 1);
-    /* assert(tA->parent[sA.mutations[0].node] != TSK_NULL); */
+    tsk_bug_assert(sA.mutations_length == 1);
+    /* tsk_bug_assert(tA->parent[sA.mutations[0].node] != TSK_NULL); */
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
-    assert(fA > 0);
+    tsk_bug_assert(fA > 0);
     ret = tsk_ld_calc_set_tracked_samples(self, sA);
     if (ret != 0) {
         goto out;
@@ -455,11 +451,11 @@ tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2)
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
     }
-    /* assert(tB->parent[sB.mutations[0].node] != TSK_NULL); */
+    /* tsk_bug_assert(tB->parent[sB.mutations[0].node] != TSK_NULL); */
     fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
-    assert(fB > 0);
+    tsk_bug_assert(fB > 0);
     nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
     fAB = nAB / n;
     D = fAB - fA * fB;
@@ -471,7 +467,7 @@ tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2)
         if (ret < 0) {
             goto out;
         }
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
     }
     ret = 0;
 out:

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
-#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <float.h>
@@ -490,9 +489,9 @@ tsk_individual_table_add_row_internal(tsk_individual_table_t *self, tsk_flags_t 
     double *location, tsk_size_t location_length, const char *metadata,
     tsk_size_t metadata_length)
 {
-    assert(self->num_rows < self->max_rows);
-    assert(self->metadata_length + metadata_length <= self->max_metadata_length);
-    assert(self->location_length + location_length <= self->max_location_length);
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    tsk_bug_assert(self->location_length + location_length <= self->max_location_length);
     self->flags[self->num_rows] = flags;
     memcpy(self->location + self->location_length, location,
         location_length * sizeof(double));
@@ -1012,8 +1011,8 @@ tsk_node_table_add_row_internal(tsk_node_table_t *self, tsk_flags_t flags, doubl
     tsk_id_t population, tsk_id_t individual, const char *metadata,
     tsk_size_t metadata_length)
 {
-    assert(self->num_rows < self->max_rows);
-    assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
     memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
     self->flags[self->num_rows] = flags;
     self->time[self->num_rows] = time;
@@ -1106,8 +1105,8 @@ tsk_node_table_print_state(tsk_node_table_t *self, FILE *out)
         }
         fprintf(out, "\n");
     }
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_offset[self->num_rows] == self->metadata_length);
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == self->metadata_length);
 }
 
 int
@@ -1416,7 +1415,7 @@ tsk_edge_table_add_row(tsk_edge_table_t *self, double left, double right,
         goto out;
     }
 
-    assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->num_rows < self->max_rows);
     self->left[self->num_rows] = left;
     self->right[self->num_rows] = right;
     self->parent[self->num_rows] = parent;
@@ -1427,7 +1426,8 @@ tsk_edge_table_add_row(tsk_edge_table_t *self, double left, double right,
         if (ret != 0) {
             goto out;
         }
-        assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+        tsk_bug_assert(
+            self->metadata_length + metadata_length <= self->max_metadata_length);
         memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
         self->metadata_offset[self->num_rows + 1]
             = self->metadata_length + metadata_length;
@@ -1636,7 +1636,7 @@ tsk_edge_table_print_state(tsk_edge_table_t *self, FILE *out)
         (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_edge_table_dump_text(self, out);
-    assert(ret == 0);
+    tsk_bug_assert(ret == 0);
 }
 
 int
@@ -1698,7 +1698,7 @@ tsk_edge_table_equals(tsk_edge_table_t *self, tsk_edge_table_t *other)
             /* The only way that the metadata lengths can be equal (which
              * we've already tests) if either one or the other of the tables
              * hasn't got metadata is if they are both zero. */
-            assert(self->metadata_length == 0);
+            tsk_bug_assert(self->metadata_length == 0);
             metadata_equal = true;
         }
         ret = memcmp(self->left, other->left, self->num_rows * sizeof(double)) == 0
@@ -1835,7 +1835,7 @@ tsk_edge_table_squash(tsk_edge_table_t *self)
         goto out;
     }
     tsk_edge_table_clear(self);
-    assert(num_output_edges <= self->max_rows);
+    tsk_bug_assert(num_output_edges <= self->max_rows);
     self->num_rows = num_output_edges;
     for (k = 0; k < (int) num_output_edges; k++) {
         self->left[k] = edges[k].left;
@@ -2013,7 +2013,8 @@ tsk_site_table_add_row(tsk_site_table_t *self, double position,
     self->position[self->num_rows] = position;
 
     ancestral_state_offset = (tsk_size_t) self->ancestral_state_length;
-    assert(self->ancestral_state_offset[self->num_rows] == ancestral_state_offset);
+    tsk_bug_assert(
+        self->ancestral_state_offset[self->num_rows] == ancestral_state_offset);
     ret = tsk_site_table_expand_ancestral_state(self, ancestral_state_length);
     if (ret != 0) {
         goto out;
@@ -2024,7 +2025,7 @@ tsk_site_table_add_row(tsk_site_table_t *self, double position,
     self->ancestral_state_offset[self->num_rows + 1] = self->ancestral_state_length;
 
     metadata_offset = (tsk_size_t) self->metadata_length;
-    assert(self->metadata_offset[self->num_rows] == metadata_offset);
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == metadata_offset);
     ret = tsk_site_table_expand_metadata(self, metadata_length);
     if (ret != 0) {
         goto out;
@@ -2232,12 +2233,13 @@ tsk_site_table_print_state(tsk_site_table_t *self, FILE *out)
         (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_site_table_dump_text(self, out);
-    assert(ret == 0);
+    tsk_bug_assert(ret == 0);
 
-    assert(self->ancestral_state_offset[0] == 0);
-    assert(self->ancestral_state_length == self->ancestral_state_offset[self->num_rows]);
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_length == self->metadata_offset[self->num_rows]);
+    tsk_bug_assert(self->ancestral_state_offset[0] == 0);
+    tsk_bug_assert(
+        self->ancestral_state_length == self->ancestral_state_offset[self->num_rows]);
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_length == self->metadata_offset[self->num_rows]);
 }
 
 static inline void
@@ -2567,7 +2569,7 @@ tsk_mutation_table_add_row(tsk_mutation_table_t *self, tsk_id_t site, tsk_id_t n
     self->time[self->num_rows] = time;
 
     derived_state_offset = self->derived_state_length;
-    assert(self->derived_state_offset[self->num_rows] == derived_state_offset);
+    tsk_bug_assert(self->derived_state_offset[self->num_rows] == derived_state_offset);
     ret = tsk_mutation_table_expand_derived_state(self, derived_state_length);
     if (ret != 0) {
         goto out;
@@ -2578,7 +2580,7 @@ tsk_mutation_table_add_row(tsk_mutation_table_t *self, tsk_id_t site, tsk_id_t n
     self->derived_state_offset[self->num_rows + 1] = self->derived_state_length;
 
     metadata_offset = self->metadata_length;
-    assert(self->metadata_offset[self->num_rows] == metadata_offset);
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == metadata_offset);
     ret = tsk_mutation_table_expand_metadata(self, metadata_length);
     if (ret != 0) {
         goto out;
@@ -2814,11 +2816,12 @@ tsk_mutation_table_print_state(tsk_mutation_table_t *self, FILE *out)
         (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_mutation_table_dump_text(self, out);
-    assert(ret == 0);
-    assert(self->derived_state_offset[0] == 0);
-    assert(self->derived_state_length == self->derived_state_offset[self->num_rows]);
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_length == self->metadata_offset[self->num_rows]);
+    tsk_bug_assert(ret == 0);
+    tsk_bug_assert(self->derived_state_offset[0] == 0);
+    tsk_bug_assert(
+        self->derived_state_length == self->derived_state_offset[self->num_rows]);
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_length == self->metadata_offset[self->num_rows]);
 }
 
 static inline void
@@ -3218,8 +3221,8 @@ tsk_migration_table_add_row(tsk_migration_table_t *self, double left, double rig
         goto out;
     }
 
-    assert(self->num_rows < self->max_rows);
-    assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
     memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
     self->left[self->num_rows] = left;
     self->right[self->num_rows] = right;
@@ -3286,7 +3289,7 @@ tsk_migration_table_print_state(tsk_migration_table_t *self, FILE *out)
         (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_migration_table_dump_text(self, out);
-    assert(ret == 0);
+    tsk_bug_assert(ret == 0);
 }
 
 static inline void
@@ -3649,8 +3652,8 @@ tsk_population_table_add_row_internal(
 {
     int ret = 0;
 
-    assert(self->num_rows < self->max_rows);
-    assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
     memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
     self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
     self->metadata_length += metadata_length;
@@ -3731,8 +3734,8 @@ tsk_population_table_print_state(tsk_population_table_t *self, FILE *out)
         }
         fprintf(out, "\n");
     }
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_offset[self->num_rows] == self->metadata_length);
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == self->metadata_length);
 }
 
 static inline void
@@ -4118,13 +4121,14 @@ tsk_provenance_table_add_row_internal(tsk_provenance_table_t *self,
 {
     int ret = 0;
 
-    assert(self->num_rows < self->max_rows);
-    assert(self->timestamp_length + timestamp_length <= self->max_timestamp_length);
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(
+        self->timestamp_length + timestamp_length <= self->max_timestamp_length);
     memcpy(self->timestamp + self->timestamp_length, timestamp, timestamp_length);
     self->timestamp_offset[self->num_rows + 1]
         = self->timestamp_length + timestamp_length;
     self->timestamp_length += timestamp_length;
-    assert(self->record_length + record_length <= self->max_record_length);
+    tsk_bug_assert(self->record_length + record_length <= self->max_record_length);
     memcpy(self->record + self->record_length, record, record_length);
     self->record_offset[self->num_rows + 1] = self->record_length + record_length;
     self->record_length += record_length;
@@ -4217,10 +4221,10 @@ tsk_provenance_table_print_state(tsk_provenance_table_t *self, FILE *out)
         }
         fprintf(out, "\n");
     }
-    assert(self->timestamp_offset[0] == 0);
-    assert(self->timestamp_offset[self->num_rows] == self->timestamp_length);
-    assert(self->record_offset[0] == 0);
-    assert(self->record_offset[self->num_rows] == self->record_length);
+    tsk_bug_assert(self->timestamp_offset[0] == 0);
+    tsk_bug_assert(self->timestamp_offset[self->num_rows] == self->timestamp_length);
+    tsk_bug_assert(self->record_offset[0] == 0);
+    tsk_bug_assert(self->record_offset[self->num_rows] == self->record_length);
 }
 
 static inline void
@@ -4848,7 +4852,7 @@ segment_overlapper_next(segment_overlapper_t *self, double *left, double *right,
             self->left = S[self->index].left;
         }
         while (self->index < n && S[self->index].left == self->left) {
-            assert(self->num_overlapping < self->max_overlapping);
+            tsk_bug_assert(self->num_overlapping < self->max_overlapping);
             self->overlapping[self->num_overlapping] = &S[self->index];
             self->num_overlapping++;
             self->index++;
@@ -4858,7 +4862,7 @@ segment_overlapper_next(segment_overlapper_t *self, double *left, double *right,
         for (j = 0; j < self->num_overlapping; j++) {
             self->right = TSK_MIN(self->right, self->overlapping[j]->right);
         }
-        assert(self->left < self->right);
+        tsk_bug_assert(self->left < self->right);
         self->index++;
         ret = 1;
     } else {
@@ -5002,7 +5006,7 @@ ancestor_mapper_record_edge(
 
     tail = self->child_edge_map_tail[child];
     if (tail == NULL) {
-        assert(self->num_buffered_children < self->tables->nodes.num_rows);
+        tsk_bug_assert(self->num_buffered_children < self->tables->nodes.num_rows);
         self->buffered_children[self->num_buffered_children] = child;
         self->num_buffered_children++;
         x = ancestor_mapper_alloc_interval_list(self, left, right);
@@ -5037,7 +5041,7 @@ ancestor_mapper_add_ancestry(ancestor_mapper_t *self, tsk_id_t input_id, double 
     tsk_segment_t *tail = self->ancestor_map_tail[input_id];
     tsk_segment_t *x;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     if (tail == NULL) {
         x = ancestor_mapper_alloc_segment(self, left, right, output_id);
         if (x == NULL) {
@@ -5209,7 +5213,7 @@ ancestor_mapper_enqueue_segment(
     tsk_segment_t *seg;
     void *p;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     /* Make sure we always have room for one more segment in the queue so we
      * can put a tail sentinel on it */
     if (self->segment_queue_size == self->max_segment_queue_size - 1) {
@@ -5244,7 +5248,7 @@ ancestor_mapper_merge_ancestors(ancestor_mapper_t *self, tsk_id_t input_id)
     if (is_sample) {
         /* Free up the existing ancestry mapping. */
         x = self->ancestor_map_tail[input_id];
-        assert(x->left == 0 && x->right == self->sequence_length);
+        tsk_bug_assert(x->left == 0 && x->right == self->sequence_length);
         self->ancestor_map_head[input_id] = NULL;
         self->ancestor_map_tail[input_id] = NULL;
     }
@@ -5258,8 +5262,8 @@ ancestor_mapper_merge_ancestors(ancestor_mapper_t *self, tsk_id_t input_id)
     while ((ret = segment_overlapper_next(
                 &self->segment_overlapper, &left, &right, &X, &num_overlapping))
            == 1) {
-        assert(left < right);
-        assert(num_overlapping > 0);
+        tsk_bug_assert(left < right);
+        tsk_bug_assert(num_overlapping > 0);
         if (is_ancestor || is_sample) {
             for (j = 0; j < num_overlapping; j++) {
                 ret = ancestor_mapper_record_edge(self, left, right, X[j]->node);
@@ -5322,7 +5326,7 @@ ancestor_mapper_process_parent_edges(
     /* Go through the edges and queue up ancestry segments for processing. */
     self->segment_queue_size = 0;
     for (j = start; j < end; j++) {
-        assert(parent == input_edges->parent[j]);
+        tsk_bug_assert(parent == input_edges->parent[j]);
         child = input_edges->child[j];
         left = input_edges->left[j];
         right = input_edges->right[j];
@@ -5412,7 +5416,7 @@ tsk_ibd_finder_add_output(
     tsk_segment_t *tail = self->ibd_segments_tail[pair_num];
     tsk_segment_t *x;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     if (tail == NULL) {
         x = tsk_ibd_finder_alloc_segment(self, left, right, node_id);
         if (x == NULL) {
@@ -5442,7 +5446,7 @@ tsk_ibd_finder_add_ancestry(tsk_ibd_finder_t *self, tsk_id_t input_id, double le
     tsk_segment_t *tail = self->ancestor_map_tail[input_id];
     tsk_segment_t *x = NULL;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     if (tail == NULL) {
         x = tsk_ibd_finder_alloc_segment(self, left, right, output_id);
         if (x == NULL) {
@@ -5580,7 +5584,7 @@ tsk_ibd_finder_enqueue_segment(
     tsk_segment_t *seg;
     void *p;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     /* Make sure we always have room for one more segment in the queue so we
      * can put a tail sentinel on it */
     if (self->segment_queue_size == self->max_segment_queue_size - 1) {
@@ -5863,42 +5867,42 @@ simplifier_check_state(simplifier_t *self)
     size_t num_intervals;
 
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
-        assert((self->ancestor_map_head[j] == NULL)
-               == (self->ancestor_map_tail[j] == NULL));
+        tsk_bug_assert((self->ancestor_map_head[j] == NULL)
+                       == (self->ancestor_map_tail[j] == NULL));
         for (u = self->ancestor_map_head[j]; u != NULL; u = u->next) {
-            assert(u->left < u->right);
+            tsk_bug_assert(u->left < u->right);
             if (u->next != NULL) {
-                assert(u->right <= u->next->left);
+                tsk_bug_assert(u->right <= u->next->left);
                 if (u->right == u->next->left) {
-                    assert(u->node != u->next->node);
+                    tsk_bug_assert(u->node != u->next->node);
                 }
             } else {
-                assert(u == self->ancestor_map_tail[j]);
+                tsk_bug_assert(u == self->ancestor_map_tail[j]);
             }
         }
     }
 
     for (j = 0; j < self->segment_queue_size; j++) {
-        assert(self->segment_queue[j].left < self->segment_queue[j].right);
+        tsk_bug_assert(self->segment_queue[j].left < self->segment_queue[j].right);
     }
 
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
         last_position = -1;
         for (list_node = self->node_mutation_list_map_head[j]; list_node != NULL;
              list_node = list_node->next) {
-            assert(
+            tsk_bug_assert(
                 self->input_tables.mutations.node[list_node->mutation] == (tsk_id_t) j);
             site = self->input_tables.mutations.site[list_node->mutation];
             position = self->input_tables.sites.position[site];
-            assert(last_position <= position);
+            tsk_bug_assert(last_position <= position);
             last_position = position;
         }
     }
 
     /* check the buffered edges */
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
-        assert((self->child_edge_map_head[j] == NULL)
-               == (self->child_edge_map_tail[j] == NULL));
+        tsk_bug_assert((self->child_edge_map_head[j] == NULL)
+                       == (self->child_edge_map_tail[j] == NULL));
         if (self->child_edge_map_head[j] != NULL) {
             /* Make sure that the child is in our list */
             found = false;
@@ -5908,24 +5912,25 @@ simplifier_check_state(simplifier_t *self)
                     break;
                 }
             }
-            assert(found);
+            tsk_bug_assert(found);
         }
     }
     num_intervals = 0;
     for (j = 0; j < self->num_buffered_children; j++) {
         child = self->buffered_children[j];
-        assert(self->child_edge_map_head[child] != NULL);
+        tsk_bug_assert(self->child_edge_map_head[child] != NULL);
         for (int_list = self->child_edge_map_head[child]; int_list != NULL;
              int_list = int_list->next) {
-            assert(int_list->left < int_list->right);
+            tsk_bug_assert(int_list->left < int_list->right);
             if (int_list->next != NULL) {
-                assert(int_list->right < int_list->next->left);
+                tsk_bug_assert(int_list->right < int_list->next->left);
             }
             num_intervals++;
         }
     }
-    assert(num_intervals
-           == self->interval_list_heap.total_allocated / (sizeof(interval_list_t)));
+    tsk_bug_assert(
+        num_intervals
+        == self->interval_list_heap.total_allocated / (sizeof(interval_list_t)));
 }
 
 static void
@@ -6180,7 +6185,7 @@ simplifier_record_edge(simplifier_t *self, double left, double right, tsk_id_t c
 
     tail = self->child_edge_map_tail[child];
     if (tail == NULL) {
-        assert(self->num_buffered_children < self->input_tables.nodes.num_rows);
+        tsk_bug_assert(self->num_buffered_children < self->input_tables.nodes.num_rows);
         self->buffered_children[self->num_buffered_children] = child;
         self->num_buffered_children++;
         x = simplifier_alloc_interval_list(self, left, right);
@@ -6280,7 +6285,7 @@ simplifier_add_ancestry(
     tsk_segment_t *tail = self->ancestor_map_tail[input_id];
     tsk_segment_t *x;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     if (tail == NULL) {
         x = simplifier_alloc_segment(self, left, right, output_id);
         if (x == NULL) {
@@ -6465,7 +6470,7 @@ simplifier_enqueue_segment(simplifier_t *self, double left, double right, tsk_id
     tsk_segment_t *seg;
     void *p;
 
-    assert(left < right);
+    tsk_bug_assert(left < right);
     /* Make sure we always have room for one more segment in the queue so we
      * can put a tail sentinel on it */
     if (self->segment_queue_size == self->max_segment_queue_size - 1) {
@@ -6502,7 +6507,7 @@ simplifier_merge_ancestors(simplifier_t *self, tsk_id_t input_id)
     if (is_sample) {
         /* Free up the existing ancestry mapping. */
         x = self->ancestor_map_tail[input_id];
-        assert(x->left == 0 && x->right == self->tables->sequence_length);
+        tsk_bug_assert(x->left == 0 && x->right == self->tables->sequence_length);
         self->ancestor_map_head[input_id] = NULL;
         self->ancestor_map_tail[input_id] = NULL;
     }
@@ -6516,8 +6521,8 @@ simplifier_merge_ancestors(simplifier_t *self, tsk_id_t input_id)
     while ((ret = segment_overlapper_next(
                 &self->segment_overlapper, &left, &right, &X, &num_overlapping))
            == 1) {
-        assert(left < right);
-        assert(num_overlapping > 0);
+        tsk_bug_assert(left < right);
+        tsk_bug_assert(num_overlapping > 0);
         if (num_overlapping == 1) {
             ancestry_node = X[0]->node;
             if (is_sample) {
@@ -6671,7 +6676,7 @@ simplifier_process_parent_edges(
     /* Go through the edges and queue up ancestry segments for processing. */
     self->segment_queue_size = 0;
     for (j = start; j < end; j++) {
-        assert(parent == input_edges->parent[j]);
+        tsk_bug_assert(parent == input_edges->parent[j]);
         child = input_edges->child[j];
         left = input_edges->left[j];
         right = input_edges->right[j];
@@ -6736,10 +6741,10 @@ simplifier_output_sites(simplifier_t *self)
             for (input_mutation = site_start; input_mutation < site_end;
                  input_mutation++) {
                 if (self->mutation_id_map[input_mutation] != TSK_NULL) {
-                    assert(self->tables->mutations.num_rows
-                           == (size_t) self->mutation_id_map[input_mutation]);
+                    tsk_bug_assert(self->tables->mutations.num_rows
+                                   == (size_t) self->mutation_id_map[input_mutation]);
                     mapped_node = self->mutation_node_map[input_mutation];
-                    assert(mapped_node != TSK_NULL);
+                    tsk_bug_assert(mapped_node != TSK_NULL);
                     mapped_parent = self->input_tables.mutations.parent[input_mutation];
                     if (mapped_parent != TSK_NULL) {
                         mapped_parent = self->mutation_id_map[mapped_parent];
@@ -6763,10 +6768,11 @@ simplifier_output_sites(simplifier_t *self)
                 goto out;
             }
         }
-        assert(num_output_mutations == (tsk_id_t) self->tables->mutations.num_rows);
+        tsk_bug_assert(
+            num_output_mutations == (tsk_id_t) self->tables->mutations.num_rows);
         input_mutation = site_end;
     }
-    assert(input_mutation == num_input_mutations);
+    tsk_bug_assert(input_mutation == num_input_mutations);
     ret = 0;
 out:
     return ret;
@@ -6913,7 +6919,7 @@ simplifier_sort_edges(simplifier_t *self)
         .sites = self->tables->sites.num_rows,
         .mutations = self->tables->mutations.num_rows,
     };
-    assert(self->edge_sort_offset >= 0);
+    tsk_bug_assert(self->edge_sort_offset >= 0);
     return tsk_table_collection_sort(self->tables, &bookmark, 0);
 }
 
@@ -7012,7 +7018,7 @@ simplifier_run(simplifier_t *self, tsk_id_t *node_map)
             self->input_tables.nodes.num_rows * sizeof(tsk_id_t));
     }
     if (self->edge_sort_offset != TSK_NULL) {
-        assert(self->options & TSK_KEEP_INPUT_ROOTS);
+        tsk_bug_assert(self->options & TSK_KEEP_INPUT_ROOTS);
         ret = simplifier_sort_edges(self);
         if (ret != 0) {
             goto out;
@@ -7497,7 +7503,7 @@ tsk_table_collection_check_tree_integrity(tsk_table_collection_t *self)
     k = 0;
     site = 0;
     mutation = 0;
-    assert(I != NULL && O != NULL);
+    tsk_bug_assert(I != NULL && O != NULL);
 
     while (j < num_edges || tree_left < sequence_length) {
         while (k < num_edges && edge_right[O[k]] == tree_left) {

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -25,7 +25,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <math.h>
@@ -47,10 +46,10 @@ tsk_treeseq_check_state(tsk_treeseq_t *self)
     for (j = 0; j < self->num_trees; j++) {
         for (k = 0; k < self->tree_sites_length[j]; k++) {
             site = self->tree_sites[j][k];
-            assert(site.id == site_id);
+            tsk_bug_assert(site.id == site_id);
             site_id++;
             for (l = 0; l < site.mutations_length; l++) {
-                assert(site.mutations[l].site == site.id);
+                tsk_bug_assert(site.mutations[l].site == site.id);
             }
         }
     }
@@ -210,8 +209,8 @@ tsk_treeseq_init_individuals(tsk_treeseq_t *self)
         ind = node_individual[node];
         if (ind != TSK_NULL) {
             node_array = self->individual_nodes[ind];
-            assert(node_array - self->individual_nodes_mem
-                   < (tsk_id_t)(total_node_refs - node_count[ind]));
+            tsk_bug_assert(node_array - self->individual_nodes_mem
+                           < (tsk_id_t)(total_node_refs - node_count[ind]));
             node_array[node_count[ind]] = node;
             node_count[ind] += 1;
         }
@@ -282,8 +281,8 @@ tsk_treeseq_init_trees(tsk_treeseq_t *self)
         tree_left = tree_right;
         tree_index++;
     }
-    assert(site == num_sites);
-    assert(tree_index == self->num_trees);
+    tsk_bug_assert(site == num_sites);
+    tsk_bug_assert(tree_index == self->num_trees);
     self->breakpoints[tree_index] = tree_right;
     ret = 0;
 out:
@@ -321,7 +320,7 @@ tsk_treeseq_init_nodes(tsk_treeseq_t *self)
             k++;
         }
     }
-    assert(k == self->num_samples);
+    tsk_bug_assert(k == self->num_samples);
 out:
     return ret;
 }
@@ -632,7 +631,7 @@ increment_nd_array_value(double *array, tsk_size_t n, const tsk_size_t *shape,
     int k;
 
     for (k = (int) n - 1; k >= 0; k--) {
-        assert(coordinate[k] < shape[k]);
+        tsk_bug_assert(coordinate[k] < shape[k]);
         offset += coordinate[k] * product;
         product *= shape[k];
     }
@@ -1168,13 +1167,13 @@ tsk_treeseq_branch_general_stat(tsk_treeseq_t *self, size_t state_dim,
         }
 
         while (windows[window_index] < t_right) {
-            assert(window_index < num_windows);
+            tsk_bug_assert(window_index < num_windows);
             w_left = windows[window_index];
             w_right = windows[window_index + 1];
             left = TSK_MAX(t_left, w_left);
             right = TSK_MIN(t_right, w_right);
             scale = (right - left);
-            assert(scale > 0);
+            tsk_bug_assert(scale > 0);
             result_row = GET_2D_ROW(result, result_dim, window_index);
             for (k = 0; k < result_dim; k++) {
                 result_row[k] += running_sum[k] * scale;
@@ -1192,7 +1191,7 @@ tsk_treeseq_branch_general_stat(tsk_treeseq_t *self, size_t state_dim,
         t_left = t_right;
         tree_index++;
     }
-    assert(window_index == num_windows);
+    tsk_bug_assert(window_index == num_windows);
 out:
     /* Can't use msp_safe_free here because of restrict */
     if (parent != NULL) {
@@ -1228,7 +1227,7 @@ get_allele_weights(tsk_site_t *site, double *state, size_t state_dim,
         goto out;
     }
 
-    assert(state != NULL);
+    tsk_bug_assert(state != NULL);
     alleles[0] = site->ancestral_state;
     allele_lengths[0] = site->ancestral_state_length;
     memcpy(allele_states, total_weight, state_dim * sizeof(*allele_states));
@@ -1248,7 +1247,7 @@ get_allele_weights(tsk_site_t *site, double *state, size_t state_dim,
             allele++;
         }
         if (allele == num_alleles) {
-            assert(allele < max_alleles);
+            tsk_bug_assert(allele < max_alleles);
             alleles[allele] = mutation.derived_state;
             allele_lengths[allele] = mutation.derived_state_length;
             num_alleles++;
@@ -1277,7 +1276,7 @@ get_allele_weights(tsk_site_t *site, double *state, size_t state_dim,
             }
             allele++;
         }
-        assert(allele < num_alleles);
+        tsk_bug_assert(allele < num_alleles);
 
         allele_row = GET_2D_ROW(allele_states, state_dim, allele);
         for (k = 0; k < state_dim; k++) {
@@ -1433,10 +1432,10 @@ tsk_treeseq_site_general_stat(tsk_treeseq_t *self, size_t state_dim,
 
             while (windows[window_index + 1] <= site->position) {
                 window_index++;
-                assert(window_index < num_windows);
+                tsk_bug_assert(window_index < num_windows);
             }
-            assert(windows[window_index] <= site->position);
-            assert(site->position < windows[window_index + 1]);
+            tsk_bug_assert(windows[window_index] <= site->position);
+            tsk_bug_assert(site->position < windows[window_index + 1]);
             result_row = GET_2D_ROW(result, result_dim, window_index);
             for (k = 0; k < result_dim; k++) {
                 result_row[k] += site_result[k];
@@ -1519,7 +1518,7 @@ tsk_treeseq_node_general_stat(tsk_treeseq_t *self, size_t state_dim,
     t_left = 0;
     window_index = 0;
     while (tj < num_edges || t_left < sequence_length) {
-        assert(window_index < num_windows);
+        tsk_bug_assert(window_index < num_windows);
         while (tk < num_edges && edge_right[O[tk]] == t_left) {
             h = O[tk];
             tk++;
@@ -1574,7 +1573,7 @@ tsk_treeseq_node_general_stat(tsk_treeseq_t *self, size_t state_dim,
             w_right = windows[window_index + 1];
             /* Flush the contributions of all nodes to the current window */
             for (u = 0; u < (tsk_id_t) num_nodes; u++) {
-                assert(last_update[u] < w_right);
+                tsk_bug_assert(last_update[u] < w_right);
                 increment_row(result_dim, w_right - last_update[u],
                     GET_2D_ROW(node_summary, result_dim, u),
                     GET_3D_ROW(result, num_nodes, result_dim, window_index, u));
@@ -1900,7 +1899,7 @@ fold(tsk_size_t *restrict coordinate, const tsk_size_t *restrict dims,
     int s = 0;
 
     for (k = 0; k < num_dims; k++) {
-        assert(coordinate[k] < dims[k]);
+        tsk_bug_assert(coordinate[k] < dims[k]);
         n += dims[k] - 1;
         s += (int) coordinate[k];
     }
@@ -1914,7 +1913,7 @@ fold(tsk_size_t *restrict coordinate, const tsk_size_t *restrict dims,
     if (s > n) {
         for (k = 0; k < num_dims; k++) {
             s = (int) (dims[k] - 1 - coordinate[k]);
-            assert(s >= 0);
+            tsk_bug_assert(s >= 0);
             coordinate[k] = (tsk_size_t) s;
         }
     }
@@ -2049,15 +2048,15 @@ tsk_treeseq_site_allele_frequency_spectrum(tsk_treeseq_t *self,
             site = self->tree_sites[tree_index] + tree_site;
             while (windows[window_index + 1] <= site->position) {
                 window_index++;
-                assert(window_index < num_windows);
+                tsk_bug_assert(window_index < num_windows);
             }
             ret = tsk_treeseq_update_site_afs(self, site, total_counts, counts,
                 num_sample_sets, window_index, result_dims, result, options);
             if (ret != 0) {
                 goto out;
             }
-            assert(windows[window_index] <= site->position);
-            assert(site->position < windows[window_index + 1]);
+            tsk_bug_assert(windows[window_index] <= site->position);
+            tsk_bug_assert(site->position < windows[window_index + 1]);
         }
         tree_index++;
         t_left = t_right;
@@ -2149,7 +2148,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(tsk_treeseq_t *self,
     t_left = 0;
     window_index = 0;
     while (tj < num_edges || t_left < sequence_length) {
-        assert(window_index < num_windows);
+        tsk_bug_assert(window_index < num_windows);
         while (tk < num_edges && edge_right[O[tk]] == t_left) {
             h = O[tk];
             tk++;
@@ -2206,7 +2205,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(tsk_treeseq_t *self,
             w_right = windows[window_index + 1];
             /* Flush the contributions of all nodes to the current window */
             for (u = 0; u < (tsk_id_t) num_nodes; u++) {
-                assert(last_update[u] < w_right);
+                tsk_bug_assert(last_update[u] < w_right);
                 ret = tsk_treeseq_update_branch_afs(self, u, w_right, branch_length,
                     last_update, counts, num_sample_sets, window_index, result_dims,
                     result, options);
@@ -3310,7 +3309,7 @@ tsk_tree_set_tracked_samples_from_sample_list(
         stop = other->right_sample[node];
         while (true) {
             u = samples[index];
-            assert(self->num_tracked_samples[u] == 0);
+            tsk_bug_assert(self->num_tracked_samples[u] == 0);
             /* Propagate this upwards */
             while (u != TSK_NULL) {
                 self->num_tracked_samples[u] += 1;
@@ -3450,7 +3449,7 @@ tsk_tree_get_mrca(tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca)
     j = u;
     l1 = 0;
     while (j != TSK_NULL) {
-        assert(l1 < (int) self->num_nodes);
+        tsk_bug_assert(l1 < (int) self->num_nodes);
         s1[l1] = j;
         l1++;
         j = self->parent[j];
@@ -3459,7 +3458,7 @@ tsk_tree_get_mrca(tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca)
     j = v;
     l2 = 0;
     while (j != TSK_NULL) {
-        assert(l2 < (int) self->num_nodes);
+        tsk_bug_assert(l2 < (int) self->num_nodes);
         s2[l2] = j;
         l2++;
         j = self->parent[j];
@@ -3675,7 +3674,7 @@ tsk_tree_check_state(tsk_tree_t *self)
     tsk_id_t *children = malloc(self->num_nodes * sizeof(tsk_id_t));
     bool *is_root = calloc(self->num_nodes, sizeof(bool));
 
-    assert(children != NULL);
+    tsk_bug_assert(children != NULL);
 
     for (j = 0; j < self->tree_sequence->num_samples; j++) {
         u = self->samples[j];
@@ -3685,55 +3684,55 @@ tsk_tree_check_state(tsk_tree_t *self)
         is_root[u] = true;
     }
     if (self->tree_sequence->num_samples == 0) {
-        assert(self->left_root == TSK_NULL);
+        tsk_bug_assert(self->left_root == TSK_NULL);
     } else {
-        assert(self->left_sib[self->left_root] == TSK_NULL);
+        tsk_bug_assert(self->left_sib[self->left_root] == TSK_NULL);
     }
     /* Iterate over the roots and make sure they are set */
     for (u = self->left_root; u != TSK_NULL; u = self->right_sib[u]) {
-        assert(is_root[u]);
+        tsk_bug_assert(is_root[u]);
         is_root[u] = false;
     }
     for (u = 0; u < (tsk_id_t) self->num_nodes; u++) {
-        assert(!is_root[u]);
+        tsk_bug_assert(!is_root[u]);
         c = 0;
         for (v = self->left_child[u]; v != TSK_NULL; v = self->right_sib[v]) {
-            assert(self->parent[v] == u);
+            tsk_bug_assert(self->parent[v] == u);
             children[c] = v;
             c++;
         }
         for (v = self->right_child[u]; v != TSK_NULL; v = self->left_sib[v]) {
-            assert(c > 0);
+            tsk_bug_assert(c > 0);
             c--;
-            assert(v == children[c]);
+            tsk_bug_assert(v == children[c]);
         }
     }
     for (j = 0; j < self->sites_length; j++) {
         site = self->sites[j];
-        assert(self->left <= site.position);
-        assert(site.position < self->right);
+        tsk_bug_assert(self->left <= site.position);
+        tsk_bug_assert(site.position < self->right);
     }
 
     if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
-        assert(self->num_samples != NULL);
-        assert(self->num_tracked_samples != NULL);
+        tsk_bug_assert(self->num_samples != NULL);
+        tsk_bug_assert(self->num_tracked_samples != NULL);
         for (u = 0; u < (tsk_id_t) self->num_nodes; u++) {
             err = tsk_tree_get_num_samples_by_traversal(self, u, &num_samples);
-            assert(err == 0);
-            assert(num_samples == (size_t) self->num_samples[u]);
+            tsk_bug_assert(err == 0);
+            tsk_bug_assert(num_samples == (size_t) self->num_samples[u]);
         }
     } else {
-        assert(self->num_samples == NULL);
-        assert(self->num_tracked_samples == NULL);
+        tsk_bug_assert(self->num_samples == NULL);
+        tsk_bug_assert(self->num_tracked_samples == NULL);
     }
     if (self->options & TSK_SAMPLE_LISTS) {
-        assert(self->right_sample != NULL);
-        assert(self->left_sample != NULL);
-        assert(self->next_sample != NULL);
+        tsk_bug_assert(self->right_sample != NULL);
+        tsk_bug_assert(self->left_sample != NULL);
+        tsk_bug_assert(self->next_sample != NULL);
     } else {
-        assert(self->right_sample == NULL);
-        assert(self->left_sample == NULL);
-        assert(self->next_sample == NULL);
+        tsk_bug_assert(self->right_sample == NULL);
+        tsk_bug_assert(self->left_sample == NULL);
+        tsk_bug_assert(self->next_sample == NULL);
     }
 
     free(children);
@@ -3806,7 +3805,7 @@ tsk_tree_update_sample_lists(tsk_tree_t *self, const tsk_id_t *restrict parent,
         }
         for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
             if (left[v] != TSK_NULL) {
-                assert(right[v] != TSK_NULL);
+                tsk_bug_assert(right[v] != TSK_NULL);
                 if (left[u] == TSK_NULL) {
                     left[u] = left[v];
                     right[u] = right[v];
@@ -4020,7 +4019,7 @@ tsk_tree_advance(tsk_tree_t *self, int direction, const double *restrict out_bre
         x = self->left;
     }
     while (out >= 0 && out < num_edges && out_breakpoints[out_order[out]] == x) {
-        assert(out < num_edges);
+        tsk_bug_assert(out < num_edges);
         k = out_order[out];
         out += direction;
         tsk_tree_remove_edge(self, edge_parent[k], edge_child[k]);
@@ -4060,7 +4059,7 @@ tsk_tree_advance(tsk_tree_t *self, int direction, const double *restrict out_bre
             self->left = TSK_MAX(self->left, in_breakpoints[in_order[in]]);
         }
     }
-    assert(self->left < self->right);
+    tsk_bug_assert(self->left < self->right);
     *out_index = out;
     *in_index = in;
     if (tables->sites.num_rows > 0) {
@@ -4376,7 +4375,7 @@ tsk_diff_iter_init(
 {
     int ret = 0;
 
-    assert(tree_sequence != NULL);
+    tsk_bug_assert(tree_sequence != NULL);
     memset(self, 0, sizeof(tsk_diff_iter_t));
     self->num_nodes = tsk_treeseq_get_num_nodes(tree_sequence);
     self->num_edges = tsk_treeseq_get_num_edges(tree_sequence);
@@ -4446,7 +4445,7 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
         while (self->removal_index < (tsk_id_t) self->num_edges
                && left == edges->right[removal_order[self->removal_index]]) {
             k = removal_order[self->removal_index];
-            assert(next_edge_list_node < self->num_edges);
+            tsk_bug_assert(next_edge_list_node < self->num_edges);
             w = &self->edge_list_nodes[next_edge_list_node];
             next_edge_list_node++;
             w->edge.id = k;
@@ -4476,7 +4475,7 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
         while (self->insertion_index < (tsk_id_t) self->num_edges
                && left == edges->left[insertion_order[self->insertion_index]]) {
             k = insertion_order[self->insertion_index];
-            assert(next_edge_list_node < self->num_edges);
+            tsk_bug_assert(next_edge_list_node < self->num_edges);
             w = &self->edge_list_nodes[next_edge_list_node];
             next_edge_list_node++;
             w->edge.id = k;
@@ -4890,7 +4889,7 @@ update_kc_incremental(tsk_tree_t *self, kc_vectors *kc, tsk_edge_list_t *edges_o
         e = &record->edge;
         u = e->child;
 
-        assert(depths[e->child] == 0);
+        tsk_bug_assert(depths[e->child] == 0);
         depths[u] = depths[e->parent] + 1;
 
         root_time = times[tsk_tree_node_root(self, u)];
@@ -4976,7 +4975,7 @@ tsk_treeseq_kc_distance(
     }
     ret = tsk_diff_iter_next(
         &diff_iters[0], &t0_left, &t0_right, &edges_out[0], &edges_in[0]);
-    assert(ret == 1);
+    tsk_bug_assert(ret == 1);
     ret = update_kc_incremental(
         &trees[0], &kcs[0], &edges_out[0], &edges_in[0], depths[0]);
     if (ret != 0) {
@@ -4989,7 +4988,7 @@ tsk_treeseq_kc_distance(
         }
         ret = tsk_diff_iter_next(
             &diff_iters[1], &t1_left, &t1_right, &edges_out[1], &edges_in[1]);
-        assert(ret == 1);
+        tsk_bug_assert(ret == 1);
 
         ret = update_kc_incremental(
             &trees[1], &kcs[1], &edges_out[1], &edges_in[1], depths[1]);
@@ -5002,14 +5001,14 @@ tsk_treeseq_kc_distance(
 
             left = t0_right;
             ret = tsk_tree_next(&trees[0]);
-            assert(ret == 1);
+            tsk_bug_assert(ret == 1);
             ret = check_kc_distance_tree_inputs(&trees[0]);
             if (ret != 0) {
                 goto out;
             }
             ret = tsk_diff_iter_next(
                 &diff_iters[0], &t0_left, &t0_right, &edges_out[0], &edges_in[0]);
-            assert(ret == 1);
+            tsk_bug_assert(ret == 1);
             ret = update_kc_incremental(
                 &trees[0], &kcs[0], &edges_out[0], &edges_in[0], depths[0]);
             if (ret != 0) {

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -681,6 +681,22 @@ of the declaration.
 Error codes are defined in ``core.h``, and these can be translated into a
 message using ``tsk_strerror(err)``.
 
++++++++++++++++++
+Using assertions
++++++++++++++++++
+
+There are two different ways to express assertions in tskit code.
+The first is using the custom ``tsk_bug_assert`` macro, which is used to
+make inexpensive checks at key points during execution. These assertions
+are always run, regardless of the compiler settings, and should not
+contribute significantly to the overall runtime.
+
+More expensive assertions, used, for example, to check pre and post conditions
+on performance critical loops should be expressed using the standard
+``assert`` macro from ``assert.h``. These assertions will be checked
+during the execution of C unit tests, but will not be enabled when
+compiled into the Python C module.
+
 ----------------
 Type conventions
 ----------------

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -25,6 +25,9 @@
 
 #define PY_SSIZE_T_CLEAN
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define TSK_BUG_ASSERT_MESSAGE "Please open an issue on"                                \
+                               " GitHub, ideally with a reproducible example."          \
+                               " (https://github.com/tskit-dev/tskit/issues)"
 
 #include <Python.h>
 #include <structmember.h>

--- a/python/setup.py
+++ b/python/setup.py
@@ -54,8 +54,6 @@ _tskit_module = Extension(
     extra_compile_args=["-std=c99"],
     libraries=libraries,
     define_macros=defines,
-    # Enable asserts
-    undef_macros=["NDEBUG"],
     include_dirs=[libdir, kastore_dir],
 )
 


### PR DESCRIPTION
Following discussion at https://github.com/tskit-dev/msprime/pull/1203 this introduces an assertion `tsk_bug_assertion` that is not disabled in production builds in the same way `assert` is.

I've replaced every `assert` - are there some we want to keep debug-only?

I also haven't yet removed any now-unneeded includes.