### PR TITLE
Convert tests to pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,8 @@ jobs:
       - run:
           name: Run Python tests
           command: |
-            PYTHONPATH=python nosetests -v --with-coverage --cover-package tskit \
-              --cover-branches --cover-erase --cover-xml \
-              --cover-inclusive python/tests
+            PYTHONPATH=python pytest --cov=python/tskit  --cov-report=xml --cov-branch \
+            -n `nproc` python
 
       - run:
           name: Upload Python coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      nosetests -vs --processes=`sysctl -n hw.ncpu` --process-timeout=5000 tests;
+      pytest -n `sysctl -n hw.ncpu` python;
     else
-      nosetests -vs --processes=`nproc` --process-timeout=5000 tests;
+      pytest -n `nproc` python;
     fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
   - cmd: python setup.py build_ext --inplace
   # Install some modules needed for tests
   - cmd: python -m pip install -r requirements/appveyor-pypi.txt
-  - cmd: python -m nose -vs --processes=%NUMBER_OF_PROCESSORS% --process-timeout=5000
+  - cmd: python -m pytest -n %NUMBER_OF_PROCESSORS%
 
 after_test:
   - cmd: python setup.py bdist_wheel

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -382,25 +382,32 @@ Tests
 -----
 
 The tests are defined in the ``tests`` directory, and run using
-`nose <http://nose.readthedocs.io/en/latest/>`_. If you want to run
+`pytest <https://docs.pytest.org/en/stable/>`_. If you want to run
 the tests in a particular module (say, ``test_tables.py``), use:
 
 .. code-block:: bash
 
-    $ python3 -m nose -vs tests/test_tables.py
+    $ python3 -m pytest tests/test_tables.py
 
 To run all the tests in a particular class in this module (say, ``TestNodeTable``)
 use:
 
 .. code-block:: bash
 
-    $ python3 -m nose -vs tests/test_tables.py:TestNodeTable
+    $ python3 -m pytest tests/test_tables.py::TestNodeTable
 
 To run a specific test case in this class (say, ``test_copy``) use:
 
 .. code-block:: bash
 
-    $ python3 -m nose -vs tests/test_tables.py:TestNodeTable.test_copy
+    $ python3 -m pytest tests/test_tables.py::TestNodeTable::test_copy
+
+You can also run tests with a keyword expression search. For example this will
+run all tests that have ``TestNodeTable`` but not ``copy`` in their name:
+
+.. code-block:: bash
+
+    $ python3 -m pytest -k "TestNodeTable and not copy"
 
 When developing your own tests, it is much quicker to run the specific tests
 that you are developing rather than rerunning large sections of the test
@@ -410,14 +417,27 @@ To run all of the tests, we can use:
 
 .. code-block:: bash
 
-    $ python3 -m nose -vs
+    $ python3 -m pytest
 
 As tskit's test suite is large, it is helpful to run the tests in parallel, e.g.:
 
 .. code-block:: bash
 
-    $ python3 -m nose -vs --processes=8 --process-timeout=5000
+    $ python3 -m pytest -n8
 
+A few of the tests take most of the time, we can skip the slow tests to get the test run
+under 20 seconds on an modern workstation:
+
+.. code-block:: bash
+
+    $ python3 -m pytest -n8 --skip-slow
+
+If you have a lot of failing tests it can be useful to have a shorter summary
+of the failing lines:
+
+.. code-block:: bash
+
+    $ python3 -m pytest -n8 --tb=line
 
 All new code must have high test coverage, which will be checked as part of the
 :ref:`sec_development_continuous_integration`
@@ -767,11 +787,11 @@ be very useful. For example, to run a particular test case, we can do:
 .. code-block:: bash
 
     $ gdb python3
-    (gdb) run -m nose -vs tests/test_lowlevel.py
+    (gdb) run -m pytest tests/test_lowlevel.py
 
 
-    (gdb) run  -m nose -vs tests/test_tables.py:TestNodeTable.test_copy
-    Starting program: /usr/bin/python3 -m nose -vs tests/test_tables.py:TestNodeTable.test_copy
+    (gdb) run  -m pytest -vs tests/test_tables.py::TestNodeTable::test_copy
+    Starting program: /usr/bin/python3 run  -m pytest tests/test_tables.py::TestNodeTable::test_copy
     [Thread debugging using libthread_db enabled]
     Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
     [New Thread 0x7ffff1e48700 (LWP 1503)]
@@ -780,12 +800,10 @@ be very useful. For example, to run a particular test case, we can do:
     [Thread 0x7fffeee46700 (LWP 1505) exited]
     [Thread 0x7fffef647700 (LWP 1504) exited]
     [Thread 0x7ffff1e48700 (LWP 1503) exited]
-    test_copy (tests.test_tables.TestNodeTable) ... ok
+    collected 1 item
 
-    ----------------------------------------------------------------------
-    Ran 1 test in 0.001s
+    tests/test_tables.py::TestNodeTable::test_copy PASSED
 
-    OK
     [Inferior 1 (process 1499) exited normally]
     (gdb)
 

--- a/python/requirements/CI/requirements.txt
+++ b/python/requirements/CI/requirements.txt
@@ -13,12 +13,14 @@ msgpack==1.0.0
 msprime==0.7.4
 networkx==2.5
 newick==1.0.0
-nose==1.3.7
 numpy==1.19.1
 portion==2.1.1
 pre-commit==2.7.1
 pyparsing==2.4.7
 pysam==0.16.0.1
+pytest==6.1.0
+pytest-cov==2.10.1
+pytest-xdist==2.1.0
 python-jsonschema-objects==0.3.12
 PyVCF==0.6.8
 sphinx==3.2.1

--- a/python/requirements/conda-minimal.txt
+++ b/python/requirements/conda-minimal.txt
@@ -1,6 +1,5 @@
 attrs>=19.2.0
 numpy
-nose
 h5py>=2.6.0
 jsonschema>=3.0.0
 svgwrite>=1.1.10
@@ -9,3 +8,5 @@ msprime
 kastore
 biopython
 networkx
+pytest
+pytest-xdist

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -13,13 +13,15 @@ msgpack>=1.0.0
 msprime
 networkx
 newick
-nose
 numpy
 packaging
 portion
 pre-commit
 pyparsing 
 pysam
+pytest
+pytest-cov
+pytest-xdist
 python_jsonschema_objects
 PyVCF
 sphinx

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-slow", action="store_true", default=False, help="Skip slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--skip-slow"):
+        skip_slow = pytest.mark.skip(reason="--skip-slow specified")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -40,6 +40,7 @@ from . import tsutil
 
 
 class TestException(Exception):
+    __test__ = False
     """
     Custom exception we can throw for testing.
     """

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -32,6 +32,7 @@ from unittest import mock
 
 import h5py
 import msprime
+import pytest
 
 import tskit
 import tskit.cli as cli
@@ -82,7 +83,7 @@ class TestCli(unittest.TestCase):
         os.unlink(self.temp_file)
 
 
-class TestTskitArgumentParser(unittest.TestCase):
+class TestTskitArgumentParser:
     """
     Tests for the argument parsers in msp.
     """
@@ -92,195 +93,195 @@ class TestTskitArgumentParser(unittest.TestCase):
         cmd = "individuals"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 6)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 6
 
     def test_individuals_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "individuals"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-p", "8"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 8)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 8
 
     def test_individuals_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "individuals"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 5)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 5
 
     def test_nodes_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "nodes"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 6)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 6
 
     def test_nodes_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "nodes"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-p", "8"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 8)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 8
 
     def test_nodes_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "nodes"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 5)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 5
 
     def test_edges_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "edges"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 6)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 6
 
     def test_edges_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "edges"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-p", "8"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 8)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 8
 
     def test_edges_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "edges"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 5)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 5
 
     def test_sites_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "sites"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 6)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 6
 
     def test_sites_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "sites"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-p", "8"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 8)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 8
 
     def test_sites_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "sites"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--precision", "5"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 5)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 5
 
     def test_mutations_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "mutations"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 6)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 6
 
     def test_mutations_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "mutations"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-p", "4"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 4)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 4
 
     def test_mutations_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "mutations"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--precision", "9"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 9)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 9
 
     def test_provenances_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "provenances"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.human, False)
+        assert args.tree_sequence == tree_sequence
+        assert not args.human
 
     def test_provenances_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "provenances"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-H"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.human, True)
+        assert args.tree_sequence == tree_sequence
+        assert args.human
 
     def test_provenances_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "provenances"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--human"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.human, True)
+        assert args.tree_sequence == tree_sequence
+        assert args.human
 
-    @unittest.skip("fasta output temporarily disabled")
+    @pytest.mark.skip(reason="fasta output temporarily disabled")
     def test_fasta_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.wrap, 60)
+        assert args.tree_sequence == tree_sequence
+        assert args.wrap == 60
 
-    @unittest.skip("fasta output temporarily disabled")
+    @pytest.mark.skip(reason="fasta output temporarily disabled")
     def test_fasta_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-w", "100"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.wrap, 100)
+        assert args.tree_sequence == tree_sequence
+        assert args.wrap == 100
 
-    @unittest.skip("fasta output temporarily disabled")
+    @pytest.mark.skip(reason="fasta output temporarily disabled")
     def test_fasta_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "fasta"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--wrap", "50"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.wrap, 50)
+        assert args.tree_sequence == tree_sequence
+        assert args.wrap == 50
 
     def test_vcf_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "vcf"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.ploidy, None)
+        assert args.tree_sequence == tree_sequence
+        assert args.ploidy is None
 
     def test_vcf_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "vcf"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-P", "2"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.ploidy, 2)
+        assert args.tree_sequence == tree_sequence
+        assert args.ploidy == 2
 
     def test_vcf_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "vcf"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--ploidy", "5"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.ploidy, 5)
+        assert args.tree_sequence == tree_sequence
+        assert args.ploidy == 5
 
     def test_upgrade_default_values(self):
         parser = cli.get_tskit_parser()
@@ -288,50 +289,50 @@ class TestTskitArgumentParser(unittest.TestCase):
         source = "in.trees"
         destination = "out.trees"
         args = parser.parse_args([cmd, source, destination])
-        self.assertEqual(args.source, source)
-        self.assertEqual(args.destination, destination)
-        self.assertEqual(args.remove_duplicate_positions, False)
+        assert args.source == source
+        assert args.destination == destination
+        assert not args.remove_duplicate_positions
 
     def test_info_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "info"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
+        assert args.tree_sequence == tree_sequence
 
     def test_populations_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "populations"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
+        assert args.tree_sequence == tree_sequence
 
     def test_trees_default_values(self):
         parser = cli.get_tskit_parser()
         cmd = "trees"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 6)
-        self.assertEqual(args.draw, False)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 6
+        assert not args.draw
 
     def test_trees_short_args(self):
         parser = cli.get_tskit_parser()
         cmd = "trees"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "-d", "-p", "8"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 8)
-        self.assertEqual(args.draw, True)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 8
+        assert args.draw
 
     def test_trees_long_args(self):
         parser = cli.get_tskit_parser()
         cmd = "trees"
         tree_sequence = "test.trees"
         args = parser.parse_args([cmd, tree_sequence, "--precision", "5", "--draw"])
-        self.assertEqual(args.tree_sequence, tree_sequence)
-        self.assertEqual(args.precision, 5)
-        self.assertEqual(args.draw, True)
+        assert args.tree_sequence == tree_sequence
+        assert args.precision == 5
+        assert args.draw
 
 
 class TestTskitConversionOutput(unittest.TestCase):
@@ -369,7 +370,7 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.dump_text(individuals=f, precision=precision)
             f.seek(0)
             output = f.read().splitlines()
-        self.assertEqual(output, output_individuals)
+        assert output == output_individuals
 
     def test_individuals(self):
         cmd = "individuals"
@@ -377,7 +378,7 @@ class TestTskitConversionOutput(unittest.TestCase):
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_individuals = stdout.splitlines()
         self.verify_individuals(output_individuals, precision)
 
@@ -386,7 +387,7 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.dump_text(nodes=f, precision=precision)
             f.seek(0)
             output = f.read().splitlines()
-        self.assertEqual(output, output_nodes)
+        assert output == output_nodes
 
     def test_nodes(self):
         cmd = "nodes"
@@ -394,7 +395,7 @@ class TestTskitConversionOutput(unittest.TestCase):
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_nodes = stdout.splitlines()
         self.verify_nodes(output_nodes, precision)
 
@@ -403,7 +404,7 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.dump_text(edges=f, precision=precision)
             f.seek(0)
             output = f.read().splitlines()
-        self.assertEqual(output, output_edges)
+        assert output == output_edges
 
     def test_edges(self):
         cmd = "edges"
@@ -411,7 +412,7 @@ class TestTskitConversionOutput(unittest.TestCase):
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_edges = stdout.splitlines()
         self.verify_edges(output_edges, precision)
 
@@ -420,7 +421,7 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.dump_text(sites=f, precision=precision)
             f.seek(0)
             output = f.read().splitlines()
-        self.assertEqual(output, output_sites)
+        assert output == output_sites
 
     def test_sites(self):
         cmd = "sites"
@@ -428,7 +429,7 @@ class TestTskitConversionOutput(unittest.TestCase):
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_sites = stdout.splitlines()
         self.verify_sites(output_sites, precision)
 
@@ -437,7 +438,7 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.dump_text(mutations=f, precision=precision)
             f.seek(0)
             output = f.read().splitlines()
-        self.assertEqual(output, output_mutations)
+        assert output == output_mutations
 
     def test_mutations(self):
         cmd = "mutations"
@@ -445,7 +446,7 @@ class TestTskitConversionOutput(unittest.TestCase):
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, self._tree_sequence_file, "-p", str(precision)]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_mutations = stdout.splitlines()
         self.verify_mutations(output_mutations, precision)
 
@@ -454,12 +455,12 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.dump_text(provenances=f)
             f.seek(0)
             output = f.read().splitlines()
-        self.assertEqual(output, output_provenances)
+        assert output == output_provenances
 
     def test_provenances(self):
         cmd = "provenances"
         stdout, stderr = capture_output(cli.tskit_main, [cmd, self._tree_sequence_file])
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_provenances = stdout.splitlines()
         self.verify_provenances(output_provenances)
 
@@ -468,23 +469,23 @@ class TestTskitConversionOutput(unittest.TestCase):
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, "-H", self._tree_sequence_file]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_provenances = stdout.splitlines()
         # TODO Check the actual output here.
-        self.assertGreater(len(output_provenances), 0)
+        assert len(output_provenances) > 0
 
     def verify_fasta(self, output_fasta):
         with tempfile.TemporaryFile("w+") as f:
             self._tree_sequence.write_fasta(f)
             f.seek(0)
             fasta = f.read()
-        self.assertEqual(output_fasta, fasta)
+        assert output_fasta == fasta
 
-    @unittest.skip("fasta output temporarily disabled")
+    @pytest.mark.skip(reason="fasta output temporarily disabled")
     def test_fasta(self):
         cmd = "fasta"
         stdout, stderr = capture_output(cli.tskit_main, [cmd, self._tree_sequence_file])
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         self.verify_fasta(stdout)
 
     def verify_vcf(self, output_vcf):
@@ -492,12 +493,12 @@ class TestTskitConversionOutput(unittest.TestCase):
             self._tree_sequence.write_vcf(f)
             f.seek(0)
             vcf = f.read()
-        self.assertEqual(output_vcf, vcf)
+        assert output_vcf == vcf
 
     def test_vcf(self):
         cmd = "vcf"
         stdout, stderr = capture_output(cli.tskit_main, [cmd, self._tree_sequence_file])
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         self.verify_vcf(stdout)
 
     def verify_info(self, ts, output_info):
@@ -514,12 +515,12 @@ class TestTskitConversionOutput(unittest.TestCase):
             "trees": ts.num_trees,
             "samples": ts.num_samples,
         }
-        self.assertEqual({k: str(v) for k, v in info.items()}, output_info)
+        assert {k: str(v) for k, v in info.items()} == output_info
 
     def test_info(self):
         cmd = "info"
         stdout, stderr = capture_output(cli.tskit_main, [cmd, self._tree_sequence_file])
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         output_provenances = {}
         for row in stdout.splitlines():
             name, value = [tok.strip() for tok in row.split(":")]
@@ -530,28 +531,28 @@ class TestTskitConversionOutput(unittest.TestCase):
     def test_trees_no_draw(self):
         cmd = "trees"
         stdout, stderr = capture_output(cli.tskit_main, [cmd, self._tree_sequence_file])
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         ts = tskit.load(self._tree_sequence_file)
-        self.assertEqual(len(stdout.splitlines()), 3 * ts.num_trees)
+        assert len(stdout.splitlines()) == 3 * ts.num_trees
 
     def test_trees_draw(self):
         cmd = "trees"
         stdout, stderr = capture_output(
             cli.tskit_main, [cmd, "-d", self._tree_sequence_file]
         )
-        self.assertEqual(len(stderr), 0)
+        assert len(stderr) == 0
         ts = tskit.load(self._tree_sequence_file)
-        self.assertGreater(len(stdout.splitlines()), 3 * ts.num_trees)
+        assert len(stdout.splitlines()) > 3 * ts.num_trees
 
 
-class TestBadFile(unittest.TestCase):
+class TestBadFile:
     """
     Tests that we deal with IO errors appropriately.
     """
 
     def verify(self, command):
         with mock.patch("sys.exit", side_effect=TestException) as mocked_exit:
-            with self.assertRaises(TestException):
+            with pytest.raises(TestException):
                 capture_output(cli.tskit_main, ["info", "/no/such/file"])
             mocked_exit.assert_called_once_with(
                 "Load error: [Errno 2] No such file or directory"
@@ -607,13 +608,13 @@ class TestUpgrade(TestCli):
                 ["upgrade", self.legacy_file_name, self.current_file_name],
             )
             ts2 = tskit.load(self.current_file_name)
-            self.assertEqual(stdout, "")
-            self.assertEqual(stderr, "")
+            assert stdout == ""
+            assert stderr == ""
             # Quick checks to ensure we have the right tree sequence.
             # More thorough checks are done elsewhere.
-            self.assertEqual(ts1.get_sample_size(), ts2.get_sample_size())
-            self.assertEqual(ts1.num_edges, ts2.num_edges)
-            self.assertEqual(ts1.get_num_trees(), ts2.get_num_trees())
+            assert ts1.get_sample_size() == ts2.get_sample_size()
+            assert ts1.num_edges == ts2.num_edges
+            assert ts1.get_num_trees() == ts2.get_num_trees()
 
     def test_duplicate_positions(self):
         ts = msprime.simulate(10, mutation_rate=10)
@@ -626,10 +627,10 @@ class TestUpgrade(TestCli):
                 cli.tskit_main,
                 ["upgrade", "-d", self.legacy_file_name, self.current_file_name],
             )
-            self.assertEqual(stdout, "")
+            assert stdout == ""
             tsp = tskit.load(self.current_file_name)
-            self.assertEqual(tsp.sample_size, ts.sample_size)
-            self.assertEqual(tsp.num_sites, 1)
+            assert tsp.sample_size == ts.sample_size
+            assert tsp.num_sites == 1
 
     def test_duplicate_positions_error(self):
         ts = msprime.simulate(10, mutation_rate=10)
@@ -639,9 +640,9 @@ class TestUpgrade(TestCli):
             root["mutations/position"][:] = 0
             root.close()
             with mock.patch("sys.exit", side_effect=TestException) as mocked_exit:
-                with self.assertRaises(TestException):
+                with pytest.raises(TestException):
                     capture_output(
                         cli.tskit_main,
                         ["upgrade", self.legacy_file_name, self.current_file_name],
                     )
-                self.assertEqual(mocked_exit.call_count, 1)
+                assert mocked_exit.call_count == 1

--- a/python/tests/test_combinatorics.py
+++ b/python/tests/test_combinatorics.py
@@ -26,10 +26,10 @@ Test cases for combinatorial algorithms.
 import collections
 import io
 import itertools
-import unittest
 
 import msprime
 import numpy as np
+import pytest
 
 import tests.test_wright_fisher as wf
 import tskit
@@ -38,7 +38,7 @@ from tests import test_stats
 from tskit.combinatorics import RankTree
 
 
-class TestCombination(unittest.TestCase):
+class TestCombination:
     def test_combination_with_replacement_rank_unrank(self):
         for n in range(9):
             for k in range(n):
@@ -47,9 +47,9 @@ class TestCombination(unittest.TestCase):
                 for exp_rank, c in enumerate(combs):
                     c = list(c)
                     actual_rank = comb.Combination.with_replacement_rank(c, n)
-                    self.assertEqual(actual_rank, exp_rank)
+                    assert actual_rank == exp_rank
                     unranked = comb.Combination.with_replacement_unrank(exp_rank, n, k)
-                    self.assertEqual(unranked, c)
+                    assert unranked == c
 
     def test_combination_rank_unrank(self):
         for n in range(11):
@@ -57,19 +57,19 @@ class TestCombination(unittest.TestCase):
                 nums = list(range(n))
                 for rank, c in enumerate(itertools.combinations(nums, k)):
                     c = list(c)
-                    self.assertEqual(comb.Combination.rank(c, nums), rank)
-                    self.assertEqual(comb.Combination.unrank(rank, nums, k), c)
+                    assert comb.Combination.rank(c, nums) == rank
+                    assert comb.Combination.unrank(rank, nums, k) == c
 
     def test_combination_unrank_errors(self):
         self.verify_unrank_errors(1, 1, 1)
         self.verify_unrank_errors(2, 0, 1)
 
     def verify_unrank_errors(self, rank, n, k):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             comb.Combination.unrank(rank, list(range(n)), k)
 
 
-class TestPartition(unittest.TestCase):
+class TestPartition:
     def test_rule_asc(self):
         self.verify_rule_asc(1, [[1]])
         self.verify_rule_asc(2, [[1, 1], [2]])
@@ -97,25 +97,25 @@ class TestPartition(unittest.TestCase):
         )
 
     def verify_rule_asc(self, n, partitions):
-        self.assertEqual(list(comb.rule_asc(n)), partitions)
+        assert list(comb.rule_asc(n)) == partitions
 
     def test_partitions(self):
-        self.assertEqual(list(comb.partitions(0)), [])
+        assert list(comb.partitions(0)) == []
         for n in range(1, 7):
-            self.assertEqual(list(comb.partitions(n)), list(comb.rule_asc(n))[:-1])
+            assert list(comb.partitions(n)) == list(comb.rule_asc(n))[:-1]
 
     def test_group_partition(self):
-        self.assertEqual(comb.group_partition([1]), [[1]])
-        self.assertEqual(comb.group_partition([1, 2]), [[1], [2]])
-        self.assertEqual(comb.group_partition([1, 1, 1]), [[1, 1, 1]])
-        self.assertEqual(comb.group_partition([1, 1, 2, 3, 3]), [[1, 1], [2], [3, 3]])
+        assert comb.group_partition([1]) == [[1]]
+        assert comb.group_partition([1, 2]) == [[1], [2]]
+        assert comb.group_partition([1, 1, 1]) == [[1, 1, 1]]
+        assert comb.group_partition([1, 1, 2, 3, 3]) == [[1, 1], [2], [3, 3]]
 
 
-class TestRankTree(unittest.TestCase):
+class TestRankTree:
     def test_num_shapes(self):
         for i in range(11):
             all_trees = RankTree.all_unlabelled_trees(i)
-            self.assertEqual(len(list(all_trees)), comb.num_shapes(i))
+            assert len(list(all_trees)) == comb.num_shapes(i)
 
     def test_num_labellings(self):
         for n in range(2, 8):
@@ -123,21 +123,19 @@ class TestRankTree(unittest.TestCase):
                 tree = tree.label_unrank(0)
                 tree2 = tree.to_tsk_tree()
                 n_labellings = sum(1 for _ in RankTree.all_labellings(tree))
-                self.assertEqual(
-                    n_labellings, RankTree.from_tsk_tree(tree2).num_labellings()
-                )
+                assert n_labellings == RankTree.from_tsk_tree(tree2).num_labellings()
 
     def test_num_labelled_trees(self):
         # Number of leaf-labelled trees with n leaves on OEIS
         n_trees = [0, 1, 1, 4, 26, 236, 2752, 39208]
         for i, expected in zip(range(len(n_trees)), n_trees):
             actual = sum(1 for _ in RankTree.all_labelled_trees(i))
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_all_labelled_trees_3(self):
         expected = ["(0,1,2)", "(0,(1,2))", "(1,(0,2))", "(2,(0,1))"]
         actual = [t.newick() for t in RankTree.all_labelled_trees(3)]
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_all_labelled_trees_4(self):
         expected = [
@@ -175,21 +173,21 @@ class TestRankTree(unittest.TestCase):
             "((0,3),(1,2))",
         ]
         actual = [t.newick() for t in RankTree.all_labelled_trees(4)]
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_generate_trees_roundtrip(self):
         n = 5
         all_rank_trees = RankTree.all_labelled_trees(n)
         all_tsk_trees = tskit.all_trees(n)
         for rank_tree, tsk_tree in zip(all_rank_trees, all_tsk_trees):
-            self.assertEqual(rank_tree, RankTree.from_tsk_tree(tsk_tree))
+            assert rank_tree == RankTree.from_tsk_tree(tsk_tree)
 
     def test_all_shapes_roundtrip(self):
         n = 5
         all_rank_tree_shapes = RankTree.all_unlabelled_trees(n)
         all_tsk_tree_shapes = tskit.all_tree_shapes(n)
         for rank_tree, tsk_tree in zip(all_rank_tree_shapes, all_tsk_tree_shapes):
-            self.assertTrue(rank_tree.shape_equal(RankTree.from_tsk_tree(tsk_tree)))
+            assert rank_tree.shape_equal(RankTree.from_tsk_tree(tsk_tree))
 
     def test_all_labellings_roundtrip(self):
         n = 5
@@ -198,25 +196,25 @@ class TestRankTree(unittest.TestCase):
         rank_tree_labellings = RankTree.all_labellings(rank_tree)
         tsk_tree_labellings = tskit.all_tree_labellings(tsk_tree)
         for rank_t, tsk_t in zip(rank_tree_labellings, tsk_tree_labellings):
-            self.assertEqual(rank_t, RankTree.from_tsk_tree(tsk_t))
+            assert rank_t == RankTree.from_tsk_tree(tsk_t)
 
     def test_unrank(self):
         for n in range(6):
             for shape_rank, t in enumerate(RankTree.all_unlabelled_trees(n)):
                 for label_rank, labelled_tree in enumerate(RankTree.all_labellings(t)):
                     unranked = RankTree.unrank((shape_rank, label_rank), n)
-                    self.assertTrue(labelled_tree == unranked)
+                    assert labelled_tree == unranked
 
         # The number of labelled trees gets very big quickly
         for n in range(6, 10):
             for shape_rank in range(comb.num_shapes(n)):
                 rank = (shape_rank, 0)
                 unranked = RankTree.unrank(rank, n)
-                self.assertTrue(rank, unranked.rank())
+                assert rank, unranked.rank()
 
                 rank = (shape_rank, comb.num_labellings(shape_rank, n) - 1)
                 unranked = RankTree.unrank(rank, n)
-                self.assertTrue(rank, unranked.rank())
+                assert rank, unranked.rank()
 
     def test_unrank_errors(self):
         self.verify_unrank_errors((-1, 0), 1)
@@ -239,34 +237,34 @@ class TestRankTree(unittest.TestCase):
         self.verify_unrank_errors(invalid_labelling, 10)
 
     def verify_unrank_errors(self, rank, n):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             RankTree.unrank(rank, n)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tskit.Tree.unrank(rank, n)
 
     def test_shape_rank(self):
         for n in range(10):
             for rank, tree in enumerate(RankTree.all_unlabelled_trees(n)):
-                self.assertEqual(tree.shape_rank(), rank)
+                assert tree.shape_rank() == rank
 
     def test_shape_unrank(self):
         for n in range(6):
             for rank, tree in enumerate(RankTree.all_unlabelled_trees(n)):
                 t = RankTree.shape_unrank(rank, n)
-                self.assertTrue(tree.shape_equal(t))
+                assert tree.shape_equal(t)
 
         for n in range(2, 9):
             for shape_rank, tree in enumerate(RankTree.all_unlabelled_trees(n)):
                 tsk_tree = tskit.Tree.unrank((shape_rank, 0), n)
-                self.assertEqual(shape_rank, tree.shape_rank())
+                assert shape_rank == tree.shape_rank()
                 shape_rank, _ = tsk_tree.rank()
-                self.assertEqual(shape_rank, tree.shape_rank())
+                assert shape_rank == tree.shape_rank()
 
     def test_label_rank(self):
         for n in range(7):
             for tree in RankTree.all_unlabelled_trees(n):
                 for rank, labelled_tree in enumerate(RankTree.all_labellings(tree)):
-                    self.assertEqual(labelled_tree.label_rank(), rank)
+                    assert labelled_tree.label_rank() == rank
 
     def test_label_unrank(self):
         for n in range(7):
@@ -276,26 +274,26 @@ class TestRankTree(unittest.TestCase):
                 ):
                     rank = (shape_rank, label_rank)
                     unranked = tree.label_unrank(label_rank)
-                    self.assertEqual(labelled_tree.rank(), rank)
-                    self.assertEqual(unranked.rank(), rank)
+                    assert labelled_tree.rank() == rank
+                    assert unranked.rank() == rank
 
     def test_unrank_rank_round_trip(self):
         for n in range(6):  # Can do more but gets slow pretty quickly after 6
             for shape_rank in range(comb.num_shapes(n)):
                 tree = RankTree.shape_unrank(shape_rank, n)
                 tree = tree.label_unrank(0)
-                self.assertEqual(tree.shape_rank(), shape_rank)
+                assert tree.shape_rank() == shape_rank
                 for label_rank in range(tree.num_labellings()):
                     tree = tree.label_unrank(label_rank)
-                    self.assertEqual(tree.label_rank(), label_rank)
+                    assert tree.label_rank() == label_rank
                     tsk_tree = tree.label_unrank(label_rank).to_tsk_tree()
                     _, tsk_label_rank = tsk_tree.rank()
-                    self.assertEqual(tsk_label_rank, label_rank)
+                    assert tsk_label_rank == label_rank
 
     def test_is_canonical(self):
         for n in range(7):
             for tree in RankTree.all_labelled_trees(n):
-                self.assertTrue(tree.is_canonical())
+                assert tree.is_canonical()
 
         shape_not_canonical = RankTree(
             children=[
@@ -313,7 +311,7 @@ class TestRankTree(unittest.TestCase):
                 ),
             ]
         )
-        self.assertFalse(shape_not_canonical.is_canonical())
+        assert not shape_not_canonical.is_canonical()
 
         labels_not_canonical = RankTree(
             children=[
@@ -336,27 +334,27 @@ class TestRankTree(unittest.TestCase):
                 ),
             ]
         )
-        self.assertFalse(labels_not_canonical.is_canonical())
+        assert not labels_not_canonical.is_canonical()
 
     def test_unranking_is_canonical(self):
         for n in range(7):
             for shape_rank in range(comb.num_shapes(n)):
                 for label_rank in range(comb.num_labellings(shape_rank, n)):
                     t = RankTree.shape_unrank(shape_rank, n)
-                    self.assertTrue(t.is_canonical())
+                    assert t.is_canonical()
                     t = t.label_unrank(label_rank)
-                    self.assertTrue(t.is_canonical())
+                    assert t.is_canonical()
                     t = tskit.Tree.unrank((shape_rank, label_rank), n)
-                    self.assertTrue(RankTree.from_tsk_tree(t).is_canonical())
+                    assert RankTree.from_tsk_tree(t).is_canonical()
 
     def test_to_from_tsk_tree(self):
         for n in range(5):
             for tree in RankTree.all_labelled_trees(n):
-                self.assertTrue(tree.is_canonical())
+                assert tree.is_canonical()
                 tsk_tree = tree.to_tsk_tree()
                 reconstructed = RankTree.from_tsk_tree(tsk_tree)
-                self.assertTrue(tree.is_canonical())
-                self.assertEqual(tree, reconstructed)
+                assert tree.is_canonical()
+                assert tree == reconstructed
 
     def test_from_unary_tree(self):
         tables = tskit.TableCollection(sequence_length=1)
@@ -365,15 +363,15 @@ class TestRankTree(unittest.TestCase):
         tables.edges.add_row(left=0, right=1, parent=p, child=c)
 
         t = tables.tree_sequence().first()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             RankTree.from_tsk_tree(t)
 
     def test_to_tsk_tree_errors(self):
         alpha_tree = RankTree.unrank((0, 0), 3, ["A", "B", "C"])
         out_of_bounds_tree = RankTree.unrank((0, 0), 3, [2, 3, 4])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             alpha_tree.to_tsk_tree()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             out_of_bounds_tree.to_tsk_tree()
 
     def test_rank_errors_multiple_roots(self):
@@ -388,7 +386,7 @@ class TestRankTree(unittest.TestCase):
             tables.nodes.add_row(flags=flags, time=t)
 
         ts = tables.tree_sequence()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.first().rank()
 
     def test_big_trees(self):
@@ -397,57 +395,57 @@ class TestRankTree(unittest.TestCase):
         labelling = 0
         tree = RankTree.unrank((shape, labelling), n)
         tsk_tree = tskit.Tree.unrank((shape, labelling), n)
-        self.assertEqual(tree.rank(), tsk_tree.rank())
+        assert tree.rank() == tsk_tree.rank()
 
         n = 10
         shape = 95
         labelling = comb.num_labellings(shape, n) // 2
         tree = RankTree.unrank((shape, labelling), n)
         tsk_tree = tskit.Tree.unrank((shape, labelling), n)
-        self.assertEqual(tree.rank(), tsk_tree.rank())
+        assert tree.rank() == tsk_tree.rank()
 
     def test_symmetrical_trees(self):
         for n in range(2, 18, 2):
             last_rank = comb.num_shapes(n) - 1
             t = RankTree.shape_unrank(last_rank, n)
-            self.assertTrue(t.is_symmetrical())
+            assert t.is_symmetrical()
 
     def test_equal(self):
         unlabelled_leaf = RankTree(children=[])
-        self.assertEqual(unlabelled_leaf, unlabelled_leaf)
-        self.assertTrue(unlabelled_leaf.shape_equal(unlabelled_leaf))
+        assert unlabelled_leaf == unlabelled_leaf
+        assert unlabelled_leaf.shape_equal(unlabelled_leaf)
 
         leaf_zero = RankTree(children=[], label=0)
         leaf_one = RankTree(children=[], label=1)
         leaf_two = RankTree(children=[], label=2)
-        self.assertEqual(leaf_zero, leaf_zero)
-        self.assertNotEqual(leaf_zero, leaf_one)
-        self.assertTrue(leaf_zero.shape_equal(leaf_one))
+        assert leaf_zero == leaf_zero
+        assert leaf_zero != leaf_one
+        assert leaf_zero.shape_equal(leaf_one)
 
         tree1 = RankTree(children=[leaf_zero, leaf_one])
-        self.assertEqual(tree1, tree1)
-        self.assertNotEqual(tree1, unlabelled_leaf)
-        self.assertFalse(tree1.shape_equal(unlabelled_leaf))
+        assert tree1 == tree1
+        assert tree1 != unlabelled_leaf
+        assert not tree1.shape_equal(unlabelled_leaf)
 
         tree2 = RankTree(children=[leaf_two, leaf_one])
-        self.assertNotEqual(tree1, tree2)
-        self.assertTrue(tree1.shape_equal(tree2))
+        assert tree1 != tree2
+        assert tree1.shape_equal(tree2)
 
     def test_is_symmetrical(self):
         unlabelled_leaf = RankTree(children=[])
-        self.assertTrue(unlabelled_leaf.is_symmetrical())
+        assert unlabelled_leaf.is_symmetrical()
         three_leaf_asym = RankTree(
             children=[
                 unlabelled_leaf,
                 RankTree(children=[unlabelled_leaf, unlabelled_leaf]),
             ]
         )
-        self.assertFalse(three_leaf_asym.is_symmetrical())
+        assert not three_leaf_asym.is_symmetrical()
         six_leaf_sym = RankTree(children=[three_leaf_asym, three_leaf_asym])
-        self.assertTrue(six_leaf_sym.is_symmetrical())
+        assert six_leaf_sym.is_symmetrical()
 
 
-class TestPartialTopologyCounter(unittest.TestCase):
+class TestPartialTopologyCounter:
     def test_add_sibling_topologies_simple(self):
         a = RankTree(children=[], label="A")
         b = RankTree(children=[], label="B")
@@ -455,11 +453,11 @@ class TestPartialTopologyCounter(unittest.TestCase):
 
         a_counter = comb.TopologyCounter()
         a_counter["A"][a.rank()] = 1
-        self.assertEqual(a_counter, comb.TopologyCounter.from_sample("A"))
+        assert a_counter == comb.TopologyCounter.from_sample("A")
 
         b_counter = comb.TopologyCounter()
         b_counter["B"][b.rank()] = 1
-        self.assertEqual(b_counter, comb.TopologyCounter.from_sample("B"))
+        assert b_counter == comb.TopologyCounter.from_sample("B")
 
         partial_counter = comb.PartialTopologyCounter()
         partial_counter.add_sibling_topologies(a_counter)
@@ -470,7 +468,7 @@ class TestPartialTopologyCounter(unittest.TestCase):
         expected["B"][b.rank()] = 1
         expected["A", "B"][ab.rank()] = 1
         joined_counter = partial_counter.join_all_combinations()
-        self.assertEqual(joined_counter, expected)
+        assert joined_counter == expected
 
     def test_add_sibling_topologies_polytomy(self):
         """
@@ -502,16 +500,16 @@ class TestPartialTopologyCounter(unittest.TestCase):
 
         partial_counter.add_sibling_topologies(a_counter)
         expected[("A",)] = collections.Counter({((("A",), (0, 0)),): 1})
-        self.assertEqual(partial_counter.partials, expected)
+        assert partial_counter.partials == expected
 
         partial_counter.add_sibling_topologies(a_counter)
         expected[("A",)][((("A",), (0, 0)),)] += 1
-        self.assertEqual(partial_counter.partials, expected)
+        assert partial_counter.partials == expected
 
         partial_counter.add_sibling_topologies(b_counter)
         expected[("B",)][((("B",), (0, 0)),)] = 1
         expected[("A", "B")][((("A",), (0, 0)), (("B",), (0, 0)))] = 2
-        self.assertEqual(partial_counter.partials, expected)
+        assert partial_counter.partials == expected
 
         partial_counter.add_sibling_topologies(ac_counter)
         expected[("A",)][((("A",), (0, 0)),)] += 1
@@ -524,7 +522,7 @@ class TestPartialTopologyCounter(unittest.TestCase):
             ((("A",), (0, 0)), (("B",), (0, 0)), (("C",), (0, 0)))
         ] = 2
         expected[("A", "B", "C")][((("A", "C"), (0, 0)), (("B",), (0, 0)))] = 1
-        self.assertEqual(partial_counter.partials, expected)
+        assert partial_counter.partials == expected
 
         expected_topologies = comb.TopologyCounter()
         expected_topologies["A"][(0, 0)] = 3
@@ -536,7 +534,7 @@ class TestPartialTopologyCounter(unittest.TestCase):
         expected_topologies["A", "B", "C"][(0, 0)] = 2
         expected_topologies["A", "B", "C"][(1, 1)] = 1
         joined_topologies = partial_counter.join_all_combinations()
-        self.assertEqual(joined_topologies, expected_topologies)
+        assert joined_topologies == expected_topologies
 
     def test_join_topologies(self):
         a = RankTree(children=[], label="A")
@@ -560,10 +558,10 @@ class TestPartialTopologyCounter(unittest.TestCase):
 
     def verify_join_topologies(self, topologies, expected_topology):
         actual_topology = comb.PartialTopologyCounter.join_topologies(topologies)
-        self.assertEqual(actual_topology, expected_topology)
+        assert actual_topology == expected_topology
 
 
-class TestCountTopologies(unittest.TestCase):
+class TestCountTopologies:
     def verify_topologies(self, ts, sample_sets=None, expected=None):
         if sample_sets is None:
             sample_sets = [ts.samples(population=pop.id) for pop in ts.populations()]
@@ -584,12 +582,10 @@ class TestCountTopologies(unittest.TestCase):
                         subsampled_topologies = self.subsample_topologies(
                             just_t, sample_sets, sample_set_indexes
                         )
-                        self.assertEqual(actual_topologies, subsampled_topologies)
+                        assert actual_topologies == subsampled_topologies
                     if expected is not None:
-                        self.assertEqual(
-                            actual_topologies, expected[i][sample_set_indexes]
-                        )
-                    self.assertEqual(actual_topologies, actual_inc_topologies)
+                        assert actual_topologies == expected[i][sample_set_indexes]
+                    assert actual_topologies == actual_inc_topologies
 
     def subsample_topologies(self, ts, sample_sets, sample_set_indexes):
         subsample_sets = [sample_sets[i] for i in sample_set_indexes]
@@ -770,8 +766,8 @@ class TestCountTopologies(unittest.TestCase):
 
         tree_topologies = ts.first().count_topologies(sample_sets)
         treeseq_topologies = list(ts.count_topologies(sample_sets))
-        self.assertEqual(tree_topologies, expected)
-        self.assertEqual(treeseq_topologies, [expected])
+        assert tree_topologies == expected
+        assert treeseq_topologies == [expected]
 
     def test_ignores_non_sample_leaves(self):
         nodes = io.StringIO(
@@ -818,8 +814,8 @@ class TestCountTopologies(unittest.TestCase):
 
         tree_topologies = ts.first().count_topologies(sample_sets)
         treeseq_topologies = list(ts.count_topologies(sample_sets))
-        self.assertEqual(tree_topologies, expected)
-        self.assertEqual(treeseq_topologies, [expected])
+        assert tree_topologies == expected
+        assert treeseq_topologies == [expected]
 
     def test_internal_samples_errors(self):
         tables = tskit.TableCollection(sequence_length=1.0)
@@ -850,15 +846,15 @@ class TestCountTopologies(unittest.TestCase):
         self.verify_node_out_of_bounds_error(tables.tree_sequence(), sample_sets)
 
     def verify_value_error(self, ts, sample_sets=None):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.first().count_topologies(sample_sets)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             list(ts.count_topologies(sample_sets))
 
     def verify_node_out_of_bounds_error(self, ts, sample_sets=None):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.first().count_topologies(sample_sets)
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             list(ts.count_topologies(sample_sets))
 
     def test_standard_msprime_migrations(self):

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -27,13 +27,14 @@ import collections
 import io
 import math
 import os
+import re
 import tempfile
-import unittest
 import xml.dom.minidom
 import xml.etree
 
 import msprime
 import numpy as np
+import pytest
 import xmlunittest
 
 import tests.tsutil as tsutil
@@ -41,7 +42,7 @@ import tskit
 from tskit import drawing
 
 
-class TestTreeDraw(unittest.TestCase):
+class TestTreeDraw:
     """
     Tests for the tree drawing functionality.
     """
@@ -88,7 +89,7 @@ class TestTreeDraw(unittest.TestCase):
         tables.edges.add_row(0, 2, 2, 0)
         tables.edges.add_row(0, 2, 2, 1)
         tree = tables.tree_sequence().first()
-        self.assertEqual(tree.num_roots, 0)
+        assert tree.num_roots == 0
         return tree
 
     def get_multiroot_tree(self):
@@ -252,7 +253,7 @@ class TestClosestLeftNode(TestTreeDraw):
         m2 = get_left_neighbour(tree, "postorder")
         np.testing.assert_array_equal(m1, m2)
         for u in tree.nodes():
-            self.assertEqual(m1[u], closest_left_node(tree, u))
+            assert m1[u] == closest_left_node(tree, u)
 
         m1 = drawing.get_left_neighbour(tree, "minlex_postorder")
         m2 = get_left_neighbour(tree, "minlex_postorder")
@@ -291,18 +292,18 @@ class TestClosestLeftNode(TestTreeDraw):
         left_child = drawing.get_left_child(t, "postorder")
         for u in t.nodes(order="postorder"):
             if t.num_children(u) > 0:
-                self.assertEqual(left_child[u], t.children(u)[0])
+                assert left_child[u] == t.children(u)[0]
 
     def test_null_node_left_child(self):
         t = self.get_nonbinary_tree()
         left_child = drawing.get_left_child(t, "minlex_postorder")
-        self.assertEqual(left_child[tskit.NULL], tskit.NULL)
+        assert left_child[tskit.NULL] == tskit.NULL
 
     def test_leaf_node_left_child(self):
         t = self.get_nonbinary_tree()
         left_child = drawing.get_left_child(t, "minlex_postorder")
         for u in t.samples():
-            self.assertEqual(left_child[u], tskit.NULL)
+            assert left_child[u] == tskit.NULL
 
 
 class TestOrder(TestTreeDraw):
@@ -312,16 +313,16 @@ class TestOrder(TestTreeDraw):
 
     def test_bad_order(self):
         for bad_order in [("sdf"), "sdf", 1234, ""]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 drawing.check_order(bad_order)
 
     def test_default_order(self):
         traversal_order = drawing.check_order(None)
-        self.assertEqual(traversal_order, "minlex_postorder")
+        assert traversal_order == "minlex_postorder"
 
     def test_order_mapping(self):
-        self.assertEqual(drawing.check_order("tree"), "postorder")
-        self.assertEqual(drawing.check_order("minlex"), "minlex_postorder")
+        assert drawing.check_order("tree") == "postorder"
+        assert drawing.check_order("minlex") == "minlex_postorder"
 
     def test_tree_svg_variants(self):
         t = self.get_binary_tree()
@@ -329,13 +330,13 @@ class TestOrder(TestTreeDraw):
         output2 = t.draw(format="svg", order="minlex")
         output3 = t.draw(format="svg", order="tree")
         # Default is minlex
-        self.assertEqual(output1, output2)
+        assert output1 == output2
         # tree is at least different to minlex
-        self.assertNotEqual(output1, output3)
+        assert output1 != output3
         # draw_svg gets the same results
-        self.assertEqual(t.draw_svg(), output1)
-        self.assertEqual(t.draw_svg(order="minlex"), output1)
-        self.assertEqual(t.draw_svg(order="tree"), output3)
+        assert t.draw_svg() == output1
+        assert t.draw_svg(order="minlex") == output1
+        assert t.draw_svg(order="tree") == output3
 
     def test_tree_text_variants(self):
         t = self.get_binary_tree()
@@ -343,13 +344,13 @@ class TestOrder(TestTreeDraw):
         output2 = t.draw(format="unicode", order="minlex")
         output3 = t.draw(format="unicode", order="tree")
         # Default is minlex
-        self.assertEqual(output1, output2)
+        assert output1 == output2
         # tree is at least different to minlex
-        self.assertNotEqual(output1, output3)
+        assert output1 != output3
         # draw_text gets the same results
-        self.assertEqual(t.draw_text(), output1)
-        self.assertEqual(t.draw_text(order="minlex"), output1)
-        self.assertEqual(t.draw_text(order="tree"), output3)
+        assert t.draw_text() == output1
+        assert t.draw_text(order="minlex") == output1
+        assert t.draw_text(order="tree") == output3
 
     def test_tree_sequence_text_variants(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -358,9 +359,9 @@ class TestOrder(TestTreeDraw):
         output3 = ts.draw_text(order="tree")
 
         # Default is minlex
-        self.assertEqual(output1, output2)
+        assert output1 == output2
         # tree is at least different to minlex
-        self.assertNotEqual(output1, output3)
+        assert output1 != output3
 
     def test_tree_sequence_svg_variants(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -369,9 +370,9 @@ class TestOrder(TestTreeDraw):
         output3 = ts.draw_svg(order="tree")
 
         # Default is minlex
-        self.assertEqual(output1, output2)
+        assert output1 == output2
         # tree is at least different to minlex
-        self.assertNotEqual(output1, output3)
+        assert output1 != output3
 
 
 class TestFormats(TestTreeDraw):
@@ -384,42 +385,41 @@ class TestFormats(TestTreeDraw):
         for svg in ["svg", "SVG", "sVg"]:
             output = t.draw(format=svg)
             root = xml.etree.ElementTree.fromstring(output)
-            self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
+            assert root.tag == "{http://www.w3.org/2000/svg}svg"
 
     def test_default(self):
         # Default is SVG
         t = self.get_binary_tree()
         output = t.draw(format=None)
         root = xml.etree.ElementTree.fromstring(output)
-        self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
+        assert root.tag == "{http://www.w3.org/2000/svg}svg"
         output = t.draw()
         root = xml.etree.ElementTree.fromstring(output)
-        self.assertEqual(root.tag, "{http://www.w3.org/2000/svg}svg")
+        assert root.tag == "{http://www.w3.org/2000/svg}svg"
 
     def test_ascii_variants(self):
         t = self.get_binary_tree()
         for fmt in ["ascii", "ASCII", "AScii"]:
             output = t.draw(format=fmt)
-            self.assertRaises(
-                xml.etree.ElementTree.ParseError,
-                xml.etree.ElementTree.fromstring,
-                output,
-            )
+            with pytest.raises(xml.etree.ElementTree.ParseError):
+                xml.etree.ElementTree.fromstring(
+                    output,
+                )
 
     def test_unicode_variants(self):
         t = self.get_binary_tree()
         for fmt in ["unicode", "UNICODE", "uniCODE"]:
             output = t.draw(format=fmt)
-            self.assertRaises(
-                xml.etree.ElementTree.ParseError,
-                xml.etree.ElementTree.fromstring,
-                output,
-            )
+            with pytest.raises(xml.etree.ElementTree.ParseError):
+                xml.etree.ElementTree.fromstring(
+                    output,
+                )
 
     def test_bad_formats(self):
         t = self.get_binary_tree()
         for bad_format in ["", "ASC", "SV", "jpeg"]:
-            self.assertRaises(ValueError, t.draw, format=bad_format)
+            with pytest.raises(ValueError):
+                t.draw(format=bad_format)
 
 
 class TestDrawText(TestTreeDraw):
@@ -431,7 +431,7 @@ class TestDrawText(TestTreeDraw):
     example_label = "XXX"
 
     def verify_basic_text(self, text):
-        self.assertTrue(isinstance(text, str))
+        assert isinstance(text, str)
         # TODO surely something else we can verify about this...
 
     def test_draw_defaults(self):
@@ -461,11 +461,13 @@ class TestDrawText(TestTreeDraw):
 
     def test_draw_empty_tree(self):
         t = self.get_empty_tree()
-        self.assertRaises(ValueError, t.draw, format=self.drawing_format)
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format)
 
     def test_draw_zero_roots_tree(self):
         t = self.get_zero_roots_tree()
-        self.assertRaises(ValueError, t.draw, format=self.drawing_format)
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format)
 
     def test_draw_zero_edge_tree(self):
         t = self.get_zero_edge_tree()
@@ -536,7 +538,7 @@ class TestDrawText(TestTreeDraw):
         j = 0
         for _ in t.nodes():
             j = text[j:].find(self.example_label)
-            self.assertNotEqual(j, -1)
+            assert j != -1
 
     def test_long_internal_labels(self):
         t = self.get_binary_tree()
@@ -550,30 +552,26 @@ class TestDrawText(TestTreeDraw):
         text = t.draw(format=self.drawing_format, node_labels=labels)
         self.verify_basic_text(text)
         for u in t.nodes():
-            self.assertEqual(text.find(str(u)), -1)
+            assert text.find(str(u)) == -1
 
     def test_unused_args(self):
         t = self.get_binary_tree()
-        self.assertRaises(ValueError, t.draw, format=self.drawing_format, width=300)
-        self.assertRaises(ValueError, t.draw, format=self.drawing_format, height=300)
-        self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, mutation_labels={}
-        )
-        self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, mutation_colours={}
-        )
-        self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, edge_colours={}
-        )
-        self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, node_colours={}
-        )
-        self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, max_tree_height=1234
-        )
-        self.assertRaises(
-            ValueError, t.draw, format=self.drawing_format, tree_height_scale="time"
-        )
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, width=300)
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, height=300)
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, mutation_labels={})
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, mutation_colours={})
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, edge_colours={})
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, node_colours={})
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, max_tree_height=1234)
+        with pytest.raises(ValueError):
+            t.draw(format=self.drawing_format, tree_height_scale="time")
 
 
 class TestDrawUnicode(TestDrawText):
@@ -585,7 +583,7 @@ class TestDrawUnicode(TestDrawText):
     example_label = "\u20ac" * 10  # euro symbol
 
 
-class TestDrawTextErrors(unittest.TestCase):
+class TestDrawTextErrors:
     """
     Tests for errors occuring in tree drawing code.
     """
@@ -593,7 +591,7 @@ class TestDrawTextErrors(unittest.TestCase):
     def test_bad_orientation(self):
         t = msprime.simulate(5, mutation_rate=0.1, random_seed=2).first()
         for bad_orientation in ["", "leftright", "sdf"]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 t.draw_text(orientation=bad_orientation)
 
 
@@ -610,10 +608,10 @@ class TestDrawTextExamples(TestTreeDraw):
             print(drawn_tree)
         tree_lines = drawn_tree.splitlines()
         drawn_lines = drawn.splitlines()
-        self.assertEqual(len(tree_lines), len(drawn_lines))
+        assert len(tree_lines) == len(drawn_lines)
         for l1, l2 in zip(tree_lines, drawn_lines):
             # Trailing white space isn't significant.
-            self.assertEqual(l1.rstrip(), l2.rstrip())
+            assert l1.rstrip() == l2.rstrip()
 
     def test_simple_tree(self):
         nodes = io.StringIO(
@@ -1394,7 +1392,7 @@ class TestDrawTextExamples(TestTreeDraw):
         t = ts.first()
         self.verify_text_rendering(t.draw_text(max_tree_height="tree"), tree)
         for bad_max_tree_height in [1, "sdfr", ""]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 t.draw_text(max_tree_height=bad_max_tree_height)
 
 
@@ -1406,38 +1404,36 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
     def verify_basic_svg(self, svg, width=200, height=200):
         prefix = "{http://www.w3.org/2000/svg}"
         root = xml.etree.ElementTree.fromstring(svg)
-        self.assertEqual(root.tag, prefix + "svg")
-        self.assertEqual(width, int(root.attrib["width"]))
-        self.assertEqual(height, int(root.attrib["height"]))
+        assert root.tag == prefix + "svg"
+        assert width == int(root.attrib["width"])
+        assert height == int(root.attrib["height"])
 
         # Verify the class structure of the svg
         root_group = root.find(prefix + "g")
-        self.assertIn("class", root_group.attrib)
-        self.assertRegexpMatches(
-            root_group.attrib["class"], r"\b(tree|tree-sequence)\b"
-        )
+        assert "class" in root_group.attrib
+        assert re.search(r"\b(tree|tree-sequence)\b", root_group.attrib["class"])
         if "tree-sequence" in root_group.attrib["class"]:
             trees = None
             for g in root_group.findall(prefix + "g"):
                 if "trees" in g.attrib.get("class", ""):
                     trees = g
                     break
-            self.assertIsNotNone(trees)  # Must have found a trees group
+            assert trees is not None  # Must have found a trees group
             first_treebox = trees.find(prefix + "g")
-            self.assertIn("class", first_treebox.attrib)
-            self.assertRegexpMatches(first_treebox.attrib["class"], r"\btreebox\b")
+            assert "class" in first_treebox.attrib
+            assert re.search(r"\btreebox\b", first_treebox.attrib["class"])
             first_tree = first_treebox.find(prefix + "g")
-            self.assertIn("class", first_tree.attrib)
-            self.assertRegexpMatches(first_tree.attrib["class"], r"\btree\b")
+            assert "class" in first_tree.attrib
+            assert re.search(r"\btree\b", first_tree.attrib["class"])
         else:
             first_tree = root_group
         # Check that we have edges, symbols, and labels groups
         groups = first_tree.findall(prefix + "g")
-        self.assertGreater(len(groups), 0)
+        assert len(groups) > 0
         for group in groups:
-            self.assertIn("class", group.attrib)
+            assert "class" in group.attrib
             cls = group.attrib["class"]
-            self.assertRegexpMatches(cls, r"\broot\b")
+            assert re.search(r"\broot\b", cls)
 
     def test_draw_file(self):
         t = self.get_binary_tree()
@@ -1445,14 +1441,14 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         try:
             os.close(fd)
             svg = t.draw(path=filename)
-            self.assertGreater(os.path.getsize(filename), 0)
+            assert os.path.getsize(filename) > 0
             with open(filename) as tmp:
                 other_svg = tmp.read()
-            self.assertEqual(svg, other_svg)
+            assert svg == other_svg
             os.unlink(filename)
 
             svg = t.draw_svg(path=filename)
-            self.assertGreater(os.path.getsize(filename), 0)
+            assert os.path.getsize(filename) > 0
             with open(filename) as tmp:
                 other_svg = tmp.read()
             self.verify_basic_svg(svg)
@@ -1460,7 +1456,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
 
             ts = t.tree_sequence
             svg = ts.draw_svg(path=filename)
-            self.assertGreater(os.path.getsize(filename), 0)
+            assert os.path.getsize(filename) > 0
             with open(filename) as tmp:
                 other_svg = tmp.read()
             self.verify_basic_svg(svg)
@@ -1505,13 +1501,17 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
 
     def test_draw_empty(self):
         t = self.get_empty_tree()
-        self.assertRaises(ValueError, t.draw)
-        self.assertRaises(ValueError, t.draw_svg)
+        with pytest.raises(ValueError):
+            t.draw()
+        with pytest.raises(ValueError):
+            t.draw_svg()
 
     def test_draw_zero_roots(self):
         t = self.get_zero_roots_tree()
-        self.assertRaises(ValueError, t.draw)
-        self.assertRaises(ValueError, t.draw_svg)
+        with pytest.raises(ValueError):
+            t.draw()
+        with pytest.raises(ValueError):
+            t.draw_svg()
 
     def test_draw_zero_edge(self):
         t = self.get_zero_edge_tree()
@@ -1534,20 +1534,20 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         labels = {u: "XXX" for u in t.nodes()}
         svg = t.draw(format="svg", node_labels=labels)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("XXX"), t.num_nodes)
+        assert svg.count("XXX") == t.num_nodes
         svg = t.draw_svg(node_label_attrs={u: {"text": labels[u]} for u in t.nodes()})
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("XXX"), t.num_nodes)
+        assert svg.count("XXX") == t.num_nodes
 
     def test_one_node_label(self):
         t = self.get_binary_tree()
         labels = {0: "XXX"}
         svg = t.draw(format="svg", node_labels=labels)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("XXX"), 1)
+        assert svg.count("XXX") == 1
         svg = t.draw_svg(node_label_attrs={0: {"text": "XXX"}})
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("XXX"), 1)
+        assert svg.count("XXX") == 1
 
     def test_no_node_labels(self):
         t = self.get_binary_tree()
@@ -1562,10 +1562,10 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         colours = {0: colour}
         svg = t.draw(format="svg", node_colours=colours)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count(f"fill:{colour}"), 1)
+        assert svg.count(f"fill:{colour}") == 1
         svg = t.draw_svg(node_attrs={0: {"fill": colour}})
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count(f'fill="{colour}"'), 1)
+        assert svg.count(f'fill="{colour}"') == 1
 
     def test_all_nodes_colour(self):
         t = self.get_binary_tree()
@@ -1573,20 +1573,20 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         svg = t.draw(format="svg", node_colours=colours)
         self.verify_basic_svg(svg)
         for colour in colours.values():
-            self.assertEqual(svg.count(f"fill:{colour}"), 1)
+            assert svg.count(f"fill:{colour}") == 1
 
         svg = t.draw_svg(node_attrs={u: {"fill": colours[u]} for u in t.nodes()})
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count(f'fill="{colour}"'), 1)
+        assert svg.count(f'fill="{colour}"') == 1
         for colour in colours.values():
-            self.assertEqual(svg.count(f'fill="{colour}"'), 1)
+            assert svg.count(f'fill="{colour}"') == 1
 
     def test_unplotted_node(self):
         t = self.get_binary_tree()
         colour = None
         colours = {0: colour}
         svg = t.draw(format="svg", node_colours=colours)
-        self.assertEqual(svg.count("opacity:0"), 1)
+        assert svg.count("opacity:0") == 1
 
     def test_one_edge_colour(self):
         t = self.get_binary_tree()
@@ -1594,28 +1594,28 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         colours = {0: colour}
         svg = t.draw(format="svg", edge_colours=colours)
         self.verify_basic_svg(svg)
-        self.assertGreater(svg.count(f"stroke:{colour}"), 0)
+        assert svg.count(f"stroke:{colour}") > 0
         svg = t.draw_svg(edge_attrs={0: {"stroke": colour}})
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count(f'stroke="{colour}"'), 1)
+        assert svg.count(f'stroke="{colour}"') == 1
 
     def test_one_mutation_label_colour(self):
         t = self.get_binary_tree()
         colour = "rgb(0, 1, 2)"
         svg = t.draw_svg(mutation_label_attrs={0: {"stroke": colour}})
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count(f'stroke="{colour}"'), 1)
+        assert svg.count(f'stroke="{colour}"') == 1
 
     def test_bad_tree_height_scale(self):
         t = self.get_binary_tree()
         for bad_scale in ["te", "asdf", "", [], b"23"]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 t.draw_svg(tree_height_scale=bad_scale)
 
     def test_bad_max_tree_height(self):
         t = self.get_binary_tree()
         for bad_height in ["te", "asdf", "", [], b"23"]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 t.draw_svg(max_tree_height=bad_height)
 
     def test_height_scale_time_and_max_tree_height(self):
@@ -1625,11 +1625,11 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         svg1 = t.draw_svg(max_tree_height="tree")
         self.verify_basic_svg(svg1)
         svg2 = t.draw_svg()
-        self.assertEqual(svg1, svg2)
+        assert svg1 == svg2
         svg3 = t.draw_svg(max_tree_height="ts")
-        self.assertNotEqual(svg1, svg3)
+        assert svg1 != svg3
         svg4 = t.draw_svg(max_tree_height=max(ts.tables.nodes.time))
-        self.assertEqual(svg3, svg4)
+        assert svg3 == svg4
 
     def test_height_scale_rank_and_max_tree_height(self):
         # Make sure the rank height scale and max_tree_height interact properly.
@@ -1639,12 +1639,12 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         svg1 = t.draw_svg(max_tree_height="tree", tree_height_scale="rank")
         self.verify_basic_svg(svg1)
         svg2 = t.draw_svg(tree_height_scale="rank")
-        self.assertEqual(svg1, svg2)
+        assert svg1 == svg2
         svg3 = t.draw_svg(max_tree_height="ts", tree_height_scale="rank")
-        self.assertNotEqual(svg1, svg3)
+        assert svg1 != svg3
         self.verify_basic_svg(svg3)
         # Numeric max tree height not supported for rank scale.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             t.draw_svg(max_tree_height=2, tree_height_scale="rank")
 
     #
@@ -1656,7 +1656,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         svg = t.draw(format="svg", edge_colours=colours)
         self.verify_basic_svg(svg)
         for colour in colours.values():
-            self.assertGreater(svg.count(f"stroke:{colour}"), 0)
+            assert svg.count(f"stroke:{colour}") > 0
 
     def test_unplotted_edge(self):
         t = self.get_binary_tree()
@@ -1664,21 +1664,21 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         colours = {0: colour}
         svg = t.draw(format="svg", edge_colours=colours)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("opacity:0"), 1)
+        assert svg.count("opacity:0") == 1
 
     def test_mutation_labels(self):
         t = self.get_binary_tree()
         labels = {u.id: "XXX" for u in t.mutations()}
         svg = t.draw(format="svg", mutation_labels=labels)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("XXX"), t.num_mutations)
+        assert svg.count("XXX") == t.num_mutations
 
     def test_one_mutation_label(self):
         t = self.get_binary_tree()
         labels = {0: "XXX"}
         svg = t.draw(format="svg", mutation_labels=labels)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("XXX"), 1)
+        assert svg.count("XXX") == 1
 
     def test_no_mutation_labels(self):
         t = self.get_binary_tree()
@@ -1693,7 +1693,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         colours = {0: colour}
         svg = t.draw(format="svg", mutation_colours=colours)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count(f"fill:{colour}"), 1)
+        assert svg.count(f"fill:{colour}") == 1
 
     def test_all_mutations_colour(self):
         t = self.get_binary_tree()
@@ -1703,7 +1703,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         svg = t.draw(format="svg", mutation_colours=colours)
         self.verify_basic_svg(svg)
         for colour in colours.values():
-            self.assertEqual(svg.count(f"fill:{colour}"), 1)
+            assert svg.count(f"fill:{colour}") == 1
 
     def test_unplotted_mutation(self):
         t = self.get_binary_tree()
@@ -1711,7 +1711,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         colours = {0: colour}
         svg = t.draw(format="svg", mutation_colours=colours)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("fill-opacity:0"), 1)
+        assert svg.count("fill-opacity:0") == 1
 
     def test_max_tree_height(self):
         nodes = io.StringIO(
@@ -1747,7 +1747,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         snippet1 = svg1[svg1.rfind("edge", 0, str_pos) : str_pos]
         str_pos = svg2.find(">0<")
         snippet2 = svg2[svg2.rfind("edge", 0, str_pos) : str_pos]
-        self.assertNotEqual(snippet1, snippet2)
+        assert snippet1 != snippet2
 
         svg1 = ts.at_index(0).draw(max_tree_height="ts")
         svg2 = ts.at_index(1).draw(max_tree_height="ts")
@@ -1759,7 +1759,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         snippet1 = svg1[svg1.rfind("edge", 0, str_pos) : str_pos]
         str_pos = svg2.find(">0<")
         snippet2 = svg2[svg2.rfind("edge", 0, str_pos) : str_pos]
-        self.assertEqual(snippet1, snippet2)
+        assert snippet1 == snippet2
 
     def test_draw_sized_tree(self):
         tree = self.get_binary_tree()
@@ -1777,13 +1777,13 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
             length=1000, rate=0.005, num_loci=1000
         )
         ts = msprime.simulate(5, recombination_map=recomb_map, random_seed=1)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         svg = ts.draw_svg()
         self.verify_basic_svg(svg, width=200 * ts.num_trees)
         axis_pos = svg.find('class="axis"')
         for b in ts.breakpoints():
-            self.assertEqual(b, round(b))
-            self.assertNotEqual(svg.find(f">{b:.0f}<", axis_pos), -1)
+            assert b == round(b)
+            assert svg.find(f">{b:.0f}<", axis_pos) != -1
 
     def test_draw_even_height_ts(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=1)
@@ -1804,7 +1804,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         svg = ts.draw_svg(tree_height_scale="rank")
         self.verify_basic_svg(svg)
         for bad_scale in [0, "", "NOT A SCALE"]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.draw_svg(tree_height_scale=bad_scale)
 
     def test_x_scale(self):
@@ -1817,7 +1817,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
     def test_bad_x_scale(self):
         ts = msprime.simulate(4, random_seed=2)
         for bad_x_scale in ["te", "asdf", "", [], b"23"]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.draw_svg(x_scale=bad_x_scale)
 
     def test_no_edges(self):
@@ -1827,25 +1827,25 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         ts_no_edges = tables.tree_sequence()
         svg = ts_no_edges.draw_svg()  # This should just be a row of 10 circles
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("circle"), 10)
-        self.assertEqual(svg.count("path"), 0)
+        assert svg.count("circle") == 10
+        assert svg.count("path") == 0
 
         svg = ts_no_edges.draw_svg(force_root_branch=True)
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("circle"), 10)
-        self.assertEqual(svg.count("path"), 10)
+        assert svg.count("circle") == 10
+        assert svg.count("path") == 10
 
         # If there is a mutation, the root branches should be there too
         ts = msprime.mutate(ts, rate=1, random_seed=1)
         tables = ts.dump_tables()
         tables.edges.clear()
         ts_no_edges = tables.tree_sequence().simplify()
-        self.assertGreater(ts_no_edges.num_mutations, 0)  # Should have some singletons
+        assert ts_no_edges.num_mutations > 0  # Should have some singletons
         svg = ts_no_edges.draw_svg()
         self.verify_basic_svg(svg)
-        self.assertEqual(svg.count("circle"), 10)
-        self.assertEqual(svg.count("path"), 10)
-        self.assertEqual(svg.count("rect"), ts_no_edges.num_mutations)
+        assert svg.count("circle") == 10
+        assert svg.count("path") == 10
+        assert svg.count("rect") == ts_no_edges.num_mutations
 
     def test_tree_root_branch(self):
         # in the simple_ts, there are root mutations in the first tree but not the second
@@ -1868,12 +1868,12 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         snippet1 = svg1[str_pos1 + len(edge_str) : svg1.find(">", str_pos1)]
         snippet2a = svg2a[str_pos2a + len(edge_str) : svg2a.find(">", str_pos2a)]
         snippet2b = svg2b[str_pos2b + len(edge_str) : svg2b.find(">", str_pos2b)]
-        self.assertTrue(snippet1.startswith('"M 0 0'))
-        self.assertTrue(snippet2a.startswith('"M 0 0'))
-        self.assertTrue(snippet2b.startswith('"M 0 0'))
-        self.assertTrue("H 0" in snippet1)
-        self.assertFalse("H 0" in snippet2a)  # No root branch
-        self.assertTrue("H 0" in snippet2b)
+        assert snippet1.startswith('"M 0 0')
+        assert snippet2a.startswith('"M 0 0')
+        assert snippet2b.startswith('"M 0 0')
+        assert "H 0" in snippet1
+        assert not ("H 0" in snippet2a)  # No root branch
+        assert "H 0" in snippet2b
 
     def test_known_svg_tree_no_mut(self):
         tree = self.get_simple_ts().at_index(1)
@@ -1913,13 +1913,13 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestCase):
         self.assertXmlEquivalentOutputs(svg, expected_svg)
 
 
-class TestRounding(unittest.TestCase):
+class TestRounding:
     def test_rnd(self):
-        self.assertEqual(0, drawing.rnd(0))
-        self.assertEqual(math.inf, drawing.rnd(math.inf))
-        self.assertEqual(1, drawing.rnd(1))
-        self.assertEqual(1.1, drawing.rnd(1.1))
-        self.assertEqual(1.11111, drawing.rnd(1.111111))
-        self.assertEqual(1111110, drawing.rnd(1111111))
-        self.assertEqual(123.457, drawing.rnd(123.4567))
-        self.assertEqual(123.456, drawing.rnd(123.4564))
+        assert 0 == drawing.rnd(0)
+        assert math.inf == drawing.rnd(math.inf)
+        assert 1 == drawing.rnd(1)
+        assert 1.1 == drawing.rnd(1.1)
+        assert 1.11111 == drawing.rnd(1.111111)
+        assert 1111110 == drawing.rnd(1111111)
+        assert 123.457 == drawing.rnd(123.4567)
+        assert 123.456 == drawing.rnd(123.4564)

--- a/python/tests/test_fasta.py
+++ b/python/tests/test_fasta.py
@@ -27,9 +27,9 @@ import io
 import itertools
 import os
 import tempfile
-import unittest
 
 import msprime
+import pytest
 from Bio import SeqIO
 
 from tests import tsutil
@@ -45,7 +45,7 @@ def create_data(length):
     return ts
 
 
-class TestLineLength(unittest.TestCase):
+class TestLineLength:
     """
     Tests if the fasta file produced has the correct line lengths for
     default, custom, and no-wrapping options.
@@ -83,19 +83,19 @@ class TestLineLength(unittest.TestCase):
                 line_chars = len(line.strip("\n"))
                 # test full default width lines
                 if seq_line_counter < lines_expect:
-                    self.assertEqual(wrap_width, line_chars)
+                    assert wrap_width == line_chars
                 elif no_hanging_line:
-                    self.assertEqual(wrap_width, line_chars)
+                    assert wrap_width == line_chars
                 # test extra line if not perfectly divided by wrap_width
                 else:
-                    self.assertEqual(extra_line_length, line_chars)
+                    assert extra_line_length == line_chars
             # testing correct number of lines per sequence and correct num sequences
             else:
                 id_lines += 1
                 if seq_line_counter > 0:
-                    self.assertEqual(lines_expect, seq_line_counter)
+                    assert lines_expect == seq_line_counter
                     seq_line_counter = 0
-        self.assertEqual(id_lines, ts.num_samples)
+        assert id_lines == ts.num_samples
 
     def test_wrap_length_default_easy(self):
         # default wrap width (60) perfectly divides sequence length
@@ -119,11 +119,11 @@ class TestLineLength(unittest.TestCase):
 
     def test_bad_wrap(self):
         ts = create_data(100)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_fasta(io.StringIO(), wrap_width=-1)
 
 
-class TestSequenceIds(unittest.TestCase):
+class TestSequenceIds:
     """
     Tests that sequence IDs are output correctly, whether default or custom
     and that the length of IDs supplied must equal number of sequences
@@ -142,11 +142,11 @@ class TestSequenceIds(unittest.TestCase):
         # test default seq ids
         if seq_ids_in in [None]:
             for i, val in enumerate(seq_ids_read):
-                self.assertEqual(f"tsk_{i}", val)
+                assert f"tsk_{i}" == val
         # test custom seq ids
         else:
             for i, j in itertools.zip_longest(seq_ids_in, seq_ids_read):
-                self.assertEqual(i, j)
+                assert i == j
 
     def test_default_ids(self):
         # test that default sequence ids, immediately following '>', are as expected
@@ -161,18 +161,18 @@ class TestSequenceIds(unittest.TestCase):
 
     def test_bad_length_ids(self):
         ts = create_data(100)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             seq_ids_in = [f"x_{_}" for _ in range(ts.num_samples - 1)]
             ts.write_fasta(io.StringIO(), sequence_ids=seq_ids_in)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             seq_ids_in = [f"x_{_}" for _ in range(ts.num_samples + 1)]
             ts.write_fasta(io.StringIO(), sequence_ids=seq_ids_in)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             seq_ids_in = []
             ts.write_fasta(io.StringIO(), sequence_ids=seq_ids_in)
 
 
-class TestRoundTrip(unittest.TestCase):
+class TestRoundTrip:
     """
     Tests that output from our code is read in by available software packages
     Here test for compatability with biopython processing - Bio.SeqIO
@@ -189,7 +189,7 @@ class TestRoundTrip(unittest.TestCase):
                     biopython_fasta_read.append(record.seq)
 
         for i, j in itertools.zip_longest(biopython_fasta_read, ts.haplotypes()):
-            self.assertEqual(i, j)
+            assert i == j
 
     def test_equal_lines(self):
         # sequence length perfectly divisible by wrap_width

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -24,10 +24,10 @@ Test cases for generating genotypes/haplotypes.
 """
 import itertools
 import random
-import unittest
 
 import msprime
 import numpy as np
+import pytest
 
 import tests.test_wright_fisher as wf
 import tests.tsutil as tsutil
@@ -58,7 +58,7 @@ def naive_get_ancestral_haplotypes(ts):
     return A
 
 
-class TestGetAncestralHaplotypes(unittest.TestCase):
+class TestGetAncestralHaplotypes:
     """
     Tests for the engine to the actual ancestors from a simulation.
     """
@@ -74,7 +74,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
         nodes.set_columns(time=nodes.time, flags=flags)
         ts = tables.tree_sequence()
         B = ts.genotype_matrix().T
-        self.assertTrue(np.array_equal(A, B))
+        assert np.array_equal(A, B)
 
     def test_single_tree(self):
         ts = msprime.simulate(5, mutation_rate=1, random_seed=234)
@@ -84,8 +84,8 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
         ts = msprime.simulate(
             8, recombination_rate=10, mutation_rate=10, random_seed=234
         )
-        self.assertGreater(ts.num_trees, 1)
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_trees > 1
+        assert ts.num_sites > 1
         self.verify(ts)
 
     def test_single_tree_jukes_cantor(self):
@@ -100,8 +100,8 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
 
     def test_many_trees_infinite_sites(self):
         ts = msprime.simulate(6, recombination_rate=2, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_sites > 0
+        assert ts.num_trees > 2
         self.verify(ts)
 
     def test_wright_fisher_initial_generation(self):
@@ -111,7 +111,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_wright_fisher_simplified(self):
@@ -126,7 +126,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_empty_ts(self):
@@ -157,7 +157,7 @@ def isolated_samples_genotype_matrix(ts):
     return G
 
 
-class TestVariantGenerator(unittest.TestCase):
+class TestVariantGenerator:
     """
     Tests the variants() method to ensure the output is consistent.
     """
@@ -166,7 +166,7 @@ class TestVariantGenerator(unittest.TestCase):
         ts = msprime.simulate(
             10, length=10, recombination_rate=1, mutation_rate=10, random_seed=3
         )
-        self.assertGreater(ts.get_num_mutations(), 10)
+        assert ts.get_num_mutations() > 10
         return ts
 
     def test_as_bytes(self):
@@ -178,48 +178,48 @@ class TestVariantGenerator(unittest.TestCase):
         for variant in ts.variants():
             A[variant.index] = variant.genotypes
         for variant in ts.variants(as_bytes=True):
-            self.assertIsInstance(variant.genotypes, bytes)
+            assert isinstance(variant.genotypes, bytes)
             B[variant.index] = np.fromstring(variant.genotypes, np.uint8) - ord("0")
-        self.assertTrue(np.all(A == B))
+        assert np.all(A == B)
         bytes_variants = list(ts.variants(as_bytes=True))
         for j, variant in enumerate(bytes_variants):
-            self.assertEqual(j, variant.index)
+            assert j == variant.index
             row = np.fromstring(variant.genotypes, np.uint8) - ord("0")
-            self.assertTrue(np.all(A[j] == row))
+            assert np.all(A[j] == row)
 
     def test_as_bytes_fails(self):
         ts = tsutil.insert_multichar_mutations(self.get_tree_sequence())
-        self.assertRaises(ValueError, list, ts.variants(as_bytes=True))
+        with pytest.raises(ValueError):
+            list(ts.variants(as_bytes=True))
 
     def test_dtype(self):
         ts = self.get_tree_sequence()
         for var in ts.variants():
-            self.assertEqual(var.genotypes.dtype, np.int8)
+            assert var.genotypes.dtype == np.int8
 
     def test_dtype_conversion(self):
         # Check if we hit any issues if we assume the variants are uint8
         # as they were prior to version 0.2.0
         ts = self.get_tree_sequence()
         G = ts.genotype_matrix().astype(np.uint8)
-        self.assertEqual(G.dtype, np.uint8)
+        assert G.dtype == np.uint8
         for var in ts.variants():
-            self.assertTrue(np.array_equal(G[var.index], var.genotypes))
-            self.assertTrue(np.all(G[var.index] == var.genotypes))
-            self.assertEqual(
-                [var.alleles[g] for g in var.genotypes],
-                [var.alleles[g] for g in G[var.index]],
-            )
+            assert np.array_equal(G[var.index], var.genotypes)
+            assert np.all(G[var.index] == var.genotypes)
+            assert [var.alleles[g] for g in var.genotypes] == [
+                var.alleles[g] for g in G[var.index]
+            ]
             G[var.index, :] = var.genotypes
-            self.assertTrue(np.array_equal(G[var.index], var.genotypes))
+            assert np.array_equal(G[var.index], var.genotypes)
 
     def test_multichar_alleles(self):
         ts = tsutil.insert_multichar_mutations(self.get_tree_sequence())
         for var in ts.variants():
-            self.assertEqual(len(var.alleles), 2)
-            self.assertEqual(var.site.ancestral_state, var.alleles[0])
-            self.assertEqual(var.site.mutations[0].derived_state, var.alleles[1])
-            self.assertTrue(all(0 <= var.genotypes))
-            self.assertTrue(all(var.genotypes <= 1))
+            assert len(var.alleles) == 2
+            assert var.site.ancestral_state == var.alleles[0]
+            assert var.site.mutations[0].derived_state == var.alleles[1]
+            assert all(0 <= var.genotypes)
+            assert all(var.genotypes <= 1)
 
     def test_many_alleles(self):
         ts = self.get_tree_sequence()
@@ -228,26 +228,25 @@ class TestVariantGenerator(unittest.TestCase):
         tables.mutations.clear()
         # This gives us a total of 360 permutations.
         alleles = list(map("".join, itertools.permutations("ABCDEF", 4)))
-        self.assertGreater(len(alleles), 127)
+        assert len(alleles) > 127
         tables.sites.add_row(0, alleles[0])
         parent = -1
         num_alleles = 1
         for allele in alleles[1:]:
             ts = tables.tree_sequence()
             if num_alleles > 127:
-                self.assertRaises(exceptions.LibraryError, next, ts.variants())
+                with pytest.raises(exceptions.LibraryError):
+                    next(ts.variants())
             else:
                 var = next(ts.variants())
-                self.assertFalse(var.has_missing_data)
-                self.assertEqual(var.num_alleles, num_alleles)
-                self.assertEqual(len(var.alleles), num_alleles)
-                self.assertEqual(list(var.alleles), alleles[:num_alleles])
-                self.assertEqual(
-                    var.alleles[var.genotypes[0]], alleles[num_alleles - 1]
-                )
+                assert not var.has_missing_data
+                assert var.num_alleles == num_alleles
+                assert len(var.alleles) == num_alleles
+                assert list(var.alleles) == alleles[:num_alleles]
+                assert var.alleles[var.genotypes[0]] == alleles[num_alleles - 1]
                 for u in ts.samples():
                     if u != 0:
-                        self.assertEqual(var.alleles[var.genotypes[u]], alleles[0])
+                        assert var.alleles[var.genotypes[u]] == alleles[0]
             tables.mutations.add_row(0, 0, allele, parent=parent)
             parent += 1
             num_alleles += 1
@@ -261,29 +260,28 @@ class TestVariantGenerator(unittest.TestCase):
         tables.nodes.add_row(flags=1, time=0)
         # This gives us a total of 360 permutations.
         alleles = list(map("".join, itertools.permutations("ABCDEF", 4)))
-        self.assertGreater(len(alleles), 127)
+        assert len(alleles) > 127
         tables.sites.add_row(0, alleles[0])
         parent = -1
         num_alleles = 1
         for allele in alleles[1:]:
             ts = tables.tree_sequence()
             if num_alleles > 127:
-                self.assertRaises(exceptions.LibraryError, next, ts.variants())
+                with pytest.raises(exceptions.LibraryError):
+                    next(ts.variants())
             else:
                 var = next(ts.variants())
-                self.assertTrue(var.has_missing_data)
-                self.assertEqual(var.num_alleles, num_alleles)
-                self.assertEqual(len(var.alleles), num_alleles + 1)
-                self.assertEqual(list(var.alleles)[:-1], alleles[:num_alleles])
-                self.assertIsNone(var.alleles[-1])
-                self.assertEqual(
-                    var.alleles[var.genotypes[0]], alleles[num_alleles - 1]
-                )
-                self.assertEqual(var.genotypes[-1], -1)
+                assert var.has_missing_data
+                assert var.num_alleles == num_alleles
+                assert len(var.alleles) == num_alleles + 1
+                assert list(var.alleles)[:-1] == alleles[:num_alleles]
+                assert var.alleles[-1] is None
+                assert var.alleles[var.genotypes[0]] == alleles[num_alleles - 1]
+                assert var.genotypes[-1] == -1
                 samples = ts.samples()
                 for u in samples[:-1]:
                     if u != 0:
-                        self.assertEqual(var.alleles[var.genotypes[u]], alleles[0])
+                        assert var.alleles[var.genotypes[u]] == alleles[0]
             tables.mutations.add_row(0, 0, allele, parent=parent)
             parent += 1
             num_alleles += 1
@@ -291,14 +289,14 @@ class TestVariantGenerator(unittest.TestCase):
     def test_site_information(self):
         ts = self.get_tree_sequence()
         for site, variant in zip(ts.sites(), ts.variants()):
-            self.assertEqual(site.position, variant.position)
-            self.assertEqual(site, variant.site)
+            assert site.position == variant.position
+            assert site == variant.site
 
     def test_no_mutations(self):
         ts = msprime.simulate(10)
-        self.assertEqual(ts.get_num_mutations(), 0)
+        assert ts.get_num_mutations() == 0
         variants = list(ts.variants())
-        self.assertEqual(len(variants), 0)
+        assert len(variants) == 0
 
     def test_genotype_matrix(self):
         ts = self.get_tree_sequence()
@@ -306,8 +304,8 @@ class TestVariantGenerator(unittest.TestCase):
         for v in ts.variants():
             G[v.index, :] = v.genotypes
         G2 = ts.genotype_matrix()
-        self.assertTrue(np.array_equal(G, G2))
-        self.assertEqual(G2.dtype, np.int8)
+        assert np.array_equal(G, G2)
+        assert G2.dtype == np.int8
 
     def test_recurrent_mutations_over_samples(self):
         ts = self.get_tree_sequence()
@@ -323,13 +321,13 @@ class TestVariantGenerator(unittest.TestCase):
                 tables.mutations.add_row(site=j, node=u, derived_state="1")
         ts = tables.tree_sequence()
         variants = list(ts.variants())
-        self.assertEqual(len(variants), num_sites)
+        assert len(variants) == num_sites
         for site, variant in zip(ts.sites(), variants):
-            self.assertEqual(site.position, variant.position)
-            self.assertEqual(site, variant.site)
-            self.assertEqual(site.id, variant.index)
-            self.assertEqual(variant.alleles, ("0", "1"))
-            self.assertTrue(np.all(variant.genotypes == np.ones(ts.sample_size)))
+            assert site.position == variant.position
+            assert site == variant.site
+            assert site.id == variant.index
+            assert variant.alleles == ("0", "1")
+            assert np.all(variant.genotypes == np.ones(ts.sample_size))
 
     def test_recurrent_mutations_errors(self):
         ts = self.get_tree_sequence()
@@ -344,21 +342,22 @@ class TestVariantGenerator(unittest.TestCase):
                     tables.mutations.add_row(site=site, node=u, derived_state="1")
                     tables.mutations.add_row(site=site, node=sample, derived_state="1")
                     ts_new = tables.tree_sequence()
-                    self.assertRaises(exceptions.LibraryError, list, ts_new.variants())
+                    with pytest.raises(exceptions.LibraryError):
+                        list(ts_new.variants())
 
     def test_zero_samples(self):
         ts = self.get_tree_sequence()
         for var1, var2 in zip(ts.variants(), ts.variants(samples=[])):
-            self.assertEqual(var1.site, var2.site)
-            self.assertEqual(var1.alleles, var2.alleles)
-            self.assertEqual(var2.genotypes.shape[0], 0)
+            assert var1.site == var2.site
+            assert var1.alleles == var2.alleles
+            assert var2.genotypes.shape[0] == 0
 
     def test_samples(self):
         n = 4
         ts = msprime.simulate(
             n, length=5, recombination_rate=1, mutation_rate=5, random_seed=2
         )
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_sites > 1
         samples = list(range(n))
         # Generate all possible sample lists.
         for j in range(n + 1):
@@ -366,19 +365,19 @@ class TestVariantGenerator(unittest.TestCase):
                 s = np.array(s, dtype=np.int32)
                 count = 0
                 for var1, var2 in zip(ts.variants(), ts.variants(samples=s)):
-                    self.assertEqual(var1.site, var2.site)
-                    self.assertEqual(var1.alleles, var2.alleles)
-                    self.assertEqual(var2.genotypes.shape, (len(s),))
-                    self.assertTrue(np.array_equal(var1.genotypes[s], var2.genotypes))
+                    assert var1.site == var2.site
+                    assert var1.alleles == var2.alleles
+                    assert var2.genotypes.shape == (len(s),)
+                    assert np.array_equal(var1.genotypes[s], var2.genotypes)
                     count += 1
-                self.assertEqual(count, ts.num_sites)
+                assert count == ts.num_sites
 
     def test_samples_missing_data(self):
         n = 4
         ts = msprime.simulate(
             n, length=5, recombination_rate=1, mutation_rate=5, random_seed=2
         )
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_sites > 1
         tables = ts.dump_tables()
         tables.delete_intervals([[0.5, 0.6]])
         tables.sites.add_row(0.5, ancestral_state="0")
@@ -391,12 +390,12 @@ class TestVariantGenerator(unittest.TestCase):
                 s = np.array(s, dtype=np.int32)
                 count = 0
                 for var1, var2 in zip(ts.variants(), ts.variants(samples=s)):
-                    self.assertEqual(var1.site, var2.site)
-                    self.assertEqual(var1.alleles, var2.alleles)
-                    self.assertEqual(var2.genotypes.shape, (len(s),))
-                    self.assertTrue(np.array_equal(var1.genotypes[s], var2.genotypes))
+                    assert var1.site == var2.site
+                    assert var1.alleles == var2.alleles
+                    assert var2.genotypes.shape == (len(s),)
+                    assert np.array_equal(var1.genotypes[s], var2.genotypes)
                     count += 1
-                self.assertEqual(count, ts.num_sites)
+                assert count == ts.num_sites
 
     def test_non_sample_samples(self):
         # We don't have to use sample nodes. This does make the terminology confusing
@@ -410,7 +409,7 @@ class TestVariantGenerator(unittest.TestCase):
             time=tables.nodes.time,
         )
         all_samples_ts = tables.tree_sequence()
-        self.assertEqual(all_samples_ts.num_samples, ts.num_nodes)
+        assert all_samples_ts.num_samples == ts.num_nodes
 
         count = 0
         samples = range(ts.num_nodes)
@@ -418,18 +417,18 @@ class TestVariantGenerator(unittest.TestCase):
             all_samples_ts.variants(isolated_as_missing=False),
             ts.variants(samples=samples, isolated_as_missing=False),
         ):
-            self.assertEqual(var1.site, var2.site)
-            self.assertEqual(var1.alleles, var2.alleles)
-            self.assertEqual(var2.genotypes.shape, (len(samples),))
-            self.assertTrue(np.array_equal(var1.genotypes, var2.genotypes))
+            assert var1.site == var2.site
+            assert var1.alleles == var2.alleles
+            assert var2.genotypes.shape == (len(samples),)
+            assert np.array_equal(var1.genotypes, var2.genotypes)
             count += 1
-        self.assertEqual(count, ts.num_sites)
+        assert count == ts.num_sites
 
     def verify_jukes_cantor(self, ts):
-        self.assertTrue(np.array_equal(ts.genotype_matrix(), ts.genotype_matrix()))
+        assert np.array_equal(ts.genotype_matrix(), ts.genotype_matrix())
         tree = ts.first()
         for variant in ts.variants():
-            self.assertFalse(variant.has_missing_data)
+            assert not variant.has_missing_data
             mutations = {
                 mutation.node: mutation.derived_state
                 for mutation in variant.site.mutations
@@ -439,7 +438,7 @@ class TestVariantGenerator(unittest.TestCase):
                     u = tree.parent(u)
                 state1 = mutations.get(u, variant.site.ancestral_state)
                 state2 = variant.alleles[variant.genotypes[sample_index]]
-                self.assertEqual(state1, state2)
+                assert state1 == state2
 
     def test_jukes_cantor_n5(self):
         ts = msprime.simulate(5, random_seed=2)
@@ -463,28 +462,28 @@ class TestVariantGenerator(unittest.TestCase):
         tables.sort()
         ts = tables.tree_sequence()
         Gnm = ts.genotype_matrix(isolated_as_missing=False)
-        self.assertTrue(np.all(Gnm[0] == 0))
-        self.assertTrue(np.all(Gnm[1] == 0))
-        self.assertTrue(np.all(Gnm[-1] == 0))
-        self.assertTrue(np.all(Gnm[-2] == 0))
+        assert np.all(Gnm[0] == 0)
+        assert np.all(Gnm[1] == 0)
+        assert np.all(Gnm[-1] == 0)
+        assert np.all(Gnm[-2] == 0)
         Gm = isolated_samples_genotype_matrix(ts)
-        self.assertTrue(np.all(Gm[0] == -1))
-        self.assertTrue(np.all(Gm[1] == -1))
-        self.assertTrue(np.all(Gm[-1] == -1))
-        self.assertTrue(np.all(Gm[-2] == -1))
+        assert np.all(Gm[0] == -1)
+        assert np.all(Gm[1] == -1)
+        assert np.all(Gm[-1] == -1)
+        assert np.all(Gm[-2] == -1)
         Gm2 = ts.genotype_matrix(isolated_as_missing=True)
-        self.assertTrue(np.array_equal(Gm, Gm2))
+        assert np.array_equal(Gm, Gm2)
 
         # Test deprecated param
         Gi = ts.genotype_matrix(impute_missing_data=True)
-        self.assertTrue(np.array_equal(Gnm, Gi))
+        assert np.array_equal(Gnm, Gi)
         Gni = ts.genotype_matrix(impute_missing_data=False)
-        self.assertTrue(np.array_equal(Gm, Gni))
+        assert np.array_equal(Gm, Gni)
 
         G = ts.genotype_matrix(isolated_as_missing=False, impute_missing_data=True)
-        self.assertTrue(np.array_equal(Gnm, G))
+        assert np.array_equal(Gnm, G)
         G = ts.genotype_matrix(isolated_as_missing=True, impute_missing_data=False)
-        self.assertTrue(np.array_equal(Gm, G))
+        assert np.array_equal(Gm, G)
 
     def test_empty_ts_missing_data(self):
         tables = tskit.TableCollection(1.0)
@@ -493,11 +492,11 @@ class TestVariantGenerator(unittest.TestCase):
         tables.sites.add_row(0.5, "A")
         ts = tables.tree_sequence()
         variants = list(ts.variants())
-        self.assertEqual(len(variants), 1)
+        assert len(variants) == 1
         var = variants[0]
-        self.assertEqual(var.alleles, ("A", None))
-        self.assertEqual(var.num_alleles, 1)
-        self.assertTrue(np.all(var.genotypes == -1))
+        assert var.alleles == ("A", None)
+        assert var.num_alleles == 1
+        assert np.all(var.genotypes == -1)
 
     def test_empty_ts_incomplete_samples(self):
         # https://github.com/tskit-dev/tskit/issues/776
@@ -507,9 +506,9 @@ class TestVariantGenerator(unittest.TestCase):
         tables.sites.add_row(0.5, "A")
         ts = tables.tree_sequence()
         variants = list(ts.variants(samples=[0]))
-        self.assertEqual(list(variants[0].genotypes), [-1])
+        assert list(variants[0].genotypes) == [-1]
         variants = list(ts.variants(samples=[1]))
-        self.assertEqual(list(variants[0].genotypes), [-1])
+        assert list(variants[0].genotypes) == [-1]
 
     def test_missing_data_samples(self):
         tables = tskit.TableCollection(1.0)
@@ -521,25 +520,25 @@ class TestVariantGenerator(unittest.TestCase):
 
         # If we have no samples we still get a list of variants.
         variants = list(ts.variants(samples=[]))
-        self.assertEqual(len(variants[0].genotypes), 0)
-        self.assertFalse(variants[0].has_missing_data)
-        self.assertEqual(variants[0].alleles, ("A", "T"))
+        assert len(variants[0].genotypes) == 0
+        assert not variants[0].has_missing_data
+        assert variants[0].alleles == ("A", "T")
 
         # If we have a single sample that's not missing, there's no
         # missing data.
         variants = list(ts.variants(samples=[0]))
-        self.assertEqual(len(variants[0].genotypes), 1)
-        self.assertEqual(variants[0].genotypes[0], 1)
-        self.assertFalse(variants[0].has_missing_data)
-        self.assertEqual(variants[0].alleles, ("A", "T"))
+        assert len(variants[0].genotypes) == 1
+        assert variants[0].genotypes[0] == 1
+        assert not variants[0].has_missing_data
+        assert variants[0].alleles == ("A", "T")
 
         # If we have a single sample that is missing, there is
         # missing data.
         variants = list(ts.variants(samples=[1]))
-        self.assertEqual(len(variants[0].genotypes), 1)
-        self.assertEqual(variants[0].genotypes[0], -1)
-        self.assertTrue(variants[0].has_missing_data)
-        self.assertEqual(variants[0].alleles, ("A", "T", None))
+        assert len(variants[0].genotypes) == 1
+        assert variants[0].genotypes[0] == -1
+        assert variants[0].has_missing_data
+        assert variants[0].alleles == ("A", "T", None)
 
     def test_mutation_over_isolated_sample_not_missing(self):
         tables = tskit.TableCollection(1.0)
@@ -549,11 +548,11 @@ class TestVariantGenerator(unittest.TestCase):
         tables.mutations.add_row(0, 0, "T")
         ts = tables.tree_sequence()
         variants = list(ts.variants())
-        self.assertEqual(len(variants), 1)
+        assert len(variants) == 1
         var = variants[0]
-        self.assertEqual(var.alleles, ("A", "T", None))
-        self.assertEqual(var.num_alleles, 2)
-        self.assertEqual(list(var.genotypes), [1, -1])
+        assert var.alleles == ("A", "T", None)
+        assert var.num_alleles == 2
+        assert list(var.genotypes) == [1, -1]
 
     def test_multiple_mutations_over_isolated_sample(self):
         tables = tskit.TableCollection(1.0)
@@ -564,12 +563,12 @@ class TestVariantGenerator(unittest.TestCase):
         tables.mutations.add_row(0, 0, "G", parent=0)
         ts = tables.tree_sequence()
         variants = list(ts.variants())
-        self.assertEqual(len(variants), 1)
+        assert len(variants) == 1
         var = variants[0]
-        self.assertEqual(var.alleles, ("A", "T", "G", None))
-        self.assertEqual(var.num_alleles, 3)
-        self.assertEqual(len(var.site.mutations), 2)
-        self.assertEqual(list(var.genotypes), [2, -1])
+        assert var.alleles == ("A", "T", "G", None)
+        assert var.num_alleles == 3
+        assert len(var.site.mutations) == 2
+        assert list(var.genotypes) == [2, -1]
 
     def test_snipped_tree_sequence_missing_data(self):
         ts = msprime.simulate(
@@ -586,24 +585,24 @@ class TestVariantGenerator(unittest.TestCase):
         num_missing = 0
         for var in ts.variants():
             if 4 <= var.site.position < 6:
-                self.assertTrue(var.has_missing_data)
-                self.assertTrue(np.all(var.genotypes == tskit.MISSING_DATA))
+                assert var.has_missing_data
+                assert np.all(var.genotypes == tskit.MISSING_DATA)
                 num_missing += 1
             else:
-                self.assertFalse(var.has_missing_data)
-                self.assertTrue(np.all(var.genotypes != tskit.MISSING_DATA))
-            self.assertTrue(np.array_equal(var.genotypes, G[var.site.id]))
-        self.assertEqual(num_missing, 3)
+                assert not var.has_missing_data
+                assert np.all(var.genotypes != tskit.MISSING_DATA)
+            assert np.array_equal(var.genotypes, G[var.site.id])
+        assert num_missing == 3
 
         G = ts.genotype_matrix(isolated_as_missing=False)
         for var in ts.variants(isolated_as_missing=False):
             if 4 <= var.site.position < 6:
-                self.assertFalse(var.has_missing_data)
-                self.assertTrue(np.all(var.genotypes == 0))
+                assert not var.has_missing_data
+                assert np.all(var.genotypes == 0)
             else:
-                self.assertFalse(var.has_missing_data)
-                self.assertTrue(np.all(var.genotypes != tskit.MISSING_DATA))
-            self.assertTrue(np.array_equal(var.genotypes, G[var.site.id]))
+                assert not var.has_missing_data
+                assert np.all(var.genotypes != tskit.MISSING_DATA)
+            assert np.array_equal(var.genotypes, G[var.site.id])
 
     def test_snipped_tree_sequence_mutations_over_isolated(self):
         ts = msprime.simulate(
@@ -627,23 +626,23 @@ class TestVariantGenerator(unittest.TestCase):
         non_missing_found = False
         for var in ts.variants():
             if var.site.position == 4:
-                self.assertTrue(var.has_missing_data)
-                self.assertEqual(var.genotypes[0], 1)
-                self.assertTrue(np.all(var.genotypes[1:] == tskit.MISSING_DATA))
+                assert var.has_missing_data
+                assert var.genotypes[0] == 1
+                assert np.all(var.genotypes[1:] == tskit.MISSING_DATA)
                 missing_found += 1
             elif var.site.position == 5:
-                self.assertFalse(var.has_missing_data)
-                self.assertTrue(np.all(var.genotypes == 0))
+                assert not var.has_missing_data
+                assert np.all(var.genotypes == 0)
                 non_missing_found = 1
             else:
-                self.assertFalse(var.has_missing_data)
-                self.assertTrue(np.all(var.genotypes != tskit.MISSING_DATA))
-            self.assertTrue(np.array_equal(var.genotypes, G[var.site.id]))
-        self.assertTrue(non_missing_found)
-        self.assertTrue(missing_found)
+                assert not var.has_missing_data
+                assert np.all(var.genotypes != tskit.MISSING_DATA)
+            assert np.array_equal(var.genotypes, G[var.site.id])
+        assert non_missing_found
+        assert missing_found
 
 
-class TestHaplotypeGenerator(unittest.TestCase):
+class TestHaplotypeGenerator:
     """
     Tests the haplotype generation code.
     """
@@ -652,10 +651,10 @@ class TestHaplotypeGenerator(unittest.TestCase):
         """
         Verify that the specified set of haplotypes is consistent.
         """
-        self.assertEqual(len(haplotypes), n)
+        assert len(haplotypes) == n
         m = len(haplotypes[0])
         for h in haplotypes:
-            self.assertEqual(len(h), m)
+            assert len(h) == m
         # Examine each column in H; we must have a mixture of 0s and 1s
         for k in range(m):
             zeros = 0
@@ -666,7 +665,7 @@ class TestHaplotypeGenerator(unittest.TestCase):
                 zeros += b == "0"
                 ones += b == "1"
                 col += b
-            self.assertEqual(zeros + ones, n)
+            assert zeros + ones == n
 
     def verify_tree_sequence(self, tree_sequence):
         n = tree_sequence.sample_size
@@ -675,11 +674,11 @@ class TestHaplotypeGenerator(unittest.TestCase):
         A = np.zeros((n, m), dtype="u1")
         B = np.zeros((n, m), dtype="u1")
         for j, h in enumerate(haplotypes):
-            self.assertEqual(len(h), m)
+            assert len(h) == m
             A[j] = np.fromstring(h, np.uint8) - ord("0")
         for variant in tree_sequence.variants():
             B[:, variant.index] = variant.genotypes
-        self.assertTrue(np.all(A == B))
+        assert np.all(A == B)
         self.verify_haplotypes(n, haplotypes)
 
     def verify_simulation(self, n, m, r, theta):
@@ -718,7 +717,7 @@ class TestHaplotypeGenerator(unittest.TestCase):
 
     def test_acgt_mutations(self):
         ts = msprime.simulate(10, mutation_rate=10)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         tables = ts.tables
         sites = tables.sites
         mutations = tables.mutations
@@ -735,28 +734,31 @@ class TestHaplotypeGenerator(unittest.TestCase):
         )
         tsp = tables.tree_sequence()
         H = [h.replace("0", "A").replace("1", "T") for h in ts.haplotypes()]
-        self.assertEqual(H, list(tsp.haplotypes()))
+        assert H == list(tsp.haplotypes())
 
     def test_fails_multiletter_mutations(self):
         ts = msprime.simulate(10, random_seed=2)
         tables = ts.tables
         tables.sites.add_row(0, "ACTG")
         tsp = tables.tree_sequence()
-        self.assertRaises(TypeError, list, tsp.haplotypes())
+        with pytest.raises(TypeError):
+            list(tsp.haplotypes())
 
     def test_fails_deletion_mutations(self):
         ts = msprime.simulate(10, random_seed=2)
         tables = ts.tables
         tables.sites.add_row(0, "")
         tsp = tables.tree_sequence()
-        self.assertRaises(TypeError, list, tsp.haplotypes())
+        with pytest.raises(TypeError):
+            list(tsp.haplotypes())
 
     def test_nonascii_mutations(self):
         ts = msprime.simulate(10, random_seed=2)
         tables = ts.tables
         tables.sites.add_row(0, chr(169))  # Copyright symbol
         tsp = tables.tree_sequence()
-        self.assertRaises(TypeError, list, tsp.haplotypes())
+        with pytest.raises(TypeError):
+            list(tsp.haplotypes())
 
     def test_recurrent_mutations_over_samples(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -771,7 +773,7 @@ class TestHaplotypeGenerator(unittest.TestCase):
         ts_new = tables.tree_sequence()
         ones = "1" * num_sites
         for h in ts_new.haplotypes():
-            self.assertEqual(ones, h)
+            assert ones == h
 
     def test_recurrent_mutations_errors(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -784,7 +786,8 @@ class TestHaplotypeGenerator(unittest.TestCase):
             tables.mutations.add_row(site=site, node=u, derived_state="1")
             tables.mutations.add_row(site=site, node=tree.root, derived_state="1")
             ts_new = tables.tree_sequence()
-            self.assertRaises(exceptions.LibraryError, list, ts_new.haplotypes())
+            with pytest.raises(exceptions.LibraryError):
+                list(ts_new.haplotypes())
             ts_new.haplotypes()
 
     def test_back_mutations(self):
@@ -799,120 +802,121 @@ class TestHaplotypeGenerator(unittest.TestCase):
         tables.nodes.add_row(tskit.NODE_IS_SAMPLE, 0)
         tables.sites.add_row(0.5, "A")
         ts = tables.tree_sequence()
-        self.assertRaises(ValueError, list, ts.haplotypes(missing_data_character="A"))
+        with pytest.raises(ValueError):
+            list(ts.haplotypes(missing_data_character="A"))
         for c in ("-", ".", "a"):
             h = list(ts.haplotypes(missing_data_character=c))
-            self.assertEqual(h, [c, c])
+            assert h == [c, c]
         h = list(ts.haplotypes(isolated_as_missing=True))
-        self.assertEqual(h, ["-", "-"])
+        assert h == ["-", "-"]
         h = list(ts.haplotypes(isolated_as_missing=False))
-        self.assertEqual(h, ["A", "A"])
+        assert h == ["A", "A"]
         h = list(ts.haplotypes())
-        self.assertEqual(h, ["-", "-"])
+        assert h == ["-", "-"]
         # Test deprecated method
         h = list(ts.haplotypes(impute_missing_data=True))
-        self.assertEqual(h, ["A", "A"])
+        assert h == ["A", "A"]
         h = list(ts.haplotypes(impute_missing_data=False))
-        self.assertEqual(h, ["-", "-"])
+        assert h == ["-", "-"]
         h = list(ts.haplotypes(isolated_as_missing=True, impute_missing_data=True))
-        self.assertEqual(h, ["-", "-"])
+        assert h == ["-", "-"]
         h = list(ts.haplotypes(isolated_as_missing=True, impute_missing_data=False))
-        self.assertEqual(h, ["-", "-"])
+        assert h == ["-", "-"]
         h = list(ts.haplotypes(isolated_as_missing=False, impute_missing_data=True))
-        self.assertEqual(h, ["A", "A"])
+        assert h == ["A", "A"]
         h = list(ts.haplotypes(isolated_as_missing=False, impute_missing_data=False))
-        self.assertEqual(h, ["A", "A"])
+        assert h == ["A", "A"]
 
 
-class TestUserAlleles(unittest.TestCase):
+class TestUserAlleles:
     """
     Tests the functionality of providing a user-specified allele mapping.
     """
 
     def test_simple_01(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         G1 = ts.genotype_matrix()
         G2 = ts.genotype_matrix(alleles=("0", "1"))
-        self.assertTrue(np.array_equal(G1, G2))
+        assert np.array_equal(G1, G2)
         for v1, v2 in itertools.zip_longest(
             ts.variants(), ts.variants(alleles=("0", "1"))
         ):
-            self.assertEqual(v1.alleles, v2.alleles)
-            self.assertEqual(v1.site, v2.site)
-            self.assertTrue(np.array_equal(v1.genotypes, v2.genotypes))
+            assert v1.alleles == v2.alleles
+            assert v1.site == v2.site
+            assert np.array_equal(v1.genotypes, v2.genotypes)
 
     def test_simple_01_trailing_alleles(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         G1 = ts.genotype_matrix()
         alleles = ("0", "1", "2", "xxxxx")
         G2 = ts.genotype_matrix(alleles=alleles)
-        self.assertTrue(np.array_equal(G1, G2))
+        assert np.array_equal(G1, G2)
         for v1, v2 in itertools.zip_longest(
             ts.variants(), ts.variants(alleles=alleles)
         ):
-            self.assertEqual(v2.alleles, alleles)
-            self.assertEqual(v1.site, v2.site)
-            self.assertTrue(np.array_equal(v1.genotypes, v2.genotypes))
+            assert v2.alleles == alleles
+            assert v1.site == v2.site
+            assert np.array_equal(v1.genotypes, v2.genotypes)
 
     def test_simple_01_leading_alleles(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         G1 = ts.genotype_matrix()
         alleles = ("A", "B", "C", "0", "1")
         G2 = ts.genotype_matrix(alleles=alleles)
-        self.assertTrue(np.array_equal(G1 + 3, G2))
+        assert np.array_equal(G1 + 3, G2)
         for v1, v2 in itertools.zip_longest(
             ts.variants(), ts.variants(alleles=alleles)
         ):
-            self.assertEqual(v2.alleles, alleles)
-            self.assertEqual(v1.site, v2.site)
-            self.assertTrue(np.array_equal(v1.genotypes + 3, v2.genotypes))
+            assert v2.alleles == alleles
+            assert v1.site == v2.site
+            assert np.array_equal(v1.genotypes + 3, v2.genotypes)
 
     def test_simple_01_duplicate_alleles(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         G1 = ts.genotype_matrix()
         alleles = ("0", "0", "1")
         G2 = ts.genotype_matrix(alleles=alleles)
         index = np.where(G1 == 1)
         G1[index] = 2
-        self.assertTrue(np.array_equal(G1, G2))
+        assert np.array_equal(G1, G2)
         for v1, v2 in itertools.zip_longest(
             ts.variants(), ts.variants(alleles=alleles)
         ):
-            self.assertEqual(v2.alleles, alleles)
-            self.assertEqual(v1.site, v2.site)
+            assert v2.alleles == alleles
+            assert v1.site == v2.site
             g = v1.genotypes
             index = np.where(g == 1)
             g[index] = 2
-            self.assertTrue(np.array_equal(g, v2.genotypes))
+            assert np.array_equal(g, v2.genotypes)
 
     def test_simple_acgt(self):
         ts = msprime.simulate(10, random_seed=2)
         ts = msprime.mutate(
             ts, rate=4, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES)
         )
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         alleles = tskit.ALLELES_ACGT
         G = ts.genotype_matrix(alleles=alleles)
         for v1, v2 in itertools.zip_longest(
             ts.variants(), ts.variants(alleles=alleles)
         ):
-            self.assertEqual(v2.alleles, alleles)
-            self.assertEqual(v1.site, v2.site)
+            assert v2.alleles == alleles
+            assert v1.site == v2.site
             h1 = "".join(v1.alleles[g] for g in v1.genotypes)
             h2 = "".join(v2.alleles[g] for g in v2.genotypes)
-            self.assertEqual(h1, h2)
-            self.assertTrue(np.array_equal(v2.genotypes, G[v1.site.id]))
+            assert h1 == h2
+            assert np.array_equal(v2.genotypes, G[v1.site.id])
 
     def test_missing_alleles(self):
         ts = msprime.simulate(10, random_seed=2)
         ts = msprime.mutate(
             ts, rate=4, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES)
         )
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         bad_allele_examples = [
             tskit.ALLELES_01,
             tuple(["A"]),
@@ -921,25 +925,25 @@ class TestUserAlleles(unittest.TestCase):
             tuple(["ACTG"]),
         ]
         for bad_alleles in bad_allele_examples:
-            with self.assertRaises(exceptions.LibraryError):
+            with pytest.raises(exceptions.LibraryError):
                 ts.genotype_matrix(alleles=bad_alleles)
-            with self.assertRaises(exceptions.LibraryError):
+            with pytest.raises(exceptions.LibraryError):
                 list(ts.variants(alleles=bad_alleles))
 
     def test_too_many_alleles(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
         for n in range(128, 138):
             bad_alleles = tuple(["0" for _ in range(n)])
-            with self.assertRaises(exceptions.LibraryError):
+            with pytest.raises(exceptions.LibraryError):
                 ts.genotype_matrix(alleles=bad_alleles)
-            with self.assertRaises(exceptions.LibraryError):
+            with pytest.raises(exceptions.LibraryError):
                 list(ts.variants(alleles=bad_alleles))
 
     def test_zero_allele(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.genotype_matrix(alleles=tuple())
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             list(ts.variants(alleles=tuple()))
 
     def test_missing_data(self):
@@ -955,18 +959,18 @@ class TestUserAlleles(unittest.TestCase):
             G2 = ts.genotype_matrix(
                 isolated_as_missing=isolated_as_missing, alleles=tskit.ALLELES_01
             )
-            self.assertTrue(np.array_equal(G1, G2))
+            assert np.array_equal(G1, G2)
             vars1 = ts.variants(isolated_as_missing=isolated_as_missing)
             vars2 = ts.variants(
                 isolated_as_missing=isolated_as_missing, alleles=tskit.ALLELES_01
             )
             for v1, v2 in itertools.zip_longest(vars1, vars2):
-                self.assertEqual(v2.alleles, v1.alleles)
-                self.assertEqual(v1.site, v2.site)
-                self.assertTrue(np.array_equal(v1.genotypes, v2.genotypes))
+                assert v2.alleles == v1.alleles
+                assert v1.site == v2.site
+                assert np.array_equal(v1.genotypes, v2.genotypes)
 
 
-class TestUserAllelesRoundTrip(unittest.TestCase):
+class TestUserAllelesRoundTrip:
     """
     Tests that we correctly produce haplotypes in a variety of situations for
     the user specified allele map encoding.
@@ -978,11 +982,11 @@ class TestUserAllelesRoundTrip(unittest.TestCase):
         ):
             h1 = [v1.alleles[g] for g in v1.genotypes]
             h2 = [v2.alleles[g] for g in v2.genotypes]
-            self.assertEqual(h1, h2)
+            assert h1 == h2
 
     def test_simple_01(self):
         ts = msprime.simulate(5, mutation_rate=2, random_seed=3)
-        self.assertGreater(ts.num_sites, 3)
+        assert ts.num_sites > 3
         valid_alleles = [
             tskit.ALLELES_01,
             ("0", "1", "xry"),
@@ -998,7 +1002,7 @@ class TestUserAllelesRoundTrip(unittest.TestCase):
         ts = msprime.mutate(
             ts, rate=4, random_seed=3, model=msprime.InfiniteSites(msprime.NUCLEOTIDES)
         )
-        self.assertGreater(ts.num_sites, 3)
+        assert ts.num_sites > 3
         valid_alleles = [
             tskit.ALLELES_ACGT,
             ("A", "C", "T", "G", "AAAAAAAAAAAAAA"),
@@ -1021,7 +1025,7 @@ class TestUserAllelesRoundTrip(unittest.TestCase):
     def test_multichar_mutations(self):
         ts = msprime.simulate(6, random_seed=1, recombination_rate=2)
         ts = tsutil.insert_multichar_mutations(ts)
-        self.assertGreater(ts.num_sites, 5)
+        assert ts.num_sites > 5
         all_alleles = set()
         for var in ts.variants():
             all_alleles.update(var.alleles)
@@ -1035,7 +1039,7 @@ class TestUserAllelesRoundTrip(unittest.TestCase):
         # Add another sample node. This will be missing data everywhere.
         tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0)
         ts = tables.tree_sequence()
-        self.assertGreater(ts.num_sites, 3)
+        assert ts.num_sites > 3
         valid_alleles = [
             tskit.ALLELES_01,
             ("0", "1", "xry"),

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -179,12 +179,12 @@ class TestVariantGenerator:
             A[variant.index] = variant.genotypes
         for variant in ts.variants(as_bytes=True):
             assert isinstance(variant.genotypes, bytes)
-            B[variant.index] = np.fromstring(variant.genotypes, np.uint8) - ord("0")
+            B[variant.index] = np.frombuffer(variant.genotypes, np.uint8) - ord("0")
         assert np.all(A == B)
         bytes_variants = list(ts.variants(as_bytes=True))
         for j, variant in enumerate(bytes_variants):
             assert j == variant.index
-            row = np.fromstring(variant.genotypes, np.uint8) - ord("0")
+            row = np.frombuffer(variant.genotypes, np.uint8) - ord("0")
             assert np.all(A[j] == row)
 
     def test_as_bytes_fails(self):
@@ -475,14 +475,19 @@ class TestVariantGenerator:
         assert np.array_equal(Gm, Gm2)
 
         # Test deprecated param
-        Gi = ts.genotype_matrix(impute_missing_data=True)
+
+        with pytest.deprecated_call():
+            Gi = ts.genotype_matrix(impute_missing_data=True)
         assert np.array_equal(Gnm, Gi)
-        Gni = ts.genotype_matrix(impute_missing_data=False)
+        with pytest.deprecated_call():
+            Gni = ts.genotype_matrix(impute_missing_data=False)
         assert np.array_equal(Gm, Gni)
 
-        G = ts.genotype_matrix(isolated_as_missing=False, impute_missing_data=True)
+        with pytest.deprecated_call():
+            G = ts.genotype_matrix(isolated_as_missing=False, impute_missing_data=True)
         assert np.array_equal(Gnm, G)
-        G = ts.genotype_matrix(isolated_as_missing=True, impute_missing_data=False)
+        with pytest.deprecated_call():
+            G = ts.genotype_matrix(isolated_as_missing=True, impute_missing_data=False)
         assert np.array_equal(Gm, G)
 
     def test_empty_ts_missing_data(self):
@@ -675,7 +680,7 @@ class TestHaplotypeGenerator:
         B = np.zeros((n, m), dtype="u1")
         for j, h in enumerate(haplotypes):
             assert len(h) == m
-            A[j] = np.fromstring(h, np.uint8) - ord("0")
+            A[j] = np.frombuffer(h.encode("ascii"), np.uint8) - ord("0")
         for variant in tree_sequence.variants():
             B[:, variant.index] = variant.genotypes
         assert np.all(A == B)
@@ -814,17 +819,25 @@ class TestHaplotypeGenerator:
         h = list(ts.haplotypes())
         assert h == ["-", "-"]
         # Test deprecated method
-        h = list(ts.haplotypes(impute_missing_data=True))
+        with pytest.deprecated_call():
+            h = list(ts.haplotypes(impute_missing_data=True))
         assert h == ["A", "A"]
-        h = list(ts.haplotypes(impute_missing_data=False))
+        with pytest.deprecated_call():
+            h = list(ts.haplotypes(impute_missing_data=False))
         assert h == ["-", "-"]
-        h = list(ts.haplotypes(isolated_as_missing=True, impute_missing_data=True))
+        with pytest.deprecated_call():
+            h = list(ts.haplotypes(isolated_as_missing=True, impute_missing_data=True))
         assert h == ["-", "-"]
-        h = list(ts.haplotypes(isolated_as_missing=True, impute_missing_data=False))
+        with pytest.deprecated_call():
+            h = list(ts.haplotypes(isolated_as_missing=True, impute_missing_data=False))
         assert h == ["-", "-"]
-        h = list(ts.haplotypes(isolated_as_missing=False, impute_missing_data=True))
+        with pytest.deprecated_call():
+            h = list(ts.haplotypes(isolated_as_missing=False, impute_missing_data=True))
         assert h == ["A", "A"]
-        h = list(ts.haplotypes(isolated_as_missing=False, impute_missing_data=False))
+        with pytest.deprecated_call():
+            h = list(
+                ts.haplotypes(isolated_as_missing=False, impute_missing_data=False)
+            )
         assert h == ["A", "A"]
 
 

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -4,9 +4,9 @@ Tests of IBD finding algorithms.
 import io
 import itertools
 import random
-import unittest
 
 import msprime
+import pytest
 
 import tests.ibd as ibd
 import tests.test_wright_fisher as wf
@@ -265,7 +265,7 @@ def segment_lists_are_equal(val1, val2):
     return True
 
 
-class TestIbdSingleBinaryTree(unittest.TestCase):
+class TestIbdSingleBinaryTree:
 
     #
     # 2        4
@@ -321,17 +321,17 @@ class TestIbdSingleBinaryTree(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
     def test_input_errors(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ibd.IbdFinder(self.ts, sample_pairs=[0])
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             ibd.IbdFinder(self.ts, sample_pairs=[(0, 1, 2)])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ibd.IbdFinder(self.ts, sample_pairs=[(0, 5)])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ibd.IbdFinder(self.ts, sample_pairs=[(0, 1), (1, 0)])
 
 
-class TestIbdTwoSamplesTwoTrees(unittest.TestCase):
+class TestIbdTwoSamplesTwoTrees:
 
     # 2
     #             |     3
@@ -381,7 +381,7 @@ class TestIbdTwoSamplesTwoTrees(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdUnrelatedSamples(unittest.TestCase):
+class TestIbdUnrelatedSamples:
 
     #
     #    2   3
@@ -423,7 +423,7 @@ class TestIbdUnrelatedSamples(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdNoSamples(unittest.TestCase):
+class TestIbdNoSamples:
     def test_no_samples(self):
         #
         #     2
@@ -448,11 +448,11 @@ class TestIbdNoSamples(unittest.TestCase):
         """
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ibd.IbdFinder(ts, sample_pairs=[(0, 1)])
 
 
-class TestIbdSamplesAreDescendants(unittest.TestCase):
+class TestIbdSamplesAreDescendants:
     #
     # 4     5
     # |     |
@@ -507,7 +507,7 @@ class TestIbdSamplesAreDescendants(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdDifferentPaths(unittest.TestCase):
+class TestIbdDifferentPaths:
     #
     #        4       |      4       |        4
     #       / \      |     / \      |       / \
@@ -566,7 +566,7 @@ class TestIbdDifferentPaths(unittest.TestCase):
 
     # This is a situation where the Python and the C libraries agree,
     # but aren't doing as expected.
-    @unittest.expectedFailure
+    @pytest.mark.xfail
     def test_input_sample_pairs(self):
         ibd_f = ibd.IbdFinder(self.ts, sample_pairs=[(0, 1), (2, 3), (1, 3)])
         ibd_segs = ibd_f.find_ibd_segments()
@@ -589,7 +589,7 @@ class TestIbdDifferentPaths(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdDifferentPaths2(unittest.TestCase):
+class TestIbdDifferentPaths2:
     #
     #        5         |
     #       / \        |
@@ -635,7 +635,7 @@ class TestIbdDifferentPaths2(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdPolytomies(unittest.TestCase):
+class TestIbdPolytomies:
     #
     #          5         |         5
     #         / \        |        / \
@@ -728,7 +728,7 @@ class TestIbdPolytomies(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdInternalSamples(unittest.TestCase):
+class TestIbdInternalSamples:
     #
     #
     #      3
@@ -763,7 +763,7 @@ class TestIbdInternalSamples(unittest.TestCase):
         assert ibd_is_equal(ibd_segs, true_segs)
 
 
-class TestIbdRandomExamples(unittest.TestCase):
+class TestIbdRandomExamples:
     """
     Randomly generated test cases.
     """

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -33,6 +33,7 @@ import unittest
 
 import msprime
 import numpy as np
+import pytest
 
 import _tskit
 
@@ -78,9 +79,9 @@ class LowLevelTestCase(unittest.TestCase):
         Verifies that the specified tree in dict format is a
         consistent coalescent history for a sample of size n.
         """
-        self.assertLessEqual(len(pi), 2 * n - 1)
+        assert len(pi) <= 2 * n - 1
         # _tskit.NULL should not be a node
-        self.assertNotIn(_tskit.NULL, pi)
+        assert _tskit.NULL not in pi
         # verify the root is equal for all samples
         root = 0
         while pi[root] != _tskit.NULL:
@@ -89,21 +90,21 @@ class LowLevelTestCase(unittest.TestCase):
             k = j
             while pi[k] != _tskit.NULL:
                 k = pi[k]
-            self.assertEqual(k, root)
+            assert k == root
         # 0 to n - 1 inclusive should always be nodes
         for j in range(n):
-            self.assertIn(j, pi)
+            assert j in pi
         num_children = collections.defaultdict(int)
         for j in pi.keys():
             num_children[pi[j]] += 1
         # nodes 0 to n are samples.
         for j in range(n):
-            self.assertNotEqual(pi[j], 0)
-            self.assertEqual(num_children[j], 0)
+            assert pi[j] != 0
+            assert num_children[j] == 0
         # All non-sample nodes should be binary
         for j in pi.keys():
             if j > n:
-                self.assertGreaterEqual(num_children[j], 2)
+                assert num_children[j] >= 2
 
     def get_example_tree_sequence(
         self, sample_size=10, length=1, mutation_rate=1, random_seed=1
@@ -141,9 +142,10 @@ class LowLevelTestCase(unittest.TestCase):
         iterator protocol correctly.
         """
         list_ = list(iterator)
-        self.assertGreater(len(list_), 0)
+        assert len(list_) > 0
         for _ in range(10):
-            self.assertRaises(StopIteration, next, iterator)
+            with pytest.raises(StopIteration):
+                next(iterator)
 
 
 class MetadataTestMixin:
@@ -180,183 +182,183 @@ class TestTableCollection(LowLevelTestCase):
         del tc
         for _ in range(10):
             for table in tables:
-                self.assertGreater(len(str(table)), 0)
+                assert len(str(table)) > 0
 
     def test_set_sequence_length_errors(self):
         tables = _tskit.TableCollection(1)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             del tables.sequence_length
         for bad_value in ["sdf", None, []]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tables.sequence_length = bad_value
 
     def test_set_sequence_length(self):
         tables = _tskit.TableCollection(1)
-        self.assertEqual(tables.sequence_length, 1)
+        assert tables.sequence_length == 1
         for value in [-1, 1e6, 1e-22, 1000, 2 ** 32, -10000]:
             tables.sequence_length = value
-            self.assertEqual(tables.sequence_length, value)
+            assert tables.sequence_length == value
 
     def test_set_metadata_errors(self):
         tables = _tskit.TableCollection(1)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del tables.metadata
         for bad_value in ["bytes only", 59, 43.4, None, []]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tables.metadata = bad_value
 
     def test_set_metadata(self):
         tables = _tskit.TableCollection(1)
-        self.assertEqual(tables.metadata, b"")
+        assert tables.metadata == b""
         for value in [b"foo", b"", "💩".encode(), b"null char \0 in string"]:
             tables.metadata = value
             tables.metadata_schema = "Test we have two separate fields"
-            self.assertEqual(tables.metadata, value)
+            assert tables.metadata == value
 
     def test_set_metadata_schema_errors(self):
         tables = _tskit.TableCollection(1)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del tables.metadata_schema
         for bad_value in [59, 43.4, None, []]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tables.metadata_schema = bad_value
 
     def test_set_metadata_schema(self):
         tables = _tskit.TableCollection(1)
-        self.assertEqual(tables.metadata_schema, "")
+        assert tables.metadata_schema == ""
         for value in ["foo", "", "💩", "null char \0 in string"]:
             tables.metadata_schema = value
             tables.metadata = b"Test we have two separate fields"
-            self.assertEqual(tables.metadata_schema, value)
+            assert tables.metadata_schema == value
 
     def test_simplify_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)
         tc = ts.tables._ll_tables
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.simplify()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.simplify("asdf")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.simplify([0, 1], keep_unary="sdf")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.simplify([0, 1], keep_input_roots="sdf")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.simplify([0, 1], filter_populations="x")
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.simplify([0, -1])
 
     def test_link_ancestors_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)
         tc = ts.tables._ll_tables
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.link_ancestors()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.link_ancestors([0, 1])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.link_ancestors(samples=[0, 1], ancestors="sdf")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.link_ancestors(samples="sdf", ancestors=[0, 1])
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.link_ancestors(samples=[0, 1], ancestors=[11, -1])
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.link_ancestors(samples=[0, -1], ancestors=[11])
 
     def test_link_ancestors(self):
         ts = msprime.simulate(2, random_seed=1)
         tc = ts.tables._ll_tables
         edges = tc.link_ancestors([0, 1], [3])
-        self.assertIsInstance(edges, _tskit.EdgeTable)
+        assert isinstance(edges, _tskit.EdgeTable)
         del edges
-        self.assertEqual(tc.edges.num_rows, 2)
+        assert tc.edges.num_rows == 2
 
     def test_subset_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)
         tc = ts.tables._ll_tables
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.subset(np.array(["a"]))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.subset(np.array([[1], [2]], dtype="int32"))
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.subset()
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.subset(np.array([100, 200], dtype="int32"))
 
     def test_union_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)
         tc = ts.tables._ll_tables
         tc2 = tc
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.union(tc2, np.array(["a"]))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.union(tc2, np.array([0], dtype="int32"))
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.union(tc2)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.union()
         node_mapping = np.arange(ts.num_nodes, dtype="int32")
         node_mapping[0] = 1200
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.union(tc2, node_mapping)
         node_mapping = np.array(
             [node_mapping.tolist(), node_mapping.tolist()], dtype="int32"
         )
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.union(tc2, np.array([[1], [2]], dtype="int32"))
 
     def test_ibd_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)
         tc = ts.tables._ll_tables
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.find_ibd()
         for bad_samples in ["sdf", None, {}]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 tc.find_ibd(bad_samples)
         for not_enough_samples in [[], [0]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 tc.find_ibd(not_enough_samples)
         # input array must be 2D
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.find_ibd([[[1], [1]]])
         # Input array must be (n, 2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.find_ibd([[1, 1, 1]])
         for bad_float in ["sdf", None, {}]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tc.find_ibd([(0, 1)], min_length=bad_float)
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tc.find_ibd([(0, 1)], max_time=bad_float)
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.find_ibd([(0, 1)], max_time=-1)
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tc.find_ibd([(0, 1)], min_length=-1)
 
     def test_ibd_output_no_recomb(self):
         ts = msprime.simulate(10, random_seed=1)
         tc = ts.tables._ll_tables
         segs = tc.find_ibd([(0, 1), (2, 3)])
-        self.assertIsInstance(segs, dict)
-        self.assertGreater(len(segs), 0)
+        assert isinstance(segs, dict)
+        assert len(segs) > 0
         for key, value in segs.items():
-            self.assertIsInstance(key, tuple)
-            self.assertEqual(len(key), 2)
-            self.assertIsInstance(value, dict)
-            self.assertEqual(len(value), 3)
-            self.assertEqual(list(value["left"]), [0])
-            self.assertEqual(list(value["right"]), [1])
-            self.assertEqual(len(value["node"]), 1)
+            assert isinstance(key, tuple)
+            assert len(key) == 2
+            assert isinstance(value, dict)
+            assert len(value) == 3
+            assert list(value["left"]) == [0]
+            assert list(value["right"]) == [1]
+            assert len(value["node"]) == 1
 
     def test_ibd_output_recomb(self):
         ts = msprime.simulate(10, recombination_rate=1, random_seed=1)
-        self.assertGreater(ts.num_trees, 1)
+        assert ts.num_trees > 1
         tc = ts.tables._ll_tables
         segs = tc.find_ibd([(0, 1), (2, 3)])
-        self.assertIsInstance(segs, dict)
-        self.assertGreater(len(segs), 0)
+        assert isinstance(segs, dict)
+        assert len(segs) > 0
         for key, value in segs.items():
-            self.assertIsInstance(key, tuple)
-            self.assertEqual(len(key), 2)
-            self.assertIsInstance(value, dict)
-            self.assertEqual(len(value), 3)
+            assert isinstance(key, tuple)
+            assert len(key) == 2
+            assert isinstance(value, dict)
+            assert len(value) == 3
 
 
 class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
@@ -371,7 +373,7 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
     def tearDown(self):
         os.unlink(self.temp_file)
 
-    @unittest.skipIf(IS_WINDOWS, "File permissions on Windows")
+    @pytest.mark.skipif(IS_WINDOWS, reason="File permissions on Windows")
     def test_file_errors(self):
         ts1 = self.get_example_tree_sequence()
 
@@ -380,37 +382,50 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
             ts2.load(*args)
 
         for func in [ts1.dump, loader]:
-            self.assertRaises(TypeError, func)
+            with pytest.raises(TypeError):
+                func()
             for bad_type in [1, None, [], {}]:
-                self.assertRaises(TypeError, func, bad_type)
+                with pytest.raises(TypeError):
+                    func(bad_type)
             # Try to dump/load files we don't have access to or don't exist.
             for f in ["/", "/test.trees", "/dir_does_not_exist/x.trees"]:
-                self.assertRaises(OSError, func, f)
+                with pytest.raises(OSError):
+                    func(f)
                 try:
                     func(f)
                 except OSError as e:
                     message = str(e)
-                    self.assertGreater(len(message), 0)
+                    assert len(message) > 0
             f = "/" + 4000 * "x"
-            self.assertRaises(OSError, func, f)
+            with pytest.raises(OSError):
+                func(f)
             try:
                 func(f)
             except OSError as e:
                 message = str(e)
-            self.assertTrue(message.endswith("File name too long"))
+            assert message.endswith("File name too long")
 
     def test_initial_state(self):
         # Check the initial state to make sure that it is empty.
         ts = _tskit.TreeSequence()
-        self.assertRaises(ValueError, ts.get_num_samples)
-        self.assertRaises(ValueError, ts.get_sequence_length)
-        self.assertRaises(ValueError, ts.get_num_trees)
-        self.assertRaises(ValueError, ts.get_num_edges)
-        self.assertRaises(ValueError, ts.get_num_mutations)
-        self.assertRaises(ValueError, ts.get_num_migrations)
-        self.assertRaises(ValueError, ts.get_num_migrations)
-        self.assertRaises(ValueError, ts.get_genotype_matrix)
-        self.assertRaises(ValueError, ts.dump)
+        with pytest.raises(ValueError):
+            ts.get_num_samples()
+        with pytest.raises(ValueError):
+            ts.get_sequence_length()
+        with pytest.raises(ValueError):
+            ts.get_num_trees()
+        with pytest.raises(ValueError):
+            ts.get_num_edges()
+        with pytest.raises(ValueError):
+            ts.get_num_mutations()
+        with pytest.raises(ValueError):
+            ts.get_num_migrations()
+        with pytest.raises(ValueError):
+            ts.get_num_migrations()
+        with pytest.raises(ValueError):
+            ts.get_genotype_matrix()
+        with pytest.raises(ValueError):
+            ts.dump()
 
     def test_num_nodes(self):
         for ts in self.get_example_tree_sequences():
@@ -420,7 +435,7 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
                 for node in [parent, child]:
                     if node > max_node:
                         max_node = node
-            self.assertEqual(max_node + 1, ts.get_num_nodes())
+            assert max_node + 1 == ts.get_num_nodes()
 
     def verify_dump_equality(self, ts):
         """
@@ -430,19 +445,19 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
         ts.dump(self.temp_file)
         ts2 = _tskit.TreeSequence()
         ts2.load(self.temp_file)
-        self.assertEqual(ts.get_num_samples(), ts2.get_num_samples())
-        self.assertEqual(ts.get_sequence_length(), ts2.get_sequence_length())
-        self.assertEqual(ts.get_num_mutations(), ts2.get_num_mutations())
-        self.assertEqual(ts.get_num_nodes(), ts2.get_num_nodes())
+        assert ts.get_num_samples() == ts2.get_num_samples()
+        assert ts.get_sequence_length() == ts2.get_sequence_length()
+        assert ts.get_num_mutations() == ts2.get_num_mutations()
+        assert ts.get_num_nodes() == ts2.get_num_nodes()
         records1 = [ts.get_edge(j) for j in range(ts.get_num_edges())]
         records2 = [ts2.get_edge(j) for j in range(ts2.get_num_edges())]
-        self.assertEqual(records1, records2)
+        assert records1 == records2
         mutations1 = [ts.get_mutation(j) for j in range(ts.get_num_mutations())]
         mutations2 = [ts2.get_mutation(j) for j in range(ts2.get_num_mutations())]
-        self.assertEqual(mutations1, mutations2)
+        assert mutations1 == mutations2
         provenances1 = [ts.get_provenance(j) for j in range(ts.get_num_provenances())]
         provenances2 = [ts2.get_provenance(j) for j in range(ts2.get_num_provenances())]
-        self.assertEqual(provenances1, provenances2)
+        assert provenances1 == provenances2
 
     def test_dump_equality(self):
         for ts in self.get_example_tree_sequences():
@@ -455,54 +470,61 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
 
     def verify_mutations(self, ts):
         mutations = [ts.get_mutation(j) for j in range(ts.get_num_mutations())]
-        self.assertGreater(ts.get_num_mutations(), 0)
-        self.assertEqual(len(mutations), ts.get_num_mutations())
+        assert ts.get_num_mutations() > 0
+        assert len(mutations) == ts.get_num_mutations()
         # Check the form of the mutations
         for j, (position, nodes, index) in enumerate(mutations):
-            self.assertEqual(j, index)
+            assert j == index
             for node in nodes:
-                self.assertIsInstance(node, int)
-                self.assertGreaterEqual(node, 0)
-                self.assertLessEqual(node, ts.get_num_nodes())
-            self.assertIsInstance(position, float)
-            self.assertGreater(position, 0)
-            self.assertLess(position, ts.get_sequence_length())
+                assert isinstance(node, int)
+                assert node >= 0
+                assert node <= ts.get_num_nodes()
+            assert isinstance(position, float)
+            assert position > 0
+            assert position < ts.get_sequence_length()
         # mutations must be sorted by position order.
-        self.assertEqual(mutations, sorted(mutations))
+        assert mutations == sorted(mutations)
 
     def test_get_edge_interface(self):
         for ts in self.get_example_tree_sequences():
             num_edges = ts.get_num_edges()
             # We don't accept Python negative indexes here.
-            self.assertRaises(IndexError, ts.get_edge, -1)
+            with pytest.raises(IndexError):
+                ts.get_edge(-1)
             for j in [0, 10, 10 ** 6]:
-                self.assertRaises(IndexError, ts.get_edge, num_edges + j)
+                with pytest.raises(IndexError):
+                    ts.get_edge(num_edges + j)
             for x in [None, "", {}, []]:
-                self.assertRaises(TypeError, ts.get_edge, x)
+                with pytest.raises(TypeError):
+                    ts.get_edge(x)
 
     def test_get_node_interface(self):
         for ts in self.get_example_tree_sequences():
             num_nodes = ts.get_num_nodes()
             # We don't accept Python negative indexes here.
-            self.assertRaises(IndexError, ts.get_node, -1)
+            with pytest.raises(IndexError):
+                ts.get_node(-1)
             for j in [0, 10, 10 ** 6]:
-                self.assertRaises(IndexError, ts.get_node, num_nodes + j)
+                with pytest.raises(IndexError):
+                    ts.get_node(num_nodes + j)
             for x in [None, "", {}, []]:
-                self.assertRaises(TypeError, ts.get_node, x)
+                with pytest.raises(TypeError):
+                    ts.get_node(x)
 
     def test_get_genotype_matrix_interface(self):
         for ts in self.get_example_tree_sequences():
             num_samples = ts.get_num_samples()
             num_sites = ts.get_num_sites()
             G = ts.get_genotype_matrix()
-            self.assertEqual(G.shape, (num_sites, num_samples))
-            self.assertRaises(
-                TypeError, ts.get_genotype_matrix, isolated_as_missing=None
-            )
-            self.assertRaises(TypeError, ts.get_genotype_matrix, alleles="XYZ")
-            self.assertRaises(ValueError, ts.get_genotype_matrix, alleles=tuple())
+            assert G.shape == (num_sites, num_samples)
+            with pytest.raises(TypeError):
+                ts.get_genotype_matrix(isolated_as_missing=None)
+            with pytest.raises(TypeError):
+                ts.get_genotype_matrix(alleles="XYZ")
+            with pytest.raises(ValueError):
+                ts.get_genotype_matrix(alleles=tuple())
             G = ts.get_genotype_matrix(isolated_as_missing=False)
-            self.assertEqual(G.shape, (num_sites, num_samples))
+            assert G.shape == (num_sites, num_samples)
 
     def test_get_genotype_matrix_missing_data(self):
         tables = _tskit.TableCollection(1)
@@ -512,92 +534,92 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
         ts = _tskit.TreeSequence(0)
         ts.load_tables(tables)
         G = ts.get_genotype_matrix(isolated_as_missing=False)
-        self.assertTrue(np.all(G == 0))
+        assert np.all(G == 0)
         G = ts.get_genotype_matrix(isolated_as_missing=True)
-        self.assertTrue(np.all(G == -1))
+        assert np.all(G == -1)
         G = ts.get_genotype_matrix()
-        self.assertTrue(np.all(G == -1))
+        assert np.all(G == -1)
 
     def test_get_migration_interface(self):
         ts = self.get_example_migration_tree_sequence()
         for bad_type in ["", None, {}]:
-            self.assertRaises(TypeError, ts.get_migration, bad_type)
+            with pytest.raises(TypeError):
+                ts.get_migration(bad_type)
         num_records = ts.get_num_migrations()
         # We don't accept Python negative indexes here.
-        self.assertRaises(IndexError, ts.get_migration, -1)
+        with pytest.raises(IndexError):
+            ts.get_migration(-1)
         for j in [0, 10, 10 ** 6]:
-            self.assertRaises(IndexError, ts.get_migration, num_records + j)
+            with pytest.raises(IndexError):
+                ts.get_migration(num_records + j)
 
     def test_get_samples(self):
         for ts in self.get_example_tree_sequences():
             # get_samples takes no arguments.
-            self.assertRaises(TypeError, ts.get_samples, 0)
-            self.assertTrue(
-                np.array_equal(
-                    np.arange(ts.get_num_samples(), dtype=np.int32), ts.get_samples()
-                )
+            with pytest.raises(TypeError):
+                ts.get_samples(0)
+            assert np.array_equal(
+                np.arange(ts.get_num_samples(), dtype=np.int32), ts.get_samples()
             )
 
     def test_genealogical_nearest_neighbours(self):
         for ts in self.get_example_tree_sequences():
-            self.assertRaises(TypeError, ts.genealogical_nearest_neighbours)
-            self.assertRaises(TypeError, ts.genealogical_nearest_neighbours, focal=None)
-            self.assertRaises(
-                TypeError,
-                ts.genealogical_nearest_neighbours,
-                focal=ts.get_samples(),
-                reference_sets={},
-            )
-            self.assertRaises(
-                ValueError,
-                ts.genealogical_nearest_neighbours,
-                focal=ts.get_samples(),
-                reference_sets=[],
-            )
+            with pytest.raises(TypeError):
+                ts.genealogical_nearest_neighbours()
+            with pytest.raises(TypeError):
+                ts.genealogical_nearest_neighbours(focal=None)
+            with pytest.raises(TypeError):
+                ts.genealogical_nearest_neighbours(
+                    focal=ts.get_samples(),
+                    reference_sets={},
+                )
+            with pytest.raises(ValueError):
+                ts.genealogical_nearest_neighbours(
+                    focal=ts.get_samples(),
+                    reference_sets=[],
+                )
 
             bad_array_values = ["", {}, "x", [[[0], [1, 2]]]]
             for bad_array_value in bad_array_values:
-                self.assertRaises(
-                    ValueError,
-                    ts.genealogical_nearest_neighbours,
-                    focal=bad_array_value,
-                    reference_sets=[[0], [1]],
-                )
-                self.assertRaises(
-                    ValueError,
-                    ts.genealogical_nearest_neighbours,
-                    focal=ts.get_samples(),
-                    reference_sets=[[0], bad_array_value],
-                )
-                self.assertRaises(
-                    ValueError,
-                    ts.genealogical_nearest_neighbours,
-                    focal=ts.get_samples(),
-                    reference_sets=[bad_array_value],
-                )
+                with pytest.raises(ValueError):
+                    ts.genealogical_nearest_neighbours(
+                        focal=bad_array_value,
+                        reference_sets=[[0], [1]],
+                    )
+                with pytest.raises(ValueError):
+                    ts.genealogical_nearest_neighbours(
+                        focal=ts.get_samples(),
+                        reference_sets=[[0], bad_array_value],
+                    )
+                with pytest.raises(ValueError):
+                    ts.genealogical_nearest_neighbours(
+                        focal=ts.get_samples(),
+                        reference_sets=[bad_array_value],
+                    )
             focal = ts.get_samples()
             A = ts.genealogical_nearest_neighbours(focal, [focal[2:], focal[:2]])
-            self.assertEqual(A.shape, (len(focal), 2))
+            assert A.shape == (len(focal), 2)
 
     def test_mean_descendants(self):
         for ts in self.get_example_tree_sequences():
-            self.assertRaises(TypeError, ts.mean_descendants)
-            self.assertRaises(TypeError, ts.mean_descendants, reference_sets={})
-            self.assertRaises(ValueError, ts.mean_descendants, reference_sets=[])
+            with pytest.raises(TypeError):
+                ts.mean_descendants()
+            with pytest.raises(TypeError):
+                ts.mean_descendants(reference_sets={})
+            with pytest.raises(ValueError):
+                ts.mean_descendants(reference_sets=[])
 
             bad_array_values = ["", {}, "x", [[[0], [1, 2]]]]
             for bad_array_value in bad_array_values:
-                self.assertRaises(
-                    ValueError,
-                    ts.mean_descendants,
-                    reference_sets=[[0], bad_array_value],
-                )
-                self.assertRaises(
-                    ValueError, ts.mean_descendants, reference_sets=[bad_array_value]
-                )
+                with pytest.raises(ValueError):
+                    ts.mean_descendants(
+                        reference_sets=[[0], bad_array_value],
+                    )
+                with pytest.raises(ValueError):
+                    ts.mean_descendants(reference_sets=[bad_array_value])
             focal = ts.get_samples()
             A = ts.mean_descendants([focal[2:], focal[:2]])
-            self.assertEqual(A.shape, (ts.get_num_nodes(), 2))
+            assert A.shape == (ts.get_num_nodes(), 2)
 
     def test_metadata_schemas(self):
         tables = _tskit.TableCollection(1.0)
@@ -610,9 +632,7 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
         ts.load_tables(tables)
         schemas = ts.get_table_metadata_schemas()
         for table_name in self.metadata_tables:
-            self.assertEqual(
-                getattr(schemas, table_name), f"{table_name} test metadata schema"
-            )
+            assert getattr(schemas, table_name) == f"{table_name} test metadata schema"
         # Clear and read back again
         for table_name in self.metadata_tables:
             getattr(tables, f"{table_name}s").metadata_schema = ""
@@ -620,38 +640,42 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
         ts.load_tables(tables)
         schemas = ts.get_table_metadata_schemas()
         for table_name in self.metadata_tables:
-            self.assertEqual(getattr(schemas, table_name), "")
+            assert getattr(schemas, table_name) == ""
 
     def test_metadata(self):
         tables = _tskit.TableCollection(1)
         ts = _tskit.TreeSequence()
         ts.load_tables(tables)
-        self.assertEqual(ts.get_metadata(), b"")
+        assert ts.get_metadata() == b""
         for value in [b"foo", b"", "💩".encode(), b"null char \0 in string"]:
             tables.metadata = value
             ts = _tskit.TreeSequence()
             ts.load_tables(tables)
-            self.assertEqual(ts.get_metadata(), value)
+            assert ts.get_metadata() == value
 
     def test_metadata_schema(self):
         tables = _tskit.TableCollection(1)
         ts = _tskit.TreeSequence()
         ts.load_tables(tables)
-        self.assertEqual(ts.get_metadata_schema(), "")
+        assert ts.get_metadata_schema() == ""
         for value in ["foo", "", "💩", "null char \0 in string"]:
             tables.metadata_schema = value
             ts = _tskit.TreeSequence()
             ts.load_tables(tables)
-            self.assertEqual(ts.get_metadata_schema(), value)
+            assert ts.get_metadata_schema() == value
 
     def test_kc_distance_errors(self):
         ts1 = self.get_example_tree_sequence(10)
-        self.assertRaises(TypeError, ts1.get_kc_distance)
-        self.assertRaises(TypeError, ts1.get_kc_distance, ts1)
+        with pytest.raises(TypeError):
+            ts1.get_kc_distance()
+        with pytest.raises(TypeError):
+            ts1.get_kc_distance(ts1)
         for bad_tree in [None, "tree", 0]:
-            self.assertRaises(TypeError, ts1.get_kc_distance, bad_tree, lambda_=0)
+            with pytest.raises(TypeError):
+                ts1.get_kc_distance(bad_tree, lambda_=0)
         for bad_value in ["tree", [], None]:
-            self.assertRaises(TypeError, ts1.get_kc_distance, ts1, lambda_=bad_value)
+            with pytest.raises(TypeError):
+                ts1.get_kc_distance(ts1, lambda_=bad_value)
 
         # Different numbers of samples fail.
         ts2 = self.get_example_tree_sequence(11)
@@ -662,7 +686,7 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
         self.verify_kc_library_error(ts1, ts2)
 
     def verify_kc_library_error(self, ts1, ts2):
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             ts1.get_kc_distance(ts2, 0)
 
     def test_kc_distance(self):
@@ -682,22 +706,22 @@ class StatsInterfaceMixin:
     def test_mode_errors(self):
         _, f, params = self.get_example()
         for bad_mode in ["", "not a mode", "SITE", "x" * 8192]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(mode=bad_mode, **params)
 
         for bad_type in [123, {}, None, [[]]]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 f(mode=bad_type, **params)
 
     def test_window_errors(self):
         ts, f, params = self.get_example()
         del params["windows"]
         for bad_array in ["asdf", None, [[[[]], [[]]]], np.zeros((10, 3, 4))]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(windows=bad_array, **params)
 
         for bad_windows in [[], [0]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(windows=bad_windows, **params)
         L = ts.get_sequence_length()
         bad_windows = [
@@ -710,7 +734,7 @@ class StatsInterfaceMixin:
             [0, 0.1, 0.05, 0.2, L],
         ]
         for bad_window in bad_windows:
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 f(windows=bad_window, **params)
 
     def test_windows_output(self):
@@ -718,9 +742,9 @@ class StatsInterfaceMixin:
         del params["windows"]
         for num_windows in range(1, 10):
             windows = np.linspace(0, ts.get_sequence_length(), num=num_windows + 1)
-            self.assertEqual(windows.shape[0], num_windows + 1)
+            assert windows.shape[0] == num_windows + 1
             sigma = f(windows=windows, **params)
-            self.assertEqual(sigma.shape[0], num_windows)
+            assert sigma.shape[0] == num_windows
 
 
 class WeightMixin(StatsInterfaceMixin):
@@ -737,11 +761,11 @@ class WeightMixin(StatsInterfaceMixin):
         del params["weights"]
         n = ts.get_num_samples()
 
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             f(weights=np.ones((n, 0)), **params)
 
         for bad_weight_shape in [(n - 1, 1), (n + 1, 1), (0, 3)]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(weights=np.ones(bad_weight_shape), **params)
 
     def test_output_dims(self):
@@ -752,19 +776,19 @@ class WeightMixin(StatsInterfaceMixin):
 
         for mode in ["site", "branch"]:
             out = method(weights[:, [0]], windows, mode=mode)
-            self.assertEqual(out.shape, (1, 1))
+            assert out.shape == (1, 1)
             out = method(weights, windows, mode=mode)
-            self.assertEqual(out.shape, (1, nw))
+            assert out.shape == (1, nw)
             out = method(weights[:, [0, 0, 0]], windows, mode=mode)
-            self.assertEqual(out.shape, (1, 3))
+            assert out.shape == (1, 3)
         mode = "node"
         N = ts.get_num_nodes()
         out = method(weights[:, [0]], windows, mode=mode)
-        self.assertEqual(out.shape, (1, N, 1))
+        assert out.shape == (1, N, 1)
         out = method(weights, windows, mode=mode)
-        self.assertEqual(out.shape, (1, N, nw))
+        assert out.shape == (1, N, nw)
         out = method(weights[:, [0, 0, 0]], windows, mode=mode)
-        self.assertEqual(out.shape, (1, N, 3))
+        assert out.shape == (1, N, 3)
 
 
 class WeightCovariateMixin(StatsInterfaceMixin):
@@ -787,19 +811,19 @@ class WeightCovariateMixin(StatsInterfaceMixin):
         for covariates in (params["covariates"], params["covariates"][:, :0]):
             for mode in ["site", "branch"]:
                 out = method(weights[:, [0]], covariates, windows, mode=mode)
-                self.assertEqual(out.shape, (1, 1))
+                assert out.shape == (1, 1)
                 out = method(weights, covariates, windows, mode=mode)
-                self.assertEqual(out.shape, (1, nw))
+                assert out.shape == (1, nw)
                 out = method(weights[:, [0, 0, 0]], covariates, windows, mode=mode)
-                self.assertEqual(out.shape, (1, 3))
+                assert out.shape == (1, 3)
             mode = "node"
             N = ts.get_num_nodes()
             out = method(weights[:, [0]], covariates, windows, mode=mode)
-            self.assertEqual(out.shape, (1, N, 1))
+            assert out.shape == (1, N, 1)
             out = method(weights, covariates, windows, mode=mode)
-            self.assertEqual(out.shape, (1, N, nw))
+            assert out.shape == (1, N, nw)
             out = method(weights[:, [0, 0, 0]], covariates, windows, mode=mode)
-            self.assertEqual(out.shape, (1, N, 3))
+            assert out.shape == (1, N, 3)
 
 
 class SampleSetMixin(StatsInterfaceMixin):
@@ -808,22 +832,22 @@ class SampleSetMixin(StatsInterfaceMixin):
         del params["sample_set_sizes"]
         del params["sample_sets"]
 
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             f(sample_sets=[], sample_set_sizes=[], **params)
 
         n = ts.get_num_samples()
         samples = ts.get_samples()
         for bad_set_sizes in [[], [1], [n - 1], [n + 1], [n - 3, 1, 1], [1, n - 2]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(sample_set_sizes=bad_set_sizes, sample_sets=samples, **params)
 
         N = ts.get_num_nodes()
         for bad_node in [-1, N, N + 1, -N]:
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 f(sample_set_sizes=[2], sample_sets=[0, bad_node], **params)
 
         for bad_sample in [n, n + 1, N - 1]:
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 f(sample_set_sizes=[2], sample_sets=[0, bad_sample], **params)
 
 
@@ -846,18 +870,18 @@ class OneWaySampleStatsMixin(SampleSetMixin):
         result = method(
             [ts.get_num_samples()], ts.get_samples(), [0, ts.get_sequence_length()]
         )
-        self.assertEqual(result.shape, (1, 1))
+        assert result.shape == (1, 1)
         result = method(
             [ts.get_num_samples()],
             ts.get_samples(),
             [0, ts.get_sequence_length()],
             mode="node",
         )
-        self.assertEqual(result.shape, (1, ts.get_num_nodes(), 1))
+        assert result.shape == (1, ts.get_num_nodes(), 1)
         result = method(
             [ts.get_num_samples()], ts.get_samples(), ts.get_breakpoints(), mode="node"
         )
-        self.assertEqual(result.shape, (ts.get_num_trees(), ts.get_num_nodes(), 1))
+        assert result.shape == (ts.get_num_trees(), ts.get_num_nodes(), 1)
 
     def test_output_dims(self):
         ts, method = self.get_method()
@@ -867,23 +891,23 @@ class OneWaySampleStatsMixin(SampleSetMixin):
 
         for mode in ["site", "branch"]:
             pi = method([n], samples, windows, mode=mode)
-            self.assertEqual(pi.shape, (1, 1))
+            assert pi.shape == (1, 1)
             pi = method([2, n - 2], samples, windows, mode=mode)
-            self.assertEqual(pi.shape, (1, 2))
+            assert pi.shape == (1, 2)
             pi = method([2, 2, n - 4], samples, windows, mode=mode)
-            self.assertEqual(pi.shape, (1, 3))
+            assert pi.shape == (1, 3)
             pi = method(np.ones(n).astype(np.uint32), samples, windows, mode=mode)
-            self.assertEqual(pi.shape, (1, n))
+            assert pi.shape == (1, n)
         mode = "node"
         N = ts.get_num_nodes()
         pi = method([n], samples, windows, mode=mode)
-        self.assertEqual(pi.shape, (1, N, 1))
+        assert pi.shape == (1, N, 1)
         pi = method([2, n - 2], samples, windows, mode=mode)
-        self.assertEqual(pi.shape, (1, N, 2))
+        assert pi.shape == (1, N, 2)
         pi = method([2, 2, n - 4], samples, windows, mode=mode)
-        self.assertEqual(pi.shape, (1, N, 3))
+        assert pi.shape == (1, N, 3)
         pi = method(np.ones(n).astype(np.uint32), samples, windows, mode=mode)
-        self.assertEqual(pi.shape, (1, N, n))
+        assert pi.shape == (1, N, n)
 
     def test_polarised(self):
         # TODO move this to the top level.
@@ -970,11 +994,11 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
         result = ts.allele_frequency_spectrum(
             [n], ts.get_samples(), [0, ts.get_sequence_length()]
         )
-        self.assertEqual(result.shape, (1, n + 1))
+        assert result.shape == (1, n + 1)
         result = ts.allele_frequency_spectrum(
             [n], ts.get_samples(), [0, ts.get_sequence_length()], polarised=True
         )
-        self.assertEqual(result.shape, (1, n + 1))
+        assert result.shape == (1, n + 1)
 
     def test_output_dims(self):
         ts = self.get_example_tree_sequence()
@@ -990,19 +1014,15 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
                     jafs = ts.allele_frequency_spectrum(
                         s, samples, windows, mode=mode, polarised=True
                     )
-                    self.assertEqual(
-                        jafs.shape, tuple([len(windows) - 1] + list(s + 1))
-                    )
+                    assert jafs.shape == tuple([len(windows) - 1] + list(s + 1))
                     jafs = ts.allele_frequency_spectrum(
                         s, samples, windows, mode=mode, polarised=False
                     )
-                    self.assertEqual(
-                        jafs.shape, tuple([len(windows) - 1] + list(s + 1))
-                    )
+                    assert jafs.shape == tuple([len(windows) - 1] + list(s + 1))
 
     def test_node_mode_not_supported(self):
         ts = self.get_example_tree_sequence()
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             ts.allele_frequency_spectrum(
                 [ts.get_num_samples()],
                 ts.get_samples(),
@@ -1034,7 +1054,7 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
             [[0, 1]],
             windows=[0, ts.get_sequence_length()],
         )
-        self.assertEqual(div.shape, (1, 1))
+        assert div.shape == (1, 1)
 
     def test_output_dims(self):
         ts, method = self.get_method()
@@ -1043,24 +1063,24 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
         n = len(samples)
         for mode in ["site", "branch"]:
             div = method([2, 2, n - 4], samples, [[0, 1]], windows, mode=mode)
-            self.assertEqual(div.shape, (1, 1))
+            assert div.shape == (1, 1)
             div = method([2, 2, n - 4], samples, [[0, 1], [1, 2]], windows, mode=mode)
-            self.assertEqual(div.shape, (1, 2))
+            assert div.shape == (1, 2)
             div = method(
                 [2, 2, n - 4], samples, [[0, 1], [1, 2], [0, 1]], windows, mode=mode
             )
-            self.assertEqual(div.shape, (1, 3))
+            assert div.shape == (1, 3)
 
         N = ts.get_num_nodes()
         mode = "node"
         div = method([2, 2, n - 4], samples, [[0, 1]], windows, mode=mode)
-        self.assertEqual(div.shape, (1, N, 1))
+        assert div.shape == (1, N, 1)
         div = method([2, 2, n - 4], samples, [[0, 1], [1, 2]], windows, mode=mode)
-        self.assertEqual(div.shape, (1, N, 2))
+        assert div.shape == (1, N, 2)
         div = method(
             [2, 2, n - 4], samples, [[0, 1], [1, 2], [0, 1]], windows, mode=mode
         )
-        self.assertEqual(div.shape, (1, N, 3))
+        assert div.shape == (1, N, 3)
 
     def test_set_index_errors(self):
         ts, method = self.get_method()
@@ -1072,10 +1092,10 @@ class TwoWaySampleStatsMixin(SampleSetMixin):
             method([2, 2, n - 4], samples, indexes, windows)
 
         for bad_array in ["wer", {}, [[[], []], [[], []]]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(bad_array)
         for bad_dim in [[[]], [[1], [1]]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(bad_dim)
 
 
@@ -1102,7 +1122,7 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
             [[0, 1, 2]],
             windows=[0, ts.get_sequence_length()],
         )
-        self.assertEqual(div.shape, (1, 1))
+        assert div.shape == (1, 1)
 
     def test_output_dims(self):
         ts, method = self.get_method()
@@ -1111,11 +1131,11 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
         n = len(samples)
         for mode in ["site", "branch"]:
             div = method([2, 2, n - 4], samples, [[0, 1, 2]], windows, mode=mode)
-            self.assertEqual(div.shape, (1, 1))
+            assert div.shape == (1, 1)
             div = method(
                 [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3]], windows, mode=mode
             )
-            self.assertEqual(div.shape, (1, 2))
+            assert div.shape == (1, 2)
             div = method(
                 [1, 1, 2, n - 4],
                 samples,
@@ -1123,16 +1143,16 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
                 windows,
                 mode=mode,
             )
-            self.assertEqual(div.shape, (1, 3))
+            assert div.shape == (1, 3)
 
         N = ts.get_num_nodes()
         mode = "node"
         div = method([2, 2, n - 4], samples, [[0, 1, 2]], windows, mode=mode)
-        self.assertEqual(div.shape, (1, N, 1))
+        assert div.shape == (1, N, 1)
         div = method(
             [1, 1, 2, n - 4], samples, [[0, 1, 2], [1, 2, 3]], windows, mode=mode
         )
-        self.assertEqual(div.shape, (1, N, 2))
+        assert div.shape == (1, N, 2)
         div = method(
             [1, 1, 2, n - 4],
             samples,
@@ -1140,7 +1160,7 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
             windows,
             mode=mode,
         )
-        self.assertEqual(div.shape, (1, N, 3))
+        assert div.shape == (1, N, 3)
 
     def test_set_index_errors(self):
         ts, method = self.get_method()
@@ -1152,10 +1172,10 @@ class ThreeWaySampleStatsMixin(SampleSetMixin):
             method([2, 2, n - 4], samples, indexes, windows)
 
         for bad_array in ["wer", {}, [[[], []], [[], []]]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(bad_array)
         for bad_dim in [[[]], [[1], [1]], [(0, 1)], [(0, 1, 2, 3)]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(bad_dim)
 
 
@@ -1182,7 +1202,7 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             [[0, 1, 2, 3]],
             windows=[0, ts.get_sequence_length()],
         )
-        self.assertEqual(div.shape, (1, 1))
+        assert div.shape == (1, 1)
 
     def test_output_dims(self):
         ts, method = self.get_method()
@@ -1191,7 +1211,7 @@ class FourWaySampleStatsMixin(SampleSetMixin):
         n = len(samples)
         for mode in ["site", "branch"]:
             div = method([2, 1, 1, n - 4], samples, [[0, 1, 2, 3]], windows, mode=mode)
-            self.assertEqual(div.shape, (1, 1))
+            assert div.shape == (1, 1)
             div = method(
                 [1, 1, 1, 1, n - 4],
                 samples,
@@ -1199,7 +1219,7 @@ class FourWaySampleStatsMixin(SampleSetMixin):
                 windows,
                 mode=mode,
             )
-            self.assertEqual(div.shape, (1, 2))
+            assert div.shape == (1, 2)
             div = method(
                 [1, 1, 1, 1, n - 4],
                 samples,
@@ -1207,12 +1227,12 @@ class FourWaySampleStatsMixin(SampleSetMixin):
                 windows,
                 mode=mode,
             )
-            self.assertEqual(div.shape, (1, 3))
+            assert div.shape == (1, 3)
 
         N = ts.get_num_nodes()
         mode = "node"
         div = method([2, 1, 1, n - 4], samples, [[0, 1, 2, 3]], windows, mode=mode)
-        self.assertEqual(div.shape, (1, N, 1))
+        assert div.shape == (1, N, 1)
         div = method(
             [1, 1, 1, 1, n - 4],
             samples,
@@ -1220,7 +1240,7 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             windows,
             mode=mode,
         )
-        self.assertEqual(div.shape, (1, N, 2))
+        assert div.shape == (1, N, 2)
         div = method(
             [1, 1, 1, 1, n - 4],
             samples,
@@ -1228,7 +1248,7 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             windows,
             mode=mode,
         )
-        self.assertEqual(div.shape, (1, N, 3))
+        assert div.shape == (1, N, 3)
 
     def test_set_index_errors(self):
         ts, method = self.get_method()
@@ -1240,10 +1260,10 @@ class FourWaySampleStatsMixin(SampleSetMixin):
             method([2, 1, 1, n - 4], samples, indexes, windows)
 
         for bad_array in ["wer", {}, [[[], []], [[], []]]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(bad_array)
         for bad_dim in [[[]], [[1], [1]], [(0, 1)], [(0, 1, 2, 3, 4)]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 f(bad_dim)
 
 
@@ -1305,7 +1325,7 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
         sigma = ts.general_stat(
             W, lambda x: np.cumsum(x), 1, ts.get_breakpoints(), mode="branch"
         )
-        self.assertEqual(sigma.shape, (ts.get_num_trees(), 1))
+        assert sigma.shape == (ts.get_num_trees(), 1)
 
     def test_non_numpy_return(self):
         ts = self.get_example_tree_sequence()
@@ -1313,11 +1333,11 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
         sigma = ts.general_stat(
             W, lambda x: [sum(x)], 1, ts.get_breakpoints(), mode="branch"
         )
-        self.assertEqual(sigma.shape, (ts.get_num_trees(), 1))
+        assert sigma.shape == (ts.get_num_trees(), 1)
         sigma = ts.general_stat(
             W, lambda x: [2, 2], 2, ts.get_breakpoints(), mode="branch"
         )
-        self.assertEqual(sigma.shape, (ts.get_num_trees(), 2))
+        assert sigma.shape == (ts.get_num_trees(), 2)
 
     def test_complicated_numpy_function(self):
         ts = self.get_example_tree_sequence(sample_size=20, length=30, random_seed=325)
@@ -1328,7 +1348,7 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
             return y
 
         sigma = ts.general_stat(W, f, 2, ts.get_breakpoints(), mode="branch")
-        self.assertEqual(sigma.shape, (ts.get_num_trees(), 2))
+        assert sigma.shape == (ts.get_num_trees(), 2)
 
     def test_input_dims(self):
         ts = self.get_example_tree_sequence()
@@ -1337,35 +1357,35 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
             sigma = ts.general_stat(
                 W, lambda x: np.cumsum(x), k, ts.get_breakpoints(), mode="branch"
             )
-            self.assertEqual(sigma.shape, (ts.get_num_trees(), k))
+            assert sigma.shape == (ts.get_num_trees(), k)
             sigma = ts.general_stat(
                 W, lambda x: [np.sum(x)], 1, ts.get_breakpoints(), mode="branch"
             )
-            self.assertEqual(sigma.shape, (ts.get_num_trees(), 1))
+            assert sigma.shape == (ts.get_num_trees(), 1)
 
     def test_W_errors(self):
         ts = self.get_example_tree_sequence()
         n = ts.get_num_samples()
         for bad_array in [[], [0, 1], [[[[]], [[]]]], np.zeros((10, 3, 4))]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.general_stat(bad_array, lambda x: x, 1, ts.get_breakpoints())
 
         for bad_size in [n - 1, n + 1, 0]:
             W = np.zeros((bad_size, 1))
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.general_stat(W, lambda x: x, 1, ts.get_breakpoints())
 
     def test_summary_func_errors(self):
         ts = self.get_example_tree_sequence()
         W = np.zeros((ts.get_num_samples(), 1))
         for bad_type in ["sdf", 1, {}]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 ts.general_stat(W, bad_type, 1, ts.get_breakpoints())
 
         # Wrong numbers of arguments to f
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ts.general_stat(W, lambda: 0, 1, ts.get_breakpoints())
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ts.general_stat(W, lambda x, y: None, 1, ts.get_breakpoints())
 
         # Exceptions within f are correctly raised.
@@ -1374,19 +1394,19 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
             def f(x):
                 raise exception("test")
 
-            with self.assertRaises(exception):
+            with pytest.raises(exception):
                 ts.general_stat(W, f, 1, ts.get_breakpoints())
 
         # Wrong output dimensions
         for bad_array in [[1, 1], range(10)]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.general_stat(W, lambda x: bad_array, 1, ts.get_breakpoints())
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.general_stat(W, lambda x: [1], 2, ts.get_breakpoints())
 
         # Bad arrays returned from f
         for bad_array in [["sdf"], 0, "w4", None]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.general_stat(W, lambda x: bad_array, 1, ts.get_breakpoints())
 
 
@@ -1397,18 +1417,21 @@ class TestTreeDiffIterator(LowLevelTestCase):
 
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
-        self.assertRaises(ValueError, _tskit.TreeDiffIterator, ts)
+        with pytest.raises(ValueError):
+            _tskit.TreeDiffIterator(ts)
 
     def test_constructor(self):
-        self.assertRaises(TypeError, _tskit.TreeDiffIterator)
-        self.assertRaises(TypeError, _tskit.TreeDiffIterator, None)
+        with pytest.raises(TypeError):
+            _tskit.TreeDiffIterator()
+        with pytest.raises(TypeError):
+            _tskit.TreeDiffIterator(None)
         ts = self.get_example_tree_sequence()
         before = list(_tskit.TreeDiffIterator(ts))
         iterator = _tskit.TreeDiffIterator(ts)
         del ts
         # We should keep a reference to the tree sequence.
         after = list(iterator)
-        self.assertEqual(before, after)
+        assert before == after
 
     def test_iterator(self):
         ts = self.get_example_tree_sequence()
@@ -1422,35 +1445,38 @@ class TestVariantGenerator(LowLevelTestCase):
 
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
-        self.assertRaises(ValueError, _tskit.VariantGenerator, ts)
+        with pytest.raises(ValueError):
+            _tskit.VariantGenerator(ts)
 
     def test_constructor(self):
-        self.assertRaises(TypeError, _tskit.VariantGenerator)
-        self.assertRaises(TypeError, _tskit.VariantGenerator, None)
+        with pytest.raises(TypeError):
+            _tskit.VariantGenerator()
+        with pytest.raises(TypeError):
+            _tskit.VariantGenerator(None)
         ts = self.get_example_tree_sequence()
-        self.assertRaises(ValueError, _tskit.VariantGenerator, ts, samples={})
-        self.assertRaises(
-            TypeError, _tskit.VariantGenerator, ts, impute_missing_data=None
-        )
-        self.assertRaises(
-            _tskit.LibraryError, _tskit.VariantGenerator, ts, samples=[-1, 2]
-        )
-        self.assertRaises(TypeError, _tskit.VariantGenerator, ts, alleles=1234)
+        with pytest.raises(ValueError):
+            _tskit.VariantGenerator(ts, samples={})
+        with pytest.raises(TypeError):
+            _tskit.VariantGenerator(ts, impute_missing_data=None)
+        with pytest.raises(_tskit.LibraryError):
+            _tskit.VariantGenerator(ts, samples=[-1, 2])
+        with pytest.raises(TypeError):
+            _tskit.VariantGenerator(ts, alleles=1234)
 
     def test_alleles(self):
         ts = self.get_example_tree_sequence()
         for bad_type in [["a", "b"], "sdf", 234]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 _tskit.VariantGenerator(ts, samples=[1, 2], alleles=bad_type)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _tskit.VariantGenerator(ts, samples=[1, 2], alleles=tuple())
 
         for bad_allele_type in [None, 0, b"x", []]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 _tskit.VariantGenerator(ts, samples=[1, 2], alleles=(bad_allele_type,))
 
         too_many_alleles = tuple(str(j) for j in range(128))
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             _tskit.VariantGenerator(ts, samples=[1, 2], alleles=too_many_alleles)
 
     def test_iterator(self):
@@ -1466,8 +1492,8 @@ class TestVariantGenerator(LowLevelTestCase):
         ts.load_tables(tables)
         variant = list(_tskit.VariantGenerator(ts))[0]
         _, genotypes, alleles = variant
-        self.assertTrue(np.all(genotypes == -1))
-        self.assertEqual(alleles, ("A", None))
+        assert np.all(genotypes == -1)
+        assert alleles == ("A", None)
 
 
 class TestLdCalculator(LowLevelTestCase):
@@ -1477,48 +1503,54 @@ class TestLdCalculator(LowLevelTestCase):
 
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
-        self.assertRaises(ValueError, _tskit.LdCalculator, ts)
+        with pytest.raises(ValueError):
+            _tskit.LdCalculator(ts)
 
     def test_constructor(self):
-        self.assertRaises(TypeError, _tskit.LdCalculator)
-        self.assertRaises(TypeError, _tskit.LdCalculator, None)
+        with pytest.raises(TypeError):
+            _tskit.LdCalculator()
+        with pytest.raises(TypeError):
+            _tskit.LdCalculator(None)
 
     def test_get_r2(self):
         ts = self.get_example_tree_sequence()
         calc = _tskit.LdCalculator(ts)
         n = ts.get_num_sites()
         for bad_id in [-1, n, n + 1]:
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 calc.get_r2(0, bad_id)
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 calc.get_r2(bad_id, 0)
 
     def test_get_r2_array(self):
         ts = self.get_example_tree_sequence()
         calc = _tskit.LdCalculator(ts)
 
-        self.assertRaises(TypeError, calc.get_r2_array)
-        self.assertRaises(TypeError, calc.get_r2_array, None)
+        with pytest.raises(TypeError):
+            calc.get_r2_array()
+        with pytest.raises(TypeError):
+            calc.get_r2_array(None)
         # Doesn't support buffer protocol, so raises typeerror
-        self.assertRaises(TypeError, calc.get_r2_array, None, 0)
+        with pytest.raises(TypeError):
+            calc.get_r2_array(None, 0)
 
         n = ts.get_num_sites()
-        self.assertGreater(n, 2)
-        with self.assertRaises(BufferError):
+        assert n > 2
+        with pytest.raises(BufferError):
             calc.get_r2_array(bytes(100), 0)
 
         buff = bytearray(1024)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             calc.get_r2_array(buff, 0, max_distance=-1)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             calc.get_r2_array(buff, 0, direction=1000)
         # TODO this API is poor, we should explicitly catch these negative
         # size errors.
         for bad_max_mutations in [-2, -3, -(2 ** 32)]:
-            with self.assertRaises(BufferError):
+            with pytest.raises(BufferError):
                 calc.get_r2_array(buff, 0, max_mutations=bad_max_mutations)
         for bad_start_pos in [-1, n, n + 1]:
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 calc.get_r2_array(buff, bad_start_pos)
 
 
@@ -1529,26 +1561,33 @@ class TestLsHmm(LowLevelTestCase):
 
     def test_uninitialised_tree_sequence(self):
         ts = _tskit.TreeSequence()
-        self.assertRaises(ValueError, _tskit.LsHmm, ts, None, None)
+        with pytest.raises(ValueError):
+            _tskit.LsHmm(ts, None, None)
 
     def test_constructor(self):
         ts = self.get_example_tree_sequence()
-        self.assertRaises(TypeError, _tskit.LsHmm)
-        self.assertRaises(TypeError, _tskit.LsHmm, None)
+        with pytest.raises(TypeError):
+            _tskit.LsHmm()
+        with pytest.raises(TypeError):
+            _tskit.LsHmm(None)
         values = np.zeros(ts.get_num_sites())
         for bad_array in ["asdf", [[], []], None]:
-            self.assertRaises(ValueError, _tskit.LsHmm, ts, bad_array, values)
-            self.assertRaises(ValueError, _tskit.LsHmm, ts, values, bad_array)
+            with pytest.raises(ValueError):
+                _tskit.LsHmm(ts, bad_array, values)
+            with pytest.raises(ValueError):
+                _tskit.LsHmm(ts, values, bad_array)
 
     def test_bad_rate_arrays(self):
         ts = self.get_example_tree_sequence()
         m = ts.get_num_sites()
-        self.assertGreater(m, 0)
+        assert m > 0
         values = np.zeros(m)
         for bad_size in [0, m - 1, m + 1, m + 2]:
             bad_array = np.zeros(bad_size)
-            self.assertRaises(ValueError, _tskit.LsHmm, ts, bad_array, values)
-            self.assertRaises(ValueError, _tskit.LsHmm, ts, values, bad_array)
+            with pytest.raises(ValueError):
+                _tskit.LsHmm(ts, bad_array, values)
+            with pytest.raises(ValueError):
+                _tskit.LsHmm(ts, values, bad_array)
 
     def test_haplotype_input(self):
         ts = self.get_example_tree_sequence()
@@ -1558,14 +1597,14 @@ class TestLsHmm(LowLevelTestCase):
         ls_hmm = _tskit.LsHmm(ts, np.zeros(m), np.zeros(m))
         for bad_size in [0, m - 1, m + 1, m + 2]:
             bad_array = np.zeros(bad_size, dtype=np.int8)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ls_hmm.forward_matrix(bad_array, fm)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ls_hmm.viterbi_matrix(bad_array, vm)
         for bad_array in [[0.002], [[], []], None]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ls_hmm.forward_matrix(bad_array, fm)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ls_hmm.viterbi_matrix(bad_array, vm)
 
     def test_output_type_errors(self):
@@ -1574,17 +1613,17 @@ class TestLsHmm(LowLevelTestCase):
         h = np.zeros(m, dtype=np.int8)
         ls_hmm = _tskit.LsHmm(ts, np.zeros(m), np.zeros(m))
         for bad_type in [ls_hmm, None, m, []]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 ls_hmm.forward_matrix(h, bad_type)
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 ls_hmm.viterbi_matrix(h, bad_type)
 
         other_ts = self.get_example_tree_sequence()
         output = _tskit.CompressedMatrix(other_ts)
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             ls_hmm.forward_matrix(h, output)
         output = _tskit.ViterbiMatrix(other_ts)
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             ls_hmm.viterbi_matrix(h, output)
 
     def test_empty_forward_matrix(self):
@@ -1592,50 +1631,48 @@ class TestLsHmm(LowLevelTestCase):
             ts = self.get_example_tree_sequence(mutation_rate=mu)
             m = ts.get_num_sites()
             fm = _tskit.CompressedMatrix(ts)
-            self.assertEqual(fm.num_sites, m)
-            self.assertTrue(np.array_equal(np.zeros(m), fm.normalisation_factor))
-            self.assertTrue(
-                np.array_equal(np.zeros(m, dtype=np.uint32), fm.num_transitions)
-            )
+            assert fm.num_sites == m
+            assert np.array_equal(np.zeros(m), fm.normalisation_factor)
+            assert np.array_equal(np.zeros(m, dtype=np.uint32), fm.num_transitions)
             F = fm.decode()
-            self.assertTrue(np.all(F >= 0))
+            assert np.all(F >= 0)
             for j in range(m):
-                self.assertEqual(fm.get_site(j), [])
+                assert fm.get_site(j) == []
 
     def test_empty_viterbi_matrix(self):
         for mu in [0, 1]:
             ts = self.get_example_tree_sequence(mutation_rate=mu)
             m = ts.get_num_sites()
             vm = _tskit.ViterbiMatrix(ts)
-            self.assertEqual(vm.num_sites, m)
+            assert vm.num_sites == m
             # TODO we should have the same semantics for 0 sites
             if m == 0:
                 h = vm.traceback()
-                self.assertEqual(len(h), 0)
+                assert len(h) == 0
             else:
-                with self.assertRaises(_tskit.LibraryError):
+                with pytest.raises(_tskit.LibraryError):
                     vm.traceback()
 
     def verify_compressed_matrix(self, ts, output):
         S = output.normalisation_factor
         N = output.num_transitions
-        self.assertTrue(np.all(0 < S))
-        self.assertTrue(np.all(S < 1))
-        self.assertTrue(np.all(N > 0))
+        assert np.all(0 < S)
+        assert np.all(S < 1)
+        assert np.all(N > 0)
         F = output.decode()
-        self.assertEqual(F.shape, (ts.get_num_sites(), ts.get_num_samples()))
-        self.assertTrue(np.all(F >= 0))
+        assert F.shape == (ts.get_num_sites(), ts.get_num_samples())
+        assert np.all(F >= 0)
         m = ts.get_num_sites()
         for j in range(m):
             site_list = output.get_site(j)
-            self.assertEqual(len(site_list), N[j])
+            assert len(site_list) == N[j]
             for item in site_list:
-                self.assertEqual(len(item), 2)
+                assert len(item) == 2
                 node, value = item
-                self.assertTrue(0 <= node < ts.get_num_nodes())
-                self.assertTrue(0 <= value <= 1)
+                assert 0 <= node < ts.get_num_nodes()
+                assert 0 <= value <= 1
         for site in [m, m + 1, 2 * m]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 output.get_site(site)
 
     def test_forward_matrix(self):
@@ -1644,7 +1681,7 @@ class TestLsHmm(LowLevelTestCase):
         output = _tskit.CompressedMatrix(ts)
         ls_hmm = _tskit.LsHmm(ts, np.zeros(m) + 0.1, np.zeros(m) + 0.1)
         rv = ls_hmm.forward_matrix([0 for _ in range(m)], output)
-        self.assertIsNone(rv)
+        assert rv is None
         self.verify_compressed_matrix(ts, output)
 
     def test_viterbi_matrix(self):
@@ -1653,10 +1690,10 @@ class TestLsHmm(LowLevelTestCase):
         output = _tskit.ViterbiMatrix(ts)
         ls_hmm = _tskit.LsHmm(ts, np.zeros(m) + 0.1, np.zeros(m) + 0.1)
         rv = ls_hmm.viterbi_matrix([0 for _ in range(m)], output)
-        self.assertIsNone(rv)
+        assert rv is None
         self.verify_compressed_matrix(ts, output)
         h = output.traceback()
-        self.assertIsInstance(h, np.ndarray)
+        assert isinstance(h, np.ndarray)
 
 
 class TestTree(LowLevelTestCase):
@@ -1667,7 +1704,7 @@ class TestTree(LowLevelTestCase):
     def test_options(self):
         ts = self.get_example_tree_sequence()
         st = _tskit.Tree(ts)
-        self.assertEqual(st.get_options(), 0)
+        assert st.get_options() == 0
         all_options = [
             0,
             _tskit.NO_SAMPLE_COUNTS,
@@ -1678,48 +1715,55 @@ class TestTree(LowLevelTestCase):
             tree = _tskit.Tree(ts, options=options)
             copy = tree.copy()
             for st in [tree, copy]:
-                self.assertEqual(st.get_options(), options)
-                self.assertEqual(st.get_num_samples(0), 1)
+                assert st.get_options() == options
+                assert st.get_num_samples(0) == 1
                 if options & _tskit.NO_SAMPLE_COUNTS:
                     # We should still be able to count the samples, just inefficiently.
-                    self.assertEqual(st.get_num_samples(0), 1)
-                    self.assertRaises(
-                        _tskit.LibraryError, st.get_num_tracked_samples, 0
-                    )
+                    assert st.get_num_samples(0) == 1
+                    with pytest.raises(_tskit.LibraryError):
+                        st.get_num_tracked_samples(0)
                 else:
-                    self.assertEqual(st.get_num_tracked_samples(0), 0)
+                    assert st.get_num_tracked_samples(0) == 0
                 if options & _tskit.SAMPLE_LISTS:
-                    self.assertEqual(0, st.get_left_sample(0))
-                    self.assertEqual(0, st.get_right_sample(0))
+                    assert 0 == st.get_left_sample(0)
+                    assert 0 == st.get_right_sample(0)
                 else:
-                    self.assertRaises(ValueError, st.get_left_sample, 0)
-                    self.assertRaises(ValueError, st.get_right_sample, 0)
-                    self.assertRaises(ValueError, st.get_next_sample, 0)
+                    with pytest.raises(ValueError):
+                        st.get_left_sample(0)
+                    with pytest.raises(ValueError):
+                        st.get_right_sample(0)
+                    with pytest.raises(ValueError):
+                        st.get_next_sample(0)
 
     def test_site_errors(self):
         ts = self.get_example_tree_sequence()
         for bad_index in [-1, ts.get_num_sites(), ts.get_num_sites() + 1]:
-            self.assertRaises(IndexError, ts.get_site, bad_index)
+            with pytest.raises(IndexError):
+                ts.get_site(bad_index)
 
     def test_mutation_errors(self):
         ts = self.get_example_tree_sequence()
         for bad_index in [-1, ts.get_num_mutations(), ts.get_num_mutations() + 1]:
-            self.assertRaises(IndexError, ts.get_mutation, bad_index)
+            with pytest.raises(IndexError):
+                ts.get_mutation(bad_index)
 
     def test_individual_errors(self):
         ts = self.get_example_tree_sequence()
         for bad_index in [-1, ts.get_num_individuals(), ts.get_num_individuals() + 1]:
-            self.assertRaises(IndexError, ts.get_individual, bad_index)
+            with pytest.raises(IndexError):
+                ts.get_individual(bad_index)
 
     def test_population_errors(self):
         ts = self.get_example_tree_sequence()
         for bad_index in [-1, ts.get_num_populations(), ts.get_num_populations() + 1]:
-            self.assertRaises(IndexError, ts.get_population, bad_index)
+            with pytest.raises(IndexError):
+                ts.get_population(bad_index)
 
     def test_provenance_errors(self):
         ts = self.get_example_tree_sequence()
         for bad_index in [-1, ts.get_num_provenances(), ts.get_num_provenances() + 1]:
-            self.assertRaises(IndexError, ts.get_provenance, bad_index)
+            with pytest.raises(IndexError):
+                ts.get_provenance(bad_index)
 
     def test_sites(self):
         for ts in self.get_example_tree_sequences():
@@ -1730,7 +1774,7 @@ class TestTree(LowLevelTestCase):
             mutation_id = 0
             while st.next():
                 tree_sites = st.get_sites()
-                self.assertEqual(st.get_num_sites(), len(tree_sites))
+                assert st.get_num_sites() == len(tree_sites)
                 all_tree_sites.extend(tree_sites)
                 for (
                     position,
@@ -1739,9 +1783,9 @@ class TestTree(LowLevelTestCase):
                     index,
                     metadata,
                 ) in tree_sites:
-                    self.assertTrue(st.get_left() <= position < st.get_right())
-                    self.assertEqual(index, j)
-                    self.assertEqual(metadata, b"")
+                    assert st.get_left() <= position < st.get_right()
+                    assert index == j
+                    assert metadata == b""
                     for mut_id in mutations:
                         (
                             site,
@@ -1751,27 +1795,27 @@ class TestTree(LowLevelTestCase):
                             metadata,
                             time,
                         ) = ts.get_mutation(mut_id)
-                        self.assertEqual(site, index)
-                        self.assertEqual(mutation_id, mut_id)
-                        self.assertNotEqual(st.get_parent(node), _tskit.NULL)
-                        self.assertEqual(metadata, b"")
+                        assert site == index
+                        assert mutation_id == mut_id
+                        assert st.get_parent(node) != _tskit.NULL
+                        assert metadata == b""
                         mutation_id += 1
                     j += 1
-            self.assertEqual(all_tree_sites, all_sites)
+            assert all_tree_sites == all_sites
 
     def test_root_threshold_errors(self):
         ts = self.get_example_tree_sequence()
         tree = _tskit.Tree(ts)
         for bad_type in ["", "x", {}]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tree.set_root_threshold(bad_type)
 
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tree.set_root_threshold(0)
         tree.set_root_threshold(2)
         # Setting when not in the null state raises an error
         tree.next()
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tree.set_root_threshold(2)
 
     def test_root_threshold(self):
@@ -1779,66 +1823,65 @@ class TestTree(LowLevelTestCase):
             tree = _tskit.Tree(ts)
             for root_threshold in [1, 2, ts.get_num_samples() * 2]:
                 tree.set_root_threshold(root_threshold)
-                self.assertEqual(tree.get_root_threshold(), root_threshold)
+                assert tree.get_root_threshold() == root_threshold
                 while tree.next():
-                    self.assertEqual(tree.get_root_threshold(), root_threshold)
-                    with self.assertRaises(_tskit.LibraryError):
+                    assert tree.get_root_threshold() == root_threshold
+                    with pytest.raises(_tskit.LibraryError):
                         tree.set_root_threshold(2)
-                self.assertEqual(tree.get_root_threshold(), root_threshold)
+                assert tree.get_root_threshold() == root_threshold
 
     def test_constructor(self):
-        self.assertRaises(TypeError, _tskit.Tree)
+        with pytest.raises(TypeError):
+            _tskit.Tree()
         for bad_type in ["", {}, [], None, 0]:
-            self.assertRaises(TypeError, _tskit.Tree, bad_type)
+            with pytest.raises(TypeError):
+                _tskit.Tree(bad_type)
         ts = self.get_example_tree_sequence()
         for bad_type in ["", {}, True, 1, None]:
-            self.assertRaises(TypeError, _tskit.Tree, ts, tracked_samples=bad_type)
+            with pytest.raises(TypeError):
+                _tskit.Tree(ts, tracked_samples=bad_type)
         for bad_type in ["", {}, None, []]:
-            self.assertRaises(TypeError, _tskit.Tree, ts, options=bad_type)
+            with pytest.raises(TypeError):
+                _tskit.Tree(ts, options=bad_type)
         for ts in self.get_example_tree_sequences():
             st = _tskit.Tree(ts)
-            self.assertEqual(st.get_num_nodes(), ts.get_num_nodes())
+            assert st.get_num_nodes() == ts.get_num_nodes()
             # An uninitialised tree should always be zero.
-            self.assertEqual(st.get_left_root(), 0)
-            self.assertEqual(st.get_left(), 0)
-            self.assertEqual(st.get_right(), 0)
+            assert st.get_left_root() == 0
+            assert st.get_left() == 0
+            assert st.get_right() == 0
             for j in range(ts.get_num_samples()):
-                self.assertEqual(st.get_parent(j), _tskit.NULL)
-                self.assertEqual(st.get_children(j), tuple())
-                self.assertEqual(st.get_time(j), 0)
+                assert st.get_parent(j) == _tskit.NULL
+                assert st.get_children(j) == tuple()
+                assert st.get_time(j) == 0
 
     def test_bad_tracked_samples(self):
         ts = self.get_example_tree_sequence()
         options = 0
         for bad_type in ["", {}, [], None]:
-            self.assertRaises(
-                TypeError, _tskit.Tree, ts, options=options, tracked_samples=[bad_type]
-            )
-            self.assertRaises(
-                TypeError,
-                _tskit.Tree,
-                ts,
-                options=options,
-                tracked_samples=[1, bad_type],
-            )
+            with pytest.raises(TypeError):
+                _tskit.Tree(ts, options=options, tracked_samples=[bad_type])
+            with pytest.raises(TypeError):
+                _tskit.Tree(
+                    ts,
+                    options=options,
+                    tracked_samples=[1, bad_type],
+                )
         for bad_sample in [10 ** 6, -1e6]:
-            self.assertRaises(
-                ValueError,
-                _tskit.Tree,
-                ts,
-                options=options,
-                tracked_samples=[bad_sample],
-            )
-            self.assertRaises(
-                ValueError,
-                _tskit.Tree,
-                ts,
-                options=options,
-                tracked_samples=[1, bad_sample],
-            )
-            self.assertRaises(
-                ValueError, _tskit.Tree, ts, tracked_samples=[1, bad_sample, 1]
-            )
+            with pytest.raises(ValueError):
+                _tskit.Tree(
+                    ts,
+                    options=options,
+                    tracked_samples=[bad_sample],
+                )
+            with pytest.raises(ValueError):
+                _tskit.Tree(
+                    ts,
+                    options=options,
+                    tracked_samples=[1, bad_sample],
+                )
+            with pytest.raises(ValueError):
+                _tskit.Tree(ts, tracked_samples=[1, bad_sample, 1])
 
     def test_while_loop_semantics(self):
         for ts in self.get_example_tree_sequences():
@@ -1847,20 +1890,20 @@ class TestTree(LowLevelTestCase):
             for _ in range(2):
                 j = 0
                 while tree.next():
-                    self.assertEqual(tree.get_index(), j)
+                    assert tree.get_index() == j
                     j += 1
-                self.assertEqual(j, ts.get_num_trees())
+                assert j == ts.get_num_trees()
             for _ in range(2):
                 j = ts.get_num_trees()
                 while tree.prev():
-                    self.assertEqual(tree.get_index(), j - 1)
+                    assert tree.get_index() == j - 1
                     j -= 1
-                self.assertEqual(j, 0)
+                assert j == 0
             j = 0
             while tree.next():
-                self.assertEqual(tree.get_index(), j)
+                assert tree.get_index() == j
                 j += 1
-            self.assertEqual(j, ts.get_num_trees())
+            assert j == ts.get_num_trees()
 
     def test_count_all_samples(self):
         for ts in self.get_example_tree_sequences():
@@ -1870,15 +1913,15 @@ class TestTree(LowLevelTestCase):
             # that is not a sample.
             for j in range(st.get_num_nodes()):
                 count = 1 if j < ts.get_num_samples() else 0
-                self.assertEqual(st.get_num_samples(j), count)
-                self.assertEqual(st.get_num_tracked_samples(j), 0)
+                assert st.get_num_samples(j) == count
+                assert st.get_num_tracked_samples(j) == 0
             while st.next():
                 nu = get_sample_counts(ts, st)
                 nu_prime = [st.get_num_samples(j) for j in range(st.get_num_nodes())]
-                self.assertEqual(nu, nu_prime)
+                assert nu == nu_prime
                 # For tracked samples, this should be all zeros.
                 nu = [st.get_num_tracked_samples(j) for j in range(st.get_num_nodes())]
-                self.assertEqual(nu, list([0 for _ in nu]))
+                assert nu == list([0 for _ in nu])
 
     def test_count_tracked_samples(self):
         # Ensure that there are some non-binary nodes.
@@ -1903,47 +1946,58 @@ class TestTree(LowLevelTestCase):
                     nu_prime = [
                         st.get_num_tracked_samples(j) for j in range(st.get_num_nodes())
                     ]
-                    self.assertEqual(nu, nu_prime)
+                    assert nu == nu_prime
             # Passing duplicated values should raise an error
             sample = 1
             for j in range(2, 20):
                 tracked_samples = [sample for _ in range(j)]
-                self.assertRaises(
-                    _tskit.LibraryError,
-                    _tskit.Tree,
-                    ts,
-                    tracked_samples=tracked_samples,
-                )
-        self.assertTrue(non_binary)
+                with pytest.raises(_tskit.LibraryError):
+                    _tskit.Tree(
+                        ts,
+                        tracked_samples=tracked_samples,
+                    )
+        assert non_binary
 
     def test_bounds_checking(self):
         for ts in self.get_example_tree_sequences():
             n = ts.get_num_nodes()
             st = _tskit.Tree(ts, options=_tskit.SAMPLE_LISTS)
             for v in [-100, -1, n + 1, n + 100, n * 100]:
-                self.assertRaises(ValueError, st.get_parent, v)
-                self.assertRaises(ValueError, st.get_children, v)
-                self.assertRaises(ValueError, st.get_time, v)
-                self.assertRaises(ValueError, st.get_left_sample, v)
-                self.assertRaises(ValueError, st.get_right_sample, v)
-                self.assertRaises(ValueError, st.is_descendant, v, 0)
-                self.assertRaises(ValueError, st.is_descendant, 0, v)
-                self.assertRaises(ValueError, st.depth, v)
+                with pytest.raises(ValueError):
+                    st.get_parent(v)
+                with pytest.raises(ValueError):
+                    st.get_children(v)
+                with pytest.raises(ValueError):
+                    st.get_time(v)
+                with pytest.raises(ValueError):
+                    st.get_left_sample(v)
+                with pytest.raises(ValueError):
+                    st.get_right_sample(v)
+                with pytest.raises(ValueError):
+                    st.is_descendant(v, 0)
+                with pytest.raises(ValueError):
+                    st.is_descendant(0, v)
+                with pytest.raises(ValueError):
+                    st.depth(v)
             n = ts.get_num_samples()
             for v in [-100, -1, n + 1, n + 100, n * 100]:
-                self.assertRaises(ValueError, st.get_next_sample, v)
+                with pytest.raises(ValueError):
+                    st.get_next_sample(v)
 
     def test_mrca_interface(self):
         for ts in self.get_example_tree_sequences():
             num_nodes = ts.get_num_nodes()
             st = _tskit.Tree(ts)
             for v in [num_nodes, 10 ** 6, _tskit.NULL]:
-                self.assertRaises(ValueError, st.get_mrca, v, v)
-                self.assertRaises(ValueError, st.get_mrca, v, 1)
-                self.assertRaises(ValueError, st.get_mrca, 1, v)
+                with pytest.raises(ValueError):
+                    st.get_mrca(v, v)
+                with pytest.raises(ValueError):
+                    st.get_mrca(v, 1)
+                with pytest.raises(ValueError):
+                    st.get_mrca(1, v)
             # All the mrcas for an uninitialised tree should be _tskit.NULL
             for u, v in itertools.combinations(range(num_nodes), 2):
-                self.assertEqual(st.get_mrca(u, v), _tskit.NULL)
+                assert st.get_mrca(u, v) == _tskit.NULL
 
     def test_newick_precision(self):
         def get_times(tree):
@@ -1965,34 +2019,37 @@ class TestTree(LowLevelTestCase):
         ts = self.get_example_tree_sequence()
         st = _tskit.Tree(ts)
         while st.next():
-            self.assertRaises(ValueError, st.get_newick, root=0, precision=-1)
-            self.assertRaises(ValueError, st.get_newick, root=0, precision=17)
-            self.assertRaises(ValueError, st.get_newick, root=0, precision=100)
+            with pytest.raises(ValueError):
+                st.get_newick(root=0, precision=-1)
+            with pytest.raises(ValueError):
+                st.get_newick(root=0, precision=17)
+            with pytest.raises(ValueError):
+                st.get_newick(root=0, precision=100)
             for precision in range(17):
                 tree = st.get_newick(
                     root=st.get_left_root(), precision=precision
                 ).decode()
                 times = get_times(tree)
-                self.assertGreater(len(times), ts.get_num_samples())
+                assert len(times) > ts.get_num_samples()
                 for t in times:
                     if precision == 0:
-                        self.assertNotIn(".", t)
+                        assert "." not in t
                     else:
                         point = t.find(".")
-                        self.assertEqual(precision, len(t) - point - 1)
+                        assert precision == len(t) - point - 1
 
     def test_cleared_tree(self):
         ts = self.get_example_tree_sequence()
         samples = ts.get_samples()
 
         def check_tree(tree):
-            self.assertEqual(tree.get_index(), -1)
-            self.assertEqual(tree.get_left_root(), samples[0])
-            self.assertEqual(tree.get_mrca(0, 1), _tskit.NULL)
+            assert tree.get_index() == -1
+            assert tree.get_left_root() == samples[0]
+            assert tree.get_mrca(0, 1) == _tskit.NULL
             for u in range(ts.get_num_nodes()):
-                self.assertEqual(tree.get_parent(u), _tskit.NULL)
-                self.assertEqual(tree.get_left_child(u), _tskit.NULL)
-                self.assertEqual(tree.get_right_child(u), _tskit.NULL)
+                assert tree.get_parent(u) == _tskit.NULL
+                assert tree.get_left_child(u) == _tskit.NULL
+                assert tree.get_right_child(u) == _tskit.NULL
 
         tree = _tskit.Tree(ts)
         check_tree(tree)
@@ -2007,17 +2064,19 @@ class TestTree(LowLevelTestCase):
         ts = self.get_example_tree_sequence()
         st = _tskit.Tree(ts)
         # TODO this will break when we correctly handle multiple roots.
-        self.assertEqual(st.get_newick(0), b"1;")
+        assert st.get_newick(0) == b"1;"
         for bad_type in [None, "", [], {}]:
-            self.assertRaises(TypeError, st.get_newick, precision=bad_type)
-            self.assertRaises(TypeError, st.get_newick, ts, buffer_size=bad_type)
+            with pytest.raises(TypeError):
+                st.get_newick(precision=bad_type)
+            with pytest.raises(TypeError):
+                st.get_newick(ts, buffer_size=bad_type)
         while st.next():
             u = st.get_left_root()
             newick = st.get_newick(u)
-            self.assertTrue(newick.endswith(b";"))
-            with self.assertRaises(ValueError):
+            assert newick.endswith(b";")
+            with pytest.raises(ValueError):
                 st.get_newick(u, buffer_size=-1)
-            with self.assertRaises(_tskit.LibraryError):
+            with pytest.raises(_tskit.LibraryError):
                 st.get_newick(u, buffer_size=1)
 
     def test_index(self):
@@ -2025,7 +2084,7 @@ class TestTree(LowLevelTestCase):
             st = _tskit.Tree(ts)
             index = 0
             while st.next():
-                self.assertEqual(index, st.get_index())
+                assert index == st.get_index()
                 index += 1
 
     def test_bad_mutations(self):
@@ -2072,13 +2131,16 @@ class TestTree(LowLevelTestCase):
             ts2 = _tskit.TreeSequence()
             ts2.load_tables(tables)
 
-        self.assertRaises(_tskit.LibraryError, f, [(0.1, -1)])
+        with pytest.raises(_tskit.LibraryError):
+            f([(0.1, -1)])
         length = ts.get_sequence_length()
         u = ts.get_num_nodes()
         for bad_node in [u, u + 1, 2 * u]:
-            self.assertRaises(_tskit.LibraryError, f, [(0.1, bad_node)])
+            with pytest.raises(_tskit.LibraryError):
+                f([(0.1, bad_node)])
         for bad_pos in [-1, length, length + 1]:
-            self.assertRaises(_tskit.LibraryError, f, [(bad_pos, 0)])
+            with pytest.raises(_tskit.LibraryError):
+                f([(bad_pos, 0)])
 
     def test_sample_list(self):
         options = _tskit.SAMPLE_LISTS
@@ -2088,8 +2150,8 @@ class TestTree(LowLevelTestCase):
             while t.next():
                 # All sample nodes should have themselves.
                 for j in range(ts.get_num_samples()):
-                    self.assertEqual(t.get_left_sample(j), j)
-                    self.assertEqual(t.get_right_sample(j), j)
+                    assert t.get_left_sample(j) == j
+                    assert t.get_right_sample(j) == j
 
                 # All non-tree nodes should have 0
                 for j in range(t.get_num_nodes()):
@@ -2097,8 +2159,8 @@ class TestTree(LowLevelTestCase):
                         t.get_parent(j) == _tskit.NULL
                         and t.get_left_child(j) == _tskit.NULL
                     ):
-                        self.assertEqual(t.get_left_sample(j), _tskit.NULL)
-                        self.assertEqual(t.get_right_sample(j), _tskit.NULL)
+                        assert t.get_left_sample(j) == _tskit.NULL
+                        assert t.get_right_sample(j) == _tskit.NULL
                 # The roots should have all samples.
                 u = t.get_left_root()
                 samples = []
@@ -2111,41 +2173,45 @@ class TestTree(LowLevelTestCase):
                             break
                         sample = t.get_next_sample(sample)
                     u = t.get_right_sib(u)
-                self.assertEqual(sorted(samples), list(range(ts.get_num_samples())))
+                assert sorted(samples) == list(range(ts.get_num_samples()))
 
     def test_equality(self):
         last_ts = None
         for ts in self.get_example_tree_sequences():
             t1 = _tskit.Tree(ts)
             t2 = _tskit.Tree(ts)
-            self.assertTrue(t1.equals(t2))
-            self.assertTrue(t2.equals(t1))
+            assert t1.equals(t2)
+            assert t2.equals(t1)
             while True:
-                self.assertTrue(t1.equals(t2))
-                self.assertTrue(t2.equals(t1))
+                assert t1.equals(t2)
+                assert t2.equals(t1)
                 n1 = t1.next()
-                self.assertFalse(t1.equals(t2))
-                self.assertFalse(t2.equals(t1))
+                assert not t1.equals(t2)
+                assert not t2.equals(t1)
                 n2 = t2.next()
-                self.assertEqual(n1, n2)
+                assert n1 == n2
                 if not n1:
                     break
             if last_ts is not None:
                 t2 = _tskit.Tree(last_ts)
-                self.assertFalse(t1.equals(t2))
-                self.assertFalse(t2.equals(t1))
+                assert not t1.equals(t2)
+                assert not t2.equals(t1)
             last_ts = ts
 
     def test_kc_distance_errors(self):
         ts1 = self.get_example_tree_sequence(10)
         t1 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)
         t1.first()
-        self.assertRaises(TypeError, t1.get_kc_distance)
-        self.assertRaises(TypeError, t1.get_kc_distance, t1)
+        with pytest.raises(TypeError):
+            t1.get_kc_distance()
+        with pytest.raises(TypeError):
+            t1.get_kc_distance(t1)
         for bad_tree in [None, "tree", 0]:
-            self.assertRaises(TypeError, t1.get_kc_distance, bad_tree, lambda_=0)
+            with pytest.raises(TypeError):
+                t1.get_kc_distance(bad_tree, lambda_=0)
         for bad_value in ["tree", [], None]:
-            self.assertRaises(TypeError, t1.get_kc_distance, t1, lambda_=bad_value)
+            with pytest.raises(TypeError):
+                t1.get_kc_distance(t1, lambda_=bad_value)
 
         t2 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)
         # If we don't seek to a specific tree, it has multiple roots (i.e., it's
@@ -2176,7 +2242,7 @@ class TestTree(LowLevelTestCase):
         self.verify_kc_library_error(t1, t1)
 
     def verify_kc_library_error(self, t1, t2):
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             t1.get_kc_distance(t2, 0)
 
     def test_kc_distance(self):
@@ -2195,11 +2261,11 @@ class TestTree(LowLevelTestCase):
         for ts in self.get_example_tree_sequences():
             t1 = _tskit.Tree(ts)
             t2 = t1.copy()
-            self.assertEqual(t1.get_index(), t2.get_index())
-            self.assertIsNot(t1, t2)
+            assert t1.get_index() == t2.get_index()
+            assert t1 is not t2
             while t1.next():
                 t2 = t1.copy()
-                self.assertEqual(t1.get_index(), t2.get_index())
+                assert t1.get_index() == t2.get_index()
 
     def test_map_mutations_null(self):
         ts = self.get_example_tree_sequence()
@@ -2207,16 +2273,16 @@ class TestTree(LowLevelTestCase):
         n = ts.get_num_samples()
         genotypes = np.zeros(n, dtype=np.int8)
         ancestral_state, transitions = tree.map_mutations(genotypes)
-        self.assertEqual(ancestral_state, 0)
-        self.assertEqual(len(transitions), 0)
+        assert ancestral_state == 0
+        assert len(transitions) == 0
 
         genotypes = np.arange(n, dtype=np.int8)
         ancestral_state, transitions = tree.map_mutations(genotypes)
-        self.assertEqual(ancestral_state, 0)
+        assert ancestral_state == 0
         for j in range(n - 1):
-            self.assertEqual(transitions[j][0], j + 1)
-            self.assertEqual(transitions[j][1], -1)
-            self.assertEqual(transitions[j][2], j + 1)
+            assert transitions[j][0] == j + 1
+            assert transitions[j][1] == -1
+            assert transitions[j][2] == j + 1
 
     def test_map_mutations(self):
         ts = self.get_example_tree_sequence()
@@ -2225,101 +2291,101 @@ class TestTree(LowLevelTestCase):
         n = ts.get_num_samples()
         genotypes = np.zeros(n, dtype=np.int8)
         ancestral_state, transitions = tree.map_mutations(genotypes)
-        self.assertEqual(ancestral_state, 0)
-        self.assertEqual(len(transitions), 0)
+        assert ancestral_state == 0
+        assert len(transitions) == 0
 
     def test_map_mutations_errors(self):
         ts = self.get_example_tree_sequence()
         tree = _tskit.Tree(ts)
         n = ts.get_num_samples()
         genotypes = np.zeros(n, dtype=np.int8)
-        self.assertRaises(TypeError, tree.map_mutations)
+        with pytest.raises(TypeError):
+            tree.map_mutations()
         for bad_size in [0, 1, n - 1, n + 1]:
-            self.assertRaises(
-                ValueError, tree.map_mutations, np.zeros(bad_size, dtype=np.int8)
-            )
+            with pytest.raises(ValueError):
+                tree.map_mutations(np.zeros(bad_size, dtype=np.int8))
         for bad_type in [None, {}, set()]:
-            self.assertRaises(TypeError, tree.map_mutations, [bad_type] * n)
+            with pytest.raises(TypeError):
+                tree.map_mutations([bad_type] * n)
         for bad_type in [np.uint8, np.uint64, np.float32]:
-            self.assertRaises(
-                TypeError, tree.map_mutations, np.zeros(bad_size, dtype=bad_type)
-            )
+            with pytest.raises(TypeError):
+                tree.map_mutations(np.zeros(bad_size, dtype=bad_type))
         genotypes = np.zeros(n, dtype=np.int8)
         tree.map_mutations(genotypes)
         for bad_value in [64, 65, 127, -2]:
             genotypes[0] = bad_value
-            self.assertRaises(_tskit.LibraryError, tree.map_mutations, genotypes)
+            with pytest.raises(_tskit.LibraryError):
+                tree.map_mutations(genotypes)
 
 
-class TestTableMetadataSchema(unittest.TestCase, MetadataTestMixin):
+class TestTableMetadataSchema(MetadataTestMixin):
     def test_metadata_schema_attribute(self):
         tables = _tskit.TableCollection(1.0)
         for table in self.metadata_tables:
             table = getattr(tables, f"{table}s")
             # Check default value
-            self.assertEqual(table.metadata_schema, "")
+            assert table.metadata_schema == ""
             # Set and read back
             example = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋"
             table.metadata_schema = example
-            self.assertEqual(table.metadata_schema, example)
+            assert table.metadata_schema == example
             # Can't del, or set to None
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 del table.metadata_schema
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 table.metadata_schema = None
             # Del or None had no effect
-            self.assertEqual(table.metadata_schema, example)
+            assert table.metadata_schema == example
             # Clear and read back
             table.metadata_schema = ""
-            self.assertEqual(table.metadata_schema, "")
+            assert table.metadata_schema == ""
 
 
-class TestMetadataSchemaNamedTuple(unittest.TestCase, MetadataTestMixin):
+class TestMetadataSchemaNamedTuple(MetadataTestMixin):
     def test_named_tuple_init(self):
         # Test init errors
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             metadata_schemas = _tskit.MetadataSchemas()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             metadata_schemas = _tskit.MetadataSchemas([])
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             metadata_schemas = _tskit.MetadataSchemas(["test_schema"])
         # Set and read back
         metadata_schemas = _tskit.MetadataSchemas(
             f"{table}_test_schema" for table in self.metadata_tables
         )
-        self.assertEqual(
-            metadata_schemas,
-            tuple(f"{table}_test_schema" for table in self.metadata_tables),
+        assert metadata_schemas == tuple(
+            f"{table}_test_schema" for table in self.metadata_tables
         )
         for i, table in enumerate(self.metadata_tables):
             # Read back via attr, index
-            self.assertEqual(getattr(metadata_schemas, table), f"{table}_test_schema")
-            self.assertEqual(metadata_schemas[i], f"{table}_test_schema")
+            assert getattr(metadata_schemas, table) == f"{table}_test_schema"
+            assert metadata_schemas[i] == f"{table}_test_schema"
             # Check read-only
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 setattr(metadata_schemas, table, "")
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 metadata_schemas[i] = ""
         # Equality
         metadata_schemas2 = _tskit.MetadataSchemas(
             f"{table}_test_schema" for table in self.metadata_tables
         )
-        self.assertEqual(metadata_schemas, metadata_schemas2)
+        assert metadata_schemas == metadata_schemas2
         metadata_schemas3 = _tskit.MetadataSchemas(
             f"{table}_test_schema_diff" for table in self.metadata_tables
         )
-        self.assertNotEqual(metadata_schemas, metadata_schemas3)
+        assert metadata_schemas != metadata_schemas3
 
 
-class TestModuleFunctions(unittest.TestCase):
+class TestModuleFunctions:
     """
     Tests for the module level functions.
     """
 
     def test_kastore_version(self):
         version = _tskit.get_kastore_version()
-        self.assertEqual(version, (2, 0, 0))
+        assert version == (2, 0, 0)
 
     def test_tskit_version(self):
         version = _tskit.get_tskit_version()
-        self.assertEqual(version, (0, 99, 7))
+        assert version == (0, 99, 7)

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1869,19 +1869,23 @@ class TestTree(LowLevelTestCase):
                 )
         for bad_sample in [10 ** 6, -1e6]:
             with pytest.raises(ValueError):
-                _tskit.Tree(
-                    ts,
-                    options=options,
-                    tracked_samples=[bad_sample],
-                )
+                # Implicit conversion to integers using __int__ is deprecated
+                with pytest.deprecated_call():
+                    _tskit.Tree(
+                        ts,
+                        options=options,
+                        tracked_samples=[bad_sample],
+                    )
             with pytest.raises(ValueError):
-                _tskit.Tree(
-                    ts,
-                    options=options,
-                    tracked_samples=[1, bad_sample],
-                )
+                with pytest.deprecated_call():
+                    _tskit.Tree(
+                        ts,
+                        options=options,
+                        tracked_samples=[1, bad_sample],
+                    )
             with pytest.raises(ValueError):
-                _tskit.Tree(ts, tracked_samples=[1, bad_sample, 1])
+                with pytest.deprecated_call():
+                    _tskit.Tree(ts, tracked_samples=[1, bad_sample, 1])
 
     def test_while_loop_semantics(self):
         for ts in self.get_example_tree_sequences():

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -35,6 +35,7 @@ import warnings
 import attr
 import msprime
 import numpy as np
+import pytest
 
 import _tskit
 import tests.test_wright_fisher as wf
@@ -90,57 +91,58 @@ class CommonTestsMixin:
 
     def test_max_rows_increment(self):
         for bad_value in [-1, -(2 ** 10)]:
-            self.assertRaises(
-                ValueError, self.table_class, max_rows_increment=bad_value
-            )
+            with pytest.raises(ValueError):
+                self.table_class(max_rows_increment=bad_value)
         for v in [1, 100, 256]:
             table = self.table_class(max_rows_increment=v)
-            self.assertEqual(table.max_rows_increment, v)
+            assert table.max_rows_increment == v
         # Setting zero or not argument both denote the default.
         table = self.table_class()
-        self.assertEqual(table.max_rows_increment, 1024)
+        assert table.max_rows_increment == 1024
         table = self.table_class(max_rows_increment=0)
-        self.assertEqual(table.max_rows_increment, 1024)
+        assert table.max_rows_increment == 1024
 
     def test_low_level_get_row(self):
         # Tests the low-level get_row interface to ensure we're getting coverage.
         t = self.table_class()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.ll_table.get_row()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.ll_table.get_row("row")
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             t.ll_table.get_row(1)
 
     def test_low_level_equals(self):
         # Tests the low-level equals interface to ensure we're getting coverage.
         t = self.table_class()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.ll_table.equals()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.ll_table.equals(None)
 
     def test_low_level_set_columns(self):
         t = self.table_class()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.ll_table.set_columns(None)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.ll_table.append_columns(None)
 
     def test_input_parameters_errors(self):
-        self.assertGreater(len(self.input_parameters), 0)
+        assert len(self.input_parameters) > 0
         for param, _ in self.input_parameters:
             for bad_value in [-1, -(2 ** 10)]:
-                self.assertRaises(ValueError, self.table_class, **{param: bad_value})
+                with pytest.raises(ValueError):
+                    self.table_class(**{param: bad_value})
             for bad_type in [None, ValueError, "ser"]:
-                self.assertRaises(TypeError, self.table_class, **{param: bad_type})
+                with pytest.raises(TypeError):
+                    self.table_class(**{param: bad_type})
 
     def test_input_parameter_values(self):
-        self.assertGreater(len(self.input_parameters), 0)
+        assert len(self.input_parameters) > 0
         for param, _ in self.input_parameters:
             for v in [1, 100, 256]:
                 table = self.table_class(**{param: v})
-                self.assertEqual(getattr(table, param), v)
+                assert getattr(table, param) == v
 
     def test_set_columns_string_errors(self):
         inputs = {c.name: c.get_input(1) for c in self.columns}
@@ -154,10 +156,12 @@ class CommonTestsMixin:
         for list_col, offset_col in self.ragged_list_columns:
             kwargs = dict(inputs)
             del kwargs[list_col.name]
-            self.assertRaises(TypeError, table.set_columns, **kwargs)
+            with pytest.raises(TypeError):
+                table.set_columns(**kwargs)
             kwargs = dict(inputs)
             del kwargs[offset_col.name]
-            self.assertRaises(TypeError, table.set_columns, **kwargs)
+            with pytest.raises(TypeError):
+                table.set_columns(**kwargs)
 
     def test_set_columns_interface(self):
         kwargs = self.make_input_data(1)
@@ -170,13 +174,17 @@ class CommonTestsMixin:
             for bad_type in [Exception, tskit]:
                 error_kwargs = dict(kwargs)
                 error_kwargs[focal_col.name] = bad_type
-                self.assertRaises(ValueError, table.set_columns, **error_kwargs)
-                self.assertRaises(ValueError, table.append_columns, **error_kwargs)
+                with pytest.raises(ValueError):
+                    table.set_columns(**error_kwargs)
+                with pytest.raises(ValueError):
+                    table.append_columns(**error_kwargs)
             for bad_value in ["qwer", [0, "sd"]]:
                 error_kwargs = dict(kwargs)
                 error_kwargs[focal_col.name] = bad_value
-                self.assertRaises(ValueError, table.set_columns, **error_kwargs)
-                self.assertRaises(ValueError, table.append_columns, **error_kwargs)
+                with pytest.raises(ValueError):
+                    table.set_columns(**error_kwargs)
+                with pytest.raises(ValueError):
+                    table.append_columns(**error_kwargs)
 
     def test_set_columns_from_dict(self):
         kwargs = self.make_input_data(1)
@@ -185,7 +193,7 @@ class CommonTestsMixin:
         t1.set_columns(**kwargs)
         t2 = self.table_class()
         t2.set_columns(**t1.asdict())
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def test_set_columns_dimension(self):
         kwargs = self.make_input_data(1)
@@ -197,17 +205,22 @@ class CommonTestsMixin:
             for bad_dims in [5, [[1], [1]], np.zeros((2, 2))]:
                 error_kwargs = dict(kwargs)
                 error_kwargs[focal_col.name] = bad_dims
-                self.assertRaises(ValueError, table.set_columns, **error_kwargs)
-                self.assertRaises(ValueError, table.append_columns, **error_kwargs)
+                with pytest.raises(ValueError):
+                    table.set_columns(**error_kwargs)
+                with pytest.raises(ValueError):
+                    table.append_columns(**error_kwargs)
         for _, offset_col in self.ragged_list_columns:
             error_kwargs = dict(kwargs)
             for bad_dims in [5, [[1], [1]], np.zeros((2, 2))]:
                 error_kwargs[offset_col.name] = bad_dims
-                self.assertRaises(ValueError, table.set_columns, **error_kwargs)
-                self.assertRaises(ValueError, table.append_columns, **error_kwargs)
+                with pytest.raises(ValueError):
+                    table.set_columns(**error_kwargs)
+                with pytest.raises(ValueError):
+                    table.append_columns(**error_kwargs)
             # Empty offset columns are caught also
             error_kwargs[offset_col.name] = []
-            self.assertRaises(ValueError, table.set_columns, **error_kwargs)
+            with pytest.raises(ValueError):
+                table.set_columns(**error_kwargs)
 
     def test_set_columns_input_sizes(self):
         input_data = self.make_input_data(100)
@@ -223,27 +236,29 @@ class CommonTestsMixin:
                 for col in equal_len_col_set:
                     kwargs = dict(input_data)
                     kwargs[col] = col_map[col].get_input(1)
-                    self.assertRaises(ValueError, table.set_columns, **kwargs)
-                    self.assertRaises(ValueError, table.append_columns, **kwargs)
+                    with pytest.raises(ValueError):
+                        table.set_columns(**kwargs)
+                    with pytest.raises(ValueError):
+                        table.append_columns(**kwargs)
 
     def test_set_read_only_attributes(self):
         table = self.table_class()
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             table.num_rows = 10
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             table.max_rows = 10
         for param, _default in self.input_parameters:
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 setattr(table, param, 2)
-        self.assertEqual(table.num_rows, 0)
-        self.assertEqual(len(table), 0)
+        assert table.num_rows == 0
+        assert len(table) == 0
 
     def test_set_column_attributes_empty(self):
         table = self.table_class()
         input_data = {col.name: col.get_input(0) for col in self.columns}
         for col, data in input_data.items():
             setattr(table, col, data)
-            self.assertEqual(len(getattr(table, col)), 0)
+            assert len(getattr(table, col)) == 0
 
     def test_set_column_attributes_data(self):
         table = self.table_class()
@@ -253,19 +268,13 @@ class CommonTestsMixin:
 
             for list_col, offset_col in self.ragged_list_columns:
                 list_data = input_data[list_col.name]
-                self.assertTrue(
-                    np.array_equal(getattr(table, list_col.name), list_data)
-                )
+                assert np.array_equal(getattr(table, list_col.name), list_data)
                 list_data += 1
-                self.assertFalse(
-                    np.array_equal(getattr(table, list_col.name), list_data)
-                )
+                assert not np.array_equal(getattr(table, list_col.name), list_data)
                 setattr(table, list_col.name, list_data)
-                self.assertTrue(
-                    np.array_equal(getattr(table, list_col.name), list_data)
-                )
+                assert np.array_equal(getattr(table, list_col.name), list_data)
                 list_value = getattr(table[0], list_col.name)
-                self.assertEqual(len(list_value), 1)
+                assert len(list_value) == 1
 
                 # Reset the offsets so that all the full array is associated with the
                 # first element.
@@ -273,17 +282,17 @@ class CommonTestsMixin:
                 offset_data[0] = 0
                 setattr(table, offset_col.name, offset_data)
                 list_value = getattr(table[0], list_col.name)
-                self.assertEqual(len(list_value), num_rows)
+                assert len(list_value) == num_rows
 
                 del input_data[list_col.name]
                 del input_data[offset_col.name]
 
             for col, data in input_data.items():
-                self.assertTrue(np.array_equal(getattr(table, col), data))
+                assert np.array_equal(getattr(table, col), data)
                 data += 1
-                self.assertFalse(np.array_equal(getattr(table, col), data))
+                assert not np.array_equal(getattr(table, col), data)
                 setattr(table, col, data)
-                self.assertTrue(np.array_equal(getattr(table, col), data))
+                assert np.array_equal(getattr(table, col), data)
 
     def test_set_column_attributes_errors(self):
         table = self.table_class()
@@ -293,10 +302,10 @@ class CommonTestsMixin:
 
         for list_col, offset_col in self.ragged_list_columns:
             for bad_list_col in [[], input_data[list_col.name][:-1]]:
-                with self.assertRaises(ValueError):
+                with pytest.raises(ValueError):
                     setattr(table, list_col.name, bad_list_col)
             for bad_offset_col in [[], np.arange(num_rows + 2, dtype=np.uint32)]:
-                with self.assertRaises(ValueError):
+                with pytest.raises(ValueError):
                     setattr(table, offset_col.name, bad_offset_col)
 
             del input_data[list_col.name]
@@ -304,23 +313,23 @@ class CommonTestsMixin:
 
         for col, data in input_data.items():
             for bad_data in [[], data[:-1]]:
-                with self.assertRaises(ValueError):
+                with pytest.raises(ValueError):
                     setattr(table, col, bad_data)
 
         # Try to read a column that isn't there. (We can always write to new attributes
         # in Python, so there's nothing to test in that case.)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             _ = table.no_such_column
 
     def test_defaults(self):
         table = self.table_class()
-        self.assertEqual(table.num_rows, 0)
-        self.assertEqual(len(table), 0)
+        assert table.num_rows == 0
+        assert len(table) == 0
         for param, default in self.input_parameters:
-            self.assertEqual(getattr(table, param), default)
+            assert getattr(table, param) == default
         for col in self.columns:
             array = getattr(table, col.name)
-            self.assertEqual(array.shape, (0,))
+            assert array.shape == (0,)
 
     def test_add_row_data(self):
         for num_rows in [0, 10, 100]:
@@ -333,14 +342,14 @@ class CommonTestsMixin:
                 for col in self.binary_colnames:
                     kwargs[col] = b"x"
                 k = table.add_row(**kwargs)
-                self.assertEqual(k, j)
+                assert k == j
             for colname, input_array in input_data.items():
                 output_array = getattr(table, colname)
-                self.assertEqual(input_array.shape, output_array.shape)
-                self.assertTrue(np.all(input_array == output_array))
+                assert input_array.shape == output_array.shape
+                assert np.all(input_array == output_array)
             table.clear()
-            self.assertEqual(table.num_rows, 0)
-            self.assertEqual(len(table), 0)
+            assert table.num_rows == 0
+            assert len(table) == 0
 
     def test_add_row_round_trip(self):
         for num_rows in [0, 10, 100]:
@@ -349,12 +358,12 @@ class CommonTestsMixin:
             t1.set_columns(**input_data)
             for colname, input_array in input_data.items():
                 output_array = getattr(t1, colname)
-                self.assertEqual(input_array.shape, output_array.shape)
-                self.assertTrue(np.all(input_array == output_array))
+                assert input_array.shape == output_array.shape
+                assert np.all(input_array == output_array)
             t2 = self.table_class()
             for row in list(t1):
                 t2.add_row(**attr.asdict(row))
-            self.assertEqual(t1, t2)
+            assert t1 == t2
 
     def test_set_columns_data(self):
         for num_rows in [0, 10, 100, 1000]:
@@ -370,16 +379,16 @@ class CommonTestsMixin:
                 table.set_columns(**input_data)
                 for colname, input_array in input_data.items():
                     output_array = getattr(table, colname)
-                    self.assertEqual(input_array.shape, output_array.shape)
-                    self.assertTrue(np.all(input_array == output_array))
+                    assert input_array.shape == output_array.shape
+                    assert np.all(input_array == output_array)
                 table.clear()
-                self.assertEqual(table.num_rows, 0)
-                self.assertEqual(len(table), 0)
+                assert table.num_rows == 0
+                assert len(table) == 0
                 for colname in input_data.keys():
                     if colname in offset_cols:
-                        self.assertEqual(list(getattr(table, colname)), [0])
+                        assert list(getattr(table, colname)) == [0]
                     else:
-                        self.assertEqual(list(getattr(table, colname)), [])
+                        assert list(getattr(table, colname)) == []
 
     def test_truncate(self):
         num_rows = 100
@@ -393,30 +402,28 @@ class CommonTestsMixin:
 
         copy = table.copy()
         table.truncate(num_rows)
-        self.assertEqual(copy, table)
+        assert copy == table
 
         for num_rows in [100, 10, 1]:
             table.truncate(num_rows)
-            self.assertEqual(table.num_rows, num_rows)
-            self.assertEqual(len(table), num_rows)
+            assert table.num_rows == num_rows
+            assert len(table) == num_rows
             used = set()
             for list_col, offset_col in self.ragged_list_columns:
                 offset = getattr(table, offset_col.name)
-                self.assertEqual(offset.shape, (num_rows + 1,))
-                self.assertTrue(
-                    np.array_equal(input_data[offset_col.name][: num_rows + 1], offset)
+                assert offset.shape == (num_rows + 1,)
+                assert np.array_equal(
+                    input_data[offset_col.name][: num_rows + 1], offset
                 )
                 list_data = getattr(table, list_col.name)
-                self.assertTrue(
-                    np.array_equal(list_data, input_data[list_col.name][: offset[-1]])
+                assert np.array_equal(
+                    list_data, input_data[list_col.name][: offset[-1]]
                 )
                 used.add(offset_col.name)
                 used.add(list_col.name)
             for name, data in input_data.items():
                 if name not in used:
-                    self.assertTrue(
-                        np.array_equal(data[:num_rows], getattr(table, name))
-                    )
+                    assert np.array_equal(data[:num_rows], getattr(table, name))
 
     def test_truncate_errors(self):
         num_rows = 10
@@ -428,9 +435,11 @@ class CommonTestsMixin:
         table = self.table_class()
         table.set_columns(**input_data)
         for bad_type in [None, 0.001, {}]:
-            self.assertRaises(TypeError, table.truncate, bad_type)
+            with pytest.raises(TypeError):
+                table.truncate(bad_type)
         for bad_num_rows in [-1, num_rows + 1, 10 ** 6]:
-            self.assertRaises(ValueError, table.truncate, bad_num_rows)
+            with pytest.raises(ValueError):
+                table.truncate(bad_num_rows)
 
     def test_append_columns_data(self):
         for num_rows in [0, 10, 100, 1000]:
@@ -449,13 +458,13 @@ class CommonTestsMixin:
                             input_array[k * num_rows : (k + 1) * num_rows + 1] = (
                                 k * values[-1]
                             ) + values
-                        self.assertEqual(input_array.shape, output_array.shape)
+                        assert input_array.shape == output_array.shape
                     else:
                         input_array = np.hstack([values for _ in range(j)])
-                        self.assertEqual(input_array.shape, output_array.shape)
-                    self.assertTrue(np.array_equal(input_array, output_array))
-                self.assertEqual(table.num_rows, j * num_rows)
-                self.assertEqual(len(table), j * num_rows)
+                        assert input_array.shape == output_array.shape
+                    assert np.array_equal(input_array, output_array)
+                assert table.num_rows == j * num_rows
+                assert len(table) == j * num_rows
 
     def test_append_columns_max_rows(self):
         for num_rows in [0, 10, 100, 1000]:
@@ -464,9 +473,9 @@ class CommonTestsMixin:
                 table = self.table_class(max_rows_increment=max_rows)
                 for j in range(1, 10):
                     table.append_columns(**input_data)
-                    self.assertEqual(table.num_rows, j * num_rows)
-                    self.assertEqual(len(table), j * num_rows)
-                    self.assertGreater(table.max_rows, table.num_rows)
+                    assert table.num_rows == j * num_rows
+                    assert len(table) == j * num_rows
+                    assert table.max_rows > table.num_rows
 
     def test_str(self):
         for num_rows in [0, 10]:
@@ -474,7 +483,7 @@ class CommonTestsMixin:
             table = self.table_class()
             table.set_columns(**input_data)
             s = str(table)
-            self.assertEqual(len(s.splitlines()), num_rows + 1)
+            assert len(s.splitlines()) == num_rows + 1
 
     def test_repr_html(self):
         for num_rows in [0, 10, 40, 50]:
@@ -487,13 +496,13 @@ class CommonTestsMixin:
             table.set_columns(**input_data)
             html = table._repr_html_()
             if num_rows == 50:
-                self.assertEqual(len(html.splitlines()), num_rows + 10)
-                self.assertEqual(
-                    html.split("</tr>")[21],
-                    "\n<tr><td><em>... skipped 10 rows ...</em></td>",
+                assert len(html.splitlines()) == num_rows + 10
+                assert (
+                    html.split("</tr>")[21]
+                    == "\n<tr><td><em>... skipped 10 rows ...</em></td>"
                 )
             else:
-                self.assertEqual(len(html.splitlines()), num_rows + 19)
+                assert len(html.splitlines()) == num_rows + 19
 
     def test_copy(self):
         for num_rows in [0, 10]:
@@ -502,9 +511,9 @@ class CommonTestsMixin:
             table.set_columns(**input_data)
             for _ in range(10):
                 copy = table.copy()
-                self.assertNotEqual(id(copy), id(table))
-                self.assertIsInstance(copy, self.table_class)
-                self.assertEqual(copy, table)
+                assert id(copy) != id(table)
+                assert isinstance(copy, self.table_class)
+                assert copy == table
                 table = copy
 
     def test_pickle(self):
@@ -514,54 +523,54 @@ class CommonTestsMixin:
             table.set_columns(**input_data)
             pkl = pickle.dumps(table)
             new_table = pickle.loads(pkl)
-            self.assertEqual(table, new_table)
+            assert table == new_table
             for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
                 pkl = pickle.dumps(table, protocol=protocol)
                 new_table = pickle.loads(pkl)
-                self.assertEqual(table, new_table)
+                assert table == new_table
 
     def test_equality(self):
         for num_rows in [1, 10, 100]:
             input_data = self.make_input_data(num_rows)
             t1 = self.table_class()
             t2 = self.table_class()
-            self.assertEqual(t1, t1)
-            self.assertEqual(t1, t2)
-            self.assertTrue(t1 == t2)
-            self.assertFalse(t1 != t2)
+            assert t1 == t1
+            assert t1 == t2
+            assert t1 == t2
+            assert not (t1 != t2)
             t1.set_columns(**input_data)
-            self.assertEqual(t1, t1)
-            self.assertNotEqual(t1, t2)
-            self.assertNotEqual(t2, t1)
+            assert t1 == t1
+            assert t1 != t2
+            assert t2 != t1
             t2.set_columns(**input_data)
-            self.assertEqual(t1, t2)
-            self.assertEqual(t2, t2)
+            assert t1 == t2
+            assert t2 == t2
             t2.clear()
-            self.assertNotEqual(t1, t2)
-            self.assertNotEqual(t2, t1)
+            assert t1 != t2
+            assert t2 != t1
             # Check each column in turn to see if we are correctly checking values.
             for col in self.columns:
                 col_copy = np.copy(input_data[col.name])
                 input_data_copy = dict(input_data)
                 input_data_copy[col.name] = col_copy
                 t2.set_columns(**input_data_copy)
-                self.assertEqual(t1, t2)
-                self.assertFalse(t1 != t2)
-                self.assertEqual(t1[0], t2[0])
+                assert t1 == t2
+                assert not (t1 != t2)
+                assert t1[0] == t2[0]
                 col_copy += 1
                 t2.set_columns(**input_data_copy)
-                self.assertNotEqual(t1, t2)
-                self.assertNotEqual(t2, t1)
-                self.assertNotEqual(t1[0], t2[0])
-                self.assertTrue(t1[0] != t2[0])
-                self.assertTrue(t1[0] != [])
+                assert t1 != t2
+                assert t2 != t1
+                assert t1[0] != t2[0]
+                assert t1[0] != t2[0]
+                assert t1[0] != []
             for list_col, offset_col in self.ragged_list_columns:
                 value = list_col.get_input(num_rows)
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value + 1
                 t2.set_columns(**input_data_copy)
-                self.assertNotEqual(t1, t2)
-                self.assertNotEqual(t1[0], t2[0])
+                assert t1 != t2
+                assert t1[0] != t2[0]
                 value = list_col.get_input(num_rows + 1)
                 input_data_copy = dict(input_data)
                 input_data_copy[list_col.name] = value
@@ -570,12 +579,12 @@ class CommonTestsMixin:
                 )
                 input_data_copy[offset_col.name][-1] = num_rows + 1
                 t2.set_columns(**input_data_copy)
-                self.assertNotEqual(t1, t2)
-                self.assertNotEqual(t2, t1)
-                self.assertNotEqual(t1[-1], t2[-1])
+                assert t1 != t2
+                assert t2 != t1
+                assert t1[-1] != t2[-1]
             # Different types should always be unequal.
-            self.assertNotEqual(t1, None)
-            self.assertNotEqual(t1, [])
+            assert t1 is not None
+            assert t1 != []
 
     def test_bad_offsets(self):
         for num_rows in [10, 100]:
@@ -585,27 +594,33 @@ class CommonTestsMixin:
 
             for _list_col, offset_col in self.ragged_list_columns:
                 input_data[offset_col.name][0] = -1
-                self.assertRaises(ValueError, t.set_columns, **input_data)
+                with pytest.raises(ValueError):
+                    t.set_columns(**input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.set_columns(**input_data)
                 input_data[offset_col.name][-1] = 0
-                self.assertRaises(ValueError, t.set_columns, **input_data)
+                with pytest.raises(ValueError):
+                    t.set_columns(**input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.set_columns(**input_data)
                 input_data[offset_col.name][num_rows // 2] = 2 ** 31
-                self.assertRaises(ValueError, t.set_columns, **input_data)
+                with pytest.raises(ValueError):
+                    t.set_columns(**input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
 
                 input_data[offset_col.name][0] = -1
-                self.assertRaises(ValueError, t.append_columns, **input_data)
+                with pytest.raises(ValueError):
+                    t.append_columns(**input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.append_columns(**input_data)
                 input_data[offset_col.name][-1] = 0
-                self.assertRaises(ValueError, t.append_columns, **input_data)
+                with pytest.raises(ValueError):
+                    t.append_columns(**input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
                 t.append_columns(**input_data)
                 input_data[offset_col.name][num_rows // 2] = 2 ** 31
-                self.assertRaises(ValueError, t.append_columns, **input_data)
+                with pytest.raises(ValueError):
+                    t.append_columns(**input_data)
                 input_data[offset_col.name] = np.arange(num_rows + 1, dtype=np.uint32)
 
 
@@ -663,7 +678,7 @@ class MetadataTestsMixin:
             unpacked_metadatas = tskit.unpack_bytes(
                 table.metadata, table.metadata_offset
             )
-            self.assertEqual(metadatas, unpacked_metadatas)
+            assert metadatas == unpacked_metadatas
 
     def test_optional_metadata(self):
         if not getattr(self, "metadata_mandatory", False):
@@ -673,18 +688,14 @@ class MetadataTestsMixin:
                 del input_data["metadata"]
                 del input_data["metadata_offset"]
                 table.set_columns(**input_data)
-                self.assertEqual(len(list(table.metadata)), 0)
-                self.assertEqual(
-                    list(table.metadata_offset), [0 for _ in range(num_rows + 1)]
-                )
+                assert len(list(table.metadata)) == 0
+                assert list(table.metadata_offset) == [0 for _ in range(num_rows + 1)]
                 # Supplying None is the same not providing the column.
                 input_data["metadata"] = None
                 input_data["metadata_offset"] = None
                 table.set_columns(**input_data)
-                self.assertEqual(len(list(table.metadata)), 0)
-                self.assertEqual(
-                    list(table.metadata_offset), [0 for _ in range(num_rows + 1)]
-                )
+                assert len(list(table.metadata)) == 0
+                assert list(table.metadata_offset) == [0 for _ in range(num_rows + 1)]
 
     def test_packset_metadata(self):
         for num_rows in [0, 10, 100]:
@@ -694,31 +705,31 @@ class MetadataTestsMixin:
             metadatas = [tsutil.random_bytes(10) for _ in range(num_rows)]
             metadata, metadata_offset = tskit.pack_bytes(metadatas)
             table.packset_metadata(metadatas)
-            self.assertTrue(np.array_equal(table.metadata, metadata))
-            self.assertTrue(np.array_equal(table.metadata_offset, metadata_offset))
+            assert np.array_equal(table.metadata, metadata)
+            assert np.array_equal(table.metadata_offset, metadata_offset)
 
     def test_set_metadata_schema(self):
         metadata_schema2 = metadata.MetadataSchema({"codec": "json"})
         table = self.table_class()
         # Default is no-op metadata codec
-        self.assertEqual(str(table.metadata_schema), str(metadata.MetadataSchema(None)))
+        assert str(table.metadata_schema) == str(metadata.MetadataSchema(None))
         # Set
         table.metadata_schema = self.metadata_schema
-        self.assertEqual(str(table.metadata_schema), str(self.metadata_schema))
+        assert str(table.metadata_schema) == str(self.metadata_schema)
         # Overwrite
         table.metadata_schema = metadata_schema2
-        self.assertEqual(str(table.metadata_schema), str(metadata_schema2))
+        assert str(table.metadata_schema) == str(metadata_schema2)
         # Remove
         table.metadata_schema = ""
-        self.assertEqual(str(table.metadata_schema), str(metadata.MetadataSchema(None)))
+        assert str(table.metadata_schema) == str(metadata.MetadataSchema(None))
         # Set after remove
         table.metadata_schema = self.metadata_schema
-        self.assertEqual(str(table.metadata_schema), str(self.metadata_schema))
+        assert str(table.metadata_schema) == str(self.metadata_schema)
         # Del should fail
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del table.metadata_schema
         # None should fail
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             table.metadata_schema = None
 
     def test_default_metadata_schema(self):
@@ -728,7 +739,7 @@ class MetadataTestsMixin:
             **{**self.input_data_for_add_row(), "metadata": b"acceptable bytes"}
         )
         # Adding non-bytes metadata should error
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             table.add_row(
                 **{
                     **self.input_data_for_add_row(),
@@ -741,23 +752,23 @@ class MetadataTestsMixin:
         table = self.table_class()
         table.metadata_schema = self.metadata_schema
         table.add_row(**{**self.input_data_for_add_row(), "metadata": data})
-        self.assertDictEqual(table[0].metadata, data)
+        assert table[0].metadata == data
 
     def test_bad_row_metadata_schema(self):
         metadata = self.metadata_example_data()
         metadata["I really shouldn't be here"] = 6
         table = self.table_class()
         table.metadata_schema = self.metadata_schema
-        with self.assertRaises(exceptions.MetadataValidationError):
+        with pytest.raises(exceptions.MetadataValidationError):
             table.add_row(**{**self.input_data_for_add_row(), "metadata": metadata})
-        self.assertEqual(len(table), 0)
+        assert len(table) == 0
 
     def test_absent_metadata_with_required_schema(self):
         table = self.table_class()
         table.metadata_schema = self.metadata_schema
         input_data = self.input_data_for_add_row()
         del input_data["metadata"]
-        with self.assertRaises(exceptions.MetadataValidationError):
+        with pytest.raises(exceptions.MetadataValidationError):
             table.add_row(**{**input_data})
 
     def test_unsupported_type(self):
@@ -772,7 +783,7 @@ class MetadataTestsMixin:
         input_data = self.input_data_for_add_row()
         # Numpy is not a JSONSchema array
         input_data["metadata"] = {"an_array": np.arange(10)}
-        with self.assertRaises(exceptions.MetadataValidationError):
+        with pytest.raises(exceptions.MetadataValidationError):
             table.add_row(**{**input_data})
 
     def test_round_trip_set_columns(self):
@@ -797,11 +808,11 @@ class MetadataTestsMixin:
                 metadata=packed_metadata, metadata_offset=metadata_offset, **input_data
             )
             for j in range(num_rows):
-                self.assertEqual(table[j].metadata, metadata_column[j])
-                self.assertEqual(table[j + num_rows].metadata, metadata_column[j])
+                assert table[j].metadata == metadata_column[j]
+                assert table[j + num_rows].metadata == metadata_column[j]
 
 
-class TestIndividualTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestIndividualTable(CommonTestsMixin, MetadataTestsMixin):
     columns = [UInt32Column("flags")]
     ragged_list_columns = [
         (DoubleColumn("location"), UInt32Column("location_offset")),
@@ -818,50 +829,51 @@ class TestIndividualTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixi
         t.add_row(flags=0, location=[], metadata=b"123")
         t.add_row(flags=1, location=(0, 1, 2, 3), metadata=b"\xf0")
         s = str(t)
-        self.assertGreater(len(s), 0)
-        self.assertEqual(len(t), 2)
-        self.assertEqual(t[0].flags, 0)
-        self.assertEqual(list(t[0].location), [])
-        self.assertEqual(t[0].metadata, b"123")
-        self.assertEqual(t[1].flags, 1)
-        self.assertEqual(list(t[1].location), [0, 1, 2, 3])
-        self.assertEqual(t[1].metadata, b"\xf0")
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(s) > 0
+        assert len(t) == 2
+        assert t[0].flags == 0
+        assert list(t[0].location) == []
+        assert t[0].metadata == b"123"
+        assert t[1].flags == 1
+        assert list(t[1].location) == [0, 1, 2, 3]
+        assert t[1].metadata == b"\xf0"
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_defaults(self):
         t = tskit.IndividualTable()
-        self.assertEqual(t.add_row(), 0)
-        self.assertEqual(t.flags[0], 0)
-        self.assertEqual(len(t.location), 0)
-        self.assertEqual(t.location_offset[0], 0)
-        self.assertEqual(len(t.metadata), 0)
-        self.assertEqual(t.metadata_offset[0], 0)
+        assert t.add_row() == 0
+        assert t.flags[0] == 0
+        assert len(t.location) == 0
+        assert t.location_offset[0] == 0
+        assert len(t.metadata) == 0
+        assert t.metadata_offset[0] == 0
 
     def test_add_row_bad_data(self):
         t = tskit.IndividualTable()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(flags="x")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(metadata=123)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             t.add_row(location="1234")
 
     def test_packset_location(self):
         t = tskit.IndividualTable()
         t.add_row(flags=0)
         t.packset_location([[0.125, 2]])
-        self.assertEqual(list(t[0].location), [0.125, 2])
+        assert list(t[0].location) == [0.125, 2]
         t.add_row(flags=1)
-        self.assertEqual(list(t[1].location), [])
+        assert list(t[1].location) == []
         t.packset_location([[0], [1, 2, 3]])
-        self.assertEqual(list(t[0].location), [0])
-        self.assertEqual(list(t[1].location), [1, 2, 3])
+        assert list(t[0].location) == [0]
+        assert list(t[1].location) == [1, 2, 3]
 
     def test_missing_time_equal_to_self(self):
         t = tskit.TableCollection(sequence_length=10)
         t.sites.add_row(position=1, ancestral_state="0")
         t.mutations.add_row(site=0, node=0, derived_state="1", time=tskit.UNKNOWN_TIME)
-        self.assertEqual(t.mutations[0], t.mutations[0])
+        assert t.mutations[0] == t.mutations[0]
 
     def test_various_not_equals(self):
         args = {
@@ -873,40 +885,40 @@ class TestIndividualTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixi
             "time": 0,
         }
         a = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, [])
-        self.assertNotEqual(a, 12)
-        self.assertNotEqual(a, None)
+        assert a != []
+        assert a != 12
+        assert a is not None
         b = tskit.MutationTableRow(**args)
-        self.assertEqual(a, b)
+        assert a == b
         args["site"] = 2
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         args["site"] = 0
         args["node"] = 2
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         args["node"] = 0
         args["derived_state"] = "b"
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         args["derived_state"] = "a"
         args["parent"] = 2
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         args["parent"] = 0
         args["metadata"] = b""
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         args["metadata"] = b"abc"
         args["time"] = 1
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         args["time"] = 0
         args["time"] = tskit.UNKNOWN_TIME
         b = tskit.MutationTableRow(**args)
-        self.assertNotEqual(a, b)
+        assert a != b
         a = tskit.MutationTableRow(**args)
-        self.assertEqual(a, b)
+        assert a == b
 
 
 class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
@@ -929,28 +941,29 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         t.add_row(flags=0, time=1, population=2, individual=0, metadata=b"123")
         t.add_row(flags=1, time=2, population=3, individual=1, metadata=b"\xf0")
         s = str(t)
-        self.assertGreater(len(s), 0)
-        self.assertEqual(len(t), 2)
-        self.assertEqual(attr.astuple(t[0]), (0, 1, 2, 0, b"123"))
-        self.assertEqual(attr.astuple(t[1]), (1, 2, 3, 1, b"\xf0"))
-        self.assertEqual(t[0].flags, 0)
-        self.assertEqual(t[0].time, 1)
-        self.assertEqual(t[0].population, 2)
-        self.assertEqual(t[0].individual, 0)
-        self.assertEqual(t[0].metadata, b"123")
-        self.assertEqual(t[0], t[-2])
-        self.assertEqual(t[1], t[-1])
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(s) > 0
+        assert len(t) == 2
+        assert attr.astuple(t[0]) == (0, 1, 2, 0, b"123")
+        assert attr.astuple(t[1]) == (1, 2, 3, 1, b"\xf0")
+        assert t[0].flags == 0
+        assert t[0].time == 1
+        assert t[0].population == 2
+        assert t[0].individual == 0
+        assert t[0].metadata == b"123"
+        assert t[0] == t[-2]
+        assert t[1] == t[-1]
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_defaults(self):
         t = tskit.NodeTable()
-        self.assertEqual(t.add_row(), 0)
-        self.assertEqual(t.time[0], 0)
-        self.assertEqual(t.flags[0], 0)
-        self.assertEqual(t.population[0], tskit.NULL)
-        self.assertEqual(t.individual[0], tskit.NULL)
-        self.assertEqual(len(t.metadata), 0)
-        self.assertEqual(t.metadata_offset[0], 0)
+        assert t.add_row() == 0
+        assert t.time[0] == 0
+        assert t.flags[0] == 0
+        assert t.population[0] == tskit.NULL
+        assert t.individual[0] == tskit.NULL
+        assert len(t.metadata) == 0
+        assert t.metadata_offset[0] == 0
 
     def test_optional_population(self):
         for num_rows in [0, 10, 100]:
@@ -965,31 +978,31 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
                 flags=flags,
                 time=time,
             )
-            self.assertEqual(list(table.population), [-1 for _ in range(num_rows)])
-            self.assertEqual(list(table.flags), flags)
-            self.assertEqual(list(table.time), time)
-            self.assertEqual(list(table.metadata), list(metadata))
-            self.assertEqual(list(table.metadata_offset), list(metadata_offset))
+            assert list(table.population) == [-1 for _ in range(num_rows)]
+            assert list(table.flags) == flags
+            assert list(table.time) == time
+            assert list(table.metadata) == list(metadata)
+            assert list(table.metadata_offset) == list(metadata_offset)
             table.set_columns(flags=flags, time=time, population=None)
-            self.assertEqual(list(table.population), [-1 for _ in range(num_rows)])
-            self.assertEqual(list(table.flags), flags)
-            self.assertEqual(list(table.time), time)
+            assert list(table.population) == [-1 for _ in range(num_rows)]
+            assert list(table.flags) == flags
+            assert list(table.time) == time
 
     def test_add_row_bad_data(self):
         t = tskit.NodeTable()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(flags="x")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(time="x")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(individual="x")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(population="x")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(metadata=123)
 
 
-class TestEdgeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestEdgeTable(CommonTestsMixin, MetadataTestsMixin):
 
     columns = [
         DoubleColumn("left"),
@@ -1008,35 +1021,36 @@ class TestEdgeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         t = tskit.EdgeTable()
         t.add_row(left=0, right=1, parent=2, child=3, metadata=b"123")
         t.add_row(1, 2, 3, 4, b"\xf0")
-        self.assertEqual(len(t), 2)
-        self.assertEqual(attr.astuple(t[0]), (0, 1, 2, 3, b"123"))
-        self.assertEqual(attr.astuple(t[1]), (1, 2, 3, 4, b"\xf0"))
-        self.assertEqual(t[0].left, 0)
-        self.assertEqual(t[0].right, 1)
-        self.assertEqual(t[0].parent, 2)
-        self.assertEqual(t[0].child, 3)
-        self.assertEqual(t[0].metadata, b"123")
-        self.assertEqual(t[0], t[-2])
-        self.assertEqual(t[1], t[-1])
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(t) == 2
+        assert attr.astuple(t[0]) == (0, 1, 2, 3, b"123")
+        assert attr.astuple(t[1]) == (1, 2, 3, 4, b"\xf0")
+        assert t[0].left == 0
+        assert t[0].right == 1
+        assert t[0].parent == 2
+        assert t[0].child == 3
+        assert t[0].metadata == b"123"
+        assert t[0] == t[-2]
+        assert t[1] == t[-1]
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_defaults(self):
         t = tskit.EdgeTable()
-        self.assertEqual(t.add_row(0, 0, 0, 0), 0)
-        self.assertEqual(len(t.metadata), 0)
-        self.assertEqual(t.metadata_offset[0], 0)
+        assert t.add_row(0, 0, 0, 0) == 0
+        assert len(t.metadata) == 0
+        assert t.metadata_offset[0] == 0
 
     def test_add_row_bad_data(self):
         t = tskit.EdgeTable()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(left="x", right=0, parent=0, child=0)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, 0, 0, 0, metadata=123)
 
 
-class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestSiteTable(CommonTestsMixin, MetadataTestsMixin):
     columns = [DoubleColumn("position")]
     ragged_list_columns = [
         (CharColumn("ancestral_state"), UInt32Column("ancestral_state_offset")),
@@ -1053,26 +1067,28 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         t.add_row(position=0, ancestral_state="1", metadata=b"2")
         t.add_row(1, "2", b"\xf0")
         s = str(t)
-        self.assertGreater(len(s), 0)
-        self.assertEqual(len(t), 2)
-        self.assertEqual(attr.astuple(t[0]), (0, "1", b"2"))
-        self.assertEqual(attr.astuple(t[1]), (1, "2", b"\xf0"))
-        self.assertEqual(t[0].position, 0)
-        self.assertEqual(t[0].ancestral_state, "1")
-        self.assertEqual(t[0].metadata, b"2")
-        self.assertEqual(t[0], t[-2])
-        self.assertEqual(t[1], t[-1])
-        self.assertRaises(IndexError, t.__getitem__, 2)
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(s) > 0
+        assert len(t) == 2
+        assert attr.astuple(t[0]) == (0, "1", b"2")
+        assert attr.astuple(t[1]) == (1, "2", b"\xf0")
+        assert t[0].position == 0
+        assert t[0].ancestral_state == "1"
+        assert t[0].metadata == b"2"
+        assert t[0] == t[-2]
+        assert t[1] == t[-1]
+        with pytest.raises(IndexError):
+            t.__getitem__(2)
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_bad_data(self):
         t = tskit.SiteTable()
         t.add_row(0, "A")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row("x", "A")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, 0)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, "A", metadata=[0, 1, 2])
 
     def test_packset_ancestral_state(self):
@@ -1085,13 +1101,11 @@ class TestSiteTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
                 ancestral_states
             )
             table.packset_ancestral_state(ancestral_states)
-            self.assertTrue(np.array_equal(table.ancestral_state, ancestral_state))
-            self.assertTrue(
-                np.array_equal(table.ancestral_state_offset, ancestral_state_offset)
-            )
+            assert np.array_equal(table.ancestral_state, ancestral_state)
+            assert np.array_equal(table.ancestral_state_offset, ancestral_state_offset)
 
 
-class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestMutationTable(CommonTestsMixin, MetadataTestsMixin):
     columns = [
         Int32Column("site"),
         Int32Column("node"),
@@ -1121,33 +1135,34 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin)
             time=tskit.UNKNOWN_TIME,
         )
         s = str(t)
-        self.assertGreater(len(s), 0)
-        self.assertEqual(len(t), 3)
-        self.assertEqual(attr.astuple(t[0]), (0, 1, "2", 3, b"4", 5))
-        self.assertEqual(attr.astuple(t[1]), (1, 2, "3", 4, b"\xf0", 6))
-        self.assertEqual(t[0].site, 0)
-        self.assertEqual(t[0].node, 1)
-        self.assertEqual(t[0].derived_state, "2")
-        self.assertEqual(t[0].parent, 3)
-        self.assertEqual(t[0].metadata, b"4")
-        self.assertEqual(t[0].time, 5)
-        self.assertEqual(t[0], t[-3])
-        self.assertEqual(t[1], t[-2])
-        self.assertEqual(t[2], t[-1])
-        self.assertRaises(IndexError, t.__getitem__, -4)
+        assert len(s) > 0
+        assert len(t) == 3
+        assert attr.astuple(t[0]) == (0, 1, "2", 3, b"4", 5)
+        assert attr.astuple(t[1]) == (1, 2, "3", 4, b"\xf0", 6)
+        assert t[0].site == 0
+        assert t[0].node == 1
+        assert t[0].derived_state == "2"
+        assert t[0].parent == 3
+        assert t[0].metadata == b"4"
+        assert t[0].time == 5
+        assert t[0] == t[-3]
+        assert t[1] == t[-2]
+        assert t[2] == t[-1]
+        with pytest.raises(IndexError):
+            t.__getitem__(-4)
 
     def test_add_row_bad_data(self):
         t = tskit.MutationTable()
         t.add_row(0, 0, "A")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row("0", 0, "A")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, "0", "A")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, 0, "A", parent=None)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, 0, "A", metadata=[0])
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, 0, "A", time="A")
 
     def test_packset_derived_state(self):
@@ -1158,13 +1173,11 @@ class TestMutationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin)
             derived_states = [tsutil.random_strings(10) for _ in range(num_rows)]
             derived_state, derived_state_offset = tskit.pack_strings(derived_states)
             table.packset_derived_state(derived_states)
-            self.assertTrue(np.array_equal(table.derived_state, derived_state))
-            self.assertTrue(
-                np.array_equal(table.derived_state_offset, derived_state_offset)
-            )
+            assert np.array_equal(table.derived_state, derived_state)
+            assert np.array_equal(table.derived_state_offset, derived_state_offset)
 
 
-class TestMigrationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestMigrationTable(CommonTestsMixin, MetadataTestsMixin):
     columns = [
         DoubleColumn("left"),
         DoubleColumn("right"),
@@ -1184,37 +1197,38 @@ class TestMigrationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin
         t = tskit.MigrationTable()
         t.add_row(left=0, right=1, node=2, source=3, dest=4, time=5, metadata=b"123")
         t.add_row(1, 2, 3, 4, 5, 6, b"\xf0")
-        self.assertEqual(len(t), 2)
-        self.assertEqual(attr.astuple(t[0]), (0, 1, 2, 3, 4, 5, b"123"))
-        self.assertEqual(attr.astuple(t[1]), (1, 2, 3, 4, 5, 6, b"\xf0"))
-        self.assertEqual(t[0].left, 0)
-        self.assertEqual(t[0].right, 1)
-        self.assertEqual(t[0].node, 2)
-        self.assertEqual(t[0].source, 3)
-        self.assertEqual(t[0].dest, 4)
-        self.assertEqual(t[0].time, 5)
-        self.assertEqual(t[0].metadata, b"123")
-        self.assertEqual(t[0], t[-2])
-        self.assertEqual(t[1], t[-1])
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(t) == 2
+        assert attr.astuple(t[0]) == (0, 1, 2, 3, 4, 5, b"123")
+        assert attr.astuple(t[1]) == (1, 2, 3, 4, 5, 6, b"\xf0")
+        assert t[0].left == 0
+        assert t[0].right == 1
+        assert t[0].node == 2
+        assert t[0].source == 3
+        assert t[0].dest == 4
+        assert t[0].time == 5
+        assert t[0].metadata == b"123"
+        assert t[0] == t[-2]
+        assert t[1] == t[-1]
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_defaults(self):
         t = tskit.MigrationTable()
-        self.assertEqual(t.add_row(0, 0, 0, 0, 0, 0), 0)
-        self.assertEqual(len(t.metadata), 0)
-        self.assertEqual(t.metadata_offset[0], 0)
+        assert t.add_row(0, 0, 0, 0, 0, 0) == 0
+        assert len(t.metadata) == 0
+        assert t.metadata_offset[0] == 0
 
     def test_add_row_bad_data(self):
         t = tskit.MigrationTable()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(left="x", right=0, node=0, source=0, dest=0, time=0)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, 0, 0, 0, 0, 0, metadata=123)
 
 
-class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
+class TestProvenanceTable(CommonTestsMixin):
     columns = []
     ragged_list_columns = [
         (CharColumn("timestamp"), UInt32Column("timestamp_offset")),
@@ -1230,21 +1244,22 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
         t = tskit.ProvenanceTable()
         t.add_row(timestamp="0", record="1")
         t.add_row("2", "1")  # The orders are reversed for default timestamp.
-        self.assertEqual(len(t), 2)
-        self.assertEqual(attr.astuple(t[0]), ("0", "1"))
-        self.assertEqual(attr.astuple(t[1]), ("1", "2"))
-        self.assertEqual(t[0].timestamp, "0")
-        self.assertEqual(t[0].record, "1")
-        self.assertEqual(t[0], t[-2])
-        self.assertEqual(t[1], t[-1])
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(t) == 2
+        assert attr.astuple(t[0]) == ("0", "1")
+        assert attr.astuple(t[1]) == ("1", "2")
+        assert t[0].timestamp == "0"
+        assert t[0].record == "1"
+        assert t[0] == t[-2]
+        assert t[1] == t[-1]
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_bad_data(self):
         t = tskit.ProvenanceTable()
         t.add_row("a", "b")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(0, "b")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row("a", 0)
 
     def test_packset_timestamp(self):
@@ -1252,19 +1267,19 @@ class TestProvenanceTable(unittest.TestCase, CommonTestsMixin):
         t.add_row(timestamp="0", record="1")
         t.add_row(timestamp="1", record="2")
         t.packset_timestamp(["AAAA", "BBBB"])
-        self.assertEqual(t[0].timestamp, "AAAA")
-        self.assertEqual(t[1].timestamp, "BBBB")
+        assert t[0].timestamp == "AAAA"
+        assert t[1].timestamp == "BBBB"
 
     def test_packset_record(self):
         t = tskit.ProvenanceTable()
         t.add_row(timestamp="0", record="1")
         t.add_row(timestamp="1", record="2")
         t.packset_record(["AAAA", "BBBB"])
-        self.assertEqual(t[0].record, "AAAA")
-        self.assertEqual(t[1].record, "BBBB")
+        assert t[0].record == "AAAA"
+        assert t[1].record == "BBBB"
 
 
-class TestPopulationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestPopulationTable(CommonTestsMixin, MetadataTestsMixin):
     metadata_mandatory = True
     columns = []
     ragged_list_columns = [(CharColumn("metadata"), UInt32Column("metadata_offset"))]
@@ -1279,21 +1294,22 @@ class TestPopulationTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixi
         t.add_row(metadata=b"\xf0")
         t.add_row(b"1")
         s = str(t)
-        self.assertGreater(len(s), 0)
-        self.assertEqual(len(t), 2)
-        self.assertEqual(attr.astuple(t[0]), (b"\xf0",))
-        self.assertEqual(t[0].metadata, b"\xf0")
-        self.assertEqual(attr.astuple(t[1]), (b"1",))
-        self.assertRaises(IndexError, t.__getitem__, -3)
+        assert len(s) > 0
+        assert len(t) == 2
+        assert attr.astuple(t[0]) == (b"\xf0",)
+        assert t[0].metadata == b"\xf0"
+        assert attr.astuple(t[1]) == (b"1",)
+        with pytest.raises(IndexError):
+            t.__getitem__(-3)
 
     def test_add_row_bad_data(self):
         t = tskit.PopulationTable()
         t.add_row()
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             t.add_row(metadata=[0])
 
 
-class TestSortTables(unittest.TestCase):
+class TestSortTables:
     """
     Tests for the TableCollection.sort() method.
     """
@@ -1313,9 +1329,10 @@ class TestSortTables(unittest.TestCase):
         for e in randomised_edges:
             tables.edges.add_row(e.left, e.right, e.parent, e.child)
         # Verify that import fails for randomised edges
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
         tables.sort()
-        self.assertEqual(tables, ts.dump_tables())
+        assert tables == ts.dump_tables()
 
         tables.sites.clear()
         tables.mutations.clear()
@@ -1341,15 +1358,16 @@ class TestSortTables(unittest.TestCase):
             )
         if ts.num_sites > 1:
             # Verify that import fails for randomised sites
-            self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+            with pytest.raises(_tskit.LibraryError):
+                tables.tree_sequence()
         tables.sort()
-        self.assertEqual(tables, ts.dump_tables())
+        assert tables == ts.dump_tables()
 
         ts_new = tables.tree_sequence()
-        self.assertEqual(ts_new.num_edges, ts.num_edges)
-        self.assertEqual(ts_new.num_trees, ts.num_trees)
-        self.assertEqual(ts_new.num_sites, ts.num_sites)
-        self.assertEqual(ts_new.num_mutations, ts.num_mutations)
+        assert ts_new.num_edges == ts.num_edges
+        assert ts_new.num_trees == ts.num_trees
+        assert ts_new.num_sites == ts.num_sites
+        assert ts_new.num_mutations == ts.num_mutations
 
     def verify_edge_sort_offset(self, ts):
         """
@@ -1371,17 +1389,19 @@ class TestSortTables(unittest.TestCase):
             for e in all_edges:
                 tables.edges.add_row(e.left, e.right, e.parent, e.child)
             # Verify that import fails for randomised edges
-            self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+            with pytest.raises(_tskit.LibraryError):
+                tables.tree_sequence()
             # If we sort after the start value we should still fail.
             tables.sort(edge_start=start + 1)
-            self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+            with pytest.raises(_tskit.LibraryError):
+                tables.tree_sequence()
             # Sorting from the correct index should give us back the original table.
             tables.edges.clear()
             for e in all_edges:
                 tables.edges.add_row(e.left, e.right, e.parent, e.child)
             tables.sort(edge_start=start)
             # Verify the new and old edges are equal.
-            self.assertEqual(edges, tables.edges)
+            assert edges == tables.edges
 
     def test_single_tree_no_mutations(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
@@ -1395,19 +1415,19 @@ class TestSortTables(unittest.TestCase):
 
     def test_many_trees_no_mutations(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
 
     def test_single_tree_mutations(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
 
     def test_single_tree_mutations_metadata(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         ts = tsutil.add_random_metadata(ts, self.random_seed)
         self.verify_randomise_tables(ts)
 
@@ -1426,20 +1446,20 @@ class TestSortTables(unittest.TestCase):
         ts = msprime.simulate(
             10, recombination_rate=2, mutation_rate=2, random_seed=self.random_seed
         )
-        self.assertGreater(ts.num_trees, 2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_trees > 2
+        assert ts.num_sites > 2
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
 
     def test_many_trees_multichar_mutations(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         ts = tsutil.insert_multichar_mutations(ts, self.random_seed)
         self.verify_randomise_tables(ts)
 
     def test_many_trees_multichar_mutations_metadata(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         ts = tsutil.insert_multichar_mutations(ts, self.random_seed)
         ts = tsutil.add_random_metadata(ts, self.random_seed)
         self.verify_randomise_tables(ts)
@@ -1460,19 +1480,19 @@ class TestSortTables(unittest.TestCase):
             if len(e.children) > 2:
                 found = True
                 break
-        self.assertTrue(found)
+        assert found
         return ts
 
     def test_nonbinary_trees(self):
         ts = self.get_nonbinary_example(mutation_rate=0)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
 
     def test_nonbinary_trees_mutations(self):
         ts = self.get_nonbinary_example(mutation_rate=2)
-        self.assertGreater(ts.num_trees, 2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_trees > 2
+        assert ts.num_sites > 2
         self.verify_randomise_tables(ts)
         self.verify_edge_sort_offset(ts)
 
@@ -1483,41 +1503,44 @@ class TestSortTables(unittest.TestCase):
         tables2 = ts2.dump_tables()
         tables2.edges.set_columns(**tables1.edges.asdict())
         # The edges in tables2 will refer to nodes that don't exist.
-        self.assertRaises(_tskit.LibraryError, tables2.sort)
+        with pytest.raises(_tskit.LibraryError):
+            tables2.sort()
 
     def test_incompatible_sites(self):
         ts1 = msprime.simulate(10, random_seed=self.random_seed)
         ts2 = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts2.num_sites, 1)
+        assert ts2.num_sites > 1
         tables1 = ts1.dump_tables()
         tables2 = ts2.dump_tables()
         # The mutations in tables2 will refer to sites that don't exist.
         tables1.mutations.set_columns(**tables2.mutations.asdict())
-        self.assertRaises(_tskit.LibraryError, tables1.sort)
+        with pytest.raises(_tskit.LibraryError):
+            tables1.sort()
 
     def test_incompatible_mutation_nodes(self):
         ts1 = msprime.simulate(2, random_seed=self.random_seed)
         ts2 = msprime.simulate(10, mutation_rate=2, random_seed=self.random_seed)
-        self.assertGreater(ts2.num_sites, 1)
+        assert ts2.num_sites > 1
         tables1 = ts1.dump_tables()
         tables2 = ts2.dump_tables()
         # The mutations in tables2 will refer to nodes that don't exist.
         # print(tables2.sites.asdict())
         tables1.sites.set_columns(**tables2.sites.asdict())
         tables1.mutations.set_columns(**tables2.mutations.asdict())
-        self.assertRaises(_tskit.LibraryError, tables1.sort)
+        with pytest.raises(_tskit.LibraryError):
+            tables1.sort()
 
     def test_empty_tables(self):
         tables = tskit.TableCollection(1)
         tables.sort()
-        self.assertEqual(tables.nodes.num_rows, 0)
-        self.assertEqual(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, 0)
+        assert tables.nodes.num_rows == 0
+        assert tables.edges.num_rows == 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows == 0
 
 
-class TestSortMutations(unittest.TestCase):
+class TestSortMutations:
     """
     Tests that mutations are correctly ordered when sorting tables.
     """
@@ -1563,10 +1586,10 @@ class TestSortMutations(unittest.TestCase):
         # output directly.
         sites = ts.tables.sites
         mutations = ts.tables.mutations
-        self.assertEqual(len(sites), 2)
-        self.assertEqual(len(mutations), 4)
-        self.assertEqual(list(mutations.site), [0, 0, 1, 1])
-        self.assertEqual(list(mutations.node), [1, 0, 0, 1])
+        assert len(sites) == 2
+        assert len(mutations) == 4
+        assert list(mutations.site) == [0, 0, 1, 1]
+        assert list(mutations.node) == [1, 0, 0, 1]
 
     def test_sort_mutations_remap_parent_id(self):
         nodes = io.StringIO(
@@ -1610,12 +1633,12 @@ class TestSortMutations(unittest.TestCase):
         # output directly.
         sites = ts.tables.sites
         mutations = ts.tables.mutations
-        self.assertEqual(len(sites), 2)
-        self.assertEqual(len(mutations), 6)
-        self.assertEqual(list(mutations.site), [0, 0, 0, 1, 1, 1])
-        self.assertEqual(list(mutations.node), [0, 0, 0, 0, 0, 0])
-        self.assertEqual(list(mutations.time), [0.5, 0.125, 0.0, 0.5, 0.25, 0.0])
-        self.assertEqual(list(mutations.parent), [-1, 0, 1, -1, 3, 4])
+        assert len(sites) == 2
+        assert len(mutations) == 6
+        assert list(mutations.site) == [0, 0, 0, 1, 1, 1]
+        assert list(mutations.node) == [0, 0, 0, 0, 0, 0]
+        assert list(mutations.time) == [0.5, 0.125, 0.0, 0.5, 0.25, 0.0]
+        assert list(mutations.parent) == [-1, 0, 1, -1, 3, 4]
 
     def test_sort_mutations_bad_parent_id(self):
         nodes = io.StringIO(
@@ -1641,16 +1664,15 @@ class TestSortMutations(unittest.TestCase):
         1       0       1               -2
         """
         )
-        self.assertRaises(
-            _tskit.LibraryError,
-            tskit.load_text,
-            nodes=nodes,
-            edges=edges,
-            sites=sites,
-            mutations=mutations,
-            sequence_length=1,
-            strict=False,
-        )
+        with pytest.raises(_tskit.LibraryError):
+            tskit.load_text(
+                nodes=nodes,
+                edges=edges,
+                sites=sites,
+                mutations=mutations,
+                sequence_length=1,
+                strict=False,
+            )
 
     def test_sort_mutations_time(self):
         nodes = io.StringIO(
@@ -1698,22 +1720,21 @@ class TestSortMutations(unittest.TestCase):
         # output directly.
         sites = ts.tables.sites
         mutations = ts.tables.mutations
-        self.assertEqual(len(sites), 3)
-        self.assertEqual(len(mutations), 9)
-        self.assertEqual(list(mutations.site), [0, 0, 0, 1, 1, 1, 2, 2, 2])
-        self.assertEqual(list(mutations.node), [0, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert len(sites) == 3
+        assert len(mutations) == 9
+        assert list(mutations.site) == [0, 0, 0, 1, 1, 1, 2, 2, 2]
+        assert list(mutations.node) == [0, 0, 0, 0, 0, 0, 0, 0, 0]
         # Nans are not equal so swap in -1
         times = mutations.time
         times[np.isnan(times)] = -1
-        self.assertEqual(list(times), [3.0, 2.0, 1.0, 0.5, 0.5, 0.5, 6.0, 4.0, -5.0])
-        self.assertEqual(
-            list(mutations.derived_state),
-            list(map(ord, ["i", "h", "g", "d", "e", "f", "c", "a", "b"])),
+        assert list(times) == [3.0, 2.0, 1.0, 0.5, 0.5, 0.5, 6.0, 4.0, -5.0]
+        assert list(mutations.derived_state) == list(
+            map(ord, ["i", "h", "g", "d", "e", "f", "c", "a", "b"])
         )
-        self.assertEqual(list(mutations.parent), [-1, -1, -1, -1, -1, -1, -1, -1, -1])
+        assert list(mutations.parent) == [-1, -1, -1, -1, -1, -1, -1, -1, -1]
 
 
-class TestTablesToTreeSequence(unittest.TestCase):
+class TestTablesToTreeSequence:
     """
     Tests for the .tree_sequence() method of a TableCollection.
     """
@@ -1722,17 +1743,18 @@ class TestTablesToTreeSequence(unittest.TestCase):
         a = msprime.simulate(5, mutation_rate=1, random_seed=42)
         tables = a.dump_tables()
         b = tables.tree_sequence()
-        self.assertEqual(a.tables, b.tables)
+        assert a.tables == b.tables
 
 
-class TestMutationTimeErrors(unittest.TestCase):
+class TestMutationTimeErrors:
     def test_younger_than_node_below(self):
         ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
         tables = ts.dump_tables()
         tables.mutations.time = np.zeros(len(tables.mutations.time), dtype=np.float64)
-        with self.assertRaisesRegex(
+        with pytest.raises(
             _tskit.LibraryError,
-            "A mutation's time must be >= the node time, or be marked as 'unknown'",
+            match="A mutation's time must be >= the node time, or be marked as"
+            " 'unknown'",
         ):
             tables.tree_sequence()
 
@@ -1742,9 +1764,9 @@ class TestMutationTimeErrors(unittest.TestCase):
         tables.mutations.time = (
             np.ones(len(tables.mutations.time), dtype=np.float64) * 42
         )
-        with self.assertRaisesRegex(
+        with pytest.raises(
             _tskit.LibraryError,
-            "A mutation's time must be < the parent node of the edge on which it"
+            match="A mutation's time must be < the parent node of the edge on which it"
             " occurs, or be marked as 'unknown'",
         ):
             tables.tree_sequence()
@@ -1757,16 +1779,16 @@ class TestMutationTimeErrors(unittest.TestCase):
             ts, num_sites=10, mu=1, multiple_per_node=False, seed=42
         )
         tables = ts.dump_tables()
-        self.assertNotEqual(sum(tables.mutations.parent != -1), 0)
+        assert sum(tables.mutations.parent != -1) != 0
         # Make all times the node time
         times = tables.nodes.time[tables.mutations.node]
         # Then make mutations without a parent really old
         times[tables.mutations.parent == -1] = 64.0
         tables.mutations.time = times
         tables.sort()
-        with self.assertRaisesRegex(
+        with pytest.raises(
             _tskit.LibraryError,
-            "A mutation's time must be < the parent node of the edge on which it"
+            match="A mutation's time must be < the parent node of the edge on which it"
             " occurs, or be marked as 'unknown'",
         ):
             tables.tree_sequence()
@@ -1780,16 +1802,12 @@ class TestMutationTimeErrors(unittest.TestCase):
         )
         tables = ts.dump_tables()
         tables.compute_mutation_times()
-        self.assertNotEqual(sum(tables.mutations.parent != -1), 0)
+        assert sum(tables.mutations.parent != -1) != 0
         times = tables.mutations.time
         # Then make mutations without a parent really old
         times[tables.mutations.parent != -1] = 64.0
         tables.mutations.time = times
-        with self.assertRaises(
-            _tskit.LibraryError,
-            msg="A mutation's time must be <= the parent mutation time (if known),"
-            " or be marked as 'unknown'",
-        ):
+        with pytest.raises(_tskit.LibraryError):
             tables.tree_sequence()
 
     def test_unsorted_times(self):
@@ -1828,9 +1846,10 @@ class TestMutationTimeErrors(unittest.TestCase):
         )
         tables = ts.dump_tables()
         tables.mutations.time = tables.mutations.time[::-1]
-        with self.assertRaisesRegex(
+        with pytest.raises(
             _tskit.LibraryError,
-            "Mutations must be provided in non-decreasing site order and non-increasing"
+            match="Mutations must be provided in non-decreasing site order and"
+            " non-increasing"
             " time order within each site",
         ):
             tables.tree_sequence()
@@ -1853,15 +1872,15 @@ class TestMutationTimeErrors(unittest.TestCase):
         # Mixed known/unknown times on sites fail
         times[::2] = tskit.UNKNOWN_TIME
         tables.mutations.time = times
-        with self.assertRaisesRegex(
+        with pytest.raises(
             _tskit.LibraryError,
-            "Mutation times must either be all marked 'unknown', or all be known "
+            match="Mutation times must either be all marked 'unknown', or all be known "
             "values for any single site.",
         ):
             tables.tree_sequence()
 
 
-class TestNanDoubleValues(unittest.TestCase):
+class TestNanDoubleValues:
     """
     In some tables we need to guard against NaN/infinite values in the input.
     """
@@ -1872,12 +1891,14 @@ class TestNanDoubleValues(unittest.TestCase):
         tables = ts.dump_tables()
         bad_coords = tables.edges.left + float("inf")
         tables.edges.left = bad_coords
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
 
         tables = ts.dump_tables()
         bad_coords = tables.edges.right + float("nan")
         tables.edges.right = bad_coords
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
 
     def test_migrations(self):
         ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
@@ -1885,17 +1906,20 @@ class TestNanDoubleValues(unittest.TestCase):
         tables = ts.dump_tables()
         tables.populations.add_row()
         tables.migrations.add_row(float("inf"), 1, time=0, node=0, source=0, dest=1)
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
 
         tables = ts.dump_tables()
         tables.populations.add_row()
         tables.migrations.add_row(0, float("nan"), time=0, node=0, source=0, dest=1)
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
 
         tables = ts.dump_tables()
         tables.populations.add_row()
         tables.migrations.add_row(0, 1, time=float("nan"), node=0, source=0, dest=1)
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
 
     def test_site_positions(self):
         ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
@@ -1903,7 +1927,8 @@ class TestNanDoubleValues(unittest.TestCase):
         bad_pos = tables.sites.position.copy()
         bad_pos[-1] = np.inf
         tables.sites.position = bad_pos
-        self.assertRaises(_tskit.LibraryError, tables.tree_sequence)
+        with pytest.raises(_tskit.LibraryError):
+            tables.tree_sequence()
 
     def test_node_times(self):
         ts = msprime.simulate(5, mutation_rate=1, random_seed=42)
@@ -1911,11 +1936,11 @@ class TestNanDoubleValues(unittest.TestCase):
         bad_times = tables.nodes.time.copy()
         bad_times[-1] = np.inf
         tables.nodes.time = bad_times
-        with self.assertRaisesRegex(_tskit.LibraryError, "Times must be finite"):
+        with pytest.raises(_tskit.LibraryError, match="Times must be finite"):
             tables.tree_sequence()
         bad_times[-1] = math.nan
         tables.nodes.time = bad_times
-        with self.assertRaisesRegex(_tskit.LibraryError, "Times must be finite"):
+        with pytest.raises(_tskit.LibraryError, match="Times must be finite"):
             tables.tree_sequence()
 
     def test_mutation_times(self):
@@ -1924,18 +1949,18 @@ class TestNanDoubleValues(unittest.TestCase):
         bad_times = tables.mutations.time.copy()
         bad_times[-1] = np.inf
         tables.mutations.time = bad_times
-        with self.assertRaisesRegex(_tskit.LibraryError, "Times must be finite"):
+        with pytest.raises(_tskit.LibraryError, match="Times must be finite"):
             tables.tree_sequence()
         bad_times = tables.mutations.time.copy()
         bad_times[-1] = math.nan
         tables.mutations.time = bad_times
-        with self.assertRaisesRegex(_tskit.LibraryError, "Times must be finite"):
+        with pytest.raises(_tskit.LibraryError, match="Times must be finite"):
             tables.tree_sequence()
 
     def test_individual(self):
         ts = msprime.simulate(12, mutation_rate=1, random_seed=42)
         ts = tsutil.insert_random_ploidy_individuals(ts, seed=42)
-        self.assertGreater(ts.num_individuals, 1)
+        assert ts.num_individuals > 1
         tables = ts.dump_tables()
         bad_locations = tables.individuals.location.copy()
         bad_locations[0] = np.inf
@@ -1943,7 +1968,7 @@ class TestNanDoubleValues(unittest.TestCase):
         ts = tables.tree_sequence()
 
 
-class TestSimplifyTables(unittest.TestCase):
+class TestSimplifyTables:
     """
     Tests for the simplify_tables function.
     """
@@ -1968,9 +1993,9 @@ class TestSimplifyTables(unittest.TestCase):
             t2.simplify([0, 1], filter_sites=filter_sites)
             t1.provenances.clear()
             t2.provenances.clear()
-            self.assertEqual(t1, t2)
+            assert t1 == t2
             if filter_sites:
-                self.assertGreater(ts.num_sites, len(t1.sites))
+                assert ts.num_sites > len(t1.sites)
 
     def test_full_samples(self):
         for n in [2, 10, 100, 1000]:
@@ -1984,20 +2009,19 @@ class TestSimplifyTables(unittest.TestCase):
             mutations_before = tables.mutations.copy()
             for samples in [None, list(ts.samples()), ts.samples()]:
                 node_map = tables.simplify(samples=samples)
-                self.assertEqual(node_map.shape, (len(nodes_before),))
-                self.assertEqual(nodes_before, tables.nodes)
-                self.assertEqual(edges_before, tables.edges)
-                self.assertEqual(sites_before, tables.sites)
-                self.assertEqual(mutations_before, tables.mutations)
+                assert node_map.shape == (len(nodes_before),)
+                assert nodes_before == tables.nodes
+                assert edges_before == tables.edges
+                assert sites_before == tables.sites
+                assert mutations_before == tables.mutations
 
     def test_bad_samples(self):
         n = 10
         ts = msprime.simulate(n, random_seed=self.random_seed)
         tables = ts.dump_tables()
         for bad_node in [-1, n, n + 1, ts.num_nodes - 1, ts.num_nodes, 2 ** 31 - 1]:
-            self.assertRaises(
-                _tskit.LibraryError, tables.simplify, samples=[0, bad_node]
-            )
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, bad_node])
 
     def test_bad_edge_ordering(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
@@ -2010,7 +2034,8 @@ class TestSimplifyTables(unittest.TestCase):
             parent=edges.parent[::-1],
             child=edges.child[::-1],
         )
-        self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+        with pytest.raises(_tskit.LibraryError):
+            tables.simplify(samples=[0, 1])
 
     def test_bad_edges(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
@@ -2023,7 +2048,8 @@ class TestSimplifyTables(unittest.TestCase):
             edges.set_columns(
                 left=edges.left, right=edges.right, parent=parent, child=edges.child
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
             # Bad child node
             tables = ts.dump_tables()
             edges = tables.edges
@@ -2032,7 +2058,8 @@ class TestSimplifyTables(unittest.TestCase):
             edges.set_columns(
                 left=edges.left, right=edges.right, parent=edges.parent, child=child
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
             # child == parent
             tables = ts.dump_tables()
             edges = tables.edges
@@ -2041,7 +2068,8 @@ class TestSimplifyTables(unittest.TestCase):
             edges.set_columns(
                 left=edges.left, right=edges.right, parent=edges.parent, child=child
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
             # left == right
             tables = ts.dump_tables()
             edges = tables.edges
@@ -2050,7 +2078,8 @@ class TestSimplifyTables(unittest.TestCase):
             edges.set_columns(
                 left=left, right=edges.right, parent=edges.parent, child=edges.child
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
             # left > right
             tables = ts.dump_tables()
             edges = tables.edges
@@ -2059,11 +2088,12 @@ class TestSimplifyTables(unittest.TestCase):
             edges.set_columns(
                 left=left, right=edges.right, parent=edges.parent, child=edges.child
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
 
     def test_bad_mutation_nodes(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, mutation_rate=1)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         for bad_node in [-1, ts.num_nodes, 2 ** 31 - 1]:
             tables = ts.dump_tables()
             mutations = tables.mutations
@@ -2075,11 +2105,12 @@ class TestSimplifyTables(unittest.TestCase):
                 derived_state=mutations.derived_state,
                 derived_state_offset=mutations.derived_state_offset,
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
 
     def test_bad_mutation_sites(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, mutation_rate=1)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         for bad_site in [-1, ts.num_sites, 2 ** 31 - 1]:
             tables = ts.dump_tables()
             mutations = tables.mutations
@@ -2091,11 +2122,12 @@ class TestSimplifyTables(unittest.TestCase):
                 derived_state=mutations.derived_state,
                 derived_state_offset=mutations.derived_state_offset,
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
 
     def test_bad_site_positions(self):
         ts = msprime.simulate(10, random_seed=self.random_seed, mutation_rate=1)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         # Positions > sequence_length are valid, as we can have gaps at the end of
         # a tree sequence.
         for bad_position in [-1, -1e-6]:
@@ -2108,13 +2140,15 @@ class TestSimplifyTables(unittest.TestCase):
                 ancestral_state=sites.ancestral_state,
                 ancestral_state_offset=sites.ancestral_state_offset,
             )
-            self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+            with pytest.raises(_tskit.LibraryError):
+                tables.simplify(samples=[0, 1])
 
     def test_duplicate_positions(self):
         tables = tskit.TableCollection(sequence_length=1)
         tables.sites.add_row(0, ancestral_state="0")
         tables.sites.add_row(0, ancestral_state="0")
-        self.assertRaises(_tskit.LibraryError, tables.simplify, [])
+        with pytest.raises(_tskit.LibraryError):
+            tables.simplify([])
 
     def test_samples_interface(self):
         ts = msprime.simulate(50, random_seed=1)
@@ -2123,17 +2157,18 @@ class TestSimplifyTables(unittest.TestCase):
             tables.simplify(good_form)
         tables = ts.dump_tables()
         for bad_values in [[[[]]], np.array([[0, 1], [2, 3]], dtype=np.int32)]:
-            self.assertRaises(ValueError, tables.simplify, bad_values)
+            with pytest.raises(ValueError):
+                tables.simplify(bad_values)
         for bad_type in [[0.1], ["string"], {}, [{}]]:
-            self.assertRaises(TypeError, tables.simplify, bad_type)
+            with pytest.raises(TypeError):
+                tables.simplify(bad_type)
         # We only convert to int if we don't overflow
         for bad_node in [np.iinfo(np.int32).min - 1, np.iinfo(np.int32).max + 1]:
-            self.assertRaises(
-                OverflowError, tables.simplify, samples=np.array([0, bad_node])
-            )
+            with pytest.raises(OverflowError):
+                tables.simplify(samples=np.array([0, bad_node]))
 
 
-class TestTableCollection(unittest.TestCase):
+class TestTableCollection:
     """
     Tests for the convenience wrapper around a collection of related tables.
     """
@@ -2186,20 +2221,20 @@ class TestTableCollection(unittest.TestCase):
         before_provenances = str(tables.provenances)
         provenances = tables.provenances
         del tables
-        self.assertEqual(str(individuals), before_individuals)
-        self.assertEqual(str(nodes), before_nodes)
-        self.assertEqual(str(edges), before_edges)
-        self.assertEqual(str(migrations), before_migrations)
-        self.assertEqual(str(sites), before_sites)
-        self.assertEqual(str(mutations), before_mutations)
-        self.assertEqual(str(populations), before_populations)
-        self.assertEqual(str(provenances), before_provenances)
+        assert str(individuals) == before_individuals
+        assert str(nodes) == before_nodes
+        assert str(edges) == before_edges
+        assert str(migrations) == before_migrations
+        assert str(sites) == before_sites
+        assert str(mutations) == before_mutations
+        assert str(populations) == before_populations
+        assert str(provenances) == before_provenances
 
     def test_str(self):
         ts = msprime.simulate(10, random_seed=1)
         tables = ts.tables
         s = str(tables)
-        self.assertGreater(len(s), 0)
+        assert len(s) > 0
 
     def test_asdict(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
@@ -2220,10 +2255,10 @@ class TestTableCollection(unittest.TestCase):
             "provenances": t.provenances.asdict(),
         }
         d2 = t.asdict()
-        self.assertEqual(set(d1.keys()), set(d2.keys()))
+        assert set(d1.keys()) == set(d2.keys())
         t1 = tskit.TableCollection.fromdict(d1)
         t2 = tskit.TableCollection.fromdict(d2)
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def test_from_dict(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
@@ -2244,17 +2279,17 @@ class TestTableCollection(unittest.TestCase):
             "provenances": t1.provenances.asdict(),
         }
         t2 = tskit.TableCollection.fromdict(d)
-        self.assertEquals(t1, t2)
+        assert t1 == t2
 
     def test_roundtrip_dict(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
         t1 = ts.tables
         t2 = tskit.TableCollection.fromdict(t1.asdict())
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
         self.add_metadata(t1)
         t2 = tskit.TableCollection.fromdict(t1.asdict())
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def test_name_map(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
@@ -2270,19 +2305,18 @@ class TestTableCollection(unittest.TestCase):
             "provenances": tables.provenances,
         }
         td2 = tables.name_map
-        self.assertIsInstance(td2, dict)
-        self.assertEqual(set(td1.keys()), set(td2.keys()))
+        assert isinstance(td2, dict)
+        assert set(td1.keys()) == set(td2.keys())
         for name in td2.keys():
-            self.assertEqual(td1[name], td2[name])
-        self.assertEqual(td1, td2)
+            assert td1[name] == td2[name]
+        assert td1 == td2
 
     def test_equals_empty(self):
-        self.assertEqual(tskit.TableCollection(), tskit.TableCollection())
+        assert tskit.TableCollection() == tskit.TableCollection()
 
     def test_equals_sequence_length(self):
-        self.assertNotEqual(
-            tskit.TableCollection(sequence_length=1),
-            tskit.TableCollection(sequence_length=2),
+        assert tskit.TableCollection(sequence_length=1) != tskit.TableCollection(
+            sequence_length=2
         )
 
     def test_copy(self):
@@ -2296,10 +2330,10 @@ class TestTableCollection(unittest.TestCase):
             random_seed=100,
         ).dump_tables()
         t2 = t1.copy()
-        self.assertIsNot(t1, t2)
-        self.assertEqual(t1, t2)
+        assert t1 is not t2
+        assert t1 == t2
         t1.edges.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
 
     def test_equals(self):
         pop_configs = [msprime.PopulationConfiguration(5) for _ in range(2)]
@@ -2318,69 +2352,69 @@ class TestTableCollection(unittest.TestCase):
             record_migrations=True,
             random_seed=1,
         ).dump_tables()
-        self.assertEqual(t1, t1)
-        self.assertEqual(t1, t1.copy())
-        self.assertEqual(t1.copy(), t1)
+        assert t1 == t1
+        assert t1 == t1.copy()
+        assert t1.copy() == t1
 
         # The provenances may or may not be equal depending on the clock
         # precision for record. So clear them first.
         t1.provenances.clear()
         t2.provenances.clear()
-        self.assertEqual(t1, t2)
-        self.assertTrue(t1 == t2)
-        self.assertFalse(t1 != t2)
+        assert t1 == t2
+        assert t1 == t2
+        assert not (t1 != t2)
 
         t1.nodes.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
         t2.nodes.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
         t1.edges.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
         t2.edges.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
         t1.migrations.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
         t2.migrations.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
         t1.sites.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
         t2.sites.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
         t1.mutations.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
         t2.mutations.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
         t1.populations.clear()
-        self.assertNotEqual(t1, t2)
+        assert t1 != t2
         t2.populations.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def test_sequence_length(self):
         for sequence_length in [0, 1, 100.1234]:
             tables = tskit.TableCollection(sequence_length=sequence_length)
-            self.assertEqual(tables.sequence_length, sequence_length)
+            assert tables.sequence_length == sequence_length
 
     def test_uuid_simulation(self):
         ts = msprime.simulate(10, random_seed=1)
         tables = ts.tables
-        self.assertIsNone(tables.file_uuid, None)
+        assert tables.file_uuid is None, None
 
     def test_uuid_empty(self):
         tables = tskit.TableCollection(sequence_length=1)
-        self.assertIsNone(tables.file_uuid, None)
+        assert tables.file_uuid is None, None
 
     def test_empty_indexes(self):
         tables = tskit.TableCollection(sequence_length=1)
-        self.assertFalse(tables.has_index())
+        assert not tables.has_index()
         tables.build_index()
-        self.assertTrue(tables.has_index())
+        assert tables.has_index()
         tables.drop_index()
-        self.assertFalse(tables.has_index())
+        assert not tables.has_index()
 
     def test_index_unsorted(self):
         tables = tskit.TableCollection(sequence_length=1)
@@ -2394,79 +2428,79 @@ class TestTableCollection(unittest.TestCase):
         tables.edges.add_row(0, 1, 4, 3)
         tables.edges.add_row(0, 1, 4, 2)
 
-        self.assertFalse(tables.has_index())
-        with self.assertRaises(tskit.LibraryError):
+        assert not tables.has_index()
+        with pytest.raises(tskit.LibraryError):
             tables.build_index()
-        self.assertFalse(tables.has_index())
+        assert not tables.has_index()
         tables.sort()
         tables.build_index()
-        self.assertTrue(tables.has_index())
+        assert tables.has_index()
         ts = tables.tree_sequence()
-        self.assertEqual(ts.tables, tables)
+        assert ts.tables == tables
 
     def test_index_from_ts(self):
         ts = msprime.simulate(10, random_seed=1)
         tables = ts.dump_tables()
-        self.assertTrue(tables.has_index())
+        assert tables.has_index()
         tables.drop_index()
-        self.assertFalse(tables.has_index())
+        assert not tables.has_index()
         ts = tables.tree_sequence()
-        self.assertEqual(ts.tables, tables)
-        self.assertFalse(tables.has_index())
+        assert ts.tables == tables
+        assert not tables.has_index()
 
     def test_set_sequence_length_errors(self):
         tables = tskit.TableCollection(1)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del tables.sequence_length
         for bad_value in ["asdf", None, []]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 tables.sequence_length = bad_value
 
     def test_set_sequence_length(self):
         tables = tskit.TableCollection(1)
         for value in [-1, 100, 2 ** 32, 1e-6]:
             tables.sequence_length = value
-            self.assertEqual(tables.sequence_length, value)
+            assert tables.sequence_length == value
 
     def test_bad_sequence_length(self):
         tables = msprime.simulate(10, random_seed=1).dump_tables()
-        self.assertEqual(tables.sequence_length, 1)
+        assert tables.sequence_length == 1
         for value in [-1, 0, -0.99, 0.9999]:
             tables.sequence_length = value
-            with self.assertRaises(tskit.LibraryError):
+            with pytest.raises(tskit.LibraryError):
                 tables.tree_sequence()
-            with self.assertRaises(tskit.LibraryError):
+            with pytest.raises(tskit.LibraryError):
                 tables.sort()
-            with self.assertRaises(tskit.LibraryError):
+            with pytest.raises(tskit.LibraryError):
                 tables.build_index()
-            with self.assertRaises(tskit.LibraryError):
+            with pytest.raises(tskit.LibraryError):
                 tables.compute_mutation_parents()
-            with self.assertRaises(tskit.LibraryError):
+            with pytest.raises(tskit.LibraryError):
                 tables.simplify()
-            self.assertEqual(tables.sequence_length, value)
+            assert tables.sequence_length == value
 
     def test_sequence_length_longer_than_edges(self):
         tables = msprime.simulate(10, random_seed=1).dump_tables()
         tables.sequence_length = 2
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 2)
-        self.assertEqual(ts.num_trees, 2)
+        assert ts.sequence_length == 2
+        assert ts.num_trees == 2
         trees = ts.trees()
         tree = next(trees)
-        self.assertGreater(len(tree.parent_dict), 0)
+        assert len(tree.parent_dict) > 0
         tree = next(trees)
-        self.assertEqual(len(tree.parent_dict), 0)
+        assert len(tree.parent_dict) == 0
 
 
-class TestTableCollectionMethodSignatures(unittest.TestCase):
+class TestTableCollectionMethodSignatures:
     tc = msprime.simulate(10, random_seed=1234).dump_tables()
 
     def test_kwargs_only(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.tc.simplify([], True)
 
 
-class TestTableCollectionMetadata(unittest.TestCase):
+class TestTableCollectionMetadata:
 
     metadata_schema = metadata.MetadataSchema(
         {
@@ -2496,62 +2530,62 @@ class TestTableCollectionMetadata(unittest.TestCase):
         tc = tskit.TableCollection(1)
         metadata_schema2 = metadata.MetadataSchema({"codec": "json"})
         # Default is no-op metadata codec
-        self.assertEqual(str(tc.metadata_schema), str(metadata.MetadataSchema(None)))
+        assert str(tc.metadata_schema) == str(metadata.MetadataSchema(None))
         # Set
         tc.metadata_schema = self.metadata_schema
-        self.assertEqual(str(tc.metadata_schema), str(self.metadata_schema))
+        assert str(tc.metadata_schema) == str(self.metadata_schema)
         # Overwrite
         tc.metadata_schema = metadata_schema2
-        self.assertEqual(str(tc.metadata_schema), str(metadata_schema2))
+        assert str(tc.metadata_schema) == str(metadata_schema2)
         # Remove
         tc.metadata_schema = ""
-        self.assertEqual(str(tc.metadata_schema), str(metadata.MetadataSchema(None)))
+        assert str(tc.metadata_schema) == str(metadata.MetadataSchema(None))
         # Set after remove
         tc.metadata_schema = self.metadata_schema
-        self.assertEqual(str(tc.metadata_schema), str(self.metadata_schema))
+        assert str(tc.metadata_schema) == str(self.metadata_schema)
         # Del should fail
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del tc.metadata_schema
         # None should fail
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tc.metadata_schema = None
 
     def test_set_metadata(self):
         tc = tskit.TableCollection(1)
         # Default is empty bytes
-        self.assertEqual(tc.metadata, b"")
-        self.assertEqual(tc.metadata_bytes, b"")
+        assert tc.metadata == b""
+        assert tc.metadata_bytes == b""
 
         tc.metadata_schema = self.metadata_schema
         md1 = self.metadata_example_data()
         md2 = self.metadata_example_data(val=2)
         # Set
         tc.metadata = md1
-        self.assertEqual(tc.metadata, md1)
-        self.assertEqual(tc.metadata_bytes, tskit.canonical_json(md1).encode())
+        assert tc.metadata == md1
+        assert tc.metadata_bytes == tskit.canonical_json(md1).encode()
         # Overwrite
         tc.metadata = md2
-        self.assertEqual(tc.metadata, md2)
-        self.assertEqual(tc.metadata_bytes, tskit.canonical_json(md2).encode())
+        assert tc.metadata == md2
+        assert tc.metadata_bytes == tskit.canonical_json(md2).encode()
         # Del should fail
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del tc.metadata
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             del tc.metadata_bytes
         # None should fail
-        with self.assertRaises(exceptions.MetadataValidationError):
+        with pytest.raises(exceptions.MetadataValidationError):
             tc.metadata = None
         # Setting bytes should fail
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             tc.metadata_bytes = b"123"
 
     def test_default_metadata_schema(self):
         # Default should allow bytes
         tc = tskit.TableCollection(1)
         tc.metadata = b"acceptable bytes"
-        self.assertEqual(tc.metadata, b"acceptable bytes")
+        assert tc.metadata == b"acceptable bytes"
         # Adding non-bytes metadata should error
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tc.metadata = self.metadata_example_data()
 
     def test_round_trip_metadata(self):
@@ -2559,17 +2593,17 @@ class TestTableCollectionMetadata(unittest.TestCase):
         tc = tskit.TableCollection(1)
         tc.metadata_schema = self.metadata_schema
         tc.metadata = data
-        self.assertDictEqual(tc.metadata, data)
-        self.assertEqual(tc.metadata_bytes, tskit.canonical_json(data).encode())
+        assert tc.metadata == data
+        assert tc.metadata_bytes == tskit.canonical_json(data).encode()
 
     def test_bad_metadata(self):
         metadata = self.metadata_example_data()
         metadata["I really shouldn't be here"] = 6
         tc = tskit.TableCollection(1)
         tc.metadata_schema = self.metadata_schema
-        with self.assertRaises(exceptions.MetadataValidationError):
+        with pytest.raises(exceptions.MetadataValidationError):
             tc.metadata = metadata
-        self.assertEqual(tc._ll_tables.metadata, b"")
+        assert tc._ll_tables.metadata == b""
 
 
 class TestTableCollectionPickle(TestTableCollection):
@@ -2580,7 +2614,7 @@ class TestTableCollectionPickle(TestTableCollection):
     def verify(self, tables):
         self.add_metadata(tables)
         other_tables = pickle.loads(pickle.dumps(tables))
-        self.assertEqual(tables, other_tables)
+        assert tables == other_tables
 
     def test_simple_simulation(self):
         ts = msprime.simulate(2, random_seed=1)
@@ -2600,20 +2634,20 @@ class TestTableCollectionPickle(TestTableCollection):
 
     def test_simulation_sites(self):
         ts = msprime.simulate(12, random_seed=1, mutation_rate=5)
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_sites > 1
         self.verify(ts.dump_tables())
 
     def test_simulation_individuals(self):
         ts = msprime.simulate(100, random_seed=1)
         ts = tsutil.insert_random_ploidy_individuals(ts, seed=1)
-        self.assertGreater(ts.num_individuals, 1)
+        assert ts.num_individuals > 1
         self.verify(ts.dump_tables())
 
     def test_empty_tables(self):
         self.verify(tskit.TableCollection())
 
 
-class TestDeduplicateSites(unittest.TestCase):
+class TestDeduplicateSites:
     """
     Tests for the TableCollection.deduplicate_sites method.
     """
@@ -2621,11 +2655,11 @@ class TestDeduplicateSites(unittest.TestCase):
     def test_empty(self):
         tables = tskit.TableCollection(1)
         tables.deduplicate_sites()
-        self.assertEqual(tables, tskit.TableCollection(1))
+        assert tables == tskit.TableCollection(1)
 
     def test_unsorted(self):
         tables = msprime.simulate(10, mutation_rate=1, random_seed=1).dump_tables()
-        self.assertGreater(len(tables.sites), 0)
+        assert len(tables.sites) > 0
         position = tables.sites.position
         for _ in range(len(position) - 1):
             position = np.roll(position, 1)
@@ -2634,50 +2668,52 @@ class TestDeduplicateSites(unittest.TestCase):
                 ancestral_state=tables.sites.ancestral_state,
                 ancestral_state_offset=tables.sites.ancestral_state_offset,
             )
-            self.assertRaises(_tskit.LibraryError, tables.deduplicate_sites)
+            with pytest.raises(_tskit.LibraryError):
+                tables.deduplicate_sites()
 
     def test_bad_position(self):
         for bad_position in [-1, -0.001]:
             tables = tskit.TableCollection()
             tables.sites.add_row(bad_position, "0")
-            self.assertRaises(_tskit.LibraryError, tables.deduplicate_sites)
+            with pytest.raises(_tskit.LibraryError):
+                tables.deduplicate_sites()
 
     def test_no_effect(self):
         t1 = msprime.simulate(10, mutation_rate=1, random_seed=1).dump_tables()
         t2 = msprime.simulate(10, mutation_rate=1, random_seed=1).dump_tables()
-        self.assertGreater(len(t1.sites), 0)
+        assert len(t1.sites) > 0
         t1.deduplicate_sites()
         t1.provenances.clear()
         t2.provenances.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def test_same_sites(self):
         t1 = msprime.simulate(10, mutation_rate=1, random_seed=1).dump_tables()
         t2 = msprime.simulate(10, mutation_rate=1, random_seed=1).dump_tables()
-        self.assertGreater(len(t1.sites), 0)
+        assert len(t1.sites) > 0
         t1.sites.append_columns(
             position=t1.sites.position,
             ancestral_state=t1.sites.ancestral_state,
             ancestral_state_offset=t1.sites.ancestral_state_offset,
         )
-        self.assertEqual(len(t1.sites), 2 * len(t2.sites))
+        assert len(t1.sites) == 2 * len(t2.sites)
         t1.sort()
         t1.deduplicate_sites()
         t1.provenances.clear()
         t2.provenances.clear()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def test_order_maintained(self):
         t1 = tskit.TableCollection(1)
         t1.sites.add_row(position=0, ancestral_state="first")
         t1.sites.add_row(position=0, ancestral_state="second")
         t1.deduplicate_sites()
-        self.assertEqual(len(t1.sites), 1)
-        self.assertEqual(t1.sites.ancestral_state.tobytes(), b"first")
+        assert len(t1.sites) == 1
+        assert t1.sites.ancestral_state.tobytes() == b"first"
 
     def test_multichar_ancestral_state(self):
         ts = msprime.simulate(8, random_seed=3, mutation_rate=1)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         tables = ts.dump_tables()
         tables.sites.clear()
         tables.mutations.clear()
@@ -2692,13 +2728,13 @@ class TestDeduplicateSites(unittest.TestCase):
                 )
         tables.deduplicate_sites()
         new_ts = tables.tree_sequence()
-        self.assertEqual(new_ts.num_sites, ts.num_sites)
+        assert new_ts.num_sites == ts.num_sites
         for site in new_ts.sites():
-            self.assertEqual(site.ancestral_state, site.id * "A")
+            assert site.ancestral_state == site.id * "A"
 
     def test_multichar_metadata(self):
         ts = msprime.simulate(8, random_seed=3, mutation_rate=1)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         tables = ts.dump_tables()
         tables.sites.clear()
         tables.mutations.clear()
@@ -2716,23 +2752,23 @@ class TestDeduplicateSites(unittest.TestCase):
                 )
         tables.deduplicate_sites()
         new_ts = tables.tree_sequence()
-        self.assertEqual(new_ts.num_sites, ts.num_sites)
+        assert new_ts.num_sites == ts.num_sites
         for site in new_ts.sites():
-            self.assertEqual(site.metadata, site.id * b"A")
+            assert site.metadata == site.id * b"A"
 
 
-class TestBaseTable(unittest.TestCase):
+class TestBaseTable:
     """
     Tests of the table superclass.
     """
 
     def test_set_columns_not_implemented(self):
         t = tskit.BaseTable(None, None)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             t.set_columns()
 
 
-class TestSubsetTables(unittest.TestCase):
+class TestSubsetTables:
     """
     Tests for the TableCollection.subset method.
     """
@@ -2776,7 +2812,7 @@ class TestSubsetTables(unittest.TestCase):
         sub2 = tables.copy()
         tsutil.py_subset(sub1, nodes, record_provenance=False)
         sub2.subset(nodes, record_provenance=False)
-        self.assertEqual(sub1, sub2)
+        assert sub1 == sub2
 
     def verify_subset(self, tables, nodes):
         self.verify_subset_equality(tables, nodes)
@@ -2798,35 +2834,35 @@ class TestSubsetTables(unittest.TestCase):
         ind_map[indivs] = np.arange(len(indivs), dtype="int32")
         pop_map = np.repeat(tskit.NULL, tables.populations.num_rows + 1)
         pop_map[pops] = np.arange(len(pops), dtype="int32")
-        self.assertEqual(subset.nodes.num_rows, len(nodes))
+        assert subset.nodes.num_rows == len(nodes)
         for k, n in zip(nodes, subset.nodes):
             nn = tables.nodes[k]
-            self.assertEqual(nn.time, n.time)
-            self.assertEqual(nn.flags, n.flags)
-            self.assertEqual(nn.metadata, n.metadata)
-            self.assertEqual(ind_map[nn.individual], n.individual)
-            self.assertEqual(pop_map[nn.population], n.population)
-        self.assertEqual(subset.individuals.num_rows, len(indivs))
+            assert nn.time == n.time
+            assert nn.flags == n.flags
+            assert nn.metadata == n.metadata
+            assert ind_map[nn.individual] == n.individual
+            assert pop_map[nn.population] == n.population
+        assert subset.individuals.num_rows == len(indivs)
         for k, i in zip(indivs, subset.individuals):
             ii = tables.individuals[k]
-            self.assertEqual(ii, i)
-        self.assertEqual(subset.populations.num_rows, len(pops))
+            assert ii == i
+        assert subset.populations.num_rows == len(pops)
         for k, p in zip(pops, subset.populations):
             pp = tables.populations[k]
-            self.assertEqual(pp, p)
+            assert pp == p
         edges = [
             i
             for i, e in enumerate(tables.edges)
             if e.parent in nodes and e.child in nodes
         ]
-        self.assertEqual(subset.edges.num_rows, len(edges))
+        assert subset.edges.num_rows == len(edges)
         for k, e in zip(edges, subset.edges):
             ee = tables.edges[k]
-            self.assertEqual(ee.left, e.left)
-            self.assertEqual(ee.right, e.right)
-            self.assertEqual(node_map[ee.parent], e.parent)
-            self.assertEqual(node_map[ee.child], e.child)
-            self.assertEqual(ee.metadata, e.metadata)
+            assert ee.left == e.left
+            assert ee.right == e.right
+            assert node_map[ee.parent] == e.parent
+            assert node_map[ee.child] == e.child
+            assert ee.metadata == e.metadata
         muts = []
         sites = []
         for k, m in enumerate(tables.mutations):
@@ -2838,20 +2874,20 @@ class TestSubsetTables(unittest.TestCase):
         site_map[sites] = np.arange(len(sites), dtype="int32")
         mutation_map = np.repeat(tskit.NULL, tables.mutations.num_rows + 1)
         mutation_map[muts] = np.arange(len(muts), dtype="int32")
-        self.assertEqual(subset.sites.num_rows, len(sites))
+        assert subset.sites.num_rows == len(sites)
         for k, s in zip(sites, subset.sites):
             ss = tables.sites[k]
-            self.assertEqual(ss, s)
-        self.assertEqual(subset.mutations.num_rows, len(muts))
+            assert ss == s
+        assert subset.mutations.num_rows == len(muts)
         for k, m in zip(muts, subset.mutations):
             mm = tables.mutations[k]
-            self.assertEqual(mutation_map[mm.parent], m.parent)
-            self.assertEqual(site_map[mm.site], m.site)
-            self.assertEqual(node_map[mm.node], m.node)
-            self.assertEqual(mm.derived_state, m.derived_state)
-            self.assertEqual(mm.metadata, m.metadata)
-        self.assertEqual(tables.migrations, subset.migrations)
-        self.assertEqual(tables.provenances, subset.provenances)
+            assert mutation_map[mm.parent] == m.parent
+            assert site_map[mm.site] == m.site
+            assert node_map[mm.node] == m.node
+            assert mm.derived_state == m.derived_state
+            assert mm.metadata == m.metadata
+        assert tables.migrations == subset.migrations
+        assert tables.provenances == subset.provenances
 
     def test_ts_subset(self):
         nodes = np.array([0, 1])
@@ -2859,7 +2895,7 @@ class TestSubsetTables(unittest.TestCase):
             ts = tables.tree_sequence()
             tables2 = ts.subset(nodes, record_provenance=False).dump_tables()
             tables.subset(nodes, record_provenance=False)
-            self.assertEqual(tables, tables2)
+            assert tables == tables2
 
     def test_subset_all(self):
         # subsetting to everything shouldn't change things
@@ -2874,7 +2910,7 @@ class TestSubsetTables(unittest.TestCase):
             tables2.individuals.clear()
             tables.nodes.clear()
             tables2.nodes.clear()
-            self.assertEqual(tables, tables2)
+            assert tables == tables2
 
     def test_random_subsets(self):
         rng = np.random.default_rng(1542)
@@ -2887,14 +2923,14 @@ class TestSubsetTables(unittest.TestCase):
         for tables in self.get_examples(8724):
             subset = tables.copy()
             subset.subset(np.array([]), record_provenance=False)
-            self.assertEqual(subset.nodes.num_rows, 0)
-            self.assertEqual(subset.edges.num_rows, 0)
-            self.assertEqual(subset.populations.num_rows, 0)
-            self.assertEqual(subset.individuals.num_rows, 0)
-            self.assertEqual(subset.migrations.num_rows, 0)
-            self.assertEqual(subset.sites.num_rows, 0)
-            self.assertEqual(subset.mutations.num_rows, 0)
-            self.assertEqual(subset.provenances, tables.provenances)
+            assert subset.nodes.num_rows == 0
+            assert subset.edges.num_rows == 0
+            assert subset.populations.num_rows == 0
+            assert subset.individuals.num_rows == 0
+            assert subset.migrations.num_rows == 0
+            assert subset.sites.num_rows == 0
+            assert subset.mutations.num_rows == 0
+            assert subset.provenances == tables.provenances
 
 
 class TestUnion(unittest.TestCase):
@@ -2968,7 +3004,7 @@ class TestUnion(unittest.TestCase):
             record_provenance=False,
             add_populations=add_populations,
         )
-        self.assertEqual(uni1, uni2)
+        assert uni1 == uni2
         # verifying that subsetting to original nodes return the same table
         orig_nodes = [j for i, j in enumerate(node_mapping) if j != tskit.NULL]
         uni1.subset(orig_nodes)
@@ -2976,7 +3012,7 @@ class TestUnion(unittest.TestCase):
         tables.subset(orig_nodes)
         uni1.provenances.clear()
         tables.provenances.clear()
-        self.assertEqual(uni1, tables)
+        assert uni1 == tables
 
     def test_noshared_example(self):
         ts1 = self.get_msprime_example(sample_size=3, T=2, seed=9328)
@@ -2985,14 +3021,14 @@ class TestUnion(unittest.TestCase):
         uni1 = ts1.union(ts2, node_mapping, record_provenance=False)
         uni2_tables = ts1.dump_tables()
         tsutil.py_union(uni2_tables, ts2.tables, node_mapping, record_provenance=False)
-        self.assertEqual(uni1.tables, uni2_tables)
+        assert uni1.tables == uni2_tables
 
     def test_all_shared_example(self):
         tables = self.get_wf_example(N=5, T=5, seed=11349).dump_tables()
         uni = tables.copy()
         node_mapping = np.arange(tables.nodes.num_rows)
         uni.union(tables, node_mapping, record_provenance=False)
-        self.assertEqual(uni, tables)
+        assert uni == tables
 
     def test_no_add_pop(self):
         self.verify_union_equality(
@@ -3013,16 +3049,14 @@ class TestUnion(unittest.TestCase):
             "other"
         ]
         recovered_prov_table = tskit.ProvenanceTable()
-        self.assertEqual(
-            len(uni_other_dict["timestamp"]), len(uni_other_dict["record"])
-        )
+        assert len(uni_other_dict["timestamp"]) == len(uni_other_dict["record"])
         for timestamp, record in zip(
             uni_other_dict["timestamp"], uni_other_dict["record"]
         ):
             recovered_prov_table.add_row(record, timestamp)
-        self.assertEqual(recovered_prov_table, other.provenances)
+        assert recovered_prov_table == other.provenances
         tables.provenances.truncate(tables.provenances.num_rows - 1)
-        self.assertEqual(tables.provenances, tables_copy.provenances)
+        assert tables.provenances == tables_copy.provenances
 
     def test_examples(self):
         for N in [2, 4, 5]:

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -921,7 +921,7 @@ class TestIndividualTable(CommonTestsMixin, MetadataTestsMixin):
         assert a == b
 
 
-class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
+class TestNodeTable(CommonTestsMixin, MetadataTestsMixin):
 
     columns = [
         UInt32Column("flags"),
@@ -1988,7 +1988,8 @@ class TestSimplifyTables:
         ts = msprime.simulate(10, mutation_rate=1, random_seed=self.random_seed)
         for filter_sites in [True, False]:
             t1 = ts.dump_tables()
-            t1.simplify([0, 1], filter_zero_mutation_sites=filter_sites)
+            with pytest.deprecated_call():
+                t1.simplify([0, 1], filter_zero_mutation_sites=filter_sites)
             t2 = ts.dump_tables()
             t2.simplify([0, 1], filter_sites=filter_sites)
             t1.provenances.clear()

--- a/python/tests/test_threads.py
+++ b/python/tests/test_threads.py
@@ -25,10 +25,10 @@ Test cases for threading enabled aspects of the API.
 """
 import platform
 import threading
-import unittest
 
 import msprime
 import numpy as np
+import pytest
 
 import tests.tsutil as tsutil
 import tskit
@@ -48,7 +48,7 @@ def run_threads(worker, num_threads):
     return results
 
 
-class TestLdCalculatorReplicates(unittest.TestCase):
+class TestLdCalculatorReplicates:
     """
     Tests the LdCalculator object to ensure we get correct results
     when using threads.
@@ -80,7 +80,7 @@ class TestLdCalculatorReplicates(unittest.TestCase):
 
         results = run_threads(worker, m)
         for j in range(m):
-            self.assertTrue(np.allclose(results[j], A[j]))
+            assert np.allclose(results[j], A[j])
 
     def test_get_r2_single_instance(self):
         # This is the degenerate case where we have a single LdCalculator
@@ -99,7 +99,7 @@ class TestLdCalculatorReplicates(unittest.TestCase):
 
         results = run_threads(worker, m)
         for j in range(m):
-            self.assertTrue(np.allclose(results[j], A[j]))
+            assert np.allclose(results[j], A[j])
 
     def test_get_r2_array_multiple_instances(self):
         # This is the nominal case where we have a separate LdCalculator
@@ -116,7 +116,7 @@ class TestLdCalculatorReplicates(unittest.TestCase):
 
         results = run_threads(worker, m)
         for j in range(m):
-            self.assertTrue(np.allclose(results[j], A[j, j + 1 :]))
+            assert np.allclose(results[j], A[j, j + 1 :])
 
     def test_get_r2_array_single_instance(self):
         # This is the degenerate case where we have a single LdCalculator
@@ -135,13 +135,13 @@ class TestLdCalculatorReplicates(unittest.TestCase):
 
         results = run_threads(worker, m)
         for j in range(m):
-            self.assertEqual(results[j][0], m - j - 1)
+            assert results[j][0] == m - j - 1
 
 
 # Temporarily skipping these on Windows. See
 # https://github.com/jeromekelleher/tskit/issues/344
-@unittest.skipIf(IS_WINDOWS, "Cannot test thread support on Windows.")
-class TestTables(unittest.TestCase):
+@pytest.mark.skipif(IS_WINDOWS, reason="Can't test thread support on Windows.")
+class TestTables:
     """
     Tests to ensure that attempts to access tables in threads correctly
     raise an exception.
@@ -171,8 +171,8 @@ class TestTables(unittest.TestCase):
         successes = num_writers - failures
         # Note: we would like to insist that #failures is > 0, but this is too
         # stochastic to guarantee for test purposes.
-        self.assertGreaterEqual(failures, 0)
-        self.assertGreater(successes, 0)
+        assert failures >= 0
+        assert successes > 0
 
     def run_failing_reader(self, writer, reader, num_readers=32):
         """
@@ -203,8 +203,8 @@ class TestTables(unittest.TestCase):
         successes = num_readers - failures
         # Note: we would like to insist that #failures is > 0, but this is too
         # stochastic to guarantee for test purposes.
-        self.assertGreaterEqual(failures, 0)
-        self.assertGreater(successes, 0)
+        assert failures >= 0
+        assert successes > 0
 
     def test_many_simplify_all_tables(self):
         tables = self.get_tables()

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -34,6 +34,7 @@ import unittest
 
 import msprime
 import numpy as np
+import pytest
 
 import _tskit
 import tests as tests
@@ -288,17 +289,17 @@ class ExampleTopologyMixin:
 
     def test_coalescent_trees(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=1, length=2)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify(ts)
 
     def test_coalescent_trees_internal_samples(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=10, length=2)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify(tsutil.jiggle_samples(ts))
 
     def test_coalescent_trees_all_samples(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=10, length=2)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         tables = ts.dump_tables()
         flags = np.zeros_like(tables.nodes.flags) + tskit.NODE_IS_SAMPLE
         tables.nodes.flags = flags
@@ -339,12 +340,12 @@ class ExampleTopologyMixin:
         for e in ts.edgesets():
             if len(e.children) > 2:
                 found = True
-        self.assertTrue(found)
+        assert found
         self.verify(ts)
 
     def test_many_multiroot_trees(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         self.verify(ts)
 
@@ -364,14 +365,14 @@ class TestKCMetric(unittest.TestCase):
             for seed in range(1, 10):
                 ts = msprime.simulate(n, random_seed=seed)
                 tree = next(ts.trees(sample_lists=True))
-                self.assertEqual(naive_kc_distance(tree, tree), 0)
-                self.assertEqual(c_kc_distance(tree, tree), 0)
-                self.assertEqual(tree.kc_distance(tree), 0)
+                assert naive_kc_distance(tree, tree) == 0
+                assert c_kc_distance(tree, tree) == 0
+                assert tree.kc_distance(tree) == 0
                 ts = msprime.simulate(n, random_seed=seed)
                 tree2 = next(ts.trees(sample_lists=True))
-                self.assertEqual(naive_kc_distance(tree, tree2), 0)
-                self.assertEqual(c_kc_distance(tree, tree2), 0)
-                self.assertEqual(tree.kc_distance(tree2), 0)
+                assert naive_kc_distance(tree, tree2) == 0
+                assert c_kc_distance(tree, tree2) == 0
+                assert tree.kc_distance(tree2) == 0
 
     def test_sample_2_zero_distance(self):
         # All trees with 2 leaves must be equal distance from each other.
@@ -380,25 +381,31 @@ class TestKCMetric(unittest.TestCase):
             tree1 = next(ts1.trees(sample_lists=True))
             ts2 = msprime.simulate(2, random_seed=seed + 1)
             tree2 = next(ts2.trees(sample_lists=True))
-            self.assertEqual(naive_kc_distance(tree1, tree2, 0), 0)
-            self.assertEqual(c_kc_distance(tree1, tree2, 0), 0)
-            self.assertEqual(tree1.kc_distance(tree2, 0), 0)
+            assert naive_kc_distance(tree1, tree2, 0) == 0
+            assert c_kc_distance(tree1, tree2, 0) == 0
+            assert tree1.kc_distance(tree2, 0) == 0
 
     def test_different_samples_error(self):
         tree1 = next(msprime.simulate(10, random_seed=1).trees(sample_lists=True))
         tree2 = next(msprime.simulate(2, random_seed=1).trees(sample_lists=True))
-        self.assertRaises(ValueError, naive_kc_distance, tree1, tree2)
-        self.assertRaises(ValueError, c_kc_distance, tree1, tree2)
-        self.assertRaises(_tskit.LibraryError, tree1.kc_distance, tree2)
+        with pytest.raises(ValueError):
+            naive_kc_distance(tree1, tree2)
+        with pytest.raises(ValueError):
+            c_kc_distance(tree1, tree2)
+        with pytest.raises(_tskit.LibraryError):
+            tree1.kc_distance(tree2)
 
         ts1 = msprime.simulate(10, random_seed=1)
         nmap = np.arange(0, ts1.num_nodes)[::-1]
         ts2 = tsutil.permute_nodes(ts1, nmap)
         tree1 = next(ts1.trees(sample_lists=True))
         tree2 = next(ts2.trees(sample_lists=True))
-        self.assertRaises(ValueError, naive_kc_distance, tree1, tree2)
-        self.assertRaises(ValueError, c_kc_distance, tree1, tree2)
-        self.assertRaises(_tskit.LibraryError, tree1.kc_distance, tree2)
+        with pytest.raises(ValueError):
+            naive_kc_distance(tree1, tree2)
+        with pytest.raises(ValueError):
+            c_kc_distance(tree1, tree2)
+        with pytest.raises(_tskit.LibraryError):
+            tree1.kc_distance(tree2)
 
         unsimplified_ts = msprime.simulate(
             10, random_seed=1, recombination_rate=10, record_full_arg=True
@@ -406,9 +413,12 @@ class TestKCMetric(unittest.TestCase):
         trees = unsimplified_ts.trees(sample_lists=True)
         tree1 = next(trees)
         tree2 = next(trees)
-        self.assertRaises(ValueError, naive_kc_distance, tree1, tree2)
-        self.assertRaises(ValueError, c_kc_distance, tree1, tree2)
-        self.assertRaises(_tskit.LibraryError, tree1.kc_distance, tree2)
+        with pytest.raises(ValueError):
+            naive_kc_distance(tree1, tree2)
+        with pytest.raises(ValueError):
+            c_kc_distance(tree1, tree2)
+        with pytest.raises(_tskit.LibraryError):
+            tree1.kc_distance(tree2)
 
     def validate_trees(self, n):
         for seed in range(1, 10):
@@ -453,7 +463,7 @@ class TestKCMetric(unittest.TestCase):
                 if len(edgeset.children) > 2:
                     found = True
                     break
-            self.assertTrue(found)
+            assert found
             tree1 = next(ts.trees(sample_lists=True))
 
             ts = msprime.simulate(
@@ -905,11 +915,11 @@ class TestKCMetric(unittest.TestCase):
 
         ts = tables.tree_sequence()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             naive_kc_distance(ts.first(), ts.first(), 0)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             c_kc_distance(ts.first(), ts.first(), 0)
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             ts.first().kc_distance(ts.first(), 0)
 
     def do_kc_distance(self, t1, t2, lambda_=0):
@@ -947,8 +957,8 @@ class TestKCMetric(unittest.TestCase):
         tables1 = tskit.TableCollection(sequence_length=1.0)
         tables1.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0)
         only_root = next(tables1.tree_sequence().trees(sample_lists=True))
-        self.assertEqual(only_root.kc_distance(only_root), 0)
-        self.assertEqual(only_root.kc_distance(only_root, lambda_=1), 0)
+        assert only_root.kc_distance(only_root) == 0
+        assert only_root.kc_distance(only_root, lambda_=1) == 0
 
     def test_non_sample_leaf(self):
         tables = tskit.TableCollection(sequence_length=1.0)
@@ -959,8 +969,8 @@ class TestKCMetric(unittest.TestCase):
         tables.edges.add_row(left=0, right=1, parent=p, child=c2)
         ts = tables.tree_sequence()
         tree = next(ts.trees(sample_lists=True))
-        self.assertEqual(ts.kc_distance(ts), 0)
-        self.assertEqual(tree.kc_distance(tree), 0)
+        assert ts.kc_distance(ts) == 0
+        assert tree.kc_distance(tree) == 0
 
         # mirrored
         tables = tskit.TableCollection(sequence_length=1.0)
@@ -971,8 +981,8 @@ class TestKCMetric(unittest.TestCase):
         tables.edges.add_row(left=0, right=1, parent=p, child=c2)
         ts = tables.tree_sequence()
         tree = next(ts.trees(sample_lists=True))
-        self.assertEqual(ts.kc_distance(ts), 0)
-        self.assertEqual(tree.kc_distance(tree), 0)
+        assert ts.kc_distance(ts) == 0
+        assert tree.kc_distance(tree) == 0
 
     def test_ignores_subtrees_with_no_samples(self):
         nodes_1 = io.StringIO(
@@ -1035,8 +1045,8 @@ class TestKCMetric(unittest.TestCase):
         simplified = tskit.load_text(
             nodes_2, edges_2, sequence_length=1, strict=False, base64_metadata=False
         )
-        self.assertEqual(redundant.kc_distance(simplified, 0), 0)
-        self.assertEqual(redundant.kc_distance(simplified, 1), 0)
+        assert redundant.kc_distance(simplified, 0) == 0
+        assert redundant.kc_distance(simplified, 1) == 0
 
 
 def ts_kc_distance(ts1, ts2, lambda_=0):
@@ -1200,14 +1210,14 @@ class TestKCSequenceMetric(unittest.TestCase):
 
     def test_0_distance_from_self(self):
         ts = msprime.simulate(10)
-        self.assertEqual(ts_kc_distance(ts, ts), 0)
+        assert ts_kc_distance(ts, ts) == 0
 
     def verify_errors(self, ts1, ts2):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts_kc_distance(ts1, ts2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts_kc_distance_incremental(ts1, ts2)
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             ts1.kc_distance(ts2)
 
     def test_errors_diff_seq_length(self):
@@ -1344,7 +1354,7 @@ class TestKCSequenceMetric(unittest.TestCase):
                 if len(edgeset.children) > 2:
                     found = True
                     break
-            self.assertTrue(found)
+            assert found
 
             ts2 = msprime.simulate(
                 n,
@@ -1372,8 +1382,8 @@ class TestKCSequenceMetric(unittest.TestCase):
         tables.edges.add_row(0, 1, 2, 0)
         tables.edges.add_row(0, 1, 2, 1)
         ts = tables.tree_sequence()
-        self.assertEqual(ts.kc_distance(ts), 0)
-        self.assertEqual(ts_kc_distance_incremental(ts, ts), 0)
+        assert ts.kc_distance(ts) == 0
+        assert ts_kc_distance_incremental(ts, ts) == 0
 
     def test_known_kc_sample_trees_different_shapes(self):
         tables_1 = tskit.TableCollection(sequence_length=2.0)
@@ -1572,11 +1582,11 @@ class TestKCSequenceMetric(unittest.TestCase):
         )
         t1 = next(redundant.trees(sample_lists=True))
         t2 = next(simplified.trees(sample_lists=True))
-        self.assertEqual(t1.kc_distance(t2, 0), 0)
-        self.assertEqual(t1.kc_distance(t2, 1), 0)
+        assert t1.kc_distance(t2, 0) == 0
+        assert t1.kc_distance(t2, 1) == 0
 
 
-class TestOverlappingSegments(unittest.TestCase):
+class TestOverlappingSegments:
     """
     Tests for the overlapping segments algorithm required for simplify.
     This test probably belongs somewhere else.
@@ -1585,110 +1595,110 @@ class TestOverlappingSegments(unittest.TestCase):
     def test_random(self):
         segs = generate_segments(10, 20, 1)
         for left, right, X in tests.overlapping_segments(segs):
-            self.assertGreater(right, left)
-            self.assertGreater(len(X), 0)
+            assert right > left
+            assert len(X) > 0
 
     def test_empty(self):
         ret = list(tests.overlapping_segments([]))
-        self.assertEqual(len(ret), 0)
+        assert len(ret) == 0
 
     def test_single_interval(self):
         for j in range(1, 10):
             segs = [tests.Segment(0, 1, j) for _ in range(j)]
             ret = list(tests.overlapping_segments(segs))
-            self.assertEqual(len(ret), 1)
+            assert len(ret) == 1
             left, right, X = ret[0]
-            self.assertEqual(left, 0)
-            self.assertEqual(right, 1)
-            self.assertEqual(sorted(segs), sorted(X))
+            assert left == 0
+            assert right == 1
+            assert sorted(segs) == sorted(X)
 
     def test_stairs_down(self):
         segs = [tests.Segment(0, 1, 0), tests.Segment(0, 2, 1), tests.Segment(0, 3, 2)]
         ret = list(tests.overlapping_segments(segs))
-        self.assertEqual(len(ret), 3)
+        assert len(ret) == 3
 
         left, right, X = ret[0]
-        self.assertEqual(left, 0)
-        self.assertEqual(right, 1)
-        self.assertEqual(sorted(X), sorted(segs))
+        assert left == 0
+        assert right == 1
+        assert sorted(X) == sorted(segs)
 
         left, right, X = ret[1]
-        self.assertEqual(left, 1)
-        self.assertEqual(right, 2)
-        self.assertEqual(sorted(X), sorted(segs[1:]))
+        assert left == 1
+        assert right == 2
+        assert sorted(X) == sorted(segs[1:])
 
         left, right, X = ret[2]
-        self.assertEqual(left, 2)
-        self.assertEqual(right, 3)
-        self.assertEqual(sorted(X), sorted(segs[2:]))
+        assert left == 2
+        assert right == 3
+        assert sorted(X) == sorted(segs[2:])
 
     def test_stairs_up(self):
         segs = [tests.Segment(0, 3, 0), tests.Segment(1, 3, 1), tests.Segment(2, 3, 2)]
         ret = list(tests.overlapping_segments(segs))
-        self.assertEqual(len(ret), 3)
+        assert len(ret) == 3
 
         left, right, X = ret[0]
-        self.assertEqual(left, 0)
-        self.assertEqual(right, 1)
-        self.assertEqual(X, segs[:1])
+        assert left == 0
+        assert right == 1
+        assert X == segs[:1]
 
         left, right, X = ret[1]
-        self.assertEqual(left, 1)
-        self.assertEqual(right, 2)
-        self.assertEqual(sorted(X), sorted(segs[:2]))
+        assert left == 1
+        assert right == 2
+        assert sorted(X) == sorted(segs[:2])
 
         left, right, X = ret[2]
-        self.assertEqual(left, 2)
-        self.assertEqual(right, 3)
-        self.assertEqual(sorted(X), sorted(segs))
+        assert left == 2
+        assert right == 3
+        assert sorted(X) == sorted(segs)
 
     def test_pyramid(self):
         segs = [tests.Segment(0, 5, 0), tests.Segment(1, 4, 1), tests.Segment(2, 3, 2)]
         ret = list(tests.overlapping_segments(segs))
-        self.assertEqual(len(ret), 5)
+        assert len(ret) == 5
 
         left, right, X = ret[0]
-        self.assertEqual(left, 0)
-        self.assertEqual(right, 1)
-        self.assertEqual(X, segs[:1])
+        assert left == 0
+        assert right == 1
+        assert X == segs[:1]
 
         left, right, X = ret[1]
-        self.assertEqual(left, 1)
-        self.assertEqual(right, 2)
-        self.assertEqual(sorted(X), sorted(segs[:2]))
+        assert left == 1
+        assert right == 2
+        assert sorted(X) == sorted(segs[:2])
 
         left, right, X = ret[2]
-        self.assertEqual(left, 2)
-        self.assertEqual(right, 3)
-        self.assertEqual(sorted(X), sorted(segs))
+        assert left == 2
+        assert right == 3
+        assert sorted(X) == sorted(segs)
 
         left, right, X = ret[3]
-        self.assertEqual(left, 3)
-        self.assertEqual(right, 4)
-        self.assertEqual(sorted(X), sorted(segs[:2]))
+        assert left == 3
+        assert right == 4
+        assert sorted(X) == sorted(segs[:2])
 
         left, right, X = ret[4]
-        self.assertEqual(left, 4)
-        self.assertEqual(right, 5)
-        self.assertEqual(sorted(X), sorted(segs[:1]))
+        assert left == 4
+        assert right == 5
+        assert sorted(X) == sorted(segs[:1])
 
     def test_gap(self):
         segs = [tests.Segment(0, 2, 0), tests.Segment(3, 4, 1)]
         ret = list(tests.overlapping_segments(segs))
-        self.assertEqual(len(ret), 2)
+        assert len(ret) == 2
 
         left, right, X = ret[0]
-        self.assertEqual(left, 0)
-        self.assertEqual(right, 2)
-        self.assertEqual(X, segs[:1])
+        assert left == 0
+        assert right == 2
+        assert X == segs[:1]
 
         left, right, X = ret[1]
-        self.assertEqual(left, 3)
-        self.assertEqual(right, 4)
-        self.assertEqual(X, segs[1:])
+        assert left == 3
+        assert right == 4
+        assert X == segs[1:]
 
 
-class TopologyTestCase(unittest.TestCase):
+class TopologyTestCase:
     """
     Superclass of test cases containing common utilities.
     """
@@ -1698,12 +1708,12 @@ class TopologyTestCase(unittest.TestCase):
     def assert_haplotypes_equal(self, ts1, ts2):
         h1 = list(ts1.haplotypes())
         h2 = list(ts2.haplotypes())
-        self.assertEqual(h1, h2)
+        assert h1 == h2
 
     def assert_variants_equal(self, ts1, ts2):
         v1 = list(ts1.variants(as_bytes=True))
         v2 = list(ts2.variants(as_bytes=True))
-        self.assertEqual(v1, v2)
+        assert v1 == v2
 
     def check_num_samples(self, ts, x):
         """
@@ -1717,7 +1727,7 @@ class TopologyTestCase(unittest.TestCase):
             while k < j:
                 t = next(tss)
                 k += 1
-            self.assertEqual(nl, t.num_samples(node))
+            assert nl == t.num_samples(node)
 
     def check_num_tracked_samples(self, ts, tracked_samples, x):
         k = 0
@@ -1727,7 +1737,7 @@ class TopologyTestCase(unittest.TestCase):
             while k < j:
                 t = next(tss)
                 k += 1
-            self.assertEqual(nl, t.num_tracked_samples(node))
+            assert nl == t.num_tracked_samples(node)
 
     def check_sample_iterator(self, ts, x):
         """
@@ -1742,10 +1752,10 @@ class TopologyTestCase(unittest.TestCase):
                 t = next(tss)
                 k += 1
             for u, v in zip(samples, t.samples(node)):
-                self.assertEqual(u, v)
+                assert u == v
 
 
-class TestZeroRoots(unittest.TestCase):
+class TestZeroRoots:
     """
     Tests that for the case in which we have zero samples and therefore
     zero roots in our trees.
@@ -1757,23 +1767,23 @@ class TestZeroRoots(unittest.TestCase):
         return tables.tree_sequence()
 
     def verify(self, ts, no_root_ts):
-        self.assertEqual(ts.num_trees, no_root_ts.num_trees)
+        assert ts.num_trees == no_root_ts.num_trees
         for tree, no_root in zip(ts.trees(), no_root_ts.trees()):
-            self.assertEqual(no_root.num_roots, 0)
-            self.assertEqual(no_root.left_root, tskit.NULL)
-            self.assertEqual(no_root.roots, [])
-            self.assertEqual(tree.parent_dict, no_root.parent_dict)
+            assert no_root.num_roots == 0
+            assert no_root.left_root == tskit.NULL
+            assert no_root.roots == []
+            assert tree.parent_dict == no_root.parent_dict
 
     def test_single_tree(self):
         ts = msprime.simulate(10, random_seed=1)
         no_root_ts = self.remove_samples(ts)
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.num_trees == 1
         self.verify(ts, no_root_ts)
 
     def test_multiple_trees(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=1)
         no_root_ts = self.remove_samples(ts)
-        self.assertGreater(ts.num_trees, 1)
+        assert ts.num_trees > 1
         self.verify(ts, no_root_ts)
 
 
@@ -1785,55 +1795,57 @@ class TestEmptyTreeSequences(TopologyTestCase):
     def test_zero_nodes(self):
         tables = tskit.TableCollection(1)
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 0)
-        self.assertEqual(ts.num_edges, 0)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 0
+        assert ts.num_edges == 0
         t = next(ts.trees())
-        self.assertEqual(t.index, 0)
-        self.assertEqual(t.left_root, tskit.NULL)
-        self.assertEqual(t.interval, (0, 1))
-        self.assertEqual(t.roots, [])
-        self.assertEqual(t.root, tskit.NULL)
-        self.assertEqual(t.parent_dict, {})
-        self.assertEqual(list(t.nodes()), [])
-        self.assertEqual(list(ts.haplotypes()), [])
-        self.assertEqual(list(ts.variants()), [])
+        assert t.index == 0
+        assert t.left_root == tskit.NULL
+        assert t.interval == (0, 1)
+        assert t.roots == []
+        assert t.root == tskit.NULL
+        assert t.parent_dict == {}
+        assert list(t.nodes()) == []
+        assert list(ts.haplotypes()) == []
+        assert list(ts.variants()) == []
         methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
         for method in methods:
             for u in [-1, 0, 1, 100]:
-                self.assertRaises(ValueError, method, u)
+                with pytest.raises(ValueError):
+                    method(u)
         tsp = ts.simplify()
-        self.assertEqual(tsp.num_nodes, 0)
-        self.assertEqual(tsp.num_edges, 0)
+        assert tsp.num_nodes == 0
+        assert tsp.num_edges == 0
 
     def test_one_node_zero_samples(self):
         tables = tskit.TableCollection(sequence_length=1)
         tables.nodes.add_row(time=0, flags=0)
         # Without a sequence length this should fail.
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 1)
-        self.assertEqual(ts.sample_size, 0)
-        self.assertEqual(ts.num_edges, 0)
-        self.assertEqual(ts.num_sites, 0)
-        self.assertEqual(ts.num_mutations, 0)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 1
+        assert ts.sample_size == 0
+        assert ts.num_edges == 0
+        assert ts.num_sites == 0
+        assert ts.num_mutations == 0
         t = next(ts.trees())
-        self.assertEqual(t.index, 0)
-        self.assertEqual(t.left_root, tskit.NULL)
-        self.assertEqual(t.interval, (0, 1))
-        self.assertEqual(t.roots, [])
-        self.assertEqual(t.root, tskit.NULL)
-        self.assertEqual(t.parent_dict, {})
-        self.assertEqual(list(t.nodes()), [])
-        self.assertEqual(list(ts.haplotypes()), [])
-        self.assertEqual(list(ts.variants()), [])
+        assert t.index == 0
+        assert t.left_root == tskit.NULL
+        assert t.interval == (0, 1)
+        assert t.roots == []
+        assert t.root == tskit.NULL
+        assert t.parent_dict == {}
+        assert list(t.nodes()) == []
+        assert list(ts.haplotypes()) == []
+        assert list(ts.variants()) == []
         methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
         for method in methods:
-            self.assertEqual(method(0), tskit.NULL)
+            assert method(0) == tskit.NULL
             for u in [-1, 1, 100]:
-                self.assertRaises(ValueError, method, u)
+                with pytest.raises(ValueError):
+                    method(u)
 
     def test_one_node_zero_samples_sites(self):
         tables = tskit.TableCollection(sequence_length=1)
@@ -1841,55 +1853,56 @@ class TestEmptyTreeSequences(TopologyTestCase):
         tables.sites.add_row(position=0.5, ancestral_state="0")
         tables.mutations.add_row(site=0, derived_state="1", node=0)
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 1)
-        self.assertEqual(ts.sample_size, 0)
-        self.assertEqual(ts.num_edges, 0)
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 1)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 1
+        assert ts.sample_size == 0
+        assert ts.num_edges == 0
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 1
         t = next(ts.trees())
-        self.assertEqual(t.index, 0)
-        self.assertEqual(t.left_root, tskit.NULL)
-        self.assertEqual(t.interval, (0, 1))
-        self.assertEqual(t.roots, [])
-        self.assertEqual(t.root, tskit.NULL)
-        self.assertEqual(t.parent_dict, {})
-        self.assertEqual(len(list(t.sites())), 1)
-        self.assertEqual(list(t.nodes()), [])
-        self.assertEqual(list(ts.haplotypes()), [])
-        self.assertEqual(len(list(ts.variants())), 1)
+        assert t.index == 0
+        assert t.left_root == tskit.NULL
+        assert t.interval == (0, 1)
+        assert t.roots == []
+        assert t.root == tskit.NULL
+        assert t.parent_dict == {}
+        assert len(list(t.sites())) == 1
+        assert list(t.nodes()) == []
+        assert list(ts.haplotypes()) == []
+        assert len(list(ts.variants())) == 1
         tsp = ts.simplify()
-        self.assertEqual(tsp.num_nodes, 0)
-        self.assertEqual(tsp.num_edges, 0)
+        assert tsp.num_nodes == 0
+        assert tsp.num_edges == 0
 
     def test_one_node_one_sample(self):
         tables = tskit.TableCollection(sequence_length=1)
         tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 1)
-        self.assertEqual(ts.sample_size, 1)
-        self.assertEqual(ts.num_edges, 0)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 1
+        assert ts.sample_size == 1
+        assert ts.num_edges == 0
         t = next(ts.trees())
-        self.assertEqual(t.index, 0)
-        self.assertEqual(t.left_root, 0)
-        self.assertEqual(t.interval, (0, 1))
-        self.assertEqual(t.roots, [0])
-        self.assertEqual(t.root, 0)
-        self.assertEqual(t.parent_dict, {})
-        self.assertEqual(list(t.nodes()), [0])
-        self.assertEqual(list(ts.haplotypes(isolated_as_missing=False)), [""])
-        self.assertEqual(list(ts.variants()), [])
+        assert t.index == 0
+        assert t.left_root == 0
+        assert t.interval == (0, 1)
+        assert t.roots == [0]
+        assert t.root == 0
+        assert t.parent_dict == {}
+        assert list(t.nodes()) == [0]
+        assert list(ts.haplotypes(isolated_as_missing=False)) == [""]
+        assert list(ts.variants()) == []
         methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
         for method in methods:
-            self.assertEqual(method(0), tskit.NULL)
+            assert method(0) == tskit.NULL
             for u in [-1, 1, 100]:
-                self.assertRaises(ValueError, method, u)
+                with pytest.raises(ValueError):
+                    method(u)
         tsp = ts.simplify()
-        self.assertEqual(tsp.num_nodes, 1)
-        self.assertEqual(tsp.num_edges, 0)
+        assert tsp.num_nodes == 1
+        assert tsp.num_edges == 0
 
     def test_one_node_one_sample_sites(self):
         tables = tskit.TableCollection(sequence_length=1)
@@ -1897,32 +1910,33 @@ class TestEmptyTreeSequences(TopologyTestCase):
         tables.sites.add_row(position=0.5, ancestral_state="0")
         tables.mutations.add_row(site=0, derived_state="1", node=0)
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 1)
-        self.assertEqual(ts.sample_size, 1)
-        self.assertEqual(ts.num_edges, 0)
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 1)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 1
+        assert ts.sample_size == 1
+        assert ts.num_edges == 0
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 1
         t = next(ts.trees())
-        self.assertEqual(t.index, 0)
-        self.assertEqual(t.left_root, 0)
-        self.assertEqual(t.interval, (0, 1))
-        self.assertEqual(t.roots, [0])
-        self.assertEqual(t.root, 0)
-        self.assertEqual(t.parent_dict, {})
-        self.assertEqual(list(t.nodes()), [0])
-        self.assertEqual(list(ts.haplotypes(isolated_as_missing=False)), ["1"])
-        self.assertEqual(len(list(ts.variants())), 1)
+        assert t.index == 0
+        assert t.left_root == 0
+        assert t.interval == (0, 1)
+        assert t.roots == [0]
+        assert t.root == 0
+        assert t.parent_dict == {}
+        assert list(t.nodes()) == [0]
+        assert list(ts.haplotypes(isolated_as_missing=False)) == ["1"]
+        assert len(list(ts.variants())) == 1
         methods = [t.parent, t.left_child, t.right_child, t.left_sib, t.right_sib]
         for method in methods:
-            self.assertEqual(method(0), tskit.NULL)
+            assert method(0) == tskit.NULL
             for u in [-1, 1, 100]:
-                self.assertRaises(ValueError, method, u)
+                with pytest.raises(ValueError):
+                    method(u)
         tsp = ts.simplify(filter_sites=False)
-        self.assertEqual(tsp.num_nodes, 1)
-        self.assertEqual(tsp.num_edges, 0)
-        self.assertEqual(tsp.num_sites, 1)
+        assert tsp.num_nodes == 1
+        assert tsp.num_edges == 0
+        assert tsp.num_sites == 1
 
 
 class TestHoleyTreeSequences(TopologyTestCase):
@@ -1935,19 +1949,19 @@ class TestHoleyTreeSequences(TopologyTestCase):
         observed = []
         for t in ts.trees():
             observed.append((t.interval, t.parent_dict))
-        self.assertEqual(expected, observed)
+        assert expected == observed
         # Test simple algorithm also.
         observed = []
         for interval, parent in tsutil.algorithm_T(ts):
             parent_dict = {j: parent[j] for j in range(ts.num_nodes) if parent[j] >= 0}
             observed.append((interval, parent_dict))
-        self.assertEqual(expected, observed)
+        assert expected == observed
 
     def verify_zero_roots(self, ts):
         for tree in ts.trees():
-            self.assertEqual(tree.num_roots, 0)
-            self.assertEqual(tree.left_root, tskit.NULL)
-            self.assertEqual(tree.roots, [])
+            assert tree.num_roots == 0
+            assert tree.left_root == tskit.NULL
+            assert tree.roots == []
 
     def test_simple_hole(self):
         nodes = io.StringIO(
@@ -2175,21 +2189,21 @@ class TestTsinferExamples(TopologyTestCase):
         num_trees = 0
         for _ in pts.trees():
             num_trees += 1
-        self.assertEqual(num_trees, ts.num_trees)
+        assert num_trees == ts.num_trees
         n = 0
         for pt, t in zip(pts.trees(), ts.trees()):
-            self.assertEqual((pt.left, pt.right), t.interval)
+            assert (pt.left, pt.right) == t.interval
             for j in range(ts.num_nodes):
-                self.assertEqual(pt.parent[j], t.parent(j))
-                self.assertEqual(pt.left_child[j], t.left_child(j))
-                self.assertEqual(pt.right_child[j], t.right_child(j))
-                self.assertEqual(pt.left_sib[j], t.left_sib(j))
-                self.assertEqual(pt.right_sib[j], t.right_sib(j))
+                assert pt.parent[j] == t.parent(j)
+                assert pt.left_child[j] == t.left_child(j)
+                assert pt.right_child[j] == t.right_child(j)
+                assert pt.left_sib[j] == t.left_sib(j)
+                assert pt.right_sib[j] == t.right_sib(j)
             n += 1
-        self.assertEqual(n, num_trees)
+        assert n == num_trees
         intervals = [t.interval for t in ts.trees()]
-        self.assertEqual(intervals[0][0], 0)
-        self.assertEqual(intervals[-1][-1], ts.sequence_length)
+        assert intervals[0][0] == 0
+        assert intervals[-1][-1] == ts.sequence_length
 
 
 class TestRecordSquashing(TopologyTestCase):
@@ -2214,28 +2228,28 @@ class TestRecordSquashing(TopologyTestCase):
         )
         ts = tskit.load_text(nodes, edges, strict=False)
         tss, node_map = ts.simplify(map_nodes=True)
-        self.assertEqual(list(node_map), [0, 1])
-        self.assertEqual(tss.dump_tables().nodes, ts.dump_tables().nodes)
+        assert list(node_map) == [0, 1]
+        assert tss.dump_tables().nodes == ts.dump_tables().nodes
         simplified_edges = list(tss.edges())
-        self.assertEqual(len(simplified_edges), 1)
+        assert len(simplified_edges) == 1
         e = simplified_edges[0]
-        self.assertEqual(e.left, 0)
-        self.assertEqual(e.right, 2)
+        assert e.left == 0
+        assert e.right == 2
 
     def test_single_tree(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
         tss = ts_redundant.simplify()
-        self.assertEqual(tss.dump_tables().nodes, ts.dump_tables().nodes)
-        self.assertEqual(tss.dump_tables().edges, ts.dump_tables().edges)
+        assert tss.dump_tables().nodes == ts.dump_tables().nodes
+        assert tss.dump_tables().edges == ts.dump_tables().edges
 
     def test_many_trees(self):
         ts = msprime.simulate(20, recombination_rate=5, random_seed=self.random_seed)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
         tss = ts_redundant.simplify()
-        self.assertEqual(tss.dump_tables().nodes, ts.dump_tables().nodes)
-        self.assertEqual(tss.dump_tables().edges, ts.dump_tables().edges)
+        assert tss.dump_tables().nodes == ts.dump_tables().nodes
+        assert tss.dump_tables().edges == ts.dump_tables().edges
 
 
 class TestRedundantBreakpoints(TopologyTestCase):
@@ -2247,31 +2261,31 @@ class TestRedundantBreakpoints(TopologyTestCase):
     def test_single_tree(self):
         ts = msprime.simulate(10, random_seed=self.random_seed)
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
-        self.assertEqual(ts.sample_size, ts_redundant.sample_size)
-        self.assertEqual(ts.sequence_length, ts_redundant.sequence_length)
-        self.assertEqual(ts_redundant.num_trees, 2)
+        assert ts.sample_size == ts_redundant.sample_size
+        assert ts.sequence_length == ts_redundant.sequence_length
+        assert ts_redundant.num_trees == 2
         trees = [t.parent_dict for t in ts_redundant.trees()]
-        self.assertEqual(len(trees), 2)
-        self.assertEqual(trees[0], trees[1])
-        self.assertEqual([t.parent_dict for t in ts.trees()][0], trees[0])
+        assert len(trees) == 2
+        assert trees[0] == trees[1]
+        assert [t.parent_dict for t in ts.trees()][0] == trees[0]
 
     def test_many_trees(self):
         ts = msprime.simulate(20, recombination_rate=5, random_seed=self.random_seed)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         ts_redundant = tsutil.insert_redundant_breakpoints(ts)
-        self.assertEqual(ts.sample_size, ts_redundant.sample_size)
-        self.assertEqual(ts.sequence_length, ts_redundant.sequence_length)
-        self.assertGreater(ts_redundant.num_trees, ts.num_trees)
-        self.assertGreater(ts_redundant.num_edges, ts.num_edges)
+        assert ts.sample_size == ts_redundant.sample_size
+        assert ts.sequence_length == ts_redundant.sequence_length
+        assert ts_redundant.num_trees > ts.num_trees
+        assert ts_redundant.num_edges > ts.num_edges
         redundant_trees = ts_redundant.trees()
         redundant_t = next(redundant_trees)
         comparisons = 0
         for t in ts.trees():
             while redundant_t is not None and redundant_t.interval[1] <= t.interval[1]:
-                self.assertEqual(t.parent_dict, redundant_t.parent_dict)
+                assert t.parent_dict == redundant_t.parent_dict
                 comparisons += 1
                 redundant_t = next(redundant_trees, None)
-        self.assertEqual(comparisons, ts_redundant.num_trees)
+        assert comparisons == ts_redundant.num_trees
 
 
 class TestUnaryNodes(TopologyTestCase):
@@ -2315,22 +2329,22 @@ class TestUnaryNodes(TopologyTestCase):
             strict=False,
         )
 
-        self.assertEqual(ts.sample_size, 2)
-        self.assertEqual(ts.num_nodes, 6)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 5)
-        self.assertEqual(ts.num_mutations, 5)
-        self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
+        assert ts.sample_size == 2
+        assert ts.num_nodes == 6
+        assert ts.num_trees == 1
+        assert ts.num_sites == 5
+        assert ts.num_mutations == 5
+        assert len(list(ts.edge_diffs())) == ts.num_trees
         t = next(ts.trees())
-        self.assertEqual(t.parent_dict, {0: 2, 1: 3, 2: 4, 3: 4, 4: 5})
-        self.assertEqual(t.mrca(0, 1), 4)
-        self.assertEqual(t.mrca(0, 2), 2)
-        self.assertEqual(t.mrca(0, 4), 4)
-        self.assertEqual(t.mrca(0, 5), 5)
-        self.assertEqual(t.mrca(0, 3), 4)
+        assert t.parent_dict == {0: 2, 1: 3, 2: 4, 3: 4, 4: 5}
+        assert t.mrca(0, 1) == 4
+        assert t.mrca(0, 2) == 2
+        assert t.mrca(0, 4) == 4
+        assert t.mrca(0, 5) == 5
+        assert t.mrca(0, 3) == 4
         H = list(ts.haplotypes())
-        self.assertEqual(H[0], "10101")
-        self.assertEqual(H[1], "01011")
+        assert H[0] == "10101"
+        assert H[1] == "01011"
 
     def test_ladder_tree(self):
         # We have a single tree with a long ladder of unary nodes along a path
@@ -2354,28 +2368,28 @@ class TestUnaryNodes(TopologyTestCase):
         edges += "0    1     {}      1,{}\n".format(root, num_unary_nodes + 2)
         ts = tskit.load_text(io.StringIO(nodes), io.StringIO(edges), strict=False)
         t = ts.first()
-        self.assertEqual(t.mrca(0, 1), root)
-        self.assertEqual(t.tmrca(0, 1), root_time)
+        assert t.mrca(0, 1) == root
+        assert t.tmrca(0, 1) == root_time
         ts_simplified, node_map = ts.simplify(map_nodes=True)
         test_map = [tskit.NULL for _ in range(ts.num_nodes)]
         test_map[0] = 0
         test_map[1] = 1
         test_map[root] = 2
-        self.assertEqual(list(node_map), test_map)
-        self.assertEqual(ts_simplified.num_edges, 2)
+        assert list(node_map) == test_map
+        assert ts_simplified.num_edges == 2
         t = ts_simplified.first()
-        self.assertEqual(t.mrca(0, 1), 2)
-        self.assertEqual(t.tmrca(0, 1), root_time)
+        assert t.mrca(0, 1) == 2
+        assert t.tmrca(0, 1) == root_time
         ts_simplified = ts.simplify(keep_unary=True, record_provenance=False)
-        self.assertEqual(ts_simplified.tables, ts.tables)
+        assert ts_simplified.tables == ts.tables
 
     def verify_unary_tree_sequence(self, ts):
         """
         Take the specified tree sequence and produce an equivalent in which
         unary records have been interspersed.
         """
-        self.assertGreater(ts.num_trees, 2)
-        self.assertGreater(ts.num_mutations, 2)
+        assert ts.num_trees > 2
+        assert ts.num_mutations > 2
         tables = ts.dump_tables()
         next_node = ts.num_nodes
         node_times = {j: node.time for j, node in enumerate(ts.nodes())}
@@ -2399,14 +2413,14 @@ class TestUnaryNodes(TopologyTestCase):
                 left=e.left, right=e.right, child=e.child, parent=e.parent
             )
         ts_new = tables.tree_sequence()
-        self.assertGreater(ts_new.num_edges, ts.num_edges)
+        assert ts_new.num_edges > ts.num_edges
         self.assert_haplotypes_equal(ts, ts_new)
         self.assert_variants_equal(ts, ts_new)
         ts_simplified = ts_new.simplify()
-        self.assertEqual(list(ts_simplified.records()), list(ts.records()))
+        assert list(ts_simplified.records()) == list(ts.records())
         self.assert_haplotypes_equal(ts, ts_simplified)
         self.assert_variants_equal(ts, ts_simplified)
-        self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
+        assert len(list(ts.edge_diffs())) == ts.num_trees
 
         for keep_unary in [True, False]:
             s = tests.Simplifier(ts, ts.samples(), keep_unary=keep_unary)
@@ -2416,8 +2430,8 @@ class TestUnaryNodes(TopologyTestCase):
             py_tables.provenances.clear()
             lib_tables = lib_ts.dump_tables()
             lib_tables.provenances.clear()
-            self.assertEqual(lib_tables, py_tables)
-            self.assertTrue(np.all(lib_node_map == py_node_map))
+            assert lib_tables == py_tables
+            assert np.all(lib_node_map == py_node_map)
 
     def test_binary_tree_sequence_unary_nodes(self):
         ts = msprime.simulate(
@@ -2440,7 +2454,7 @@ class TestUnaryNodes(TopologyTestCase):
         for r in ts.edgesets():
             if len(r.children) > 2:
                 found = True
-        self.assertTrue(found)
+        assert found
         self.verify_unary_tree_sequence(ts)
 
 
@@ -2491,38 +2505,38 @@ class TestGeneralSamples(TopologyTestCase):
             nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
 
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(list(ts.samples()), [2, 3, 4])
-        self.assertEqual(ts.num_nodes, 5)
-        self.assertEqual(ts.num_nodes, 5)
-        self.assertEqual(ts.num_sites, 4)
-        self.assertEqual(ts.num_mutations, 4)
-        self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
+        assert ts.sample_size == 3
+        assert list(ts.samples()) == [2, 3, 4]
+        assert ts.num_nodes == 5
+        assert ts.num_nodes == 5
+        assert ts.num_sites == 4
+        assert ts.num_mutations == 4
+        assert len(list(ts.edge_diffs())) == ts.num_trees
         t = next(ts.trees())
-        self.assertEqual(t.root, 0)
-        self.assertEqual(t.parent_dict, {1: 0, 2: 1, 3: 1, 4: 0})
+        assert t.root == 0
+        assert t.parent_dict == {1: 0, 2: 1, 3: 1, 4: 0}
         H = list(ts.haplotypes())
-        self.assertEqual(H[0], "1001")
-        self.assertEqual(H[1], "0101")
-        self.assertEqual(H[2], "0010")
+        assert H[0] == "1001"
+        assert H[1] == "0101"
+        assert H[2] == "0010"
 
         tss, node_map = ts.simplify(map_nodes=True)
-        self.assertEqual(list(node_map), [4, 3, 0, 1, 2])
+        assert list(node_map) == [4, 3, 0, 1, 2]
         # We should have the same tree sequence just with canonicalised nodes.
-        self.assertEqual(tss.sample_size, 3)
-        self.assertEqual(list(tss.samples()), [0, 1, 2])
-        self.assertEqual(tss.num_nodes, 5)
-        self.assertEqual(tss.num_trees, 1)
-        self.assertEqual(tss.num_sites, 4)
-        self.assertEqual(tss.num_mutations, 4)
-        self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
+        assert tss.sample_size == 3
+        assert list(tss.samples()) == [0, 1, 2]
+        assert tss.num_nodes == 5
+        assert tss.num_trees == 1
+        assert tss.num_sites == 4
+        assert tss.num_mutations == 4
+        assert len(list(ts.edge_diffs())) == ts.num_trees
         t = next(tss.trees())
-        self.assertEqual(t.root, 4)
-        self.assertEqual(t.parent_dict, {0: 3, 1: 3, 2: 4, 3: 4})
+        assert t.root == 4
+        assert t.parent_dict == {0: 3, 1: 3, 2: 4, 3: 4}
         H = list(tss.haplotypes())
-        self.assertEqual(H[0], "1001")
-        self.assertEqual(H[1], "0101")
-        self.assertEqual(H[2], "0010")
+        assert H[0] == "1001"
+        assert H[1] == "0101"
+        assert H[2] == "0010"
 
     def verify_permuted_nodes(self, ts):
         """
@@ -2538,27 +2552,25 @@ class TestGeneralSamples(TopologyTestCase):
         samples = sorted(node_map[: ts.sample_size])
         node_map = samples + node_map[ts.sample_size :]
         permuted = tsutil.permute_nodes(ts, node_map)
-        self.assertEqual(ts.sequence_length, permuted.sequence_length)
-        self.assertEqual(list(permuted.samples()), samples)
-        self.assertEqual(list(permuted.haplotypes()), list(ts.haplotypes()))
-        self.assertEqual(
-            [v.genotypes for v in permuted.variants(as_bytes=True)],
-            [v.genotypes for v in ts.variants(as_bytes=True)],
-        )
-        self.assertEqual(ts.num_trees, permuted.num_trees)
+        assert ts.sequence_length == permuted.sequence_length
+        assert list(permuted.samples()) == samples
+        assert list(permuted.haplotypes()) == list(ts.haplotypes())
+        assert [v.genotypes for v in permuted.variants(as_bytes=True)] == [
+            v.genotypes for v in ts.variants(as_bytes=True)
+        ]
+        assert ts.num_trees == permuted.num_trees
         j = 0
         for t1, t2 in zip(ts.trees(), permuted.trees()):
             t1_dict = {node_map[k]: node_map[v] for k, v in t1.parent_dict.items()}
-            self.assertEqual(node_map[t1.root], t2.root)
-            self.assertEqual(t1_dict, t2.parent_dict)
+            assert node_map[t1.root] == t2.root
+            assert t1_dict == t2.parent_dict
             for u1 in t1.nodes():
                 u2 = node_map[u1]
-                self.assertEqual(
-                    sorted([node_map[v] for v in t1.samples(u1)]),
-                    sorted(list(t2.samples(u2))),
+                assert sorted([node_map[v] for v in t1.samples(u1)]) == sorted(
+                    list(t2.samples(u2))
                 )
             j += 1
-        self.assertEqual(j, ts.num_trees)
+        assert j == ts.num_trees
 
         # The simplified version of the permuted tree sequence should be in canonical
         # form, and identical to the original.
@@ -2569,30 +2581,28 @@ class TestGeneralSamples(TopologyTestCase):
         original_tables.provenances.clear()
         simplified_tables.provenances.clear()
 
-        self.assertEqual(
-            original_tables.sequence_length, simplified_tables.sequence_length
-        )
-        self.assertEqual(original_tables.nodes, simplified_tables.nodes)
-        self.assertEqual(original_tables.edges, simplified_tables.edges)
-        self.assertEqual(original_tables.sites, simplified_tables.sites)
-        self.assertEqual(original_tables.mutations, simplified_tables.mutations)
-        self.assertEqual(original_tables.individuals, simplified_tables.individuals)
-        self.assertEqual(original_tables.populations, simplified_tables.populations)
+        assert original_tables.sequence_length == simplified_tables.sequence_length
+        assert original_tables.nodes == simplified_tables.nodes
+        assert original_tables.edges == simplified_tables.edges
+        assert original_tables.sites == simplified_tables.sites
+        assert original_tables.mutations == simplified_tables.mutations
+        assert original_tables.individuals == simplified_tables.individuals
+        assert original_tables.populations == simplified_tables.populations
 
-        self.assertEqual(original_tables, simplified_tables)
-        self.assertEqual(ts.sequence_length, simplified.sequence_length)
+        assert original_tables == simplified_tables
+        assert ts.sequence_length == simplified.sequence_length
         for _ in simplified.trees():
             pass
 
         for u, v in enumerate(node_map):
-            self.assertEqual(s_node_map[v], u)
-        self.assertTrue(np.array_equal(simplified.samples(), ts.samples()))
-        self.assertEqual(list(simplified.nodes()), list(ts.nodes()))
-        self.assertEqual(list(simplified.edges()), list(ts.edges()))
-        self.assertEqual(list(simplified.sites()), list(ts.sites()))
-        self.assertEqual(list(simplified.haplotypes()), list(ts.haplotypes()))
-        self.assertEqual(
-            list(simplified.variants(as_bytes=True)), list(ts.variants(as_bytes=True))
+            assert s_node_map[v] == u
+        assert np.array_equal(simplified.samples(), ts.samples())
+        assert list(simplified.nodes()) == list(ts.nodes())
+        assert list(simplified.edges()) == list(ts.edges())
+        assert list(simplified.sites()) == list(ts.sites())
+        assert list(simplified.haplotypes()) == list(ts.haplotypes())
+        assert list(simplified.variants(as_bytes=True)) == list(
+            ts.variants(as_bytes=True)
         )
 
     def test_single_tree_permuted_nodes(self):
@@ -2620,11 +2630,11 @@ class TestGeneralSamples(TopologyTestCase):
         for e in ts.edgesets():
             if len(e.children) > 2:
                 found = True
-        self.assertTrue(found)
+        assert found
         self.verify_permuted_nodes(ts)
 
 
-class TestTraversalOrder(unittest.TestCase):
+class TestTraversalOrder:
     """
     Tests node traversal orders.
     """
@@ -2683,7 +2693,7 @@ class TestTraversalOrder(unittest.TestCase):
             tree_orders = []
             for tree in ts.trees():
                 tree_orders.append(list(tree.nodes(order=test_order)))
-            self.assertEqual(tree_orders, expected_result)
+            assert tree_orders == expected_result
 
     def test_polytomy_inorder(self):
         """
@@ -2738,7 +2748,7 @@ class TestTraversalOrder(unittest.TestCase):
             tree_orders = []
             for tree in ts.trees():
                 tree_orders.append(list(tree.nodes(order="inorder")))
-            self.assertEqual(tree_orders, expected_result)
+            assert tree_orders == expected_result
 
     def test_minlex_postorder_multiple_roots(self):
         #
@@ -2777,7 +2787,7 @@ class TestTraversalOrder(unittest.TestCase):
         tree_orders = []
         for tree in ts.trees():
             tree_orders.append(list(tree.nodes(order="minlex_postorder")))
-        self.assertEqual(tree_orders, expected_result)
+        assert tree_orders == expected_result
 
 
 class TestSimplifyExamples(TopologyTestCase):
@@ -2842,7 +2852,7 @@ class TestSimplifyExamples(TopologyTestCase):
             print("after")
             print(after)
             print(after.tree_sequence().draw_text())
-        self.assertEqual(before, after)
+        assert before == after
 
     def test_unsorted_edges(self):
         # We have two nodes at the same time and interleave edges for
@@ -2868,7 +2878,8 @@ class TestSimplifyExamples(TopologyTestCase):
         tables = tskit.TableCollection(sequence_length=2)
         tables.nodes.set_columns(**nodes.asdict())
         tables.edges.set_columns(**edges.asdict())
-        self.assertRaises(_tskit.LibraryError, tables.simplify, samples=[0, 1])
+        with pytest.raises(_tskit.LibraryError):
+            tables.simplify(samples=[0, 1])
 
     def test_single_binary_tree(self):
         #
@@ -3442,23 +3453,23 @@ class TestNonSampleExternalNodes(TopologyTestCase):
         ts = tskit.load_text(
             nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
-        self.assertEqual(ts.sample_size, 2)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 5)
-        self.assertEqual(ts.num_sites, 4)
-        self.assertEqual(ts.num_mutations, 4)
+        assert ts.sample_size == 2
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 5
+        assert ts.num_sites == 4
+        assert ts.num_mutations == 4
         t = next(ts.trees())
-        self.assertEqual(t.parent_dict, {0: 2, 1: 2, 3: 2, 4: 2})
-        self.assertEqual(t.root, 2)
+        assert t.parent_dict == {0: 2, 1: 2, 3: 2, 4: 2}
+        assert t.root == 2
         ts_simplified, node_map = ts.simplify(map_nodes=True)
-        self.assertEqual(list(node_map), [0, 1, 2, -1, -1])
-        self.assertEqual(ts_simplified.num_nodes, 3)
-        self.assertEqual(ts_simplified.num_trees, 1)
+        assert list(node_map) == [0, 1, 2, -1, -1]
+        assert ts_simplified.num_nodes == 3
+        assert ts_simplified.num_trees == 1
         t = next(ts_simplified.trees())
-        self.assertEqual(t.parent_dict, {0: 2, 1: 2})
-        self.assertEqual(t.root, 2)
+        assert t.parent_dict == {0: 2, 1: 2}
+        assert t.root == 2
         # We should have removed the two non-sample mutations.
-        self.assertEqual([s.position for s in t.sites()], [0.1, 0.2])
+        assert [s.position for s in t.sites()] == [0.1, 0.2]
 
     def test_unary_non_sample_external_nodes(self):
         # Take an ordinary tree sequence and put a bunch of external non
@@ -3466,8 +3477,8 @@ class TestNonSampleExternalNodes(TopologyTestCase):
         ts = msprime.simulate(
             15, recombination_rate=5, random_seed=self.random_seed, mutation_rate=5
         )
-        self.assertGreater(ts.num_trees, 2)
-        self.assertGreater(ts.num_mutations, 2)
+        assert ts.num_trees > 2
+        assert ts.num_mutations > 2
         tables = ts.dump_tables()
         next_node = ts.num_nodes
         tables.edges.reset()
@@ -3478,14 +3489,14 @@ class TestNonSampleExternalNodes(TopologyTestCase):
             next_node += 1
         tables.sort()
         ts_new = tables.tree_sequence()
-        self.assertEqual(ts_new.num_nodes, next_node)
-        self.assertEqual(ts_new.sample_size, ts.sample_size)
+        assert ts_new.num_nodes == next_node
+        assert ts_new.sample_size == ts.sample_size
         self.assert_haplotypes_equal(ts, ts_new)
         self.assert_variants_equal(ts, ts_new)
         ts_simplified = ts_new.simplify()
-        self.assertEqual(ts_simplified.num_nodes, ts.num_nodes)
-        self.assertEqual(ts_simplified.sample_size, ts.sample_size)
-        self.assertEqual(list(ts_simplified.records()), list(ts.records()))
+        assert ts_simplified.num_nodes == ts.num_nodes
+        assert ts_simplified.sample_size == ts.sample_size
+        assert list(ts_simplified.records()) == list(ts.records())
         self.assert_haplotypes_equal(ts, ts_simplified)
         self.assert_variants_equal(ts, ts_simplified)
 
@@ -3531,26 +3542,22 @@ class TestMultipleRoots(TopologyTestCase):
             sequence_length=1,
             strict=False,
         )
-        self.assertEqual(ts.num_nodes, 2)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 2)
-        self.assertEqual(ts.num_mutations, 2)
+        assert ts.num_nodes == 2
+        assert ts.num_trees == 1
+        assert ts.num_sites == 2
+        assert ts.num_mutations == 2
         t = next(ts.trees())
-        self.assertEqual(t.parent_dict, {})
-        self.assertEqual(sorted(t.roots), [0, 1])
-        self.assertEqual(list(ts.haplotypes(isolated_as_missing=False)), ["10", "01"])
-        self.assertEqual(
-            [
-                v.genotypes
-                for v in ts.variants(as_bytes=True, isolated_as_missing=False)
-            ],
-            [b"10", b"01"],
-        )
+        assert t.parent_dict == {}
+        assert sorted(t.roots) == [0, 1]
+        assert list(ts.haplotypes(isolated_as_missing=False)) == ["10", "01"]
+        assert [
+            v.genotypes for v in ts.variants(as_bytes=True, isolated_as_missing=False)
+        ] == [b"10", b"01"]
         simplified = ts.simplify()
         t1 = ts.dump_tables()
         t2 = simplified.dump_tables()
-        self.assertEqual(t1.nodes, t2.nodes)
-        self.assertEqual(t1.edges, t2.edges)
+        assert t1.nodes == t2.nodes
+        assert t1.edges == t2.edges
 
     def test_simplest_non_degenerate_case(self):
         # Simplest case where we have n = 4 and two trees.
@@ -3593,32 +3600,34 @@ class TestMultipleRoots(TopologyTestCase):
         ts = tskit.load_text(
             nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
-        self.assertEqual(ts.num_nodes, 6)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 4)
-        self.assertEqual(ts.num_mutations, 4)
+        assert ts.num_nodes == 6
+        assert ts.num_trees == 1
+        assert ts.num_sites == 4
+        assert ts.num_mutations == 4
         t = next(ts.trees())
-        self.assertEqual(t.parent_dict, {0: 4, 1: 4, 2: 5, 3: 5})
-        self.assertEqual(list(ts.haplotypes()), ["1000", "0100", "0010", "0001"])
-        self.assertEqual(
-            [v.genotypes for v in ts.variants(as_bytes=True)],
-            [b"1000", b"0100", b"0010", b"0001"],
-        )
-        self.assertEqual(t.mrca(0, 1), 4)
-        self.assertEqual(t.mrca(0, 4), 4)
-        self.assertEqual(t.mrca(2, 3), 5)
-        self.assertEqual(t.mrca(0, 2), tskit.NULL)
-        self.assertEqual(t.mrca(0, 3), tskit.NULL)
-        self.assertEqual(t.mrca(2, 4), tskit.NULL)
+        assert t.parent_dict == {0: 4, 1: 4, 2: 5, 3: 5}
+        assert list(ts.haplotypes()) == ["1000", "0100", "0010", "0001"]
+        assert [v.genotypes for v in ts.variants(as_bytes=True)] == [
+            b"1000",
+            b"0100",
+            b"0010",
+            b"0001",
+        ]
+        assert t.mrca(0, 1) == 4
+        assert t.mrca(0, 4) == 4
+        assert t.mrca(2, 3) == 5
+        assert t.mrca(0, 2) == tskit.NULL
+        assert t.mrca(0, 3) == tskit.NULL
+        assert t.mrca(2, 4) == tskit.NULL
         ts_simplified, node_map = ts.simplify(map_nodes=True)
         for j in range(4):
-            self.assertEqual(node_map[j], j)
-        self.assertEqual(ts_simplified.num_nodes, 6)
-        self.assertEqual(ts_simplified.num_trees, 1)
-        self.assertEqual(ts_simplified.num_sites, 4)
-        self.assertEqual(ts_simplified.num_mutations, 4)
+            assert node_map[j] == j
+        assert ts_simplified.num_nodes == 6
+        assert ts_simplified.num_trees == 1
+        assert ts_simplified.num_sites == 4
+        assert ts_simplified.num_mutations == 4
         t = next(ts_simplified.trees())
-        self.assertEqual(t.parent_dict, {0: 4, 1: 4, 2: 5, 3: 5})
+        assert t.parent_dict == {0: 4, 1: 4, 2: 5, 3: 5}
 
     def test_two_reducible_trees(self):
         # We have n = 4 and two trees, with some unary nodes and non-sample leaves
@@ -3668,41 +3677,44 @@ class TestMultipleRoots(TopologyTestCase):
         ts = tskit.load_text(
             nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
-        self.assertEqual(ts.num_nodes, 9)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 5)
-        self.assertEqual(ts.num_mutations, 5)
+        assert ts.num_nodes == 9
+        assert ts.num_trees == 1
+        assert ts.num_sites == 5
+        assert ts.num_mutations == 5
         t = next(ts.trees())
-        self.assertEqual(t.parent_dict, {0: 4, 1: 5, 2: 7, 3: 7, 4: 6, 5: 6, 8: 7})
-        self.assertEqual(list(ts.haplotypes()), ["10000", "01000", "00100", "00010"])
-        self.assertEqual(
-            [v.genotypes for v in ts.variants(as_bytes=True)],
-            [b"1000", b"0100", b"0010", b"0001", b"0000"],
-        )
-        self.assertEqual(t.mrca(0, 1), 6)
-        self.assertEqual(t.mrca(2, 3), 7)
-        self.assertEqual(t.mrca(2, 8), 7)
-        self.assertEqual(t.mrca(0, 2), tskit.NULL)
-        self.assertEqual(t.mrca(0, 3), tskit.NULL)
-        self.assertEqual(t.mrca(0, 8), tskit.NULL)
+        assert t.parent_dict == {0: 4, 1: 5, 2: 7, 3: 7, 4: 6, 5: 6, 8: 7}
+        assert list(ts.haplotypes()) == ["10000", "01000", "00100", "00010"]
+        assert [v.genotypes for v in ts.variants(as_bytes=True)] == [
+            b"1000",
+            b"0100",
+            b"0010",
+            b"0001",
+            b"0000",
+        ]
+        assert t.mrca(0, 1) == 6
+        assert t.mrca(2, 3) == 7
+        assert t.mrca(2, 8) == 7
+        assert t.mrca(0, 2) == tskit.NULL
+        assert t.mrca(0, 3) == tskit.NULL
+        assert t.mrca(0, 8) == tskit.NULL
         ts_simplified, node_map = ts.simplify(map_nodes=True)
         for j in range(4):
-            self.assertEqual(node_map[j], j)
-        self.assertEqual(ts_simplified.num_nodes, 6)
-        self.assertEqual(ts_simplified.num_trees, 1)
+            assert node_map[j] == j
+        assert ts_simplified.num_nodes == 6
+        assert ts_simplified.num_trees == 1
         t = next(ts_simplified.trees())
         # print(ts_simplified.tables)
-        self.assertEqual(
-            list(ts_simplified.haplotypes()), ["1000", "0100", "0010", "0001"]
-        )
-        self.assertEqual(
-            [v.genotypes for v in ts_simplified.variants(as_bytes=True)],
-            [b"1000", b"0100", b"0010", b"0001"],
-        )
+        assert list(ts_simplified.haplotypes()) == ["1000", "0100", "0010", "0001"]
+        assert [v.genotypes for v in ts_simplified.variants(as_bytes=True)] == [
+            b"1000",
+            b"0100",
+            b"0010",
+            b"0001",
+        ]
         # The site over the non-sample external node should have been discarded.
         sites = list(t.sites())
-        self.assertEqual(sites[-1].position, 0.4)
-        self.assertEqual(t.parent_dict, {0: 4, 1: 4, 2: 5, 3: 5})
+        assert sites[-1].position == 0.4
+        assert t.parent_dict == {0: 4, 1: 4, 2: 5, 3: 5}
 
     def test_one_reducible_tree(self):
         # We have n = 4 and two trees. One tree is reducible and the other isn't.
@@ -3730,21 +3742,21 @@ class TestMultipleRoots(TopologyTestCase):
         """
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
-        self.assertEqual(ts.num_nodes, 9)
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.num_nodes == 9
+        assert ts.num_trees == 1
         t = next(ts.trees())
-        self.assertEqual(t.parent_dict, {0: 4, 1: 5, 2: 7, 3: 7, 4: 6, 5: 6, 8: 7})
-        self.assertEqual(t.mrca(0, 1), 6)
-        self.assertEqual(t.mrca(2, 3), 7)
-        self.assertEqual(t.mrca(2, 8), 7)
-        self.assertEqual(t.mrca(0, 2), tskit.NULL)
-        self.assertEqual(t.mrca(0, 3), tskit.NULL)
-        self.assertEqual(t.mrca(0, 8), tskit.NULL)
+        assert t.parent_dict == {0: 4, 1: 5, 2: 7, 3: 7, 4: 6, 5: 6, 8: 7}
+        assert t.mrca(0, 1) == 6
+        assert t.mrca(2, 3) == 7
+        assert t.mrca(2, 8) == 7
+        assert t.mrca(0, 2) == tskit.NULL
+        assert t.mrca(0, 3) == tskit.NULL
+        assert t.mrca(0, 8) == tskit.NULL
         ts_simplified = ts.simplify()
-        self.assertEqual(ts_simplified.num_nodes, 6)
-        self.assertEqual(ts_simplified.num_trees, 1)
+        assert ts_simplified.num_nodes == 6
+        assert ts_simplified.num_trees == 1
         t = next(ts_simplified.trees())
-        self.assertEqual(t.parent_dict, {0: 4, 1: 4, 2: 5, 3: 5})
+        assert t.parent_dict == {0: 4, 1: 4, 2: 5, 3: 5}
 
     # NOTE: This test has not been checked since updating to the text representation
     # so there might be other problems with it.
@@ -3794,35 +3806,28 @@ class TestMultipleRoots(TopologyTestCase):
         ts = tskit.load_text(
             nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
-        self.assertEqual(ts.num_nodes, 6)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 6)
-        self.assertEqual(ts.num_mutations, 6)
+        assert ts.num_nodes == 6
+        assert ts.num_trees == 1
+        assert ts.num_sites == 6
+        assert ts.num_mutations == 6
         t = next(ts.trees())
-        self.assertEqual(len(list(t.sites())), 6)
+        assert len(list(t.sites())) == 6
         haplotypes = ["101100", "011100", "000011"]
         variants = [b"100", b"010", b"110", b"110", b"001", b"001"]
-        self.assertEqual(list(ts.haplotypes()), haplotypes)
-        self.assertEqual([v.genotypes for v in ts.variants(as_bytes=True)], variants)
+        assert list(ts.haplotypes()) == haplotypes
+        assert [v.genotypes for v in ts.variants(as_bytes=True)] == variants
         ts_simplified = ts.simplify(filter_sites=False)
-        self.assertEqual(
-            list(ts_simplified.haplotypes(isolated_as_missing=False)), haplotypes
-        )
-        self.assertEqual(
-            variants,
-            [
-                v.genotypes
-                for v in ts_simplified.variants(
-                    as_bytes=True, isolated_as_missing=False
-                )
-            ],
-        )
+        assert list(ts_simplified.haplotypes(isolated_as_missing=False)) == haplotypes
+        assert variants == [
+            v.genotypes
+            for v in ts_simplified.variants(as_bytes=True, isolated_as_missing=False)
+        ]
 
     def test_break_single_tree(self):
         # Take a single largish tree from tskit, and remove the oldest record.
         # This breaks it into two subtrees.
         ts = msprime.simulate(20, random_seed=self.random_seed, mutation_rate=4)
-        self.assertGreater(ts.num_mutations, 5)
+        assert ts.num_mutations > 5
         tables = ts.dump_tables()
         tables.edges.set_columns(
             left=tables.edges.left[:-1],
@@ -3831,9 +3836,9 @@ class TestMultipleRoots(TopologyTestCase):
             child=tables.edges.child[:-1],
         )
         ts_new = tables.tree_sequence()
-        self.assertEqual(ts.sample_size, ts_new.sample_size)
-        self.assertEqual(ts.num_edges, ts_new.num_edges + 1)
-        self.assertEqual(ts.num_trees, ts_new.num_trees)
+        assert ts.sample_size == ts_new.sample_size
+        assert ts.num_edges == ts_new.num_edges + 1
+        assert ts.num_trees == ts_new.num_trees
         self.assert_haplotypes_equal(ts, ts_new)
         self.assert_variants_equal(ts, ts_new)
         roots = set()
@@ -3842,8 +3847,8 @@ class TestMultipleRoots(TopologyTestCase):
             while t_new.parent(u) != tskit.NULL:
                 u = t_new.parent(u)
             roots.add(u)
-        self.assertEqual(len(roots), 2)
-        self.assertEqual(sorted(roots), sorted(t_new.roots))
+        assert len(roots) == 2
+        assert sorted(roots) == sorted(t_new.roots)
 
 
 class TestWithVisuals(TopologyTestCase):
@@ -3856,7 +3861,7 @@ class TestWithVisuals(TopologyTestCase):
         new_ts, node_map = ts.simplify(sample, map_nodes=True)
         old_trees = ts.trees()
         old_tree = next(old_trees)
-        self.assertGreaterEqual(ts.get_num_trees(), new_ts.get_num_trees())
+        assert ts.get_num_trees() >= new_ts.get_num_trees()
         for new_tree in new_ts.trees():
             new_left, new_right = new_tree.get_interval()
             old_left, old_right = old_tree.get_interval()
@@ -3871,12 +3876,12 @@ class TestWithVisuals(TopologyTestCase):
                 mapped_pair = [node_map[u] for u in pair]
                 mrca1 = old_tree.get_mrca(*pair)
                 mrca2 = new_tree.get_mrca(*mapped_pair)
-                self.assertEqual(mrca2, node_map[mrca1])
+                assert mrca2 == node_map[mrca1]
         if haplotypes:
             orig_haps = list(ts.haplotypes())
             simp_haps = list(new_ts.haplotypes())
             for i, j in enumerate(sample):
-                self.assertEqual(orig_haps[j], simp_haps[i])
+                assert orig_haps[j] == simp_haps[i]
 
     def test_partial_non_sample_external_nodes(self):
         # A somewhat more complicated test case with a partially specified,
@@ -3928,16 +3933,16 @@ class TestWithVisuals(TopologyTestCase):
         ]
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(ts.num_nodes, 8)
+        assert ts.sample_size == 3
+        assert ts.num_trees == 3
+        assert ts.num_nodes == 8
         # check topologies agree:
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         # check .simplify() works here
         self.verify_simplify_topology(ts, [0, 1, 2])
 
@@ -3990,16 +3995,16 @@ class TestWithVisuals(TopologyTestCase):
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
         # sample size check works here since 7 > 3
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(ts.num_nodes, 8)
+        assert ts.sample_size == 3
+        assert ts.num_trees == 3
+        assert ts.num_nodes == 8
         # check topologies agree:
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         self.verify_simplify_topology(ts, [0, 1, 2])
 
     def test_single_offspring_records(self):
@@ -4050,16 +4055,16 @@ class TestWithVisuals(TopologyTestCase):
             {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
         ]
         tree_dicts = [t.parent_dict for t in ts.trees()]
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(ts.num_nodes, 8)
+        assert ts.sample_size == 3
+        assert ts.num_trees == 3
+        assert ts.num_nodes == 8
         # check topologies agree:
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         self.verify_simplify_topology(ts, [0, 1, 2])
 
     def test_many_single_offspring(self):
@@ -4183,19 +4188,19 @@ class TestWithVisuals(TopologyTestCase):
         )
         ts = tskit.load_text(nodes, edges, sites, mutations, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.num_trees, len(true_trees))
-        self.assertEqual(ts.num_nodes, 11)
-        self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
+        assert ts.sample_size == 3
+        assert ts.num_trees == len(true_trees)
+        assert ts.num_nodes == 11
+        assert len(list(ts.edge_diffs())) == ts.num_trees
         # check topologies agree:
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         for j, x in enumerate(ts.haplotypes()):
-            self.assertEqual(x, true_haplotypes[j])
+            assert x == true_haplotypes[j]
         self.verify_simplify_topology(ts, [0, 1, 2], haplotypes=True)
         self.verify_simplify_topology(ts, [1, 0, 2], haplotypes=True)
         self.verify_simplify_topology(ts, [0, 1], haplotypes=False)
@@ -4309,17 +4314,17 @@ class TestWithVisuals(TopologyTestCase):
         ]
         ts = tskit.load_text(nodes, edges, strict=False)
         tree_dicts = [t.parent_dict for t in ts.trees()]
-        self.assertEqual(ts.sample_size, 6)
-        self.assertEqual(ts.num_trees, len(true_trees))
-        self.assertEqual(ts.num_nodes, 13)
-        self.assertEqual(len(list(ts.edge_diffs())), ts.num_trees)
+        assert ts.sample_size == 6
+        assert ts.num_trees == len(true_trees)
+        assert ts.num_nodes == 13
+        assert len(list(ts.edge_diffs())) == ts.num_trees
         # check topologies agree:
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         self.verify_simplify_topology(ts, [0, 2])
         self.verify_simplify_topology(ts, [0, 4])
         self.verify_simplify_topology(ts, [2, 4])
@@ -4436,12 +4441,12 @@ class TestWithVisuals(TopologyTestCase):
             },
         ]
         big_ts = tskit.load_text(nodes, edges, strict=False)
-        self.assertEqual(big_ts.num_trees, 1 + len(true_trees))
-        self.assertEqual(big_ts.num_nodes, 16)
+        assert big_ts.num_trees == 1 + len(true_trees)
+        assert big_ts.num_nodes == 16
         ts, node_map = big_ts.simplify(map_nodes=True)
-        self.assertEqual(list(node_map[:6]), list(range(6)))
-        self.assertEqual(ts.sample_size, 6)
-        self.assertEqual(ts.num_nodes, 13)
+        assert list(node_map[:6]) == list(range(6))
+        assert ts.sample_size == 6
+        assert ts.num_nodes == 13
 
     def test_ancestral_samples(self):
         # Check that specifying samples to be not at time 0.0 works.
@@ -4508,37 +4513,37 @@ class TestWithVisuals(TopologyTestCase):
             {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
         ]
         # maps [1,2,3] -> [0,1,2]
-        self.assertEqual(node_map[1], 0)
-        self.assertEqual(node_map[2], 1)
-        self.assertEqual(node_map[3], 2)
+        assert node_map[1] == 0
+        assert node_map[2] == 1
+        assert node_map[3] == 2
         true_simplified_trees = [
             {0: 4, 1: 3, 2: 3, 3: 4},
             {0: 4, 1: 4, 2: 5, 4: 5},
             {0: 4, 1: 3, 2: 3, 3: 4},
         ]
-        self.assertEqual(first_ts.sample_size, 3)
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(first_ts.num_trees, 3)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(first_ts.num_nodes, 9)
-        self.assertEqual(ts.num_nodes, 6)
-        self.assertEqual(first_ts.node(3).time, 0.2)
-        self.assertEqual(ts.node(2).time, 0.2)
+        assert first_ts.sample_size == 3
+        assert ts.sample_size == 3
+        assert first_ts.num_trees == 3
+        assert ts.num_trees == 3
+        assert first_ts.num_nodes == 9
+        assert ts.num_nodes == 6
+        assert first_ts.node(3).time == 0.2
+        assert ts.node(2).time == 0.2
         # check topologies agree:
         tree_dicts = [t.parent_dict for t in first_ts.trees()]
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         tree_simplified_dicts = [t.parent_dict for t in ts.trees()]
         for a, t in zip(true_simplified_trees, tree_simplified_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         # check .simplify() works here
         self.verify_simplify_topology(first_ts, [1, 2, 3])
 
@@ -4590,21 +4595,21 @@ class TestWithVisuals(TopologyTestCase):
             {0: 4, 1: 5, 2: 4, 3: 8, 4: 5, 5: 8, 6: -1, 7: -1},
             {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
         ]
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(ts.num_nodes, 9)
-        self.assertEqual(ts.node(0).time, 0.0)
-        self.assertEqual(ts.node(1).time, 0.1)
-        self.assertEqual(ts.node(2).time, 0.1)
-        self.assertEqual(ts.node(3).time, 0.2)
+        assert ts.sample_size == 3
+        assert ts.num_trees == 3
+        assert ts.num_nodes == 9
+        assert ts.node(0).time == 0.0
+        assert ts.node(1).time == 0.1
+        assert ts.node(2).time == 0.1
+        assert ts.node(3).time == 0.2
         # check topologies agree:
         tree_dicts = [t.parent_dict for t in ts.trees()]
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         # check .simplify() works here
         self.verify_simplify_topology(ts, [1, 2, 3])
 
@@ -4653,21 +4658,21 @@ class TestWithVisuals(TopologyTestCase):
             {0: 4, 1: 5, 2: 4, 3: 8, 4: 5, 5: 8, 6: -1, 7: -1},
             {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1},
         ]
-        self.assertEqual(ts.sample_size, 4)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(ts.num_nodes, 9)
-        self.assertEqual(ts.node(0).time, 0.0)
-        self.assertEqual(ts.node(1).time, 0.1)
-        self.assertEqual(ts.node(2).time, 0.1)
-        self.assertEqual(ts.node(3).time, 0.2)
+        assert ts.sample_size == 4
+        assert ts.num_trees == 3
+        assert ts.num_nodes == 9
+        assert ts.node(0).time == 0.0
+        assert ts.node(1).time == 0.1
+        assert ts.node(2).time == 0.1
+        assert ts.node(3).time == 0.2
         # check topologies agree:
         tree_dicts = [t.parent_dict for t in ts.trees()]
         for a, t in zip(true_trees, tree_dicts):
             for k in a.keys():
                 if k in t.keys():
-                    self.assertEqual(t[k], a[k])
+                    assert t[k] == a[k]
                 else:
-                    self.assertEqual(a[k], tskit.NULL)
+                    assert a[k] == tskit.NULL
         # check .simplify() works here
         self.verify_simplify_topology(ts, [1, 2, 3])
         self.check_num_samples(
@@ -4715,25 +4720,25 @@ class TestWithVisuals(TopologyTestCase):
         tst = ts.trees()
         t = next(tst)
         t = next(tst)
-        self.assertEqual(t.branch_length(1), 0.4)
-        self.assertEqual(t.is_internal(0), False)
-        self.assertEqual(t.is_leaf(0), True)
-        self.assertEqual(t.is_sample(0), False)
-        self.assertEqual(t.is_internal(1), False)
-        self.assertEqual(t.is_leaf(1), True)
-        self.assertEqual(t.is_sample(1), True)
-        self.assertEqual(t.is_internal(5), True)
-        self.assertEqual(t.is_leaf(5), False)
-        self.assertEqual(t.is_sample(5), True)
-        self.assertEqual(t.is_internal(4), True)
-        self.assertEqual(t.is_leaf(4), False)
-        self.assertEqual(t.is_sample(4), False)
-        self.assertEqual(t.root, 8)
-        self.assertEqual(t.mrca(0, 1), 5)
-        self.assertEqual(t.sample_size, 4)
+        assert t.branch_length(1) == 0.4
+        assert not t.is_internal(0)
+        assert t.is_leaf(0)
+        assert not t.is_sample(0)
+        assert not t.is_internal(1)
+        assert t.is_leaf(1)
+        assert t.is_sample(1)
+        assert t.is_internal(5)
+        assert not t.is_leaf(5)
+        assert t.is_sample(5)
+        assert t.is_internal(4)
+        assert not t.is_leaf(4)
+        assert not t.is_sample(4)
+        assert t.root == 8
+        assert t.mrca(0, 1) == 5
+        assert t.sample_size == 4
 
 
-class TestBadTrees(unittest.TestCase):
+class TestBadTrees:
     """
     Tests for bad tree sequence topologies that can only be detected when we
     try to create trees.
@@ -4756,7 +4761,7 @@ class TestBadTrees(unittest.TestCase):
         0.0     1.0     3       0
         """
         )
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
     def test_partial_overlap_contradictory_children(self):
@@ -4776,11 +4781,11 @@ class TestBadTrees(unittest.TestCase):
         0.5     1.0     3       0
         """
         )
-        with self.assertRaises(_tskit.LibraryError):
+        with pytest.raises(_tskit.LibraryError):
             tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
-class SimplifyTestBase(unittest.TestCase):
+class SimplifyTestBase:
     """
     Base class for simplify tests.
     """
@@ -4839,14 +4844,14 @@ class SimplifyTestBase(unittest.TestCase):
                 (lib_tables2, lib_node_map2),
             ]:
 
-                self.assertEqual(lib_tables.nodes, py_tables.nodes)
-                self.assertEqual(lib_tables.edges, py_tables.edges)
-                self.assertEqual(lib_tables.migrations, py_tables.migrations)
-                self.assertEqual(lib_tables.sites, py_tables.sites)
-                self.assertEqual(lib_tables.mutations, py_tables.mutations)
-                self.assertEqual(lib_tables.individuals, py_tables.individuals)
-                self.assertEqual(lib_tables.populations, py_tables.populations)
-                self.assertTrue(all(node_map == lib_node_map))
+                assert lib_tables.nodes == py_tables.nodes
+                assert lib_tables.edges == py_tables.edges
+                assert lib_tables.migrations == py_tables.migrations
+                assert lib_tables.sites == py_tables.sites
+                assert lib_tables.mutations == py_tables.mutations
+                assert lib_tables.individuals == py_tables.individuals
+                assert lib_tables.populations == py_tables.populations
+                assert all(node_map == lib_node_map)
         return new_ts, node_map
 
 
@@ -4899,7 +4904,7 @@ class TestSimplify(SimplifyTestBase):
         t1 = ts1.dump_tables()
         ts2, node_map2 = self.do_simplify(ts, keep_unary=keep_unary)
         t2 = ts2.dump_tables()
-        self.assertEqual(t1, t2)
+        assert t1 == t2
 
     def verify_single_childified(self, ts, keep_unary=False):
         """
@@ -4913,34 +4918,34 @@ class TestSimplify(SimplifyTestBase):
         tss, node_map = self.do_simplify(ts_single, keep_unary=keep_unary)
         # All original nodes should still be present.
         for u in range(ts.num_samples):
-            self.assertEqual(u, node_map[u])
+            assert u == node_map[u]
         # All introduced nodes should be mapped to null.
         for u in range(ts.num_samples, ts_single.num_samples):
-            self.assertEqual(node_map[u], tskit.NULL)
+            assert node_map[u] == tskit.NULL
         t1 = ts.dump_tables()
         t2 = tss.dump_tables()
         t3 = ts_single.dump_tables()
         if keep_unary:
-            self.assertEqual(set(t3.nodes.time), set(t2.nodes.time))
-            self.assertEqual(len(t3.edges), len(t2.edges))
-            self.assertEqual(t3.sites, t2.sites)
-            self.assertEqual(len(t3.mutations), len(t2.mutations))
+            assert set(t3.nodes.time) == set(t2.nodes.time)
+            assert len(t3.edges) == len(t2.edges)
+            assert t3.sites == t2.sites
+            assert len(t3.mutations) == len(t2.mutations)
         else:
-            self.assertEqual(t1.nodes, t2.nodes)
-            self.assertEqual(t1.edges, t2.edges)
-            self.assertEqual(t1.sites, t2.sites)
-            self.assertEqual(t1.mutations, t2.mutations)
+            assert t1.nodes == t2.nodes
+            assert t1.edges == t2.edges
+            assert t1.sites == t2.sites
+            assert t1.mutations == t2.mutations
 
     def verify_multiroot_internal_samples(self, ts, keep_unary=False):
         ts_multiroot = tsutil.decapitate(ts, ts.num_edges // 2)
         ts1 = tsutil.jiggle_samples(ts_multiroot)
         ts2, node_map = self.do_simplify(ts1, keep_unary=keep_unary)
-        self.assertGreaterEqual(ts1.num_trees, ts2.num_trees)
+        assert ts1.num_trees >= ts2.num_trees
         trees2 = ts2.trees()
         t2 = next(trees2)
         for t1 in ts1.trees():
-            self.assertTrue(t2.interval[0] <= t1.interval[0])
-            self.assertTrue(t2.interval[1] >= t1.interval[1])
+            assert t2.interval[0] <= t1.interval[0]
+            assert t2.interval[1] >= t1.interval[1]
             pairs = itertools.combinations(ts1.samples(), 2)
             for pair in pairs:
                 mapped_pair = [node_map[u] for u in pair]
@@ -4949,7 +4954,7 @@ class TestSimplify(SimplifyTestBase):
                 if mrca1 == tskit.NULL:
                     assert mrca2 == tskit.NULL
                 else:
-                    self.assertEqual(node_map[mrca1], mrca2)
+                    assert node_map[mrca1] == mrca2
             if t2.interval[1] == t1.interval[1]:
                 t2 = next(trees2, None)
 
@@ -4965,7 +4970,7 @@ class TestSimplify(SimplifyTestBase):
 
     def test_single_tree_mutations(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=self.random_seed)
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_sites > 1
         self.do_simplify(ts)
         self.verify_single_childified(ts)
         # Also with keep_unary == True.
@@ -4976,8 +4981,8 @@ class TestSimplify(SimplifyTestBase):
         ts = msprime.simulate(
             10, recombination_rate=1, mutation_rate=10, random_seed=self.random_seed
         )
-        self.assertGreater(ts.num_trees, 2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_trees > 2
+        assert ts.num_sites > 2
         self.verify_no_samples(ts)
         self.do_simplify(ts)
         self.verify_single_childified(ts)
@@ -4987,7 +4992,7 @@ class TestSimplify(SimplifyTestBase):
 
     def test_many_trees(self):
         ts = msprime.simulate(5, recombination_rate=4, random_seed=self.random_seed)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify_no_samples(ts)
         self.verify_single_childified(ts)
         self.verify_multiroot_internal_samples(ts)
@@ -5012,19 +5017,19 @@ class TestSimplify(SimplifyTestBase):
         flags[5] = tskit.NODE_IS_SAMPLE
         nodes.flags = flags
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sample_size, 5)
+        assert ts.sample_size == 5
         tss, node_map = self.do_simplify(ts, [3, 5])
-        self.assertEqual(node_map[3], 0)
-        self.assertEqual(node_map[5], 1)
-        self.assertEqual(tss.num_nodes, 3)
-        self.assertEqual(tss.num_edges, 2)
+        assert node_map[3] == 0
+        assert node_map[5] == 1
+        assert tss.num_nodes == 3
+        assert tss.num_edges == 2
         self.verify_no_samples(ts)
         # with keep_unary == True
         tss, node_map = self.do_simplify(ts, [3, 5], keep_unary=True)
-        self.assertEqual(node_map[3], 0)
-        self.assertEqual(node_map[5], 1)
-        self.assertEqual(tss.num_nodes, 5)
-        self.assertEqual(tss.num_edges, 4)
+        assert node_map[3] == 0
+        assert node_map[5] == 1
+        assert tss.num_nodes == 5
+        assert tss.num_edges == 4
         self.verify_no_samples(ts, keep_unary=True)
 
     def test_small_tree_linear_samples(self):
@@ -5042,20 +5047,20 @@ class TestSimplify(SimplifyTestBase):
         flags[7] = tskit.NODE_IS_SAMPLE
         nodes.flags = flags
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sample_size, 2)
+        assert ts.sample_size == 2
         tss, node_map = self.do_simplify(ts, [0, 7])
-        self.assertEqual(node_map[0], 0)
-        self.assertEqual(node_map[7], 1)
-        self.assertEqual(tss.num_nodes, 2)
-        self.assertEqual(tss.num_edges, 1)
+        assert node_map[0] == 0
+        assert node_map[7] == 1
+        assert tss.num_nodes == 2
+        assert tss.num_edges == 1
         t = next(tss.trees())
-        self.assertEqual(t.parent_dict, {0: 1})
+        assert t.parent_dict == {0: 1}
         # with keep_unary == True
         tss, node_map = self.do_simplify(ts, [0, 7], keep_unary=True)
-        self.assertEqual(node_map[0], 0)
-        self.assertEqual(node_map[7], 1)
-        self.assertEqual(tss.num_nodes, 4)
-        self.assertEqual(tss.num_edges, 3)
+        assert node_map[0] == 0
+        assert node_map[7] == 1
+        assert tss.num_nodes == 4
+        assert tss.num_edges == 3
         t = next(tss.trees())
 
     def test_small_tree_internal_and_external_samples(self):
@@ -5074,24 +5079,24 @@ class TestSimplify(SimplifyTestBase):
         flags[7] = tskit.NODE_IS_SAMPLE
         nodes.flags = flags
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sample_size, 3)
+        assert ts.sample_size == 3
         tss, node_map = self.do_simplify(ts, [0, 1, 7])
-        self.assertEqual(node_map[0], 0)
-        self.assertEqual(node_map[1], 1)
-        self.assertEqual(node_map[7], 2)
-        self.assertEqual(tss.num_nodes, 4)
-        self.assertEqual(tss.num_edges, 3)
+        assert node_map[0] == 0
+        assert node_map[1] == 1
+        assert node_map[7] == 2
+        assert tss.num_nodes == 4
+        assert tss.num_edges == 3
         t = next(tss.trees())
-        self.assertEqual(t.parent_dict, {0: 3, 1: 3, 3: 2})
+        assert t.parent_dict == {0: 3, 1: 3, 3: 2}
         # with keep_unary == True
         tss, node_map = self.do_simplify(ts, [0, 1, 7], keep_unary=True)
-        self.assertEqual(node_map[0], 0)
-        self.assertEqual(node_map[1], 1)
-        self.assertEqual(node_map[7], 2)
-        self.assertEqual(tss.num_nodes, 5)
-        self.assertEqual(tss.num_edges, 4)
+        assert node_map[0] == 0
+        assert node_map[1] == 1
+        assert node_map[7] == 2
+        assert tss.num_nodes == 5
+        assert tss.num_edges == 4
         t = next(tss.trees())
-        self.assertEqual(t.parent_dict, {0: 3, 1: 3, 3: 2, 2: 4})
+        assert t.parent_dict == {0: 3, 1: 3, 3: 2, 2: 4}
 
     def test_small_tree_mutations(self):
         ts = tskit.load_text(
@@ -5110,13 +5115,13 @@ class TestSimplify(SimplifyTestBase):
         tables.mutations.add_row(site=2, node=7, derived_state="1")
         tables.mutations.add_row(site=3, node=0, derived_state="1")
         ts = tables.tree_sequence()
-        self.assertEqual(ts.num_sites, 4)
-        self.assertEqual(ts.num_mutations, 4)
+        assert ts.num_sites == 4
+        assert ts.num_mutations == 4
         for keep in [True, False]:
             tss = self.do_simplify(ts, [0, 2], keep_unary=keep)[0]
-            self.assertEqual(tss.sample_size, 2)
-            self.assertEqual(tss.num_mutations, 4)
-            self.assertEqual(list(tss.haplotypes()), ["1011", "0100"])
+            assert tss.sample_size == 2
+            assert tss.num_mutations == 4
+            assert list(tss.haplotypes()) == ["1011", "0100"]
 
     def test_small_tree_filter_zero_mutations(self):
         ts = tskit.load_text(
@@ -5125,17 +5130,17 @@ class TestSimplify(SimplifyTestBase):
             strict=False,
         )
         ts = tsutil.insert_branch_sites(ts)
-        self.assertEqual(ts.num_sites, 8)
-        self.assertEqual(ts.num_mutations, 8)
+        assert ts.num_sites == 8
+        assert ts.num_mutations == 8
         for keep in [True, False]:
             tss, _ = self.do_simplify(ts, [4, 0, 1], filter_sites=True, keep_unary=keep)
-            self.assertEqual(tss.num_sites, 5)
-            self.assertEqual(tss.num_mutations, 5)
+            assert tss.num_sites == 5
+            assert tss.num_mutations == 5
             tss, _ = self.do_simplify(
                 ts, [4, 0, 1], filter_sites=False, keep_unary=keep
             )
-            self.assertEqual(tss.num_sites, 8)
-            self.assertEqual(tss.num_mutations, 5)
+            assert tss.num_sites == 8
+            assert tss.num_mutations == 5
 
     def test_small_tree_fixed_sites(self):
         ts = tskit.load_text(
@@ -5152,13 +5157,13 @@ class TestSimplify(SimplifyTestBase):
         tables.mutations.add_row(site=1, node=3, derived_state="1")
         tables.mutations.add_row(site=2, node=6, derived_state="1")
         ts = tables.tree_sequence()
-        self.assertEqual(ts.num_sites, 3)
-        self.assertEqual(ts.num_mutations, 3)
+        assert ts.num_sites == 3
+        assert ts.num_mutations == 3
         for keep in [True, False]:
             tss, _ = self.do_simplify(ts, [4, 1], keep_unary=keep)
-            self.assertEqual(tss.sample_size, 2)
-            self.assertEqual(tss.num_mutations, 0)
-            self.assertEqual(list(tss.haplotypes()), ["", ""])
+            assert tss.sample_size == 2
+            assert tss.num_mutations == 0
+            assert list(tss.haplotypes()) == ["", ""]
 
     def test_small_tree_mutations_over_root(self):
         ts = tskit.load_text(
@@ -5170,14 +5175,14 @@ class TestSimplify(SimplifyTestBase):
         tables.sites.add_row(position=0.25, ancestral_state="0")
         tables.mutations.add_row(site=0, node=8, derived_state="1")
         ts = tables.tree_sequence()
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 1)
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 1
         for keep_unary, filter_sites in itertools.product([True, False], repeat=2):
             tss, _ = self.do_simplify(
                 ts, [0, 1], filter_sites=filter_sites, keep_unary=keep_unary
             )
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 1)
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 1
 
     def test_small_tree_recurrent_mutations(self):
         ts = tskit.load_text(
@@ -5191,14 +5196,14 @@ class TestSimplify(SimplifyTestBase):
         tables.mutations.add_row(site=0, node=6, derived_state="1")
         tables.mutations.add_row(site=0, node=7, derived_state="1")
         ts = tables.tree_sequence()
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 2)
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 2
         for keep in [True, False]:
             tss = self.do_simplify(ts, [4, 3], keep_unary=keep)[0]
-            self.assertEqual(tss.sample_size, 2)
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 2)
-            self.assertEqual(list(tss.haplotypes()), ["1", "1"])
+            assert tss.sample_size == 2
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 2
+            assert list(tss.haplotypes()) == ["1", "1"]
 
     def test_small_tree_back_mutations(self):
         ts = tskit.load_text(
@@ -5213,32 +5218,32 @@ class TestSimplify(SimplifyTestBase):
         tables.mutations.add_row(site=0, node=5, derived_state="0")
         tables.mutations.add_row(site=0, node=1, derived_state="1")
         ts = tables.tree_sequence()
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 3)
-        self.assertEqual(list(ts.haplotypes()), ["0", "1", "0", "0", "1"])
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 3
+        assert list(ts.haplotypes()) == ["0", "1", "0", "0", "1"]
         # First check if we simplify for all samples and keep original state.
         for keep in [True, False]:
             tss = self.do_simplify(ts, [0, 1, 2, 3, 4], keep_unary=keep)[0]
-            self.assertEqual(tss.sample_size, 5)
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 3)
-            self.assertEqual(list(tss.haplotypes()), ["0", "1", "0", "0", "1"])
+            assert tss.sample_size == 5
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 3
+            assert list(tss.haplotypes()) == ["0", "1", "0", "0", "1"]
 
         # The ancestral state above 5 should be 0.
         for keep in [True, False]:
             tss = self.do_simplify(ts, [0, 1], keep_unary=keep)[0]
-            self.assertEqual(tss.sample_size, 2)
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 3)
-            self.assertEqual(list(tss.haplotypes()), ["0", "1"])
+            assert tss.sample_size == 2
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 3
+            assert list(tss.haplotypes()) == ["0", "1"]
 
         # The ancestral state above 7 should be 1.
         for keep in [True, False]:
             tss = self.do_simplify(ts, [4, 0, 1], keep_unary=keep)[0]
-            self.assertEqual(tss.sample_size, 3)
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 3)
-            self.assertEqual(list(tss.haplotypes()), ["1", "0", "1"])
+            assert tss.sample_size == 3
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 3
+            assert list(tss.haplotypes()) == ["1", "0", "1"]
 
     def test_overlapping_unary_edges(self):
         nodes = io.StringIO(
@@ -5257,15 +5262,15 @@ class TestSimplify(SimplifyTestBase):
         """
         )
         ts = tskit.load_text(nodes, edges, strict=False)
-        self.assertEqual(ts.sample_size, 2)
-        self.assertEqual(ts.num_trees, 3)
-        self.assertEqual(ts.sequence_length, 3)
+        assert ts.sample_size == 2
+        assert ts.num_trees == 3
+        assert ts.sequence_length == 3
         for keep in [True, False]:
             tss, node_map = self.do_simplify(ts, samples=[0, 1, 2], keep_unary=keep)
-            self.assertEqual(list(node_map), [0, 1, 2])
+            assert list(node_map) == [0, 1, 2]
             trees = [{0: 2}, {0: 2, 1: 2}, {1: 2}]
             for t in tss.trees():
-                self.assertEqual(t.parent_dict, trees[t.index])
+                assert t.parent_dict == trees[t.index]
 
     def test_overlapping_unary_edges_internal_samples(self):
         nodes = io.StringIO(
@@ -5284,13 +5289,13 @@ class TestSimplify(SimplifyTestBase):
         """
         )
         ts = tskit.load_text(nodes, edges, strict=False)
-        self.assertEqual(ts.sample_size, 3)
-        self.assertEqual(ts.num_trees, 3)
+        assert ts.sample_size == 3
+        assert ts.num_trees == 3
         trees = [{0: 2}, {0: 2, 1: 2}, {1: 2}]
         for t in ts.trees():
-            self.assertEqual(t.parent_dict, trees[t.index])
+            assert t.parent_dict == trees[t.index]
         tss, node_map = self.do_simplify(ts)
-        self.assertEqual(list(node_map), [0, 1, 2])
+        assert list(node_map) == [0, 1, 2]
 
     def test_isolated_samples(self):
         nodes = io.StringIO(
@@ -5307,14 +5312,14 @@ class TestSimplify(SimplifyTestBase):
         """
         )
         ts = tskit.load_text(nodes, edges, sequence_length=1, strict=False)
-        self.assertEqual(ts.num_samples, 3)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, 3)
+        assert ts.num_samples == 3
+        assert ts.num_trees == 1
+        assert ts.num_nodes == 3
         for keep in [True, False]:
             tss, node_map = self.do_simplify(ts, keep_unary=keep)
-            self.assertEqual(ts.tables.nodes, tss.tables.nodes)
-            self.assertEqual(ts.tables.edges, tss.tables.edges)
-            self.assertEqual(list(node_map), [0, 1, 2])
+            assert ts.tables.nodes == tss.tables.nodes
+            assert ts.tables.edges == tss.tables.edges
+            assert list(node_map) == [0, 1, 2]
 
     def test_internal_samples(self):
         nodes = io.StringIO(
@@ -5345,37 +5350,37 @@ class TestSimplify(SimplifyTestBase):
 
         ts = tskit.load_text(nodes, edges, strict=False)
         tss, node_map = self.do_simplify(ts, [5, 2, 0])
-        self.assertEqual(node_map[0], 2)
-        self.assertEqual(node_map[1], -1)
-        self.assertEqual(node_map[2], 1)
-        self.assertEqual(node_map[3], 3)
-        self.assertEqual(node_map[4], 4)
-        self.assertEqual(node_map[5], 0)
-        self.assertEqual(node_map[6], -1)
-        self.assertEqual(node_map[7], -1)
-        self.assertEqual(tss.sample_size, 3)
-        self.assertEqual(tss.num_trees, 2)
+        assert node_map[0] == 2
+        assert node_map[1] == -1
+        assert node_map[2] == 1
+        assert node_map[3] == 3
+        assert node_map[4] == 4
+        assert node_map[5] == 0
+        assert node_map[6] == -1
+        assert node_map[7] == -1
+        assert tss.sample_size == 3
+        assert tss.num_trees == 2
         trees = [{0: 1, 1: 3, 2: 3}, {0: 4, 1: 3, 2: 3, 3: 4}]
         for t in tss.trees():
-            self.assertEqual(t.parent_dict, trees[t.index])
+            assert t.parent_dict == trees[t.index]
         # with keep_unary == True
         tss, node_map = self.do_simplify(ts, [5, 2, 0], keep_unary=True)
-        self.assertEqual(node_map[0], 2)
-        self.assertEqual(node_map[1], 4)
-        self.assertEqual(node_map[2], 1)
-        self.assertEqual(node_map[3], 5)
-        self.assertEqual(node_map[4], 7)
-        self.assertEqual(node_map[5], 0)
-        self.assertEqual(node_map[6], 3)
-        self.assertEqual(node_map[7], 6)
-        self.assertEqual(tss.sample_size, 3)
-        self.assertEqual(tss.num_trees, 2)
+        assert node_map[0] == 2
+        assert node_map[1] == 4
+        assert node_map[2] == 1
+        assert node_map[3] == 5
+        assert node_map[4] == 7
+        assert node_map[5] == 0
+        assert node_map[6] == 3
+        assert node_map[7] == 6
+        assert tss.sample_size == 3
+        assert tss.num_trees == 2
         trees = [
             {0: 3, 1: 5, 2: 5, 3: 1, 5: 7},
             {0: 3, 1: 5, 2: 5, 3: 4, 4: 6, 5: 7, 6: 7},
         ]
         for t in tss.trees():
-            self.assertEqual(t.parent_dict, trees[t.index])
+            assert t.parent_dict == trees[t.index]
 
     def test_many_mutations_over_single_sample_ancestral_state(self):
         nodes = io.StringIO(
@@ -5407,15 +5412,15 @@ class TestSimplify(SimplifyTestBase):
         ts = tskit.load_text(
             nodes, edges, sites=sites, mutations=mutations, strict=False
         )
-        self.assertEqual(ts.sample_size, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 2)
+        assert ts.sample_size == 1
+        assert ts.num_trees == 1
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 2
         for keep in [True, False]:
             tss, node_map = self.do_simplify(ts, keep_unary=keep)
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 2)
-            self.assertEqual(list(tss.haplotypes(isolated_as_missing=False)), ["0"])
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 2
+            assert list(tss.haplotypes(isolated_as_missing=False)) == ["0"]
 
     def test_many_mutations_over_single_sample_derived_state(self):
         nodes = io.StringIO(
@@ -5448,58 +5453,58 @@ class TestSimplify(SimplifyTestBase):
         ts = tskit.load_text(
             nodes, edges, sites=sites, mutations=mutations, strict=False
         )
-        self.assertEqual(ts.sample_size, 1)
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 3)
+        assert ts.sample_size == 1
+        assert ts.num_trees == 1
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 3
         for keep in [True, False]:
             tss, node_map = self.do_simplify(ts, keep_unary=keep)
-            self.assertEqual(tss.num_sites, 1)
-            self.assertEqual(tss.num_mutations, 3)
-            self.assertEqual(list(tss.haplotypes(isolated_as_missing=False)), ["1"])
+            assert tss.num_sites == 1
+            assert tss.num_mutations == 3
+            assert list(tss.haplotypes(isolated_as_missing=False)) == ["1"]
 
     def test_many_trees_filter_zero_mutations(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.insert_branch_sites(ts)
-        self.assertEqual(ts.num_sites, ts.num_mutations)
-        self.assertGreater(ts.num_sites, ts.num_trees)
+        assert ts.num_sites == ts.num_mutations
+        assert ts.num_sites > ts.num_trees
         for keep in [True, False]:
             for filter_sites in [True, False]:
                 tss, _ = self.do_simplify(
                     ts, samples=None, filter_sites=filter_sites, keep_unary=keep
                 )
-                self.assertEqual(ts.num_sites, tss.num_sites)
-                self.assertEqual(ts.num_mutations, tss.num_mutations)
+                assert ts.num_sites == tss.num_sites
+                assert ts.num_mutations == tss.num_mutations
 
     def test_many_trees_filter_zero_multichar_mutations(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.insert_multichar_mutations(ts)
-        self.assertEqual(ts.num_sites, ts.num_trees)
-        self.assertEqual(ts.num_mutations, ts.num_trees)
+        assert ts.num_sites == ts.num_trees
+        assert ts.num_mutations == ts.num_trees
         for keep in [True, False]:
             for filter_sites in [True, False]:
                 tss, _ = self.do_simplify(
                     ts, samples=None, filter_sites=filter_sites, keep_unary=keep
                 )
-                self.assertEqual(ts.num_sites, tss.num_sites)
-                self.assertEqual(ts.num_mutations, tss.num_mutations)
+                assert ts.num_sites == tss.num_sites
+                assert ts.num_mutations == tss.num_mutations
 
     def test_simple_population_filter(self):
         ts = msprime.simulate(10, random_seed=2)
         tables = ts.dump_tables()
         tables.populations.add_row(metadata=b"unreferenced")
-        self.assertEqual(len(tables.populations), 2)
+        assert len(tables.populations) == 2
         for keep in [True, False]:
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_populations=True, keep_unary=keep
             )
-            self.assertEqual(tss.num_populations, 1)
+            assert tss.num_populations == 1
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_populations=False, keep_unary=keep
             )
-            self.assertEqual(tss.num_populations, 2)
+            assert tss.num_populations == 2
 
     def test_interleaved_populations_filter(self):
         ts = msprime.simulate(
@@ -5511,7 +5516,7 @@ class TestSimplify(SimplifyTestBase):
             ],
             random_seed=2,
         )
-        self.assertEqual(ts.num_populations, 4)
+        assert ts.num_populations == 4
         tables = ts.dump_tables()
         # Edit the populations so we can identify the rows.
         tables.populations.clear()
@@ -5521,16 +5526,14 @@ class TestSimplify(SimplifyTestBase):
         id_map = np.array([-1, 0, -1, -1], dtype=np.int32)
         for keep in [True, False]:
             tss, _ = self.do_simplify(ts, filter_populations=True, keep_unary=keep)
-            self.assertEqual(tss.num_populations, 1)
+            assert tss.num_populations == 1
             population = tss.population(0)
-            self.assertEqual(population.metadata, bytes([1]))
-            self.assertTrue(
-                np.array_equal(
-                    id_map[ts.tables.nodes.population], tss.tables.nodes.population
-                )
+            assert population.metadata == bytes([1])
+            assert np.array_equal(
+                id_map[ts.tables.nodes.population], tss.tables.nodes.population
             )
             tss, _ = self.do_simplify(ts, filter_populations=False, keep_unary=keep)
-            self.assertEqual(tss.num_populations, 4)
+            assert tss.num_populations == 4
 
     def test_removed_node_population_filter(self):
         tables = tskit.TableCollection(1)
@@ -5546,17 +5549,17 @@ class TestSimplify(SimplifyTestBase):
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_populations=True, keep_unary=keep
             )
-            self.assertEqual(tss.num_nodes, 2)
-            self.assertEqual(tss.num_populations, 2)
-            self.assertEqual(tss.population(0).metadata, bytes(0))
-            self.assertEqual(tss.population(1).metadata, bytes(2))
-            self.assertEqual(tss.node(0).population, 0)
-            self.assertEqual(tss.node(1).population, 1)
+            assert tss.num_nodes == 2
+            assert tss.num_populations == 2
+            assert tss.population(0).metadata == bytes(0)
+            assert tss.population(1).metadata == bytes(2)
+            assert tss.node(0).population == 0
+            assert tss.node(1).population == 1
 
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_populations=False, keep_unary=keep
             )
-            self.assertEqual(tss.tables.populations, tables.populations)
+            assert tss.tables.populations == tables.populations
 
     def test_simple_individual_filter(self):
         tables = tskit.TableCollection(1)
@@ -5568,12 +5571,12 @@ class TestSimplify(SimplifyTestBase):
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_individuals=True, keep_unary=keep
             )
-            self.assertEqual(tss.num_nodes, 2)
-            self.assertEqual(tss.num_individuals, 1)
-            self.assertEqual(tss.individual(0).flags, 0)
+            assert tss.num_nodes == 2
+            assert tss.num_individuals == 1
+            assert tss.individual(0).flags == 0
 
         tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=False)
-        self.assertEqual(tss.tables.individuals, tables.individuals)
+        assert tss.tables.individuals == tables.individuals
 
     def test_interleaved_individual_filter(self):
         tables = tskit.TableCollection(1)
@@ -5587,14 +5590,14 @@ class TestSimplify(SimplifyTestBase):
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_individuals=True, keep_unary=keep
             )
-            self.assertEqual(tss.num_nodes, 3)
-            self.assertEqual(tss.num_individuals, 1)
-            self.assertEqual(tss.individual(0).flags, 1)
+            assert tss.num_nodes == 3
+            assert tss.num_individuals == 1
+            assert tss.individual(0).flags == 1
 
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_individuals=False, keep_unary=keep
             )
-            self.assertEqual(tss.tables.individuals, tables.individuals)
+            assert tss.tables.individuals == tables.individuals
 
     def test_removed_node_individual_filter(self):
         tables = tskit.TableCollection(1)
@@ -5610,23 +5613,23 @@ class TestSimplify(SimplifyTestBase):
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_individuals=True, keep_unary=keep
             )
-            self.assertEqual(tss.num_nodes, 2)
-            self.assertEqual(tss.num_individuals, 2)
-            self.assertEqual(tss.individual(0).flags, 0)
-            self.assertEqual(tss.individual(1).flags, 2)
-            self.assertEqual(tss.node(0).individual, 0)
-            self.assertEqual(tss.node(1).individual, 1)
+            assert tss.num_nodes == 2
+            assert tss.num_individuals == 2
+            assert tss.individual(0).flags == 0
+            assert tss.individual(1).flags == 2
+            assert tss.node(0).individual == 0
+            assert tss.node(1).individual == 1
 
             tss, _ = self.do_simplify(
                 tables.tree_sequence(), filter_individuals=False, keep_unary=keep
             )
-            self.assertEqual(tss.tables.individuals, tables.individuals)
+            assert tss.tables.individuals == tables.individuals
 
     def verify_simplify_haplotypes(self, ts, samples, keep_unary=False):
         sub_ts, node_map = self.do_simplify(
             ts, samples, filter_sites=False, keep_unary=keep_unary
         )
-        self.assertEqual(ts.num_sites, sub_ts.num_sites)
+        assert ts.num_sites == sub_ts.num_sites
         sub_haplotypes = list(sub_ts.haplotypes(isolated_as_missing=False))
         all_samples = list(ts.samples())
         k = 0
@@ -5634,7 +5637,7 @@ class TestSimplify(SimplifyTestBase):
             if k == len(samples):
                 break
             if samples[k] == all_samples[j]:
-                self.assertEqual(h, sub_haplotypes[k])
+                assert h == sub_haplotypes[k]
                 k += 1
 
     def test_single_tree_recurrent_mutations(self):
@@ -5648,7 +5651,7 @@ class TestSimplify(SimplifyTestBase):
 
     def test_many_trees_recurrent_mutations(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         for mutations_per_branch in [1, 2, 3]:
             ts = tsutil.insert_branch_mutations(ts, mutations_per_branch)
             for num_samples in range(1, ts.num_samples):
@@ -5668,7 +5671,7 @@ class TestSimplify(SimplifyTestBase):
 
     def test_many_multiroot_trees_recurrent_mutations(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         for mutations_per_branch in [1, 2, 3]:
             ts = tsutil.insert_branch_mutations(ts, mutations_per_branch)
@@ -5690,7 +5693,7 @@ class TestSimplify(SimplifyTestBase):
     def test_many_trees_recurrent_mutations_internal_samples(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
         ts = tsutil.jiggle_samples(ts)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         for mutations_per_branch in [1, 2, 3]:
             ts = tsutil.insert_branch_mutations(ts, mutations_per_branch)
             for num_samples in range(1, ts.num_samples):
@@ -5723,28 +5726,28 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
             ts, ts_with_roots
         ):
             input_roots = input_tree.roots
-            self.assertGreater(len(tree_with_roots.roots), 0)
+            assert len(tree_with_roots.roots) > 0
             for root in tree_with_roots.roots:
                 # Check that the roots in the current
                 input_root = new_to_input_map[root]
-                self.assertIn(input_root, input_roots)
+                assert input_root in input_roots
                 input_node = ts.node(input_root)
                 new_node = ts_with_roots.node(root)
-                self.assertEqual(new_node.time, input_node.time)
-                self.assertEqual(new_node.population, input_node.population)
-                self.assertEqual(new_node.individual, input_node.individual)
-                self.assertEqual(new_node.metadata, input_node.metadata)
+                assert new_node.time == input_node.time
+                assert new_node.population == input_node.population
+                assert new_node.individual == input_node.individual
+                assert new_node.metadata == input_node.metadata
                 # This should only be marked as a sample if it's an
                 # element of the samples list.
-                self.assertEqual(new_node.is_sample(), input_root in samples)
+                assert new_node.is_sample() == (input_root in samples)
                 # Find the MRCA of the samples below this root.
                 root_samples = list(tree_with_roots.samples(root))
                 mrca = functools.reduce(tree_with_roots.mrca, root_samples)
                 if mrca != root:
                     # If the MRCA is not equal to the root, then there should
                     # be a unary branch joining them.
-                    self.assertEqual(tree_with_roots.parent(mrca), root)
-                    self.assertEqual(tree_with_roots.children(root), (mrca,))
+                    assert tree_with_roots.parent(mrca) == root
+                    assert tree_with_roots.children(root) == (mrca,)
 
                     # Any mutations that were on the path from the old MRCA
                     # to the root should be mapped to this node, and any mutations
@@ -5764,17 +5767,17 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
                         for site in tree_with_roots.sites()
                         if site.position >= left and site.position < right
                     }
-                    self.assertEqual(set(input_sites.keys()), set(new_sites.keys()))
+                    assert set(input_sites.keys()) == set(new_sites.keys())
                     positions = input_sites.keys()
                     for position in positions:
-                        self.assertTrue(left <= position < right)
+                        assert left <= position < right
                         new_site = new_sites[position]
                         # We assume the metadata contains a unique key for each mutation.
                         new_mutations = {
                             mut.metadata: mut for mut in new_site.mutations
                         }
                         # Just make sure the metadata is actually unique.
-                        self.assertEqual(len(new_mutations), len(new_site.mutations))
+                        assert len(new_mutations) == len(new_site.mutations)
                         input_site = input_sites[position]
                         for input_mutation in input_site.mutations:
                             if input_mutation.node in root_path:
@@ -5786,18 +5789,18 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
                                 new_mutation = new_mutations[input_mutation.metadata]
                                 # We have turned filter sites off, so sites should
                                 # be comparable
-                                self.assertEqual(new_mutation.site, input_mutation.site)
-                                self.assertEqual(
-                                    new_mutation.derived_state,
-                                    input_mutation.derived_state,
+                                assert new_mutation.site == input_mutation.site
+                                assert (
+                                    new_mutation.derived_state
+                                    == input_mutation.derived_state
                                 )
-                                self.assertEqual(new_mutation.node, new_node)
+                                assert new_mutation.node == new_node
 
         return ts_with_roots
 
     def test_many_trees(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         for num_samples in range(1, ts.num_samples):
             for samples in itertools.combinations(ts.samples(), num_samples):
                 self.verify_keep_input_roots(ts, samples)
@@ -5805,14 +5808,14 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
     def test_many_trees_internal_samples(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=10)
         ts = tsutil.jiggle_samples(ts)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         for num_samples in range(1, ts.num_samples):
             for samples in itertools.combinations(ts.samples(), num_samples):
                 self.verify_keep_input_roots(ts, samples)
 
     def test_many_multiroot_trees(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         for num_samples in range(1, ts.num_samples):
             for samples in itertools.combinations(ts.samples(), num_samples):
@@ -5828,9 +5831,9 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
         for tree in simplified.trees():
             for root in tree.roots:
                 roots.add(root)
-                self.assertEqual(tree.time(root), num_generations)
+                assert tree.time(root) == num_generations
         init_nodes = np.where(simplified.tables.nodes.time == num_generations)[0]
-        self.assertEqual(set(init_nodes), roots)
+        assert set(init_nodes) == roots
 
     def test_single_tree_recurrent_mutations(self):
         ts = msprime.simulate(6, random_seed=10)
@@ -5842,7 +5845,7 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
 
     def test_many_trees_recurrent_mutations(self):
         ts = msprime.simulate(5, recombination_rate=1, random_seed=8)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         for mutations_per_branch in [1, 2, 3]:
             ts = tsutil.insert_branch_mutations(ts, mutations_per_branch)
             for num_samples in range(1, ts.num_samples):
@@ -5850,7 +5853,7 @@ class TestSimplifyKeepInputRoots(SimplifyTestBase, ExampleTopologyMixin):
                     self.verify_keep_input_roots(ts, samples)
 
 
-class TestMapToAncestors(unittest.TestCase):
+class TestMapToAncestors:
     """
     Tests the AncestorMap class.
     """
@@ -5941,7 +5944,7 @@ class TestMapToAncestors(unittest.TestCase):
         ancestor_table = s.link_ancestors()
         if compare_lib:
             lib_result = ts.tables.link_ancestors(samples, ancestors)
-            self.assertEqual(ancestor_table, lib_result)
+            assert ancestor_table == lib_result
         return ancestor_table
 
     def test_deprecated_name(self):
@@ -5954,56 +5957,56 @@ class TestMapToAncestors(unittest.TestCase):
         s = tests.AncestorMap(ts, samples, ancestors)
         tss = s.link_ancestors()
         lib_result = ts.tables.map_ancestors(samples, ancestors)
-        self.assertEqual(tss, lib_result)
-        self.assertEqual(list(tss.parent), [8, 8, 8, 8, 8])
-        self.assertEqual(list(tss.child), [0, 1, 2, 3, 4])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert tss == lib_result
+        assert list(tss.parent) == [8, 8, 8, 8, 8]
+        assert list(tss.child) == [0, 1, 2, 3, 4]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_one_ancestor(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, ancestors=[8])
-        self.assertEqual(list(tss.parent), [8, 8, 8, 8, 8])
-        self.assertEqual(list(tss.child), [0, 1, 2, 3, 4])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [8, 8, 8, 8, 8]
+        assert list(tss.child) == [0, 1, 2, 3, 4]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_unordered_nodes(self):
         nodes = io.StringIO(self.nodes1)
         edges = io.StringIO(self.edges1)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, ancestors=[0])
-        self.assertEqual(list(tss.parent), [0, 0])
-        self.assertEqual(list(tss.child), [1, 2])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [0, 0]
+        assert list(tss.child) == [1, 2]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_two_ancestors(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, ancestors=[6, 7])
-        self.assertEqual(list(tss.parent), [6, 6, 7, 7, 7])
-        self.assertEqual(list(tss.child), [2, 3, 0, 1, 4])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [6, 6, 7, 7, 7]
+        assert list(tss.child) == [2, 3, 0, 1, 4]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_no_ancestors(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, samples=[2, 3], ancestors=[7])
-        self.assertEqual(tss.num_rows, 0)
+        assert tss.num_rows == 0
 
     def test_single_tree_samples_or_ancestors_not_in_tree(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.do_map(ts, samples=[-1, 3], ancestors=[5])
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.do_map(ts, samples=[2, 3], ancestors=[10])
 
     def test_single_tree_ancestors_descend_from_other_ancestors(self):
@@ -6011,80 +6014,80 @@ class TestMapToAncestors(unittest.TestCase):
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, ancestors=[7, 8])
-        self.assertEqual(list(tss.parent), [7, 7, 7, 8, 8, 8])
-        self.assertEqual(list(tss.child), [0, 1, 4, 2, 3, 7])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [7, 7, 7, 8, 8, 8]
+        assert list(tss.child) == [0, 1, 4, 2, 3, 7]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_internal_samples(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, samples=[2, 3, 4, 5], ancestors=[7, 8])
-        self.assertEqual(list(tss.parent), [7, 7, 8, 8, 8])
-        self.assertEqual(list(tss.child), [4, 5, 2, 3, 7])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [7, 7, 8, 8, 8]
+        assert list(tss.child) == [4, 5, 2, 3, 7]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_samples_and_ancestors_overlap(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, samples=[1, 2, 3, 5], ancestors=[5, 6, 7])
-        self.assertEqual(list(tss.parent), [5, 6, 6, 7])
-        self.assertEqual(list(tss.child), [1, 2, 3, 5])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [5, 6, 6, 7]
+        assert list(tss.child) == [1, 2, 3, 5]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_unary_ancestor(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, samples=[1, 2, 4], ancestors=[5, 7, 8])
-        self.assertEqual(list(tss.parent), [5, 7, 7, 8, 8])
-        self.assertEqual(list(tss.child), [1, 4, 5, 2, 7])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [5, 7, 7, 8, 8]
+        assert list(tss.child) == [1, 4, 5, 2, 7]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_ancestors_descend_from_samples(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, samples=[1, 7], ancestors=[5, 8])
-        self.assertEqual(list(tss.parent), [5, 7, 8])
-        self.assertEqual(list(tss.child), [1, 5, 7])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [5, 7, 8]
+        assert list(tss.child) == [1, 5, 7]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_single_tree_samples_descend_from_samples(self):
         nodes = io.StringIO(self.nodes)
         edges = io.StringIO(self.edges)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, samples=[3, 6], ancestors=[8])
-        self.assertEqual(list(tss.parent), [6, 8])
-        self.assertEqual(list(tss.child), [3, 6])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [6, 8]
+        assert list(tss.child) == [3, 6]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_multiple_trees_to_single_tree(self):
         nodes = io.StringIO(self.nodes0)
         edges = io.StringIO(self.edges0)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, ancestors=[5, 6])
-        self.assertEqual(list(tss.parent), [5, 5, 6, 6])
-        self.assertEqual(list(tss.child), [0, 1, 2, 3])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [5, 5, 6, 6]
+        assert list(tss.child) == [0, 1, 2, 3]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def test_multiple_trees_one_ancestor(self):
         nodes = io.StringIO(self.nodes0)
         edges = io.StringIO(self.edges0)
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         tss = self.do_map(ts, ancestors=[9, 10])
-        self.assertEqual(list(tss.parent), [9, 9, 9, 9, 9, 10, 10, 10, 10, 10])
-        self.assertEqual(list(tss.child), [0, 1, 2, 3, 4, 0, 1, 2, 3, 4])
-        self.assertEqual(all(tss.left), 0)
-        self.assertEqual(all(tss.right), 1)
+        assert list(tss.parent) == [9, 9, 9, 9, 9, 10, 10, 10, 10, 10]
+        assert list(tss.child) == [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
+        assert all(tss.left) == 0
+        assert all(tss.right) == 1
 
     def verify(self, ts, sample_nodes, ancestral_nodes):
         tss = self.do_map(ts, ancestors=ancestral_nodes, samples=sample_nodes)
@@ -6113,7 +6116,7 @@ class TestMapToAncestors(unittest.TestCase):
                         par = tree.get_parent(des)
                         while par not in ancestral_nodes and par not in sample_nodes:
                             par = tree.get_parent(par)
-                        self.assertEqual(par, current_ancestor)
+                        assert par == current_ancestor
                 # Reset the current ancestor and descendants, left and right coords.
                 current_ancestor = row.parent
                 current_descendants = [row.child]
@@ -6139,7 +6142,7 @@ class TestMapToAncestors(unittest.TestCase):
 
     def test_sim_coalescent_trees_internal_samples(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=10, length=2)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         ancestors = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(tsutil.jiggle_samples(ts), ts.samples(), ancestors)
         random_samples = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
@@ -6147,7 +6150,7 @@ class TestMapToAncestors(unittest.TestCase):
 
     def test_sim_many_multiroot_trees(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         ancestors = [4 * n for n in np.arange(0, ts.num_nodes // 4)]
         self.verify(ts, ts.samples(), ancestors)
@@ -6172,7 +6175,7 @@ class TestMapToAncestors(unittest.TestCase):
             self.verify(ts, random_samples, ancestors)
 
 
-class TestMutationParent(unittest.TestCase):
+class TestMutationParent:
     """
     Tests that mutation parent is correctly specified, and that we correctly
     recompute it with compute_mutation_parent.
@@ -6183,11 +6186,11 @@ class TestMutationParent(unittest.TestCase):
     def verify_parents(self, ts):
         parent = tsutil.compute_mutation_parent(ts)
         tables = ts.tables
-        self.assertTrue(np.array_equal(parent, tables.mutations.parent))
+        assert np.array_equal(parent, tables.mutations.parent)
         tables.mutations.parent = np.zeros_like(tables.mutations.parent) - 1
-        self.assertTrue(np.all(tables.mutations.parent == tskit.NULL))
+        assert np.all(tables.mutations.parent == tskit.NULL)
         tables.compute_mutation_parents()
-        self.assertTrue(np.array_equal(parent, tables.mutations.parent))
+        assert np.array_equal(parent, tables.mutations.parent)
 
     def test_example(self):
         nodes = io.StringIO(
@@ -6269,7 +6272,7 @@ class TestMutationParent(unittest.TestCase):
 
     def verify_branch_mutations(self, ts, mutations_per_branch):
         ts = tsutil.insert_branch_mutations(ts, mutations_per_branch)
-        self.assertGreater(ts.num_mutations, 1)
+        assert ts.num_mutations > 1
         self.verify_parents(ts)
 
     def test_single_tree_one_mutation_per_branch(self):
@@ -6292,13 +6295,13 @@ class TestMutationParent(unittest.TestCase):
 
     def test_many_multiroot_trees_recurrent_mutations(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         for mutations_per_branch in [1, 2, 3]:
             self.verify_branch_mutations(ts, mutations_per_branch)
 
 
-class TestMutationTime(unittest.TestCase):
+class TestMutationTime:
     """
     Tests that mutation time is correctly specified, and that we correctly
     recompute it with compute_mutation_times.
@@ -6312,13 +6315,11 @@ class TestMutationTime(unittest.TestCase):
         tables.mutations.time = np.full(
             tables.mutations.time.shape, -1, dtype=np.float64
         )
-        self.assertTrue(np.all(tables.mutations.time == -1))
+        assert np.all(tables.mutations.time == -1)
         # Compute times with C method and dumb python method
         tables.compute_mutation_times()
         python_time = tsutil.compute_mutation_times(ts)
-        self.assertTrue(
-            np.allclose(python_time, tables.mutations.time, rtol=1e-15, atol=1e-15)
-        )
+        assert np.allclose(python_time, tables.mutations.time, rtol=1e-15, atol=1e-15)
 
     def test_example(self):
         nodes = io.StringIO(
@@ -6374,17 +6375,13 @@ class TestMutationTime(unittest.TestCase):
         # self.assertFalse(True)
         tables = ts.tables
         python_time = tsutil.compute_mutation_times(ts)
-        self.assertTrue(
-            np.allclose(python_time, tables.mutations.time, rtol=1e-15, atol=1e-15)
-        )
+        assert np.allclose(python_time, tables.mutations.time, rtol=1e-15, atol=1e-15)
         tables.mutations.time = np.full(
             tables.mutations.time.shape, -1, dtype=np.float64
         )
-        self.assertTrue(np.all(tables.mutations.time == -1))
+        assert np.all(tables.mutations.time == -1)
         tables.compute_mutation_times()
-        self.assertTrue(
-            np.allclose(python_time, tables.mutations.time, rtol=1e-15, atol=1e-15)
-        )
+        assert np.allclose(python_time, tables.mutations.time, rtol=1e-15, atol=1e-15)
 
     def test_single_muts(self):
         ts = msprime.simulate(
@@ -6414,7 +6411,7 @@ class TestMutationTime(unittest.TestCase):
 
     def verify_branch_mutations(self, ts, mutations_per_branch):
         ts = tsutil.insert_branch_mutations(ts, mutations_per_branch)
-        self.assertGreater(ts.num_mutations, 1)
+        assert ts.num_mutations > 1
         self.verify_times(ts)
 
     def test_single_tree_one_mutation_per_branch(self):
@@ -6437,13 +6434,13 @@ class TestMutationTime(unittest.TestCase):
 
     def test_many_multiroot_trees_recurrent_mutations(self):
         ts = msprime.simulate(7, recombination_rate=1, random_seed=10)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         ts = tsutil.decapitate(ts, ts.num_edges // 2)
         for mutations_per_branch in [1, 2, 3]:
             self.verify_branch_mutations(ts, mutations_per_branch)
 
 
-class TestSimpleTreeAlgorithm(unittest.TestCase):
+class TestSimpleTreeAlgorithm:
     """
     Tests for the direct implementation of Algorithm T in tsutil.py.
 
@@ -6453,51 +6450,52 @@ class TestSimpleTreeAlgorithm(unittest.TestCase):
     def test_zero_nodes(self):
         tables = tskit.TableCollection(1)
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
         # Test the simple tree iterator.
         trees = list(tsutil.algorithm_T(ts))
-        self.assertEqual(len(trees), 1)
+        assert len(trees) == 1
         (left, right), parent = trees[0]
-        self.assertEqual(left, 0)
-        self.assertEqual(right, 1)
-        self.assertEqual(parent, [])
+        assert left == 0
+        assert right == 1
+        assert parent == []
 
     def test_one_node(self):
         tables = tskit.TableCollection(1)
         tables.nodes.add_row()
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sequence_length, 1)
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.sequence_length == 1
+        assert ts.num_trees == 1
         # Test the simple tree iterator.
         trees = list(tsutil.algorithm_T(ts))
-        self.assertEqual(len(trees), 1)
+        assert len(trees) == 1
         (left, right), parent = trees[0]
-        self.assertEqual(left, 0)
-        self.assertEqual(right, 1)
-        self.assertEqual(parent, [-1])
+        assert left == 0
+        assert right == 1
+        assert parent == [-1]
 
     def test_single_coalescent_tree(self):
         ts = msprime.simulate(10, random_seed=1, length=10)
         tree = ts.first()
         p1 = [tree.parent(j) for j in range(ts.num_nodes)]
         interval, p2 = next(tsutil.algorithm_T(ts))
-        self.assertEqual(interval, tree.interval)
-        self.assertEqual(p1, p2)
+        assert interval == tree.interval
+        assert p1 == p2
 
     def test_coalescent_trees(self):
         ts = msprime.simulate(8, recombination_rate=5, random_seed=1, length=2)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         new_trees = tsutil.algorithm_T(ts)
         for tree in ts.trees():
             interval, p2 = next(new_trees)
             p1 = [tree.parent(j) for j in range(ts.num_nodes)]
-            self.assertEqual(interval, tree.interval)
-            self.assertEqual(p1, p2)
-        self.assertRaises(StopIteration, next, new_trees)
+            assert interval == tree.interval
+            assert p1 == p2
+        with pytest.raises(StopIteration):
+            next(new_trees)
 
 
-class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
+class TestSampleLists(ExampleTopologyMixin):
     """
     Tests for the sample lists algorithm.
     """
@@ -6505,16 +6503,16 @@ class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
     def verify(self, ts):
         tree1 = tsutil.SampleListTree(ts)
         s = str(tree1)
-        self.assertIsNotNone(s)
+        assert s is not None
         trees = ts.trees(sample_lists=True)
         for left, right in tree1.sample_lists():
             tree2 = next(trees)
             assert (left, right) == tree2.interval
             for u in tree2.nodes():
-                self.assertEqual(tree1.left_sample[u], tree2.left_sample(u))
-                self.assertEqual(tree1.right_sample[u], tree2.right_sample(u))
+                assert tree1.left_sample[u] == tree2.left_sample(u)
+                assert tree1.right_sample[u] == tree2.right_sample(u)
             for j in range(ts.num_samples):
-                self.assertEqual(tree1.next_sample[j], tree2.next_sample(j))
+                assert tree1.next_sample[j] == tree2.next_sample(j)
         assert right == ts.sequence_length
 
         tree1 = tsutil.SampleListTree(ts)
@@ -6527,12 +6525,8 @@ class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
                 samples1 = []
                 index = tree1.left_sample[u]
                 if index != tskit.NULL:
-                    self.assertEqual(
-                        sample_index_map[tree1.left_sample[u]], samples2[0]
-                    )
-                    self.assertEqual(
-                        sample_index_map[tree1.right_sample[u]], samples2[-1]
-                    )
+                    assert sample_index_map[tree1.left_sample[u]] == samples2[0]
+                    assert sample_index_map[tree1.right_sample[u]] == samples2[-1]
                     stop = tree1.right_sample[u]
                     while True:
                         assert index != -1
@@ -6540,11 +6534,11 @@ class TestSampleLists(unittest.TestCase, ExampleTopologyMixin):
                         if index == stop:
                             break
                         index = tree1.next_sample[index]
-                self.assertEqual(samples1, samples2)
+                assert samples1 == samples2
         assert right == ts.sequence_length
 
 
-class TestOneSampleRoot(unittest.TestCase, ExampleTopologyMixin):
+class TestOneSampleRoot(ExampleTopologyMixin):
     """
     Tests for the standard root threshold of subtending at least
     one sample.
@@ -6555,8 +6549,8 @@ class TestOneSampleRoot(unittest.TestCase, ExampleTopologyMixin):
         tree2 = tskit.Tree(ts)
         tree2.first()
         for interval in tree1.iterate():
-            self.assertEqual(interval, tree2.interval)
-            self.assertEqual(tree1.roots(), tree2.roots)
+            assert interval == tree2.interval
+            assert tree1.roots() == tree2.roots
             # Definition here is the set unique path ends from samples
             roots = set()
             for u in ts.samples():
@@ -6564,12 +6558,12 @@ class TestOneSampleRoot(unittest.TestCase, ExampleTopologyMixin):
                     path_end = u
                     u = tree2.parent(u)
                 roots.add(path_end)
-            self.assertEqual(set(tree1.roots()), roots)
+            assert set(tree1.roots()) == roots
             tree2.next()
-        self.assertEqual(tree2.index, -1)
+        assert tree2.index == -1
 
 
-class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
+class TestKSamplesRoot(ExampleTopologyMixin):
     """
     Tests for the root criteria of subtending at least k samples.
     """
@@ -6580,7 +6574,7 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
             tree2 = tskit.Tree(ts, root_threshold=k)
             tree2.first()
             for interval in tree1.iterate():
-                self.assertEqual(interval, tree2.interval)
+                assert interval == tree2.interval
                 # Definition here is the set unique path ends from samples
                 # that subtend at least k samples
                 roots = set()
@@ -6590,13 +6584,13 @@ class TestKSamplesRoot(unittest.TestCase, ExampleTopologyMixin):
                         u = tree2.parent(u)
                     if tree2.num_samples(path_end) >= k:
                         roots.add(path_end)
-                self.assertEqual(set(tree1.roots()), roots)
-                self.assertEqual(tree1.roots(), tree2.roots)
+                assert set(tree1.roots()) == roots
+                assert tree1.roots() == tree2.roots
                 tree2.next()
-            self.assertEqual(tree2.index, -1)
+            assert tree2.index == -1
 
 
-class TestSquashEdges(unittest.TestCase):
+class TestSquashEdges:
     """
     Tests of the squash_edges function.
     """
@@ -6610,7 +6604,7 @@ class TestSquashEdges(unittest.TestCase):
             for e in squashed_list:
                 squashed_py.add_row(e.left, e.right, e.parent, e.child)
             # Check the Python and C implementations produce the same output.
-            self.assertEqual(squashed_py, squashed)
+            assert squashed_py == squashed
         return squashed
 
     def test_simple_case(self):
@@ -6636,10 +6630,10 @@ class TestSquashEdges(unittest.TestCase):
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
-        self.assertEqual(all(edges.left), 0)
-        self.assertEqual(all(edges.right), 1)
-        self.assertEqual(list(edges.parent), [2, 2])
-        self.assertEqual(list(edges.child), [0, 1])
+        assert all(edges.left) == 0
+        assert all(edges.right) == 1
+        assert list(edges.parent) == [2, 2]
+        assert list(edges.child) == [0, 1]
 
     def test_simple_case_unordered_intervals(self):
         # 1
@@ -6661,10 +6655,10 @@ class TestSquashEdges(unittest.TestCase):
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
-        self.assertEqual(edges.left[0], 0)
-        self.assertEqual(edges.right[0], 1)
-        self.assertEqual(edges.parent[0], 1)
-        self.assertEqual(edges.child[0], 0)
+        assert edges.left[0] == 0
+        assert edges.right[0] == 1
+        assert edges.parent[0] == 1
+        assert edges.child[0] == 0
 
     def test_simple_case_unordered_children(self):
         #   2
@@ -6689,10 +6683,10 @@ class TestSquashEdges(unittest.TestCase):
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
-        self.assertEqual(all(edges.left), 0)
-        self.assertEqual(all(edges.right), 1)
-        self.assertEqual(list(edges.parent), [2, 2])
-        self.assertEqual(list(edges.child), [0, 1])
+        assert all(edges.left) == 0
+        assert all(edges.right) == 1
+        assert list(edges.parent) == [2, 2]
+        assert list(edges.child) == [0, 1]
 
     def test_simple_case_unordered_children_and_intervals(self):
         #   2
@@ -6717,10 +6711,10 @@ class TestSquashEdges(unittest.TestCase):
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
-        self.assertEqual(all(edges.left), 0)
-        self.assertEqual(all(edges.right), 1)
-        self.assertEqual(list(edges.parent), [2, 2])
-        self.assertEqual(list(edges.child), [0, 1])
+        assert all(edges.left) == 0
+        assert all(edges.right) == 1
+        assert list(edges.parent) == [2, 2]
+        assert list(edges.child) == [0, 1]
 
     def test_squash_multiple_parents_and_children(self):
         #   4       5
@@ -6752,10 +6746,10 @@ class TestSquashEdges(unittest.TestCase):
         )
         ts = tskit.load_text(nodes=nodes, edges=edges, strict=False)
         edges = self.do_squash(ts)
-        self.assertEqual(all(edges.left), 0)
-        self.assertEqual(all(edges.right), 1)
-        self.assertEqual(list(edges.parent), [4, 4, 5, 5])
-        self.assertEqual(list(edges.child), [0, 1, 2, 3])
+        assert all(edges.left) == 0
+        assert all(edges.right) == 1
+        assert list(edges.parent) == [4, 4, 5, 5]
+        assert list(edges.child) == [0, 1, 2, 3]
 
     def test_squash_overlapping_intervals(self):
         nodes = io.StringIO(
@@ -6773,7 +6767,7 @@ class TestSquashEdges(unittest.TestCase):
         2       0.60            1.00            1       0
         """
         )
-        with self.assertRaises(tskit.LibraryError):
+        with pytest.raises(tskit.LibraryError):
             tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
     def verify_slice_and_squash(self, ts):
@@ -6816,16 +6810,16 @@ class TestSquashEdges(unittest.TestCase):
 
         # Squash the edges and check against input table.
         sliced_table.squash()
-        self.assertEqual(sliced_table, ts.tables.edges)
+        assert sliced_table == ts.tables.edges
 
     def test_sim_single_coalescent_tree(self):
         ts = msprime.simulate(20, random_seed=4, length=10)
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.num_trees == 1
         self.verify_slice_and_squash(ts)
 
     def test_sim_big_coalescent_trees(self):
         ts = msprime.simulate(20, recombination_rate=5, random_seed=4, length=10)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify_slice_and_squash(ts)
 
 
@@ -6912,7 +6906,7 @@ def reduce_topology(ts):
     return ts.simplify(map_nodes=True, filter_sites=False)
 
 
-class TestReduceTopology(unittest.TestCase):
+class TestReduceTopology:
     """
     Tests to ensure that reduce topology in simplify is equivalent to the
     reduce_topology function above.
@@ -6926,17 +6920,17 @@ class TestReduceTopology(unittest.TestCase):
         position_count[ts.sequence_length] = 0
         mts, node_map = reduce_topology(ts)
         for edge in mts.edges():
-            self.assertIn(edge.left, position_count)
-            self.assertIn(edge.right, position_count)
+            assert edge.left in position_count
+            assert edge.right in position_count
             position_count[edge.left] += 1
             position_count[edge.right] += 1
         if ts.num_sites == 0:
             # We should have zero edges output.
-            self.assertEqual(mts.num_edges, 0)
+            assert mts.num_edges == 0
         elif X[0] != 0:
             # The first site (if it's not zero) should be mapped to zero so
             # this never occurs in edges.
-            self.assertEqual(position_count[X[0]], 0)
+            assert position_count[X[0]] == 0
 
         minimised_trees = mts.trees()
         minimised_tree = next(minimised_trees)
@@ -6948,31 +6942,29 @@ class TestReduceTopology(unittest.TestCase):
                     minimised_tree = next(minimised_trees)
                     minimised_tree_sites = minimised_tree.sites()
                     minimised_site = next(minimised_tree_sites)
-                self.assertEqual(site.position, minimised_site.position)
-                self.assertEqual(site.ancestral_state, minimised_site.ancestral_state)
-                self.assertEqual(site.metadata, minimised_site.metadata)
-                self.assertEqual(len(site.mutations), len(minimised_site.mutations))
+                assert site.position == minimised_site.position
+                assert site.ancestral_state == minimised_site.ancestral_state
+                assert site.metadata == minimised_site.metadata
+                assert len(site.mutations) == len(minimised_site.mutations)
 
                 for mutation, minimised_mutation in zip(
                     site.mutations, minimised_site.mutations
                 ):
-                    self.assertEqual(
-                        mutation.derived_state, minimised_mutation.derived_state
-                    )
-                    self.assertEqual(mutation.metadata, minimised_mutation.metadata)
-                    self.assertEqual(mutation.parent, minimised_mutation.parent)
-                    self.assertEqual(node_map[mutation.node], minimised_mutation.node)
+                    assert mutation.derived_state == minimised_mutation.derived_state
+                    assert mutation.metadata == minimised_mutation.metadata
+                    assert mutation.parent == minimised_mutation.parent
+                    assert node_map[mutation.node] == minimised_mutation.node
             if tree.num_sites > 0:
                 mapped_dict = {
                     node_map[u]: node_map[v] for u, v in tree.parent_dict.items()
                 }
-                self.assertEqual(mapped_dict, minimised_tree.parent_dict)
-        self.assertTrue(np.array_equal(ts.genotype_matrix(), mts.genotype_matrix()))
+                assert mapped_dict == minimised_tree.parent_dict
+        assert np.array_equal(ts.genotype_matrix(), mts.genotype_matrix())
 
         edges = list(mts.edges())
         squashed = squash_edges(mts)
-        self.assertEqual(len(edges), len(squashed))
-        self.assertEqual(edges, squashed)
+        assert len(edges) == len(squashed)
+        assert edges == squashed
 
         # Verify against simplify implementations.
         s = tests.Simplifier(
@@ -6983,12 +6975,12 @@ class TestReduceTopology(unittest.TestCase):
         t1 = mts.tables
         for sts in [sts2, sts2]:
             t2 = sts.tables
-            self.assertEqual(t1.nodes, t2.nodes)
-            self.assertEqual(t1.edges, t2.edges)
-            self.assertEqual(t1.sites, t2.sites)
-            self.assertEqual(t1.mutations, t2.mutations)
-            self.assertEqual(t1.populations, t2.populations)
-            self.assertEqual(t1.individuals, t2.individuals)
+            assert t1.nodes == t2.nodes
+            assert t1.edges == t2.edges
+            assert t1.sites == t2.sites
+            assert t1.mutations == t2.mutations
+            assert t1.populations == t2.populations
+            assert t1.individuals == t2.individuals
         return mts
 
     def test_no_recombination_one_site(self):
@@ -6996,14 +6988,14 @@ class TestReduceTopology(unittest.TestCase):
         tables = ts.dump_tables()
         tables.sites.add_row(position=0.25, ancestral_state="0")
         mts = self.verify(tables.tree_sequence())
-        self.assertEqual(mts.num_trees, 1)
+        assert mts.num_trees == 1
 
     def test_simple_recombination_one_site(self):
         ts = msprime.simulate(15, random_seed=1, recombination_rate=2)
         tables = ts.dump_tables()
         tables.sites.add_row(position=0.25, ancestral_state="0")
         mts = self.verify(tables.tree_sequence())
-        self.assertEqual(mts.num_trees, 1)
+        assert mts.num_trees == 1
 
     def test_simple_recombination_fixed_sites(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2)
@@ -7015,10 +7007,10 @@ class TestReduceTopology(unittest.TestCase):
     def get_integer_edge_ts(self, n, m):
         recombination_map = msprime.RecombinationMap.uniform_map(m, 1, num_loci=m)
         ts = msprime.simulate(n, random_seed=1, recombination_map=recombination_map)
-        self.assertGreater(ts.num_trees, 1)
+        assert ts.num_trees > 1
         for edge in ts.edges():
-            self.assertEqual(int(edge.left), edge.left)
-            self.assertEqual(int(edge.right), edge.right)
+            assert int(edge.left) == edge.left
+            assert int(edge.right) == edge.right
         return ts
 
     def test_integer_edges_one_site(self):
@@ -7026,7 +7018,7 @@ class TestReduceTopology(unittest.TestCase):
         tables = ts.dump_tables()
         tables.sites.add_row(position=1, ancestral_state="0")
         mts = self.verify(tables.tree_sequence())
-        self.assertEqual(mts.num_trees, 1)
+        assert mts.num_trees == 1
 
     def test_integer_edges_all_sites(self):
         ts = self.get_integer_edge_ts(5, 10)
@@ -7034,14 +7026,14 @@ class TestReduceTopology(unittest.TestCase):
         for x in range(10):
             tables.sites.add_row(position=x, ancestral_state="0")
         mts = self.verify(tables.tree_sequence())
-        self.assertEqual(mts.num_trees, ts.num_trees)
+        assert mts.num_trees == ts.num_trees
 
     def test_simple_recombination_site_at_zero(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2)
         tables = ts.dump_tables()
         tables.sites.add_row(position=0, ancestral_state="0")
         mts = self.verify(tables.tree_sequence())
-        self.assertEqual(mts.num_trees, 1)
+        assert mts.num_trees == 1
 
     def test_simple_recombination(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
@@ -7063,10 +7055,10 @@ class TestReduceTopology(unittest.TestCase):
 
     def test_zero_sites(self):
         ts = msprime.simulate(5, random_seed=2)
-        self.assertEqual(ts.num_sites, 0)
+        assert ts.num_sites == 0
         mts = ts.simplify(reduce_to_site_topology=True)
-        self.assertEqual(mts.num_trees, 1)
-        self.assertEqual(mts.num_edges, 0)
+        assert mts.num_trees == 1
+        assert mts.num_edges == 0
 
     def test_many_roots(self):
         ts = msprime.simulate(25, random_seed=12, recombination_rate=2, length=10)
@@ -7108,7 +7100,7 @@ def search_sorted(a, v):
     return lower + offset
 
 
-class TestSearchSorted(unittest.TestCase):
+class TestSearchSorted:
     """
     Tests for the basic implementation of search_sorted.
     """
@@ -7119,13 +7111,13 @@ class TestSearchSorted(unittest.TestCase):
         # Check random values.
         np.random.seed(43)
         for v in np.random.uniform(start, end, 10):
-            self.assertEqual(search_sorted(a, v), np.searchsorted(a, v))
+            assert search_sorted(a, v) == np.searchsorted(a, v)
         # Check equal values.
         for v in a:
-            self.assertEqual(search_sorted(a, v), np.searchsorted(a, v))
+            assert search_sorted(a, v) == np.searchsorted(a, v)
         # Check values outside bounds.
         for v in [start - 2, start - 1, end, end + 1, end + 2]:
-            self.assertEqual(search_sorted(a, v), np.searchsorted(a, v))
+            assert search_sorted(a, v) == np.searchsorted(a, v)
 
     def test_range(self):
         for j in range(1, 20):
@@ -7162,11 +7154,11 @@ class TestSearchSorted(unittest.TestCase):
 
     def test_edge_cases(self):
         for v in [0, 1]:
-            self.assertEqual(search_sorted([], v), np.searchsorted([], v))
-            self.assertEqual(search_sorted([1], v), np.searchsorted([1], v))
+            assert search_sorted([], v) == np.searchsorted([], v)
+            assert search_sorted([1], v) == np.searchsorted([1], v)
 
 
-class TestDeleteSites(unittest.TestCase):
+class TestDeleteSites:
     """
     Tests for the TreeSequence.delete_sites method
     """
@@ -7182,19 +7174,19 @@ class TestDeleteSites(unittest.TestCase):
 
     def test_remove_by_index(self):
         ts = self.ts_with_4_sites().delete_sites([])
-        self.assertEquals(ts.num_sites, 4)
-        self.assertEquals(ts.num_mutations, 3)
+        assert ts.num_sites == 4
+        assert ts.num_mutations == 3
         ts = ts.delete_sites(2)
-        self.assertEquals(ts.num_sites, 3)
-        self.assertEquals(ts.num_mutations, 2)
+        assert ts.num_sites == 3
+        assert ts.num_mutations == 2
         ts = ts.delete_sites([1, 2])
-        self.assertEquals(ts.num_sites, 1)
-        self.assertEquals(ts.num_mutations, 0)
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 0
 
     def test_remove_all(self):
         ts = self.ts_with_4_sites().delete_sites(range(4))
-        self.assertEquals(ts.num_sites, 0)
-        self.assertEquals(ts.num_mutations, 0)
+        assert ts.num_sites == 0
+        assert ts.num_mutations == 0
         # should be OK to run on a siteless tree seq as no sites specified
         ts.delete_sites([])
 
@@ -7203,22 +7195,25 @@ class TestDeleteSites(unittest.TestCase):
         t1 = ts.delete_sites([0, 1], record_provenance=False)
         t2 = ts.delete_sites([0, 0, 1], record_provenance=False)
         t3 = ts.delete_sites([0, 0, 0, 1], record_provenance=False)
-        self.assertEquals(t1.tables, t2.tables)
-        self.assertEquals(t1.tables, t3.tables)
+        assert t1.tables == t2.tables
+        assert t1.tables == t3.tables
 
     def test_remove_different_orders(self):
         ts = self.ts_with_4_sites()
         t1 = ts.delete_sites([0, 1, 3], record_provenance=False)
         t2 = ts.delete_sites([0, 3, 1], record_provenance=False)
         t3 = ts.delete_sites([3, 0, 1], record_provenance=False)
-        self.assertEquals(t1.tables, t2.tables)
-        self.assertEquals(t1.tables, t3.tables)
+        assert t1.tables == t2.tables
+        assert t1.tables == t3.tables
 
     def test_remove_bad(self):
         ts = self.ts_with_4_sites()
-        self.assertRaises(TypeError, ts.delete_sites, ["1"])
-        self.assertRaises(ValueError, ts.delete_sites, 4)
-        self.assertRaises(ValueError, ts.delete_sites, -5)
+        with pytest.raises(TypeError):
+            ts.delete_sites(["1"])
+        with pytest.raises(ValueError):
+            ts.delete_sites(4)
+        with pytest.raises(ValueError):
+            ts.delete_sites(-5)
 
     def verify_removal(self, ts, remove_sites):
         tables = ts.dump_tables()
@@ -7227,33 +7222,33 @@ class TestDeleteSites(unittest.TestCase):
         # Make sure we've computed the mutation parents properly.
         mutation_parent = tables.mutations.parent
         tables.compute_mutation_parents()
-        self.assertTrue(np.array_equal(mutation_parent, tables.mutations.parent))
+        assert np.array_equal(mutation_parent, tables.mutations.parent)
 
         tsd = tables.tree_sequence()
-        self.assertEqual(tsd.num_sites, ts.num_sites - len(remove_sites))
+        assert tsd.num_sites == ts.num_sites - len(remove_sites)
         source_sites = [site for site in ts.sites() if site.id not in remove_sites]
-        self.assertEqual(len(source_sites), tsd.num_sites)
+        assert len(source_sites) == tsd.num_sites
         for s1, s2 in zip(source_sites, tsd.sites()):
-            self.assertEqual(s1.position, s2.position)
-            self.assertEqual(s1.ancestral_state, s2.ancestral_state)
-            self.assertEqual(s1.metadata, s2.metadata)
-            self.assertEqual(len(s1.mutations), len(s2.mutations))
+            assert s1.position == s2.position
+            assert s1.ancestral_state == s2.ancestral_state
+            assert s1.metadata == s2.metadata
+            assert len(s1.mutations) == len(s2.mutations)
             for m1, m2 in zip(s1.mutations, s2.mutations):
-                self.assertEqual(m1.node, m2.node)
-                self.assertEqual(m1.derived_state, m2.derived_state)
-                self.assertEqual(m1.metadata, m2.metadata)
+                assert m1.node == m2.node
+                assert m1.derived_state == m2.derived_state
+                assert m1.metadata == m2.metadata
 
         # Check we get the same genotype_matrix
         G1 = ts.genotype_matrix()
         G2 = tsd.genotype_matrix()
         keep = np.ones(ts.num_sites, dtype=bool)
         keep[remove_sites] = 0
-        self.assertTrue(np.array_equal(G1[keep], G2))
+        assert np.array_equal(G1[keep], G2)
 
     def test_simple_random_metadata(self):
         ts = msprime.simulate(10, mutation_rate=10, random_seed=2)
         ts = tsutil.add_random_metadata(ts)
-        self.assertGreater(ts.num_mutations, 5)
+        assert ts.num_mutations > 5
         self.verify_removal(ts, [1, 3])
 
     def test_simple_mixed_length_states(self):
@@ -7269,7 +7264,7 @@ class TestDeleteSites(unittest.TestCase):
         ts = msprime.simulate(10, random_seed=2)
         ts = tsutil.jukes_cantor(ts, 10, 1, seed=2)
         ts = tsutil.add_random_metadata(ts)
-        self.assertGreater(ts.num_mutations, 10)
+        assert ts.num_mutations > 10
         self.verify_removal(ts, [])
         self.verify_removal(ts, [0, 2, 4, 8])
         self.verify_removal(ts, range(5))
@@ -7277,7 +7272,7 @@ class TestDeleteSites(unittest.TestCase):
     def test_jukes_cantor_many_mutations(self):
         ts = msprime.simulate(2, random_seed=2)
         ts = tsutil.jukes_cantor(ts, 10, mu=10, seed=2)
-        self.assertGreater(ts.num_mutations, 100)
+        assert ts.num_mutations > 100
         self.verify_removal(ts, [1, 3, 5, 7])
         self.verify_removal(ts, [1])
         self.verify_removal(ts, [9])
@@ -7285,7 +7280,7 @@ class TestDeleteSites(unittest.TestCase):
     def test_jukes_cantor_one_site(self):
         ts = msprime.simulate(5, random_seed=2)
         ts = tsutil.jukes_cantor(ts, 1, mu=10, seed=2)
-        self.assertGreater(ts.num_mutations, 10)
+        assert ts.num_mutations > 10
         self.verify_removal(ts, [])
         self.verify_removal(ts, [0])
 
@@ -7301,65 +7296,63 @@ class TestKeepSingleInterval(unittest.TestCase):
 
         # Keep the last 3 trees (from 4th last breakpoint onwards)
         ts_sliced = ts.keep_intervals([[breakpoints[-4], ts.sequence_length]])
-        self.assertEqual(ts_sliced.num_trees, 4)
-        self.assertLess(ts_sliced.num_edges, ts.num_edges)
+        assert ts_sliced.num_trees == 4
+        assert ts_sliced.num_edges < ts.num_edges
         self.assertAlmostEqual(ts_sliced.sequence_length, 1.0)
         last_3_mutations = 0
         for tree_index in range(-3, 0):
             last_3_mutations += ts.at_index(tree_index).num_mutations
-        self.assertEqual(ts_sliced.num_mutations, last_3_mutations)
+        assert ts_sliced.num_mutations == last_3_mutations
 
         # Keep the first 3 trees
         ts_sliced = ts.keep_intervals([[0, breakpoints[3]]])
-        self.assertEqual(ts_sliced.num_trees, 4)
-        self.assertLess(ts_sliced.num_edges, ts.num_edges)
+        assert ts_sliced.num_trees == 4
+        assert ts_sliced.num_edges < ts.num_edges
         self.assertAlmostEqual(ts_sliced.sequence_length, 1)
         first_3_mutations = 0
         for tree_index in range(0, 3):
             first_3_mutations += ts.at_index(tree_index).num_mutations
-        self.assertEqual(ts_sliced.num_mutations, first_3_mutations)
+        assert ts_sliced.num_mutations == first_3_mutations
 
         # Slice out the middle
         ts_sliced = ts.keep_intervals([[breakpoints[3], breakpoints[-4]]])
-        self.assertEqual(ts_sliced.num_trees, ts.num_trees - 4)
-        self.assertLess(ts_sliced.num_edges, ts.num_edges)
+        assert ts_sliced.num_trees == ts.num_trees - 4
+        assert ts_sliced.num_edges < ts.num_edges
         self.assertAlmostEqual(ts_sliced.sequence_length, 1.0)
-        self.assertEqual(
-            ts_sliced.num_mutations,
-            ts.num_mutations - first_3_mutations - last_3_mutations,
+        assert (
+            ts_sliced.num_mutations
+            == ts.num_mutations - first_3_mutations - last_3_mutations
         )
 
     def test_slice_by_position(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
         ts_sliced = ts.keep_intervals([[0.4, 0.6]])
         positions = ts.tables.sites.position
-        self.assertEqual(
-            ts_sliced.num_sites, np.sum((positions >= 0.4) & (positions < 0.6))
-        )
+        assert ts_sliced.num_sites == np.sum((positions >= 0.4) & (positions < 0.6))
 
     def test_slice_unsimplified(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
         ts_sliced = ts.keep_intervals([[0.4, 0.6]], simplify=True)
-        self.assertNotEqual(ts.num_nodes, ts_sliced.num_nodes)
+        assert ts.num_nodes != ts_sliced.num_nodes
         self.assertAlmostEqual(ts_sliced.sequence_length, 1.0)
         ts_sliced = ts.keep_intervals([[0.4, 0.6]], simplify=False)
-        self.assertEqual(ts.num_nodes, ts_sliced.num_nodes)
+        assert ts.num_nodes == ts_sliced.num_nodes
         self.assertAlmostEqual(ts_sliced.sequence_length, 1.0)
 
     def test_slice_coordinates(self):
         ts = msprime.simulate(5, random_seed=1, recombination_rate=2, mutation_rate=2)
         ts_sliced = ts.keep_intervals([[0.4, 0.6]])
         self.assertAlmostEqual(ts_sliced.sequence_length, 1)
-        self.assertNotEqual(ts_sliced.num_trees, ts.num_trees)
-        self.assertEqual(ts_sliced.at_index(0).total_branch_length, 0)
-        self.assertEqual(ts_sliced.at(0).total_branch_length, 0)
-        self.assertEqual(ts_sliced.at(0.399).total_branch_length, 0)
-        self.assertNotEqual(ts_sliced.at(0.4).total_branch_length, 0)
-        self.assertNotEqual(ts_sliced.at(0.5).total_branch_length, 0)
-        self.assertNotEqual(ts_sliced.at(0.599).total_branch_length, 0)
-        self.assertEqual(ts_sliced.at(0.6).total_branch_length, 0)
-        self.assertEqual(ts_sliced.at(0.999).total_branch_length, 0)
-        self.assertEqual(ts_sliced.at_index(-1).total_branch_length, 0)
+        assert ts_sliced.num_trees != ts.num_trees
+        assert ts_sliced.at_index(0).total_branch_length == 0
+        assert ts_sliced.at(0).total_branch_length == 0
+        assert ts_sliced.at(0.399).total_branch_length == 0
+        assert ts_sliced.at(0.4).total_branch_length != 0
+        assert ts_sliced.at(0.5).total_branch_length != 0
+        assert ts_sliced.at(0.599).total_branch_length != 0
+        assert ts_sliced.at(0.6).total_branch_length == 0
+        assert ts_sliced.at(0.999).total_branch_length == 0
+        assert ts_sliced.at_index(-1).total_branch_length == 0
 
 
 class TestKeepIntervals(TopologyTestCase):
@@ -7385,22 +7378,22 @@ class TestKeepIntervals(TopologyTestCase):
         simple_keep_intervals(t1, intervals, simplify, record_provenance)
         t2 = tables.copy()
         t2.keep_intervals(intervals, simplify, record_provenance)
-        self.assertTrue(tables_equal(t1, t2))
+        assert tables_equal(t1, t2)
         return t2
 
     def test_migration_error(self):
         tables = tskit.TableCollection(1)
         tables.migrations.add_row(0, 1, 0, 0, 0, 0)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tables.keep_intervals([[0, 1]])
 
     def test_bad_intervals(self):
         tables = tskit.TableCollection(10)
         bad_intervals = [[[1, 1]], [[-1, 0]], [[0, 11]], [[0, 5], [4, 6]]]
         for intervals in bad_intervals:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 tables.keep_intervals(intervals)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 tables.delete_intervals(intervals)
 
     def test_one_interval(self):
@@ -7459,11 +7452,11 @@ class TestKeepIntervals(TopologyTestCase):
         tables.sites.add_row(0.1, "A")
         tables.sites.add_row(0.2, "T")
         for intervals in self.example_intervals(tables):
-            self.assertEqual(len(tables.sites), 2)
+            assert len(tables.sites) == 2
             diced = self.do_keep_intervals(tables, intervals)
-            self.assertEqual(diced.sequence_length, 1)
-            self.assertEqual(len(diced.edges), 0)
-            self.assertEqual(len(diced.sites), 0)
+            assert diced.sequence_length == 1
+            assert len(diced.edges) == 0
+            assert len(diced.sites) == 0
 
     def verify(self, tables):
         for intervals in self.example_intervals(tables):
@@ -7486,8 +7479,8 @@ class TestKeepIntervals(TopologyTestCase):
 
     def test_many_trees_infinite_sites(self):
         ts = msprime.simulate(6, recombination_rate=2, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_sites > 0
+        assert ts.num_trees > 2
         self.verify(ts.tables)
 
     def test_many_trees_sequence_length_infinite_sites(self):
@@ -7508,7 +7501,7 @@ class TestKeepIntervals(TopologyTestCase):
         )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.05, random_seed=234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts.tables)
 
     def test_wright_fisher_initial_generation(self):
@@ -7518,7 +7511,7 @@ class TestKeepIntervals(TopologyTestCase):
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts.tables)
 
     def test_wright_fisher_initial_generation_no_deep_history(self):
@@ -7533,7 +7526,7 @@ class TestKeepIntervals(TopologyTestCase):
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.01, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts.tables)
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
@@ -7547,7 +7540,7 @@ class TestKeepIntervals(TopologyTestCase):
         )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.006, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts.tables)
 
     def test_wright_fisher_simplified(self):
@@ -7562,11 +7555,11 @@ class TestKeepIntervals(TopologyTestCase):
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts.tables)
 
 
-class TestKeepDeleteIntervalsExamples(unittest.TestCase):
+class TestKeepDeleteIntervalsExamples:
     """
     Simple examples of keep/delete intervals at work.
     """
@@ -7577,7 +7570,7 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
         t_keep.keep_intervals([[0.25, 0.5]], record_provenance=False)
         t_delete = ts.dump_tables()
         t_delete.delete_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
-        self.assertEqual(t_keep, t_delete)
+        assert t_keep == t_delete
 
     def test_tables_single_tree_delete_middle(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -7585,7 +7578,7 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
         t_keep.delete_intervals([[0.25, 0.5]], record_provenance=False)
         t_delete = ts.dump_tables()
         t_delete.keep_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
-        self.assertEqual(t_keep, t_delete)
+        assert t_keep == t_delete
 
     def test_ts_single_tree_keep_middle(self):
         ts = msprime.simulate(10, random_seed=2)
@@ -7593,13 +7586,13 @@ class TestKeepDeleteIntervalsExamples(unittest.TestCase):
         ts_delete = ts.delete_intervals(
             [[0, 0.25], [0.5, 1.0]], record_provenance=False
         )
-        self.assertTrue(ts_equal(ts_keep, ts_delete))
+        assert ts_equal(ts_keep, ts_delete)
 
     def test_ts_single_tree_delete_middle(self):
         ts = msprime.simulate(10, random_seed=2)
         ts_keep = ts.delete_intervals([[0.25, 0.5]], record_provenance=False)
         ts_delete = ts.keep_intervals([[0, 0.25], [0.5, 1.0]], record_provenance=False)
-        self.assertTrue(ts_equal(ts_keep, ts_delete))
+        assert ts_equal(ts_keep, ts_delete)
 
 
 class TestTrim(unittest.TestCase):
@@ -7624,27 +7617,27 @@ class TestTrim(unittest.TestCase):
     def verify_sites(self, source_tree, trimmed_tree, position_offset):
         source_sites = list(source_tree.sites())
         trimmed_sites = list(trimmed_tree.sites())
-        self.assertEqual(len(source_sites), len(trimmed_sites))
+        assert len(source_sites) == len(trimmed_sites)
         for source_site, trimmed_site in zip(source_sites, trimmed_sites):
             self.assertAlmostEqual(
                 source_site.position, position_offset + trimmed_site.position
             )
-            self.assertEqual(source_site.ancestral_state, trimmed_site.ancestral_state)
-            self.assertEqual(source_site.metadata, trimmed_site.metadata)
-            self.assertEqual(len(source_site.mutations), len(trimmed_site.mutations))
+            assert source_site.ancestral_state == trimmed_site.ancestral_state
+            assert source_site.metadata == trimmed_site.metadata
+            assert len(source_site.mutations) == len(trimmed_site.mutations)
             for source_mut, trimmed_mut in zip(
                 source_site.mutations, trimmed_site.mutations
             ):
-                self.assertEqual(source_mut.node, trimmed_mut.node)
-                self.assertEqual(source_mut.derived_state, trimmed_mut.derived_state)
-                self.assertEqual(source_mut.metadata, trimmed_mut.metadata)
+                assert source_mut.node == trimmed_mut.node
+                assert source_mut.derived_state == trimmed_mut.derived_state
+                assert source_mut.metadata == trimmed_mut.metadata
                 # mutation.parent id may have changed after deleting redundant mutations
                 if source_mut.parent == trimmed_mut.parent == tskit.NULL:
                     pass
                 else:
-                    self.assertEqual(
-                        source_tree.tree_sequence.mutation(source_mut.parent).node,
-                        trimmed_tree.tree_sequence.mutation(trimmed_mut.parent).node,
+                    assert (
+                        source_tree.tree_sequence.mutation(source_mut.parent).node
+                        == trimmed_tree.tree_sequence.mutation(trimmed_mut.parent).node
                     )
 
     def verify_ltrim(self, source_ts, trimmed_ts):
@@ -7652,11 +7645,11 @@ class TestTrim(unittest.TestCase):
         self.assertAlmostEqual(
             source_ts.sequence_length, trimmed_ts.sequence_length + deleted_span
         )
-        self.assertEqual(source_ts.num_trees, trimmed_ts.num_trees + 1)
+        assert source_ts.num_trees == trimmed_ts.num_trees + 1
         for j in range(trimmed_ts.num_trees):
             source_tree = source_ts.at_index(j + 1)
             trimmed_tree = trimmed_ts.at_index(j)
-            self.assertEqual(source_tree.parent_dict, trimmed_tree.parent_dict)
+            assert source_tree.parent_dict == trimmed_tree.parent_dict
             self.assertAlmostEqual(source_tree.span, trimmed_tree.span)
             self.assertAlmostEqual(
                 source_tree.interval[0], trimmed_tree.interval[0] + deleted_span
@@ -7668,12 +7661,12 @@ class TestTrim(unittest.TestCase):
         self.assertAlmostEqual(
             source_ts.sequence_length, trimmed_ts.sequence_length + deleted_span
         )
-        self.assertEqual(source_ts.num_trees, trimmed_ts.num_trees + 1)
+        assert source_ts.num_trees == trimmed_ts.num_trees + 1
         for j in range(trimmed_ts.num_trees):
             source_tree = source_ts.at_index(j)
             trimmed_tree = trimmed_ts.at_index(j)
-            self.assertEqual(source_tree.parent_dict, trimmed_tree.parent_dict)
-            self.assertEqual(source_tree.interval, trimmed_tree.interval)
+            assert source_tree.parent_dict == trimmed_tree.parent_dict
+            assert source_tree.interval == trimmed_tree.interval
             self.verify_sites(source_tree, trimmed_tree, 0)
 
     def clear_left_mutate(self, ts, left, num_sites):
@@ -7719,9 +7712,9 @@ class TestTrim(unittest.TestCase):
         ts = self.add_mutations(
             ts, right_pos, "X", ["T", "C", "G", "A"], [right_root, 0, 1, 2]
         )
-        self.assertNotEqual(np.min(ts.tables.edges.left), 0)
-        self.assertEqual(ts.num_mutations, 9)
-        self.assertEqual(ts.num_sites, 3)
+        assert np.min(ts.tables.edges.left) != 0
+        assert ts.num_mutations == 9
+        assert ts.num_sites == 3
         return ts
 
     def test_ltrim_single_tree(self):
@@ -7763,15 +7756,16 @@ class TestTrim(unittest.TestCase):
     def test_ltrim_empty(self):
         ts = msprime.simulate(2, random_seed=2)
         ts = ts.delete_intervals([[0, 1]])
-        self.assertRaises(ValueError, ts.ltrim)
+        with pytest.raises(ValueError):
+            ts.ltrim()
 
     def test_ltrim_multiple_mutations(self):
         ts = self.clear_left_right_234(0.1, 0.5)
         trimmed_ts = ts.ltrim()
         self.assertAlmostEqual(trimmed_ts.sequence_length, 0.9)
-        self.assertEqual(trimmed_ts.num_sites, 2)
-        self.assertEqual(trimmed_ts.num_mutations, 7)  # We should have deleted 2
-        self.assertEqual(np.min(trimmed_ts.tables.edges.left), 0)
+        assert trimmed_ts.num_sites == 2
+        assert trimmed_ts.num_mutations == 7  # We should have deleted 2
+        assert np.min(trimmed_ts.tables.edges.left) == 0
         self.verify_ltrim(ts, trimmed_ts)
 
     def test_rtrim_single_tree(self):
@@ -7813,16 +7807,17 @@ class TestTrim(unittest.TestCase):
     def test_rtrim_empty(self):
         ts = msprime.simulate(2, random_seed=2)
         ts = ts.delete_intervals([[0, 1]])
-        self.assertRaises(ValueError, ts.rtrim)
+        with pytest.raises(ValueError):
+            ts.rtrim()
 
     def test_rtrim_multiple_mutations(self):
         ts = self.clear_left_right_234(0.1, 0.5)
         trimmed_ts = ts.rtrim()
         self.assertAlmostEqual(trimmed_ts.sequence_length, 0.5)
-        self.assertEqual(trimmed_ts.num_sites, 2)
-        self.assertEqual(trimmed_ts.num_mutations, 5)  # We should have deleted 4
-        self.assertEqual(
-            np.max(trimmed_ts.tables.edges.right), trimmed_ts.tables.sequence_length
+        assert trimmed_ts.num_sites == 2
+        assert trimmed_ts.num_mutations == 5  # We should have deleted 4
+        assert (
+            np.max(trimmed_ts.tables.edges.right) == trimmed_ts.tables.sequence_length
         )
         self.verify_rtrim(ts, trimmed_ts)
 
@@ -7830,11 +7825,11 @@ class TestTrim(unittest.TestCase):
         ts = self.clear_left_right_234(0.1, 0.5)
         trimmed_ts = ts.trim()
         self.assertAlmostEqual(trimmed_ts.sequence_length, 0.4)
-        self.assertEqual(trimmed_ts.num_mutations, 3)
-        self.assertEqual(trimmed_ts.num_sites, 1)
-        self.assertEqual(np.min(trimmed_ts.tables.edges.left), 0)
-        self.assertEqual(
-            np.max(trimmed_ts.tables.edges.right), trimmed_ts.tables.sequence_length
+        assert trimmed_ts.num_mutations == 3
+        assert trimmed_ts.num_sites == 1
+        assert np.min(trimmed_ts.tables.edges.left) == 0
+        assert (
+            np.max(trimmed_ts.tables.edges.right) == trimmed_ts.tables.sequence_length
         )
 
     def test_trims_no_effect(self):
@@ -7842,11 +7837,11 @@ class TestTrim(unittest.TestCase):
         ts = msprime.simulate(10, recombination_rate=2, mutation_rate=50, random_seed=2)
         ts = ts.delete_intervals([[0.1, 0.5]])
         trimmed_ts = ts.ltrim(record_provenance=False)
-        self.assertTrue(ts_equal(ts, trimmed_ts))
+        assert ts_equal(ts, trimmed_ts)
         trimmed_ts = ts.rtrim(record_provenance=False)
-        self.assertTrue(ts_equal(ts, trimmed_ts))
+        assert ts_equal(ts, trimmed_ts)
         trimmed_ts = ts.trim(record_provenance=False)
-        self.assertTrue(ts_equal(ts, trimmed_ts))
+        assert ts_equal(ts, trimmed_ts)
 
     def test_failure_with_migrations(self):
         # All trim functions fail if migrations present
@@ -7855,12 +7850,15 @@ class TestTrim(unittest.TestCase):
         tables = ts.dump_tables()
         tables.migrations.add_row(0, 1, 0, 0, 0, 0)
         ts = tables.tree_sequence()
-        self.assertRaises(ValueError, ts.ltrim)
-        self.assertRaises(ValueError, ts.rtrim)
-        self.assertRaises(ValueError, ts.trim)
+        with pytest.raises(ValueError):
+            ts.ltrim()
+        with pytest.raises(ValueError):
+            ts.rtrim()
+        with pytest.raises(ValueError):
+            ts.trim()
 
 
-class TestMissingData(unittest.TestCase):
+class TestMissingData:
     """
     Test various aspects of missing data functionality
     """
@@ -7883,33 +7881,39 @@ class TestMissingData(unittest.TestCase):
                     continue  # omit this edge => node is isolated
             tables.edges.add_row(e.left, e.right, e.parent, e.child)
         # Check we have non-missing to L & R
-        self.assertTrue(0.0 < missing_from < 1.0)
-        self.assertTrue(0.0 < missing_to < 1.0)
+        assert 0.0 < missing_from < 1.0
+        assert 0.0 < missing_to < 1.0
         return tables.tree_sequence(), missing_from, missing_to
 
     def test_is_isolated(self):
         ts, missing_from, missing_to = self.ts_missing_middle()
         for tree in ts.trees():
             if tree.interval[1] > missing_from and tree.interval[0] < missing_to:
-                self.assertTrue(tree.is_isolated(0))
-                self.assertFalse(tree.is_isolated(1))
+                assert tree.is_isolated(0)
+                assert not tree.is_isolated(1)
             else:
-                self.assertFalse(tree.is_isolated(0))
-                self.assertFalse(tree.is_isolated(1))
+                assert not tree.is_isolated(0)
+                assert not tree.is_isolated(1)
             # A non-sample node is isolated if not in the tree
             tree_nodes = set(tree.nodes())
             for nonsample_node in np.setdiff1d(np.arange(ts.num_nodes), ts.samples()):
                 if nonsample_node in tree_nodes:
-                    self.assertFalse(tree.is_isolated(nonsample_node))
+                    assert not tree.is_isolated(nonsample_node)
                 else:
-                    self.assertTrue(tree.is_isolated(nonsample_node))
+                    assert tree.is_isolated(nonsample_node)
 
     def test_is_isolated_bad(self):
         ts, missing_from, missing_to = self.ts_missing_middle()
         for tree in ts.trees():
-            self.assertRaises(ValueError, tree.is_isolated, tskit.NULL)
-            self.assertRaises(ValueError, tree.is_isolated, ts.num_nodes)
-            self.assertRaises(ValueError, tree.is_isolated, -2)
-            self.assertRaises(TypeError, tree.is_isolated, None)
-            self.assertRaises(TypeError, tree.is_isolated, "abc")
-            self.assertRaises(TypeError, tree.is_isolated, 1.1)
+            with pytest.raises(ValueError):
+                tree.is_isolated(tskit.NULL)
+            with pytest.raises(ValueError):
+                tree.is_isolated(ts.num_nodes)
+            with pytest.raises(ValueError):
+                tree.is_isolated(-2)
+            with pytest.raises(TypeError):
+                tree.is_isolated(None)
+            with pytest.raises(TypeError):
+                tree.is_isolated("abc")
+            with pytest.raises(TypeError):
+                tree.is_isolated(1.1)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -29,11 +29,11 @@ import functools
 import io
 import itertools
 import random
-import unittest
 
 import msprime
 import numpy as np
 import numpy.testing as nt
+import pytest
 
 import tests.test_wright_fisher as wf
 import tests.tsutil as tsutil
@@ -524,13 +524,13 @@ def upper_tri_to_matrix(x):
 ##################################
 
 
-class StatsTestCase(unittest.TestCase):
+class StatsTestCase:
     """
     Provides convenience functions.
     """
 
     def assertListAlmostEqual(self, x, y):
-        self.assertEqual(len(x), len(y))
+        assert len(x) == len(y)
         for a, b in zip(x, y):
             self.assertAlmostEqual(a, b)
 
@@ -572,7 +572,7 @@ class TopologyExamplesMixin:
 
     def test_many_trees(self):
         ts = msprime.simulate(6, recombination_rate=2, random_seed=1)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_trees > 2
         self.verify(ts)
 
     def test_many_trees_sequence_length(self):
@@ -593,6 +593,7 @@ class TopologyExamplesMixin:
         ts = tables.tree_sequence()
         self.verify(ts)
 
+    @pytest.mark.slow
     def test_wright_fisher_initial_generation(self):
         tables = wf.wf_sim(
             6, 5, seed=3, deep_history=True, initial_generation_samples=True, num_loci=2
@@ -689,7 +690,7 @@ class MutatedTopologyExamplesMixin:
 
     def test_single_tree_no_sites(self):
         ts = msprime.simulate(6, random_seed=1)
-        self.assertEqual(ts.num_sites, 0)
+        assert ts.num_sites == 0
         self.verify(ts)
 
     def test_ghost_allele(self):
@@ -757,7 +758,7 @@ class MutatedTopologyExamplesMixin:
 
     def test_single_tree_infinite_sites(self):
         ts = msprime.simulate(6, random_seed=1, mutation_rate=1)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_single_tree_sites_no_mutations(self):
@@ -779,8 +780,8 @@ class MutatedTopologyExamplesMixin:
 
     def test_many_trees_infinite_sites(self):
         ts = msprime.simulate(6, recombination_rate=2, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_sites > 0
+        assert ts.num_trees > 2
         self.verify(ts)
 
     def test_many_trees_sequence_length_infinite_sites(self):
@@ -801,7 +802,7 @@ class MutatedTopologyExamplesMixin:
         )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.05, random_seed=234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_wright_fisher_initial_generation(self):
@@ -811,7 +812,7 @@ class MutatedTopologyExamplesMixin:
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_wright_fisher_initial_generation_no_deep_history(self):
@@ -826,7 +827,7 @@ class MutatedTopologyExamplesMixin:
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.01, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_wright_fisher_unsimplified_multiple_roots(self):
@@ -840,7 +841,7 @@ class MutatedTopologyExamplesMixin:
         )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.006, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_wright_fisher_simplified(self):
@@ -855,7 +856,7 @@ class MutatedTopologyExamplesMixin:
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         self.verify(ts)
 
     def test_empty_ts(self):
@@ -976,9 +977,9 @@ class WeightStatsMixin:
                 ts, W, windows=windows, mode=self.mode, span_normalise=sn
             )
 
-            self.assertEqual(sigma1.shape, sigma2.shape)
-            self.assertEqual(sigma1.shape, sigma3.shape)
-            self.assertEqual(sigma1.shape, sigma4.shape)
+            assert sigma1.shape == sigma2.shape
+            assert sigma1.shape == sigma3.shape
+            assert sigma1.shape == sigma4.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
             self.assertArrayAlmostEqual(sigma1, sigma3)
             self.assertArrayAlmostEqual(sigma1, sigma4)
@@ -1022,9 +1023,9 @@ class SampleSetStatsMixin:
                 ts, sample_sets, windows=windows, mode=self.mode, span_normalise=sn
             )
 
-            self.assertEqual(sigma1.shape, sigma2.shape)
-            self.assertEqual(sigma1.shape, sigma3.shape)
-            self.assertEqual(sigma1.shape, sigma4.shape)
+            assert sigma1.shape == sigma2.shape
+            assert sigma1.shape == sigma3.shape
+            assert sigma1.shape == sigma4.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
             self.assertArrayAlmostEqual(sigma1, sigma3)
             self.assertArrayAlmostEqual(sigma1, sigma4)
@@ -1055,9 +1056,9 @@ class KWaySampleSetStatsMixin(SampleSetStatsMixin):
             ts, sample_sets, indexes=indexes, windows=windows, mode=self.mode
         )
 
-        self.assertEqual(sigma1.shape, sigma2.shape)
-        self.assertEqual(sigma1.shape, sigma3.shape)
-        self.assertEqual(sigma1.shape, sigma4.shape)
+        assert sigma1.shape == sigma2.shape
+        assert sigma1.shape == sigma3.shape
+        assert sigma1.shape == sigma4.shape
         self.assertArrayAlmostEqual(sigma1, sigma2)
         self.assertArrayAlmostEqual(sigma1, sigma3)
         self.assertArrayAlmostEqual(sigma1, sigma4)
@@ -1454,7 +1455,7 @@ class TestTajimasD(StatsTestCase, SampleSetStatsMixin):
         for windows in self.get_windows(ts):
             sigma1 = ts.Tajimas_D(sample_sets, windows=windows, mode=self.mode)
             sigma2 = site_tajimas_d(ts, sample_sets, windows=windows)
-            self.assertEqual(sigma1.shape, sigma2.shape)
+            assert sigma1.shape == sigma2.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
 
 
@@ -1827,7 +1828,7 @@ class TestFst(StatsTestCase, TwoWaySampleSetStatsMixin):
             span_normalise=False,
         )
         sigma2 = single_site_Fst(ts, sample_sets, indexes)
-        self.assertEqual(sigma1.shape, sigma2.shape)
+        assert sigma1.shape == sigma2.shape
         self.assertArrayAlmostEqual(sigma1, sigma2)
 
 
@@ -1835,11 +1836,11 @@ class FstInterfaceMixin:
     def test_interface(self):
         ts = msprime.simulate(10, mutation_rate=0.0)
         sample_sets = [[0, 1, 2], [6, 7], [4]]
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.Fst(sample_sets, mode=self.mode)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.Fst(sample_sets, indexes=[(0, 1, 2), (3, 4, 5)], mode=self.mode)
-        with self.assertRaises(tskit.LibraryError):
+        with pytest.raises(tskit.LibraryError):
             ts.Fst(sample_sets, indexes=[(0, 1), (0, 20)])
         sigma1 = ts.Fst(sample_sets, indexes=[(0, 1)], mode=self.mode)
         sigma2 = ts.Fst(sample_sets, indexes=[(0, 1), (0, 2), (1, 2)], mode=self.mode)
@@ -2787,7 +2788,7 @@ def foldit(A):
     return B
 
 
-class TestFold(unittest.TestCase):
+class TestFold:
     """
     Tests for the fold operation used in the AFS.
     """
@@ -2798,13 +2799,13 @@ class TestFold(unittest.TestCase):
             [11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         )
 
-        self.assertTrue(np.all(foldit(A) == Af))
+        assert np.all(foldit(A) == Af)
 
         B = A.copy().reshape(3, 4)
         Bf = np.array(
             [[11.0, 11.0, 11.0, 0.0], [11.0, 11.0, 0.0, 0.0], [11.0, 0.0, 0.0, 0.0]]
         )
-        self.assertTrue(np.all(foldit(B) == Bf))
+        assert np.all(foldit(B) == Bf)
 
         C = A.copy().reshape(3, 2, 2)
         Cf = np.array(
@@ -2814,15 +2815,15 @@ class TestFold(unittest.TestCase):
                 [[0.0, 0.0], [0.0, 0.0]],
             ]
         )
-        self.assertTrue(np.all(foldit(C) == Cf))
+        assert np.all(foldit(C) == Cf)
 
         D = np.arange(9).reshape((3, 3))
         Df = np.array([[8.0, 8.0, 8.0], [8.0, 4.0, 0.0], [0.0, 0.0, 0.0]])
-        self.assertTrue(np.all(foldit(D) == Df))
+        assert np.all(foldit(D) == Df)
 
         E = np.arange(9)
         Ef = np.array([8.0, 8.0, 8.0, 8.0, 4.0, 0.0, 0.0, 0.0, 0.0])
-        self.assertTrue(np.all(foldit(E) == Ef))
+        assert np.all(foldit(E) == Ef)
 
 
 def naive_site_allele_frequency_spectrum(
@@ -3203,15 +3204,15 @@ class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
                 polarised=polarised,
                 span_normalise=span_normalise,
             )
-            self.assertEqual(sfs1.shape[0], len(windows) - 1)
-            self.assertEqual(len(sfs1.shape), len(sample_sets) + 1)
+            assert sfs1.shape[0] == len(windows) - 1
+            assert len(sfs1.shape) == len(sample_sets) + 1
             for j, sample_set in enumerate(sample_sets):
                 n = 1 + len(sample_set)
-                self.assertEqual(sfs1.shape[j + 1], n)
+                assert sfs1.shape[j + 1] == n
 
-            self.assertEqual(len(sfs1.shape), len(sample_sets) + 1)
-            self.assertEqual(sfs1.shape, sfs2.shape)
-            self.assertEqual(sfs1.shape, sfs3.shape)
+            assert len(sfs1.shape) == len(sample_sets) + 1
+            assert sfs1.shape == sfs2.shape
+            assert sfs1.shape == sfs3.shape
             if not np.allclose(sfs1, sfs3):
                 print()
                 print("sample sets", sample_sets)
@@ -3307,7 +3308,7 @@ class TestWindowedTreeStat(StatsTestCase):
     # TODO add more tests here covering the various windowing possibilities.
     def get_tree_sequence(self):
         ts = msprime.simulate(10, recombination_rate=2, random_seed=1)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         return ts
 
     def test_all_trees(self):
@@ -3317,7 +3318,7 @@ class TestWindowedTreeStat(StatsTestCase):
         A2 = windowed_tree_stat(ts, A1, windows)
         # print("breakpoints = ", windows)
         # print(A2)
-        self.assertEqual(A1.shape, A2.shape)
+        assert A1.shape == A2.shape
         # JK: I don't understand what we're computing here, this normalisation
         # seems pretty weird.
         # for tree in ts.trees():
@@ -3328,7 +3329,7 @@ class TestWindowedTreeStat(StatsTestCase):
         A1 = np.ones((ts.num_trees, 1))
         windows = np.array([0, ts.sequence_length])
         A2 = windowed_tree_stat(ts, A1, windows)
-        self.assertEqual(A2.shape, (1, 1))
+        assert A2.shape == (1, 1)
         # TODO: Test output
 
 
@@ -3345,34 +3346,34 @@ class TestSampleSets(StatsTestCase):
     def test_duplicate_samples(self):
         ts = self.get_example_ts()
         for bad_set in [[1, 1], [1, 2, 1], list(range(10)) + [9]]:
-            with self.assertRaises(exceptions.LibraryError):
+            with pytest.raises(exceptions.LibraryError):
                 ts.diversity([bad_set])
-            with self.assertRaises(exceptions.LibraryError):
+            with pytest.raises(exceptions.LibraryError):
                 ts.divergence([[0, 1], bad_set])
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.sample_count_stat([bad_set], self.identity_f(ts), 1)
 
     def test_empty_sample_set(self):
         ts = self.get_example_ts()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.diversity([[]])
         for bad_sample_sets in [[[], []], [[1], []], [[1, 2], [1], []]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.diversity(bad_sample_sets)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.divergence(bad_sample_sets)
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.sample_count_stat(bad_sample_sets, self.identity_f(ts), 1)
 
     def test_non_samples(self):
         ts = self.get_example_ts()
-        with self.assertRaises(exceptions.LibraryError):
+        with pytest.raises(exceptions.LibraryError):
             ts.diversity([[ts.num_samples]])
 
-        with self.assertRaises(exceptions.LibraryError):
+        with pytest.raises(exceptions.LibraryError):
             ts.divergence([[ts.num_samples], [1, 2]])
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.sample_count_stat([[ts.num_samples]], self.identity_f(ts), 1)
 
     def test_span_normalise(self):
@@ -3400,8 +3401,8 @@ class TestSampleSets(StatsTestCase):
             if mode == "node":
                 denom = np.diff(windows)[:, np.newaxis, np.newaxis]
 
-            self.assertEqual(sigma1.shape, sigma2.shape)
-            self.assertEqual(sigma1.shape, sigma3.shape)
+            assert sigma1.shape == sigma2.shape
+            assert sigma1.shape == sigma3.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
             self.assertArrayAlmostEqual(sigma1, sigma3 / denom)
 
@@ -3414,7 +3415,7 @@ class TestSampleSetIndexes(StatsTestCase):
 
     def get_example_ts(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         return ts
 
     def test_2_way_default(self):
@@ -3423,13 +3424,13 @@ class TestSampleSetIndexes(StatsTestCase):
         S1 = ts.divergence(sample_sets)
         S2 = divergence(ts, sample_sets)[0, 0]
         S3 = ts.divergence(sample_sets, [0, 1])
-        self.assertEqual(S1.shape, S2.shape)
+        assert S1.shape == S2.shape
         self.assertArrayAlmostEqual(S1, S2)
         self.assertArrayAlmostEqual(S1, S3)
         sample_sets = np.array_split(ts.samples(), 3)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _ = ts.divergence(sample_sets)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _ = ts.divergence([sample_sets[0]])
 
     def test_3_way_default(self):
@@ -3438,11 +3439,11 @@ class TestSampleSetIndexes(StatsTestCase):
         S1 = ts.f3(sample_sets)
         S2 = f3(ts, sample_sets)[0, 0]
         S3 = ts.f3(sample_sets, [0, 1, 2])
-        self.assertEqual(S1.shape, S2.shape)
+        assert S1.shape == S2.shape
         self.assertArrayAlmostEqual(S1, S2)
         self.assertArrayAlmostEqual(S1, S3)
         sample_sets = np.array_split(ts.samples(), 4)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _ = ts.f3(sample_sets)
 
     def test_4_way_default(self):
@@ -3451,11 +3452,11 @@ class TestSampleSetIndexes(StatsTestCase):
         S1 = ts.f4(sample_sets)
         S2 = f4(ts, sample_sets)
         S3 = ts.f4(sample_sets, [0, 1, 2, 3])
-        self.assertEqual(S1.shape, S3.shape)
+        assert S1.shape == S3.shape
         self.assertArrayAlmostEqual(S1, S2)
         self.assertArrayAlmostEqual(S1, S3)
         sample_sets = np.array_split(ts.samples(), 5)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _ = ts.f4(sample_sets)
 
     def test_2_way_combinations(self):
@@ -3465,8 +3466,8 @@ class TestSampleSetIndexes(StatsTestCase):
         for k in range(1, len(pairs)):
             S1 = ts.divergence(sample_sets, pairs[:k])
             S2 = divergence(ts, sample_sets, pairs[:k])[0]
-            self.assertEqual(S1.shape[-1], k)
-            self.assertEqual(S1.shape, S2.shape)
+            assert S1.shape[-1] == k
+            assert S1.shape == S2.shape
             self.assertArrayAlmostEqual(S1, S2)
 
     def test_3_way_combinations(self):
@@ -3476,8 +3477,8 @@ class TestSampleSetIndexes(StatsTestCase):
         for k in range(1, len(triples)):
             S1 = ts.Y3(sample_sets, triples[:k])
             S2 = Y3(ts, sample_sets, triples[:k])[0]
-            self.assertEqual(S1.shape[-1], k)
-            self.assertEqual(S1.shape, S2.shape)
+            assert S1.shape[-1] == k
+            assert S1.shape == S2.shape
             self.assertArrayAlmostEqual(S1, S2)
 
     def test_4_way_combinations(self):
@@ -3487,18 +3488,18 @@ class TestSampleSetIndexes(StatsTestCase):
         for k in range(1, len(quads)):
             S1 = ts.f4(sample_sets, quads[:k], windows=[0, ts.sequence_length])
             S2 = f4(ts, sample_sets, quads[:k])
-            self.assertEqual(S1.shape[-1], k)
-            self.assertEqual(S2.shape, S2.shape)
+            assert S1.shape[-1] == k
+            assert S2.shape == S2.shape
             self.assertArrayAlmostEqual(S1, S2)
 
     def test_errors(self):
         ts = self.get_example_ts()
         sample_sets = np.array_split(ts.samples(), 2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.divergence(sample_sets, indexes=[])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.divergence(sample_sets, indexes=[(1, 1, 1)])
-        with self.assertRaises(exceptions.LibraryError):
+        with pytest.raises(exceptions.LibraryError):
             ts.divergence(sample_sets, indexes=[(1, 2)])
 
 
@@ -3551,24 +3552,24 @@ class TestGeneralStatInterface(StatsTestCase):
         ts = msprime.simulate(10, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 2))
         for bad_mode in ["", "MODE", "x" * 8192]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.general_stat(W, self.identity_f(ts), W.shape[1], mode=bad_mode)
 
     def test_bad_window_strings(self):
         ts = self.get_tree_sequence()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.diversity([ts.samples()], mode="site", windows="abc")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.diversity([ts.samples()], mode="site", windows="")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.diversity([ts.samples()], mode="tree", windows="abc")
 
     def test_bad_summary_function(self):
         ts = self.get_tree_sequence()
         W = np.ones((ts.num_samples, 3))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.general_stat(W, lambda x: x, 3, windows="sites")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.general_stat(W, lambda x: np.array([1.0]), 1, windows="sites")
 
     def test_nonnumpy_summary_function(self):
@@ -3590,8 +3591,8 @@ class TestGeneralBranchStats(StatsTestCase):
         sigma1 = naive_branch_general_stat(ts, W, f, windows, polarised=polarised)
         sigma2 = ts.general_stat(W, f, M, windows, polarised=polarised, mode="branch")
         sigma3 = branch_general_stat(ts, W, f, windows, polarised=polarised)
-        self.assertEqual(sigma1.shape, sigma2.shape)
-        self.assertEqual(sigma1.shape, sigma3.shape)
+        assert sigma1.shape == sigma2.shape
+        assert sigma1.shape == sigma3.shape
         self.assertArrayAlmostEqual(sigma1, sigma2)
         self.assertArrayAlmostEqual(sigma1, sigma3)
         return sigma1
@@ -3603,8 +3604,8 @@ class TestGeneralBranchStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.identity_f(ts), windows="trees", polarised=polarised
             )
-            self.assertEqual(sigma.shape, (ts.num_trees, W.shape[1]))
-            self.assertTrue(np.all(sigma == 0))
+            assert sigma.shape == (ts.num_trees, W.shape[1])
+            assert np.all(sigma == 0)
 
     def test_simple_identity_f_w_ones(self):
         ts = msprime.simulate(10, recombination_rate=1, random_seed=2)
@@ -3612,12 +3613,12 @@ class TestGeneralBranchStats(StatsTestCase):
         sigma = self.compare_general_stat(
             ts, W, self.identity_f(ts), windows="trees", polarised=True
         )
-        self.assertEqual(sigma.shape, (ts.num_trees, W.shape[1]))
+        assert sigma.shape == (ts.num_trees, W.shape[1])
         # A W of 1 for every node and identity f counts the samples in the subtree
         # if polarised is True.
         for tree in ts.trees():
             s = sum(tree.num_samples(u) * tree.branch_length(u) for u in tree.nodes())
-            self.assertTrue(np.allclose(sigma[tree.index], s))
+            assert np.allclose(sigma[tree.index], s)
 
     def test_simple_cumsum_f_w_ones(self):
         ts = msprime.simulate(13, recombination_rate=1, random_seed=2)
@@ -3626,15 +3627,15 @@ class TestGeneralBranchStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.cumsum_f(ts), windows="trees", polarised=polarised
             )
-            self.assertEqual(sigma.shape, (ts.num_trees, W.shape[1]))
+            assert sigma.shape == (ts.num_trees, W.shape[1])
 
     def test_simple_cumsum_f_w_ones_many_windows(self):
         ts = msprime.simulate(15, recombination_rate=3, random_seed=3)
-        self.assertGreater(ts.num_trees, 3)
+        assert ts.num_trees > 3
         windows = np.linspace(0, ts.sequence_length, num=ts.num_trees * 10)
         W = np.ones((ts.num_samples, 3))
         sigma = self.compare_general_stat(ts, W, self.cumsum_f(ts), windows=windows)
-        self.assertEqual(sigma.shape, (windows.shape[0] - 1, W.shape[1]))
+        assert sigma.shape == (windows.shape[0] - 1, W.shape[1])
 
     def test_windows_equal_to_ts_breakpoints(self):
         ts = msprime.simulate(14, recombination_rate=1, random_seed=2)
@@ -3643,7 +3644,7 @@ class TestGeneralBranchStats(StatsTestCase):
             sigma_no_windows = self.compare_general_stat(
                 ts, W, self.cumsum_f(ts), windows="trees", polarised=polarised
             )
-            self.assertEqual(sigma_no_windows.shape, (ts.num_trees, W.shape[1]))
+            assert sigma_no_windows.shape == (ts.num_trees, W.shape[1])
             sigma_windows = self.compare_general_stat(
                 ts,
                 W,
@@ -3651,8 +3652,8 @@ class TestGeneralBranchStats(StatsTestCase):
                 windows=ts.breakpoints(as_array=True),
                 polarised=polarised,
             )
-            self.assertEqual(sigma_windows.shape, sigma_no_windows.shape)
-            self.assertTrue(np.allclose(sigma_windows.shape, sigma_no_windows.shape))
+            assert sigma_windows.shape == sigma_no_windows.shape
+            assert np.allclose(sigma_windows.shape, sigma_no_windows.shape)
 
     def test_single_tree_windows(self):
         ts = msprime.simulate(15, random_seed=2, length=100)
@@ -3662,7 +3663,7 @@ class TestGeneralBranchStats(StatsTestCase):
         for num_windows in [2]:
             windows = np.linspace(0, ts.sequence_length, num=num_windows + 1)
             sigma = self.compare_general_stat(ts, W, f, windows)
-            self.assertEqual(sigma.shape, (num_windows, 1))
+            assert sigma.shape == (num_windows, 1)
 
     def test_simple_identity_f_w_zeros_windows(self):
         ts = msprime.simulate(15, recombination_rate=3, random_seed=2)
@@ -3671,8 +3672,8 @@ class TestGeneralBranchStats(StatsTestCase):
         windows = np.linspace(0, ts.sequence_length, num=11)
         for polarised in [True, False]:
             sigma = self.compare_general_stat(ts, W, f, windows, polarised=polarised)
-            self.assertEqual(sigma.shape, (10, W.shape[1]))
-            self.assertTrue(np.all(sigma == 0))
+            assert sigma.shape == (10, W.shape[1])
+            assert np.all(sigma == 0)
 
 
 class TestGeneralSiteStats(StatsTestCase):
@@ -3686,8 +3687,8 @@ class TestGeneralSiteStats(StatsTestCase):
         sigma1 = naive_site_general_stat(ts, W, f, windows, polarised=polarised)
         sigma2 = ts.general_stat(W, f, M, windows, polarised=polarised, mode="site")
         sigma3 = site_general_stat(ts, W, f, windows, polarised=polarised)
-        self.assertEqual(sigma1.shape, sigma2.shape)
-        self.assertEqual(sigma1.shape, sigma3.shape)
+        assert sigma1.shape == sigma2.shape
+        assert sigma1.shape == sigma3.shape
         self.assertArrayAlmostEqual(sigma1, sigma2)
         self.assertArrayAlmostEqual(sigma1, sigma3)
         return sigma1
@@ -3700,8 +3701,8 @@ class TestGeneralSiteStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.identity_f(ts), windows="sites", polarised=polarised
             )
-            self.assertEqual(sigma.shape, (ts.num_sites, W.shape[1]))
-            self.assertTrue(np.all(sigma == 0))
+            assert sigma.shape == (ts.num_sites, W.shape[1])
+            assert np.all(sigma == 0)
 
     def test_identity_f_W_0_multiple_alleles_windows(self):
         ts = msprime.simulate(34, recombination_rate=0, random_seed=2)
@@ -3712,8 +3713,8 @@ class TestGeneralSiteStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.identity_f(ts), windows=windows, polarised=polarised
             )
-            self.assertEqual(sigma.shape, (windows.shape[0] - 1, W.shape[1]))
-            self.assertTrue(np.all(sigma == 0))
+            assert sigma.shape == (windows.shape[0] - 1, W.shape[1])
+            assert np.all(sigma == 0)
 
     def test_cumsum_f_W_1_multiple_alleles(self):
         ts = msprime.simulate(3, recombination_rate=2, random_seed=2)
@@ -3723,7 +3724,7 @@ class TestGeneralSiteStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.cumsum_f(ts), windows="sites", polarised=polarised
             )
-            self.assertEqual(sigma.shape, (ts.num_sites, W.shape[1]))
+            assert sigma.shape == (ts.num_sites, W.shape[1])
 
     def test_cumsum_f_W_1_two_alleles(self):
         ts = msprime.simulate(33, recombination_rate=1, mutation_rate=2, random_seed=1)
@@ -3732,7 +3733,7 @@ class TestGeneralSiteStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.cumsum_f(ts), windows="sites", polarised=polarised
             )
-            self.assertEqual(sigma.shape, (ts.num_sites, W.shape[1]))
+            assert sigma.shape == (ts.num_sites, W.shape[1])
 
 
 class TestGeneralNodeStats(StatsTestCase):
@@ -3746,8 +3747,8 @@ class TestGeneralNodeStats(StatsTestCase):
         sigma1 = naive_node_general_stat(ts, W, f, windows, polarised=polarised)
         sigma2 = ts.general_stat(W, f, M, windows, polarised=polarised, mode="node")
         sigma3 = node_general_stat(ts, W, f, windows, polarised=polarised)
-        self.assertEqual(sigma1.shape, sigma2.shape)
-        self.assertEqual(sigma1.shape, sigma3.shape)
+        assert sigma1.shape == sigma2.shape
+        assert sigma1.shape == sigma3.shape
         self.assertArrayAlmostEqual(sigma1, sigma2)
         self.assertArrayAlmostEqual(sigma1, sigma3)
         return sigma1
@@ -3759,15 +3760,15 @@ class TestGeneralNodeStats(StatsTestCase):
             sigma = self.compare_general_stat(
                 ts, W, self.identity_f(ts), windows="trees", polarised=polarised
             )
-            self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 3))
-            self.assertTrue(np.all(sigma == 0))
+            assert sigma.shape == (ts.num_trees, ts.num_nodes, 3)
+            assert np.all(sigma == 0)
 
     def test_simple_sum_f_w_ones(self):
         ts = msprime.simulate(44, recombination_rate=1, random_seed=2)
         W = np.ones((ts.num_samples, 2))
         f = self.sum_f(ts)
         sigma = self.compare_general_stat(ts, W, f, windows="trees", polarised=True)
-        self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 1))
+        assert sigma.shape == (ts.num_trees, ts.num_nodes, 1)
         # Drop the last dimension
         sigma = sigma.reshape((ts.num_trees, ts.num_nodes))
         # A W of 1 for every node and f(x)=sum(x) counts the samples in the subtree
@@ -3793,7 +3794,7 @@ class TestGeneralNodeStats(StatsTestCase):
             mode="node",
             strict=False,
         )
-        self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 1))
+        assert sigma.shape == (ts.num_trees, ts.num_nodes, 1)
         # Drop the last dimension
         sigma = sigma.reshape((ts.num_trees, ts.num_nodes))
         # A W of 1 for every node and f(x)=sum(x) counts the samples in the subtree
@@ -3804,7 +3805,7 @@ class TestGeneralNodeStats(StatsTestCase):
 
     def test_small_tree_windows_polarised(self):
         ts = msprime.simulate(4, recombination_rate=0.5, random_seed=2)
-        self.assertGreater(ts.num_trees, 1)
+        assert ts.num_trees > 1
         W = np.ones((ts.num_samples, 1))
         sigma = self.compare_general_stat(
             ts,
@@ -3813,7 +3814,7 @@ class TestGeneralNodeStats(StatsTestCase):
             windows=ts.breakpoints(as_array=True),
             polarised=True,
         )
-        self.assertEqual(sigma.shape, (ts.num_trees, ts.num_nodes, 1))
+        assert sigma.shape == (ts.num_trees, ts.num_nodes, 1)
 
     def test_one_window_polarised(self):
         ts = msprime.simulate(4, recombination_rate=1, random_seed=2)
@@ -3821,7 +3822,7 @@ class TestGeneralNodeStats(StatsTestCase):
         sigma = self.compare_general_stat(
             ts, W, self.cumsum_f(ts), windows=[0, ts.sequence_length], polarised=True
         )
-        self.assertEqual(sigma.shape, (1, ts.num_nodes, W.shape[1]))
+        assert sigma.shape == (1, ts.num_nodes, W.shape[1])
 
     def test_one_window_unpolarised(self):
         ts = msprime.simulate(4, recombination_rate=1, random_seed=2)
@@ -3829,7 +3830,7 @@ class TestGeneralNodeStats(StatsTestCase):
         sigma = self.compare_general_stat(
             ts, W, self.cumsum_f(ts), windows=[0, ts.sequence_length], polarised=False
         )
-        self.assertEqual(sigma.shape, (1, ts.num_nodes, 2))
+        assert sigma.shape == (1, ts.num_nodes, 2)
 
     def test_many_windows(self):
         ts = msprime.simulate(24, recombination_rate=3, random_seed=2)
@@ -3840,14 +3841,14 @@ class TestGeneralNodeStats(StatsTestCase):
                 sigma = self.compare_general_stat(
                     ts, W, self.cumsum_f(ts), windows=windows, polarised=polarised
                 )
-            self.assertEqual(sigma.shape, (k, ts.num_nodes, 3))
+            assert sigma.shape == (k, ts.num_nodes, 3)
 
     def test_one_tree(self):
         ts = msprime.simulate(10, random_seed=3)
         W = np.ones((ts.num_samples, 2))
         f = self.sum_f(ts, k=2)
         sigma = self.compare_general_stat(ts, W, f, windows=[0, 1], polarised=True)
-        self.assertEqual(sigma.shape, (1, ts.num_nodes, 2))
+        assert sigma.shape == (1, ts.num_nodes, 2)
         # A W of 1 for every node and f(x)=sum(x) counts the samples in the subtree
         # times 2 if polarised is True.
         tree = ts.first()
@@ -3996,7 +3997,7 @@ class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
 
     def get_example_ts(self):
         ts = msprime.simulate(10, mutation_rate=1, recombination_rate=2, random_seed=1)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         return ts
 
     def transform_weights(self, W):
@@ -4019,7 +4020,7 @@ class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
         sigma1 = ts_method(W, mode=self.mode)
         sigma2 = ts_method(W, windows=None, mode=self.mode)
         sigma3 = ts_method(W, windows=[0.0, ts.sequence_length], mode=self.mode)
-        self.assertEqual(sigma1.shape, sigma2.shape)
+        assert sigma1.shape == sigma2.shape
         self.assertArrayAlmostEqual(sigma1, sigma2)
         self.assertArrayAlmostEqual(sigma1, sigma3[0])
 
@@ -4034,9 +4035,9 @@ class TestTraitCovariance(StatsTestCase, WeightStatsMixin):
             sigma2 = ts_method(W + shift, windows=windows, mode=self.mode)
             sigma3 = method(ts, W, windows=windows, mode=self.mode)
             sigma4 = method(ts, W + shift, windows=windows, mode=self.mode)
-            self.assertEqual(sigma1.shape, sigma2.shape)
-            self.assertEqual(sigma1.shape, sigma3.shape)
-            self.assertEqual(sigma1.shape, sigma4.shape)
+            assert sigma1.shape == sigma2.shape
+            assert sigma1.shape == sigma3.shape
+            assert sigma1.shape == sigma4.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
             self.assertArrayAlmostEqual(sigma1, sigma3)
             self.assertArrayAlmostEqual(sigma1, sigma4)
@@ -4055,15 +4056,18 @@ class TraitCovarianceMixin:
         ts = self.get_example_ts()
         W = np.ones((ts.num_samples, 2))
         # W must have the right number of rows
-        self.assertRaises(ValueError, ts.trait_correlation, W[1:, :])
+        with pytest.raises(ValueError):
+            ts.trait_correlation(W[1:, :])
 
 
+@pytest.mark.slow
 class TestBranchTraitCovariance(
     TestTraitCovariance, TopologyExamplesMixin, TraitCovarianceMixin
 ):
     mode = "branch"
 
 
+@pytest.mark.slow
 class TestNodeTraitCovariance(
     TestTraitCovariance, TopologyExamplesMixin, TraitCovarianceMixin
 ):
@@ -4242,9 +4246,11 @@ class TestTraitCorrelation(TestTraitCovariance):
         ts = self.get_example_ts()
         # columns of W must have positive SD
         W = np.ones((ts.num_samples, 2))
-        self.assertRaises(ValueError, ts.trait_correlation, W)
+        with pytest.raises(ValueError):
+            ts.trait_correlation(W)
         # W must have the right number of rows
-        self.assertRaises(ValueError, ts.trait_correlation, W[1:, :])
+        with pytest.raises(ValueError):
+            ts.trait_correlation(W[1:, :])
 
     def verify_standardising(self, ts, method, ts_method):
         """
@@ -4259,7 +4265,7 @@ class TestTraitCorrelation(TestTraitCovariance):
             sigma2 = ts_method(W * scale, windows=windows, mode=self.mode)
             sigma3 = method(ts, W, windows=windows, mode=self.mode)
             sigma4 = method(ts, W * scale, windows=windows, mode=self.mode)
-            self.assertEqual(sigma1.shape, sigma2.shape)
+            assert sigma1.shape == sigma2.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
             self.assertArrayAlmostEqual(sigma1, sigma3)
             self.assertArrayAlmostEqual(sigma1, sigma4)
@@ -4276,12 +4282,14 @@ class TraitCorrelationMixin:
         self.verify_standardising(ts, trait_correlation, ts.trait_correlation)
 
 
+@pytest.mark.slow
 class TestBranchTraitCorrelation(
     TestTraitCorrelation, TopologyExamplesMixin, TraitCorrelationMixin
 ):
     mode = "branch"
 
 
+@pytest.mark.slow
 class TestNodeTraitCorrelation(
     TestTraitCorrelation, TopologyExamplesMixin, TraitCorrelationMixin
 ):
@@ -4443,7 +4451,7 @@ class TestTraitRegression(StatsTestCase, WeightStatsMixin):
 
     def get_example_ts(self):
         ts = msprime.simulate(10, mutation_rate=1, recombination_rate=2, random_seed=1)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         return ts
 
     def example_covariates(self, ts):
@@ -4531,9 +4539,9 @@ class TestTraitRegression(StatsTestCase, WeightStatsMixin):
                 ts, W, Z, windows=windows, mode=self.mode, span_normalise=sn
             )
 
-            self.assertEqual(sigma1.shape, sigma2.shape)
-            self.assertEqual(sigma1.shape, sigma3.shape)
-            self.assertEqual(sigma1.shape, sigma4.shape)
+            assert sigma1.shape == sigma2.shape
+            assert sigma1.shape == sigma3.shape
+            assert sigma1.shape == sigma4.shape
             self.assertArrayAlmostEqual(sigma1, sigma2)
             self.assertArrayAlmostEqual(sigma1, sigma3)
             self.assertArrayAlmostEqual(sigma1, sigma4)
@@ -4552,10 +4560,10 @@ class TraitRegressionMixin:
         sigma4 = ts.trait_regression(
             W, Z=None, windows=[0.0, ts.sequence_length], mode=self.mode
         )
-        self.assertEqual(sigma1.shape, sigma2.shape)
-        self.assertEqual(sigma3.shape[0], 1)
-        self.assertEqual(sigma1.shape, sigma3.shape[1:])
-        self.assertEqual(sigma1.shape, sigma4.shape[1:])
+        assert sigma1.shape == sigma2.shape
+        assert sigma3.shape[0] == 1
+        assert sigma1.shape == sigma3.shape[1:]
+        assert sigma1.shape == sigma4.shape[1:]
         self.assertArrayAlmostEqual(sigma1, sigma2)
         self.assertArrayAlmostEqual(sigma1, sigma3[0])
         self.assertArrayAlmostEqual(sigma1, sigma4[0])
@@ -4565,25 +4573,28 @@ class TraitRegressionMixin:
         W = np.array([np.arange(ts.num_samples)]).T
         Z = np.ones((ts.num_samples, 1))
         # singular covariates
-        self.assertRaises(
-            ValueError,
-            ts.trait_regression,
-            W,
-            np.ones((ts.num_samples, 2)),
-            mode=self.mode,
-        )
+        with pytest.raises(ValueError):
+            ts.trait_regression(
+                W,
+                np.ones((ts.num_samples, 2)),
+                mode=self.mode,
+            )
         # wrong dimensions of W
-        self.assertRaises(ValueError, ts.trait_regression, W[1:, :], Z, mode=self.mode)
+        with pytest.raises(ValueError):
+            ts.trait_regression(W[1:, :], Z, mode=self.mode)
         # wrong dimensions of Z
-        self.assertRaises(ValueError, ts.trait_regression, W, Z[1:, :], mode=self.mode)
+        with pytest.raises(ValueError):
+            ts.trait_regression(W, Z[1:, :], mode=self.mode)
 
 
+@pytest.mark.slow
 class TestBranchTraitRegression(
     TestTraitRegression, TopologyExamplesMixin, TraitRegressionMixin
 ):
     mode = "branch"
 
 
+@pytest.mark.slow
 class TestNodeTraitRegression(
     TestTraitRegression, TopologyExamplesMixin, TraitRegressionMixin
 ):
@@ -4601,7 +4612,7 @@ class TestSiteTraitRegression(
 ##############################
 
 
-@unittest.skip("Broken - need to port tests")
+@pytest.mark.skip(reason="Broken - need to port tests")
 class SampleSetStatTestCase(StatsTestCase):
     """
     Provides checks for testing of sample set-based statistics.  Actual testing
@@ -4626,7 +4637,7 @@ class SampleSetStatTestCase(StatsTestCase):
             tree_vals = [tree_fn(sample_set, **b) for b in win_args]
 
             tsc_vals = tsc_fn(sample_set, windows)
-            self.assertEqual(len(tsc_vals), len(windows) - 1)
+            assert len(tsc_vals) == len(windows) - 1
             for i in range(len(windows) - 1):
                 self.assertListAlmostEqual(tsc_vals[i], tree_vals[i])
 
@@ -4634,48 +4645,44 @@ class SampleSetStatTestCase(StatsTestCase):
         samples = ts.samples()
 
         # empty sample sets will raise an error
-        self.assertRaises(ValueError, ts.site_frequency_spectrum, [], self.stat_type)
+        with pytest.raises(ValueError):
+            ts.site_frequency_spectrum([], self.stat_type)
         # sample_sets must be lists without repeated elements
-        self.assertRaises(
-            ValueError,
-            ts.site_frequency_spectrum,
-            [samples[2], samples[2]],
-            self.stat_type,
-        )
+        with pytest.raises(ValueError):
+            ts.site_frequency_spectrum(
+                [samples[2], samples[2]],
+                self.stat_type,
+            )
         # and must all be samples
-        self.assertRaises(
-            ValueError,
-            ts.site_frequency_spectrum,
-            [samples[0], max(samples) + 1],
-            self.stat_type,
-        )
+        with pytest.raises(ValueError):
+            ts.site_frequency_spectrum(
+                [samples[0], max(samples) + 1],
+                self.stat_type,
+            )
         # windows must start at 0.0, be increasing, and extend to the end
-        self.assertRaises(
-            ValueError,
-            ts.site_frequency_spectrum,
-            samples[0:2],
-            [0.1, ts.sequence_length],
-            self.stat_type,
-        )
-        self.assertRaises(
-            ValueError,
-            ts.site_frequency_spectrum,
-            samples[0:2],
-            [0.0, 0.8 * ts.sequence_length],
-            self.stat_type,
-        )
-        self.assertRaises(
-            ValueError,
-            ts.site_frequency_spectrum,
-            samples[0:2],
-            [
-                0.0,
-                0.8 * ts.sequence_length,
-                0.4 * ts.sequence_length,
-                ts.sequence_length,
-            ],
-            self.stat_type,
-        )
+        with pytest.raises(ValueError):
+            ts.site_frequency_spectrum(
+                samples[0:2],
+                [0.1, ts.sequence_length],
+                self.stat_type,
+            )
+        with pytest.raises(ValueError):
+            ts.site_frequency_spectrum(
+                samples[0:2],
+                [0.0, 0.8 * ts.sequence_length],
+                self.stat_type,
+            )
+        with pytest.raises(ValueError):
+            ts.site_frequency_spectrum(
+                samples[0:2],
+                [
+                    0.0,
+                    0.8 * ts.sequence_length,
+                    0.4 * ts.sequence_length,
+                    ts.sequence_length,
+                ],
+                self.stat_type,
+            )
 
     def check_sfs(self, ts):
         # check site frequency spectrum
@@ -4710,31 +4717,33 @@ class BranchSampleSetStatsTestCase(SampleSetStatTestCase):
                 N, random_seed=self.random_seed, recombination_rate=10
             )
 
-    @unittest.skip("Skipping SFS.")
+    @pytest.mark.skip(reason="Skipping SFS.")
     def test_sfs_interface(self):
         ts = msprime.simulate(10)
         tsc = tskit.BranchStatCalculator(ts)
 
         # Duplicated samples raise an error
-        self.assertRaises(ValueError, tsc.site_frequency_spectrum, [1, 1])
-        self.assertRaises(ValueError, tsc.site_frequency_spectrum, [])
-        self.assertRaises(ValueError, tsc.site_frequency_spectrum, [0, 11])
+        with pytest.raises(ValueError):
+            tsc.site_frequency_spectrum([1, 1])
+        with pytest.raises(ValueError):
+            tsc.site_frequency_spectrum([])
+        with pytest.raises(ValueError):
+            tsc.site_frequency_spectrum([0, 11])
         # Check for bad windows
         for bad_start in [-1, 1, 1e-7]:
-            self.assertRaises(
-                ValueError,
-                tsc.site_frequency_spectrum,
-                [1, 2],
-                [bad_start, ts.sequence_length],
-            )
+            with pytest.raises(ValueError):
+                tsc.site_frequency_spectrum(
+                    [1, 2],
+                    [bad_start, ts.sequence_length],
+                )
         for bad_end in [0, ts.sequence_length - 1, ts.sequence_length + 1]:
-            self.assertRaises(
-                ValueError, tsc.site_frequency_spectrum, [1, 2], [0, bad_end]
-            )
+            with pytest.raises(ValueError):
+                tsc.site_frequency_spectrum([1, 2], [0, bad_end])
         # Windows must be increasing.
-        self.assertRaises(ValueError, tsc.site_frequency_spectrum, [1, 2], [0, 1, 1])
+        with pytest.raises(ValueError):
+            tsc.site_frequency_spectrum([1, 2], [0, 1, 1])
 
-    @unittest.skip("No SFS.")
+    @pytest.mark.skip(reason="No SFS.")
     def test_branch_sfs(self):
         for ts in self.get_ts():
             self.check_sfs(ts)
@@ -5476,7 +5485,7 @@ class TestOutputDimensions(StatsTestCase):
 
     def get_example_ts(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_sites > 1
         return ts
 
     def test_afs_default_windows(self):
@@ -5487,12 +5496,12 @@ class TestOutputDimensions(StatsTestCase):
         for mode in ["site", "branch"]:
             x = ts.allele_frequency_spectrum(mode=mode)
             # x is a 1D numpy array with n + 1 values
-            self.assertEqual(x.shape, (n + 1,))
+            assert x.shape == (n + 1,)
             self.assertArrayEqual(
                 x, ts.allele_frequency_spectrum([ts.samples()], mode=mode)
             )
             x = ts.allele_frequency_spectrum([A, B], mode=mode)
-            self.assertEqual(x.shape, (len(A) + 1, len(B) + 1))
+            assert x.shape == (len(A) + 1, len(B) + 1)
 
     def test_afs_windows(self):
         ts = self.get_example_ts()
@@ -5503,14 +5512,14 @@ class TestOutputDimensions(StatsTestCase):
         B = ts.samples()[6:]
         for mode in ["site", "branch"]:
             x = ts.allele_frequency_spectrum([A, B], windows=windows, mode=mode)
-            self.assertEqual(x.shape, (3, len(A) + 1, len(B) + 1))
+            assert x.shape == (3, len(A) + 1, len(B) + 1)
 
             x = ts.allele_frequency_spectrum([A], windows=windows, mode=mode)
-            self.assertEqual(x.shape, (3, len(A) + 1))
+            assert x.shape == (3, len(A) + 1)
 
             x = ts.allele_frequency_spectrum(windows=windows, mode=mode)
             # Default returns this for all samples
-            self.assertEqual(x.shape, (3, ts.num_samples + 1))
+            assert x.shape == (3, ts.num_samples + 1)
             y = ts.allele_frequency_spectrum([ts.samples()], windows=windows, mode=mode)
             self.assertArrayEqual(x, y)
 
@@ -5520,15 +5529,15 @@ class TestOutputDimensions(StatsTestCase):
         for mode in ["site", "branch"]:
             x = ts.diversity(mode=mode)
             # x is a zero-d numpy value
-            self.assertEqual(np.shape(x), tuple())
-            self.assertEqual(x, float(x))
-            self.assertEqual(x, ts.diversity(ts.samples(), mode=mode))
+            assert np.shape(x) == tuple()
+            assert x == float(x)
+            assert x == ts.diversity(ts.samples(), mode=mode)
             self.assertArrayEqual([x], ts.diversity([ts.samples()], mode=mode))
 
         mode = "node"
         x = ts.diversity(mode=mode)
         # x is a 1D numpy array with N values
-        self.assertEqual(x.shape, (ts.num_nodes,))
+        assert x.shape == (ts.num_nodes,)
         self.assertArrayEqual(x, ts.diversity(ts.samples(), mode=mode))
         y = ts.diversity([ts.samples()], mode=mode)
         # We're adding on the *last* dimension, so must reshape
@@ -5544,40 +5553,40 @@ class TestOutputDimensions(StatsTestCase):
         for mode in ["site", "branch"]:
             x = method([A, B], windows=windows, mode=mode)
             # Four windows, 2 sets.
-            self.assertEqual(x.shape, (4, 2))
+            assert x.shape == (4, 2)
 
             x = method([A], windows=windows, mode=mode)
             # Four windows, 1 sets.
-            self.assertEqual(x.shape, (4, 1))
+            assert x.shape == (4, 1)
 
             x = method(A, windows=windows, mode=mode)
             # Dropping the outer list removes the last dimension
-            self.assertEqual(x.shape, (4,))
+            assert x.shape == (4,)
 
             x = method(windows=windows, mode=mode)
             # Default returns this for all samples
-            self.assertEqual(x.shape, (4,))
+            assert x.shape == (4,)
             y = method(ts.samples(), windows=windows, mode=mode)
             self.assertArrayEqual(x, y)
 
         mode = "node"
         x = method([A, B], windows=windows, mode=mode)
         # Four windows, N nodes and 2 sets.
-        self.assertEqual(x.shape, (4, N, 2))
+        assert x.shape == (4, N, 2)
 
         x = method([A], windows=windows, mode=mode)
         # Four windows, N nodes and 1 set.
-        self.assertEqual(x.shape, (4, N, 1))
+        assert x.shape == (4, N, 1)
 
         x = method(A, windows=windows, mode=mode)
         # Drop the outer list, so we lose the last dimension
-        self.assertEqual(x.shape, (4, N))
+        assert x.shape == (4, N)
 
         x = method(windows=windows, mode=mode)
         # The default sample sets also drops the last dimension
-        self.assertEqual(x.shape, (4, N))
+        assert x.shape == (4, N)
 
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.num_trees == 1
         # In this example, we know that the trees are all the same so check this
         # for sanity.
         self.assertArrayEqual(x[0], x[1])
@@ -5603,17 +5612,17 @@ class TestOutputDimensions(StatsTestCase):
         for mode in ["site", "branch"]:
             x = ts.divergence([A, B], mode=mode)
             # x is a zero-d numpy value
-            self.assertEqual(np.shape(x), tuple())
-            self.assertEqual(x, float(x))
+            assert np.shape(x) == tuple()
+            assert x == float(x)
             # If indexes is a 1D array, we also drop the outer dimension
-            self.assertEqual(x, ts.divergence([A, B, A], indexes=[0, 1], mode=mode))
+            assert x == ts.divergence([A, B, A], indexes=[0, 1], mode=mode)
             # But, if it's a 2D array we keep the outer dimension
-            self.assertEqual([x], ts.divergence([A, B], indexes=[[0, 1]], mode=mode))
+            assert [x] == ts.divergence([A, B], indexes=[[0, 1]], mode=mode)
 
         mode = "node"
         x = ts.divergence([A, B], mode=mode)
         # x is a 1D numpy array with N values
-        self.assertEqual(x.shape, (ts.num_nodes,))
+        assert x.shape == (ts.num_nodes,)
         self.assertArrayEqual(x, ts.divergence([A, B], indexes=[0, 1], mode=mode))
         y = ts.divergence([A, B], indexes=[[0, 1]], mode=mode)
         # We're adding on the *last* dimension, so must reshape
@@ -5629,38 +5638,38 @@ class TestOutputDimensions(StatsTestCase):
         for mode in ["site", "branch"]:
             x = method([A, B, A], indexes=[[0, 1], [0, 2]], windows=windows, mode=mode)
             # Three windows, 2 pairs
-            self.assertEqual(x.shape, (3, 2))
+            assert x.shape == (3, 2)
 
             x = method([A, B], indexes=[[0, 1]], windows=windows, mode=mode)
             # Three windows, 1 pair
-            self.assertEqual(x.shape, (3, 1))
+            assert x.shape == (3, 1)
 
             x = method([A, B], indexes=[0, 1], windows=windows, mode=mode)
             # Dropping the outer list removes the last dimension
-            self.assertEqual(x.shape, (3,))
+            assert x.shape == (3,)
 
             y = method([A, B], windows=windows, mode=mode)
-            self.assertEqual(y.shape, (3,))
+            assert y.shape == (3,)
             self.assertArrayEqual(x, y)
 
         mode = "node"
         x = method([A, B], indexes=[[0, 1], [0, 1]], windows=windows, mode=mode)
         # Three windows, N nodes and 2 pairs
-        self.assertEqual(x.shape, (3, N, 2))
+        assert x.shape == (3, N, 2)
 
         x = method([A, B], indexes=[[0, 1]], windows=windows, mode=mode)
         # Three windows, N nodes and 1 pairs
-        self.assertEqual(x.shape, (3, N, 1))
+        assert x.shape == (3, N, 1)
 
         x = method([A, B], indexes=[0, 1], windows=windows, mode=mode)
         # Drop the outer list, so we lose the last dimension
-        self.assertEqual(x.shape, (3, N))
+        assert x.shape == (3, N)
 
         x = method([A, B], windows=windows, mode=mode)
         # The default sample sets also drops the last dimension
-        self.assertEqual(x.shape, (3, N))
+        assert x.shape == (3, N)
 
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.num_trees == 1
         # In this example, we know that the trees are all the same so check this
         # for sanity.
         self.assertArrayEqual(x[0], x[1])
@@ -5691,18 +5700,18 @@ class TestOutputDimensions(StatsTestCase):
                 [A, B, C], indexes=[[0, 1, 2], [0, 2, 1]], windows=windows, mode=mode
             )
             # Three windows, 2 triple
-            self.assertEqual(x.shape, (3, 2))
+            assert x.shape == (3, 2)
 
             x = method([A, B, C], indexes=[[0, 1, 2]], windows=windows, mode=mode)
             # Three windows, 1 triple
-            self.assertEqual(x.shape, (3, 1))
+            assert x.shape == (3, 1)
 
             x = method([A, B, C], indexes=[0, 1, 2], windows=windows, mode=mode)
             # Dropping the outer list removes the last dimension
-            self.assertEqual(x.shape, (3,))
+            assert x.shape == (3,)
 
             y = method([A, B, C], windows=windows, mode=mode)
-            self.assertEqual(y.shape, (3,))
+            assert y.shape == (3,)
             self.assertArrayEqual(x, y)
 
         mode = "node"
@@ -5710,21 +5719,21 @@ class TestOutputDimensions(StatsTestCase):
             [A, B, C], indexes=[[0, 1, 2], [0, 2, 1]], windows=windows, mode=mode
         )
         # Three windows, N nodes and 2 triples
-        self.assertEqual(x.shape, (3, N, 2))
+        assert x.shape == (3, N, 2)
 
         x = method([A, B, C], indexes=[[0, 1, 2]], windows=windows, mode=mode)
         # Three windows, N nodes and 1 triples
-        self.assertEqual(x.shape, (3, N, 1))
+        assert x.shape == (3, N, 1)
 
         x = method([A, B, C], indexes=[0, 1, 2], windows=windows, mode=mode)
         # Drop the outer list, so we lose the last dimension
-        self.assertEqual(x.shape, (3, N))
+        assert x.shape == (3, N)
 
         x = method([A, B, C], windows=windows, mode=mode)
         # The default sample sets also drops the last dimension
-        self.assertEqual(x.shape, (3, N))
+        assert x.shape == (3, N)
 
-        self.assertEqual(ts.num_trees, 1)
+        assert ts.num_trees == 1
         # In this example, we know that the trees are all the same so check this
         # for sanity.
         self.assertArrayEqual(x[0], x[1])

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -26,9 +26,9 @@ import collections
 import itertools
 import math
 import pickle
-import unittest
 
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 import tests.tsutil as tsutil
@@ -36,14 +36,14 @@ import tskit.util as util
 from tskit import UNKNOWN_TIME
 
 
-class TestCanonicalJSON(unittest.TestCase):
+class TestCanonicalJSON:
     def test_canonical_json(self):
-        self.assertEqual(util.canonical_json([3, 2, 1]), "[3,2,1]")
-        self.assertEqual(
-            util.canonical_json(collections.OrderedDict(c=3, b=2, a=1)),
-            '{"a":1,"b":2,"c":3}',
+        assert util.canonical_json([3, 2, 1]) == "[3,2,1]"
+        assert (
+            util.canonical_json(collections.OrderedDict(c=3, b=2, a=1))
+            == '{"a":1,"b":2,"c":3}'
         )
-        self.assertEqual(
+        assert (
             util.canonical_json(
                 collections.OrderedDict(
                     c="3",
@@ -58,31 +58,31 @@ class TestCanonicalJSON(unittest.TestCase):
                     ),
                     a="1",
                 )
-            ),
-            '{"a":"1","b":{" space":42,"1":"number",'
-            '"_":"underscore","b":1,"z":{}},"c":"3"}',
+            )
+            == '{"a":"1","b":{" space":42,"1":"number",'
+            '"_":"underscore","b":1,"z":{}},"c":"3"}'
         )
 
 
-class TestUnknownTime(unittest.TestCase):
+class TestUnknownTime:
     def test_unknown_time_bad_types(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.is_unknown_time("bad")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.is_unknown_time(np.array(["bad"]))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.is_unknown_time(["bad"])
 
     def test_unknown_time_scalar(self):
-        self.assertTrue(math.isnan(UNKNOWN_TIME))
-        self.assertTrue(util.is_unknown_time(UNKNOWN_TIME))
-        self.assertFalse(util.is_unknown_time(math.nan))
-        self.assertFalse(util.is_unknown_time(np.nan))
-        self.assertFalse(util.is_unknown_time(0))
-        self.assertFalse(util.is_unknown_time(math.inf))
-        self.assertFalse(util.is_unknown_time(1))
-        self.assertFalse(util.is_unknown_time(None))
-        self.assertFalse(util.is_unknown_time([None]))
+        assert math.isnan(UNKNOWN_TIME)
+        assert util.is_unknown_time(UNKNOWN_TIME)
+        assert not util.is_unknown_time(math.nan)
+        assert not util.is_unknown_time(np.nan)
+        assert not util.is_unknown_time(0)
+        assert not util.is_unknown_time(math.inf)
+        assert not util.is_unknown_time(1)
+        assert not util.is_unknown_time(None)
+        assert not util.is_unknown_time([None])
 
     def test_unknown_time_array(self):
         test_arrays = (
@@ -105,7 +105,7 @@ class TestUnknownTime(unittest.TestCase):
         )
 
 
-class TestNumpyArrayCasting(unittest.TestCase):
+class TestNumpyArrayCasting:
     """
     Tests that the safe_np_int_cast() function works.
     """
@@ -119,12 +119,12 @@ class TestNumpyArrayCasting(unittest.TestCase):
             for test_array in [[0, 1], (0, 1), np.array([0, 1]), target]:
                 converted = util.safe_np_int_cast(test_array, dtype=dtype)
                 # Use pickle to test exact equality including dtype
-                self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+                assert pickle.dumps(converted) == pickle.dumps(target)
             # Nested array
             target = np.array([[0, 1], [2, 3]], dtype=dtype)
             for test_array in [[[0, 1], [2, 3]], np.array([[0, 1], [2, 3]]), target]:
                 converted = util.safe_np_int_cast(test_array, dtype=dtype)
-                self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+                assert pickle.dumps(converted) == pickle.dumps(target)
 
     def test_copy(self):
         # Check that a copy is not returned if copy=False & the original matches
@@ -132,24 +132,24 @@ class TestNumpyArrayCasting(unittest.TestCase):
         for dtype in self.dtypes_to_test:
             for orig in (np.array([0, 1], dtype=dtype), np.array([], dtype=dtype)):
                 converted = util.safe_np_int_cast(orig, dtype=dtype, copy=True)
-                self.assertNotEqual(id(orig), id(converted))
+                assert id(orig) != id(converted)
                 converted = util.safe_np_int_cast(orig, dtype=dtype, copy=False)
-                self.assertEqual(id(orig), id(converted))
+                assert id(orig) == id(converted)
         for dtype in [d for d in self.dtypes_to_test if d != np.int64]:
             # non numpy arrays, or arrays of a different dtype don't get converted
             for orig in ([0, 1], np.array([0, 1], dtype=np.int64)):
                 converted = util.safe_np_int_cast(orig, dtype=dtype, copy=False)
-                self.assertNotEqual(id(orig), id(converted))
+                assert id(orig) != id(converted)
 
     def test_empty_arrays(self):
         # Empty arrays of any type (including float) should be allowed
         for dtype in self.dtypes_to_test:
             target = np.array([], dtype=dtype)
             converted = util.safe_np_int_cast([], dtype=dtype)
-            self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+            assert pickle.dumps(converted) == pickle.dumps(target)
             target = np.array([[]], dtype=dtype)
             converted = util.safe_np_int_cast([[]], dtype=dtype)
-            self.assertEqual(pickle.dumps(converted), pickle.dumps(target))
+            assert pickle.dumps(converted) == pickle.dumps(target)
 
     def test_bad_types(self):
         # Shouldn't be able to convert a float (possibility of rounding error)
@@ -161,26 +161,23 @@ class TestNumpyArrayCasting(unittest.TestCase):
                 [{}],
                 np.array([0, 1], dtype=np.float),
             ]:
-                self.assertRaises(TypeError, util.safe_np_int_cast, bad_type, dtype)
+                with pytest.raises(TypeError):
+                    util.safe_np_int_cast(bad_type, dtype)
 
     def test_overflow(self):
         for dtype in self.dtypes_to_test:
             for bad_node in [np.iinfo(dtype).min - 1, np.iinfo(dtype).max + 1]:
-                self.assertRaises(  # Test plain array
-                    OverflowError, util.safe_np_int_cast, [0, bad_node], dtype
-                )
-                self.assertRaises(  # Test numpy array
-                    OverflowError, util.safe_np_int_cast, np.array([0, bad_node]), dtype
-                )
+                with pytest.raises(OverflowError):
+                    util.safe_np_int_cast([0, bad_node], dtype)
+                with pytest.raises(OverflowError):
+                    util.safe_np_int_cast(np.array([0, bad_node]), dtype)
             for good_node in [np.iinfo(dtype).min, np.iinfo(dtype).max]:
                 target = np.array([good_node], dtype=dtype)
-                self.assertEqual(  # Test plain array
-                    pickle.dumps(target),
-                    pickle.dumps(util.safe_np_int_cast([good_node], dtype)),
+                assert pickle.dumps(target) == pickle.dumps(
+                    util.safe_np_int_cast([good_node], dtype)
                 )
-                self.assertEqual(  # Test numpy array
-                    pickle.dumps(target),
-                    pickle.dumps(util.safe_np_int_cast(np.array([good_node]), dtype)),
+                assert pickle.dumps(target) == pickle.dumps(
+                    util.safe_np_int_cast(np.array([good_node]), dtype)
                 )
 
     def test_nonrectangular_input(self):
@@ -196,46 +193,46 @@ class TestNumpyArrayCasting(unittest.TestCase):
             for bad_input in bad_inputs:
                 # On some platforms and Python / numpy versions, a ValueError
                 # occurs instead
-                with self.assertRaises((TypeError, ValueError)):
+                with pytest.raises((TypeError, ValueError)):
                     util.safe_np_int_cast(bad_input, dtype)
 
 
-class TestIntervalOps(unittest.TestCase):
+class TestIntervalOps:
     """
     Test cases for the interval operations used in masks and slicing operations.
     """
 
     def test_bad_intervals(self):
         for bad_type in [{}, Exception]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 util.intervals_to_np_array(bad_type, 0, 1)
         for bad_depth in [[[[]]]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 util.intervals_to_np_array(bad_depth, 0, 1)
         for bad_shape in [[[0], [0]], [[[0, 1, 2], [0, 1]]]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 util.intervals_to_np_array(bad_shape, 0, 1)
 
         # Out of bounds
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.intervals_to_np_array([[-1, 0]], 0, 1)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.intervals_to_np_array([[0, 1]], 1, 2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.intervals_to_np_array([[0, 1]], 0, 0.5)
 
         # Overlapping intervals
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.intervals_to_np_array([[0, 1], [0.9, 2.0]], 0, 10)
 
         # Empty intervals
         for bad_interval in [[0, 0], [1, 0]]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 util.intervals_to_np_array([bad_interval], 0, 10)
 
     def test_empty_interval_list(self):
         intervals = util.intervals_to_np_array([], 0, 10)
-        self.assertEqual(len(intervals), 0)
+        assert len(intervals) == 0
 
     def test_negate_intervals(self):
         L = 10
@@ -247,10 +244,10 @@ class TestIntervalOps(unittest.TestCase):
             ([[0, 1], [2, 3], [3, 4], [5, 6]], [[1, 2], [4, 5], [6, L]]),
         ]
         for source, dest in cases:
-            self.assertTrue(np.array_equal(util.negate_intervals(source, 0, L), dest))
+            assert np.array_equal(util.negate_intervals(source, 0, L), dest)
 
 
-class TestStringPacking(unittest.TestCase):
+class TestStringPacking:
     """
     Tests the code for packing and unpacking unicode string data into numpy arrays.
     """
@@ -258,18 +255,18 @@ class TestStringPacking(unittest.TestCase):
     def test_simple_string_case(self):
         strings = ["hello", "world"]
         packed, offset = util.pack_strings(strings)
-        self.assertEqual(list(offset), [0, 5, 10])
-        self.assertEqual(packed.shape, (10,))
+        assert list(offset) == [0, 5, 10]
+        assert packed.shape == (10,)
         returned = util.unpack_strings(packed, offset)
-        self.assertEqual(returned, strings)
+        assert returned == strings
 
     def verify_packing(self, strings):
         packed, offset = util.pack_strings(strings)
-        self.assertEqual(packed.dtype, np.int8)
-        self.assertEqual(offset.dtype, np.uint32)
-        self.assertEqual(packed.shape[0], offset[-1])
+        assert packed.dtype == np.int8
+        assert offset.dtype == np.uint32
+        assert packed.shape[0] == offset[-1]
         returned = util.unpack_strings(packed, offset)
-        self.assertEqual(strings, returned)
+        assert strings == returned
 
     def test_regular_cases(self):
         for n in range(10):
@@ -285,7 +282,7 @@ class TestStringPacking(unittest.TestCase):
         self.verify_packing(["abcdé", "€"])
 
 
-class TestBytePacking(unittest.TestCase):
+class TestBytePacking:
     """
     Tests the code for packing and unpacking binary data into numpy arrays.
     """
@@ -293,18 +290,18 @@ class TestBytePacking(unittest.TestCase):
     def test_simple_string_case(self):
         strings = [b"hello", b"world"]
         packed, offset = util.pack_bytes(strings)
-        self.assertEqual(list(offset), [0, 5, 10])
-        self.assertEqual(packed.shape, (10,))
+        assert list(offset) == [0, 5, 10]
+        assert packed.shape == (10,)
         returned = util.unpack_bytes(packed, offset)
-        self.assertEqual(returned, strings)
+        assert returned == strings
 
     def verify_packing(self, data):
         packed, offset = util.pack_bytes(data)
-        self.assertEqual(packed.dtype, np.int8)
-        self.assertEqual(offset.dtype, np.uint32)
-        self.assertEqual(packed.shape[0], offset[-1])
+        assert packed.dtype == np.int8
+        assert offset.dtype == np.uint32
+        assert packed.shape[0] == offset[-1]
         returned = util.unpack_bytes(packed, offset)
-        self.assertEqual(data, returned)
+        assert data == returned
         return returned
 
     def test_random_cases(self):
@@ -318,10 +315,10 @@ class TestBytePacking(unittest.TestCase):
         pickled = [pickle.dumps(d) for d in data]
         unpacked = self.verify_packing(pickled)
         unpickled = [pickle.loads(p) for p in unpacked]
-        self.assertEqual(data, unpickled)
+        assert data == unpickled
 
 
-class TestArrayPacking(unittest.TestCase):
+class TestArrayPacking:
     """
     Tests the code for packing and unpacking numpy data into numpy arrays.
     """
@@ -329,20 +326,20 @@ class TestArrayPacking(unittest.TestCase):
     def test_simple_case(self):
         lists = [[0], [1.125, 1.25]]
         packed, offset = util.pack_arrays(lists)
-        self.assertEqual(list(offset), [0, 1, 3])
-        self.assertEqual(list(packed), [0, 1.125, 1.25])
+        assert list(offset) == [0, 1, 3]
+        assert list(packed) == [0, 1.125, 1.25]
         returned = util.unpack_arrays(packed, offset)
         for a1, a2 in itertools.zip_longest(lists, returned):
-            self.assertEqual(a1, list(a2))
+            assert a1 == list(a2)
 
     def verify_packing(self, data):
         packed, offset = util.pack_arrays(data)
-        self.assertEqual(packed.dtype, np.float64)
-        self.assertEqual(offset.dtype, np.uint32)
-        self.assertEqual(packed.shape[0], offset[-1])
+        assert packed.dtype == np.float64
+        assert offset.dtype == np.uint32
+        assert packed.shape[0] == offset[-1]
         returned = util.unpack_arrays(packed, offset)
         for a1, a2 in itertools.zip_longest(data, returned):
-            self.assertTrue(np.array_equal(a1, a2))
+            assert np.array_equal(a1, a2)
         return returned
 
     def test_regular_cases(self):

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -194,7 +194,8 @@ class TestNumpyArrayCasting:
                 # On some platforms and Python / numpy versions, a ValueError
                 # occurs instead
                 with pytest.raises((TypeError, ValueError)):
-                    util.safe_np_int_cast(bad_input, dtype)
+                    with pytest.deprecated_call():
+                        util.safe_np_int_cast(bad_input, dtype)
 
 
 class TestIntervalOps:

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -22,14 +22,13 @@
 """
 Tests for the various testing utilities.
 """
-import unittest
-
 import msprime
+import pytest
 
 import tests.tsutil as tsutil
 
 
-class TestJukesCantor(unittest.TestCase):
+class TestJukesCantor:
     """
     Check that the we get useable tree sequences.
     """
@@ -37,9 +36,9 @@ class TestJukesCantor(unittest.TestCase):
     def verify(self, ts):
         tables = ts.dump_tables()
         tables.compute_mutation_parents()
-        self.assertEqual(tables, ts.tables)
+        assert tables == ts.tables
         # This will catch inconsistent mutations.
-        self.assertIsNotNone(ts.genotype_matrix())
+        assert ts.genotype_matrix() is not None
 
     def test_n10_multiroot(self):
         ts = msprime.simulate(10, random_seed=1)
@@ -54,19 +53,19 @@ class TestJukesCantor(unittest.TestCase):
         self.verify(ts)
 
 
-class TestCaterpillarTree(unittest.TestCase):
+class TestCaterpillarTree:
     """
     Tests for the caterpillar tree method.
     """
 
     def verify(self, ts, n):
-        self.assertEqual(ts.num_trees, 1)
-        self.assertEqual(ts.num_nodes, ts.num_samples * 2 - 1)
+        assert ts.num_trees == 1
+        assert ts.num_nodes == ts.num_samples * 2 - 1
         tree = ts.first()
         for j in range(1, n):
-            self.assertEqual(tree.parent(j), n + j - 1)
+            assert tree.parent(j) == n + j - 1
         # This will catch inconsistent mutations.
-        self.assertIsNotNone(ts.genotype_matrix())
+        assert ts.genotype_matrix() is not None
 
     def test_n_2(self):
         ts = tsutil.caterpillar_tree(2)
@@ -83,22 +82,22 @@ class TestCaterpillarTree(unittest.TestCase):
     def test_n_5_sites(self):
         ts = tsutil.caterpillar_tree(5, num_sites=4)
         self.verify(ts, 5)
-        self.assertEqual(ts.num_sites, 4)
-        self.assertEqual(ts.num_mutations, 4)
-        self.assertEqual(list(ts.tables.sites.position), [0.2, 0.4, 0.6, 0.8])
+        assert ts.num_sites == 4
+        assert ts.num_mutations == 4
+        assert list(ts.tables.sites.position) == [0.2, 0.4, 0.6, 0.8]
         ts = tsutil.caterpillar_tree(5, num_sites=1, num_mutations=1)
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 1)
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 1
         site = ts.site(0)
-        self.assertEqual(site.mutations[0].node, 7)
+        assert site.mutations[0].node == 7
 
     def test_n_5_mutations(self):
         ts = tsutil.caterpillar_tree(5, num_sites=1, num_mutations=3)
         self.verify(ts, 5)
-        self.assertEqual(ts.num_sites, 1)
-        self.assertEqual(ts.num_mutations, 3)
+        assert ts.num_sites == 1
+        assert ts.num_mutations == 3
         node = ts.tables.mutations.node
-        self.assertEqual(list(node), [7, 6, 5])
+        assert list(node) == [7, 6, 5]
 
     def test_n_many_mutations(self):
         for n in range(10, 15):
@@ -107,39 +106,39 @@ class TestCaterpillarTree(unittest.TestCase):
                     n, num_sites=1, num_mutations=num_mutations
                 )
                 self.verify(ts, n)
-                self.assertEqual(ts.num_sites, 1)
-                self.assertEqual(ts.num_mutations, num_mutations)
+                assert ts.num_sites == 1
+                assert ts.num_mutations == num_mutations
             for num_mutations in range(n - 1, n + 2):
-                with self.assertRaises(ValueError):
+                with pytest.raises(ValueError):
                     tsutil.caterpillar_tree(n, num_sites=1, num_mutations=num_mutations)
 
 
-class TestInsertIndividuals(unittest.TestCase):
+class TestInsertIndividuals:
     """
     Test that we insert individuals correctly.
     """
 
     def test_ploidy_1(self):
         ts = msprime.simulate(10, random_seed=1)
-        self.assertEqual(ts.num_individuals, 0)
+        assert ts.num_individuals == 0
         ts = tsutil.insert_individuals(ts, ploidy=1)
-        self.assertEqual(ts.num_individuals, 10)
+        assert ts.num_individuals == 10
         for j, ind in enumerate(ts.individuals()):
-            self.assertEqual(list(ind.nodes), [j])
+            assert list(ind.nodes) == [j]
 
     def test_ploidy_2(self):
         ts = msprime.simulate(10, random_seed=1)
-        self.assertEqual(ts.num_individuals, 0)
+        assert ts.num_individuals == 0
         ts = tsutil.insert_individuals(ts, ploidy=2)
-        self.assertEqual(ts.num_individuals, 5)
+        assert ts.num_individuals == 5
         for j, ind in enumerate(ts.individuals()):
-            self.assertEqual(list(ind.nodes), [2 * j, 2 * j + 1])
+            assert list(ind.nodes) == [2 * j, 2 * j + 1]
 
     def test_ploidy_2_reversed(self):
         ts = msprime.simulate(10, random_seed=1)
-        self.assertEqual(ts.num_individuals, 0)
+        assert ts.num_individuals == 0
         samples = ts.samples()[::-1]
         ts = tsutil.insert_individuals(ts, samples=samples, ploidy=2)
-        self.assertEqual(ts.num_individuals, 5)
+        assert ts.num_individuals == 5
         for j, ind in enumerate(ts.individuals()):
-            self.assertEqual(list(ind.nodes), [samples[2 * j + 1], samples[2 * j]])
+            assert list(ind.nodes) == [samples[2 * j + 1], samples[2 * j]]

--- a/python/tests/test_vcf.py
+++ b/python/tests/test_vcf.py
@@ -29,10 +29,10 @@ import itertools
 import math
 import os
 import tempfile
-import unittest
 
 import msprime
 import numpy as np
+import pytest
 import vcf
 
 import tests.test_wright_fisher as wf
@@ -150,14 +150,14 @@ def legacy_write_vcf(tree_sequence, output, ploidy, contig_id):
         print(file=output)
 
 
-class TestLegacyOutput(unittest.TestCase):
+class TestLegacyOutput:
     """
     Tests if the VCF file produced by the low level code is the
     same as one we generate here.
     """
 
     def verify(self, ts, ploidy=1, contig_id="1"):
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         f = io.StringIO()
         legacy_write_vcf(ts, f, ploidy=ploidy, contig_id=contig_id)
         vcf1 = f.getvalue()
@@ -173,7 +173,7 @@ class TestLegacyOutput(unittest.TestCase):
             individual_names=individual_names,
         )
         vcf2 = f.getvalue()
-        self.assertEqual(vcf1, vcf2)
+        assert vcf1 == vcf2
 
     def test_msprime_length_1(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=666)
@@ -200,27 +200,27 @@ class ExamplesMixin:
     def test_simple_infinite_sites_random_ploidy(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
         ts = tsutil.insert_random_ploidy_individuals(ts)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         self.verify(ts)
 
     def test_simple_infinite_sites_ploidy_2(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
         ts = tsutil.insert_individuals(ts, ploidy=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         self.verify(ts)
 
     def test_simple_infinite_sites_ploidy_2_reversed_samples(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
         samples = ts.samples()[::-1]
         ts = tsutil.insert_individuals(ts, samples=samples, ploidy=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         self.verify(ts)
 
     def test_simple_infinite_sites_ploidy_2_even_samples(self):
         ts = msprime.simulate(20, mutation_rate=1, random_seed=2)
         samples = ts.samples()[0::2]
         ts = tsutil.insert_individuals(ts, samples=samples, ploidy=2)
-        self.assertGreater(ts.num_sites, 2)
+        assert ts.num_sites > 2
         self.verify(ts)
 
     def test_simple_jukes_cantor_random_ploidy(self):
@@ -237,8 +237,8 @@ class ExamplesMixin:
 
     def test_many_trees_infinite_sites(self):
         ts = msprime.simulate(6, recombination_rate=2, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
-        self.assertGreater(ts.num_trees, 2)
+        assert ts.num_sites > 0
+        assert ts.num_trees > 2
         ts = tsutil.insert_individuals(ts, ploidy=2)
         self.verify(ts)
 
@@ -247,7 +247,7 @@ class ExamplesMixin:
             ts = msprime.simulate(
                 6, length=L, recombination_rate=2, mutation_rate=1, random_seed=1
             )
-            self.assertGreater(ts.num_sites, 0)
+            assert ts.num_sites > 0
             ts = tsutil.insert_individuals(ts, ploidy=2)
             self.verify(ts)
 
@@ -262,7 +262,7 @@ class ExamplesMixin:
         )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.05, random_seed=234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         ts = tsutil.insert_individuals(ts, ploidy=4)
         self.verify(ts)
 
@@ -273,7 +273,7 @@ class ExamplesMixin:
         tables.sort()
         tables.simplify()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.08, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         ts = tsutil.insert_individuals(ts, ploidy=3)
         self.verify(ts)
 
@@ -288,7 +288,7 @@ class ExamplesMixin:
         )
         tables.sort()
         ts = msprime.mutate(tables.tree_sequence(), rate=0.006, random_seed=2)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         ts = tsutil.insert_individuals(ts, ploidy=2)
         self.verify(ts)
 
@@ -304,12 +304,12 @@ class ExamplesMixin:
         tables.sort()
         ts = tables.tree_sequence().simplify()
         ts = msprime.mutate(ts, rate=0.01, random_seed=1234)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         ts = tsutil.insert_individuals(ts, ploidy=3)
         self.verify(ts)
 
 
-class TestParseHeaderPyvcf(unittest.TestCase, ExamplesMixin):
+class TestParseHeaderPyvcf(ExamplesMixin):
     """
     Test that pyvcf can parse the headers correctly.
     """
@@ -318,23 +318,23 @@ class TestParseHeaderPyvcf(unittest.TestCase, ExamplesMixin):
         contig_id = "pyvcf"
         for indivs, num_indivs in example_individuals(ts):
             with ts_to_pyvcf(ts, contig_id=contig_id, individuals=indivs) as reader:
-                self.assertEqual(len(reader.contigs), 1)
+                assert len(reader.contigs) == 1
                 contig = reader.contigs[contig_id]
-                self.assertEqual(contig.id, contig_id)
-                self.assertGreater(contig.length, 0)
-                self.assertEqual(len(reader.alts), 0)
-                self.assertEqual(len(reader.filters), 1)
+                assert contig.id == contig_id
+                assert contig.length > 0
+                assert len(reader.alts) == 0
+                assert len(reader.filters) == 1
                 p = reader.filters["PASS"]
-                self.assertEqual(p.id, "PASS")
-                self.assertEqual(len(reader.formats), 1)
+                assert p.id == "PASS"
+                assert len(reader.formats) == 1
                 f = reader.formats["GT"]
-                self.assertEqual(f.id, "GT")
-                self.assertEqual(len(reader.infos), 0)
-                self.assertEqual(len(reader.samples), num_indivs)
+                assert f.id == "GT"
+                assert len(reader.infos) == 0
+                assert len(reader.samples) == num_indivs
 
 
-@unittest.skipIf(not _pysam_imported, "pysam not available")
-class TestParseHeaderPysam(unittest.TestCase, ExamplesMixin):
+@pytest.mark.skipif(not _pysam_imported, reason="pysam not available")
+class TestParseHeaderPysam(ExamplesMixin):
     """
     Test that pysam can parse the headers correctly.
     """
@@ -343,51 +343,51 @@ class TestParseHeaderPysam(unittest.TestCase, ExamplesMixin):
         contig_id = "pysam"
         for indivs, num_indivs in example_individuals(ts):
             with ts_to_pysam(ts, contig_id=contig_id, individuals=indivs) as bcf_file:
-                self.assertEqual(bcf_file.format, "VCF")
-                self.assertEqual(bcf_file.version, (4, 2))
+                assert bcf_file.format == "VCF"
+                assert bcf_file.version == (4, 2)
                 header = bcf_file.header
-                self.assertEqual(len(header.contigs), 1)
+                assert len(header.contigs) == 1
                 contig = header.contigs[0]
-                self.assertEqual(contig.name, contig_id)
-                self.assertGreater(contig.length, 0)
-                self.assertEqual(len(header.filters), 1)
+                assert contig.name == contig_id
+                assert contig.length > 0
+                assert len(header.filters) == 1
                 p = header.filters["PASS"]
-                self.assertEqual(p.name, "PASS")
-                self.assertEqual(p.description, "All filters passed")
-                self.assertEqual(len(header.info), 0)
-                self.assertEqual(len(header.formats), 1)
+                assert p.name == "PASS"
+                assert p.description == "All filters passed"
+                assert len(header.info) == 0
+                assert len(header.formats) == 1
                 fmt = header.formats["GT"]
-                self.assertEqual(fmt.name, "GT")
-                self.assertEqual(fmt.number, 1)
-                self.assertEqual(fmt.type, "String")
-                self.assertEqual(fmt.description, "Genotype")
-                self.assertEqual(len(bcf_file.header.samples), num_indivs)
+                assert fmt.name == "GT"
+                assert fmt.number == 1
+                assert fmt.type == "String"
+                assert fmt.description == "Genotype"
+                assert len(bcf_file.header.samples) == num_indivs
 
 
-@unittest.skipIf(not _pysam_imported, "pysam not available")
-class TestRecordsEqual(unittest.TestCase, ExamplesMixin):
+@pytest.mark.skipif(not _pysam_imported, reason="pysam not available")
+class TestRecordsEqual(ExamplesMixin):
     """
     Tests where we parse the input using PyVCF and Pysam
     """
 
     def verify_records(self, pyvcf_records, pysam_records):
-        self.assertEqual(len(pyvcf_records), len(pysam_records))
+        assert len(pyvcf_records) == len(pysam_records)
         for pyvcf_record, pysam_record in zip(pyvcf_records, pysam_records):
-            self.assertEqual(pyvcf_record.CHROM, pysam_record.chrom)
-            self.assertEqual(pyvcf_record.POS, pysam_record.pos)
-            self.assertEqual(pyvcf_record.ID, pysam_record.id)
-            self.assertEqual(pyvcf_record.ALT, list(pysam_record.alts))
-            self.assertEqual(pyvcf_record.REF, pysam_record.ref)
-            self.assertEqual(pysam_record.filter[0].name, "PASS")
-            self.assertEqual(pyvcf_record.FORMAT, "GT")
+            assert pyvcf_record.CHROM == pysam_record.chrom
+            assert pyvcf_record.POS == pysam_record.pos
+            assert pyvcf_record.ID == pysam_record.id
+            assert pyvcf_record.ALT == list(pysam_record.alts)
+            assert pyvcf_record.REF == pysam_record.ref
+            assert pysam_record.filter[0].name == "PASS"
+            assert pyvcf_record.FORMAT == "GT"
             pysam_samples = list(pysam_record.samples.keys())
             pyvcf_samples = [sample.sample for sample in pyvcf_record.samples]
-            self.assertEqual(pysam_samples, pyvcf_samples)
+            assert pysam_samples == pyvcf_samples
             for index, name in enumerate(pysam_samples):
                 pyvcf_sample = pyvcf_record.samples[index]
                 pysam_sample = pysam_record.samples[name]
                 pyvcf_alleles = pyvcf_sample.gt_bases.split("|")
-                self.assertEqual(list(pysam_sample.alleles), pyvcf_alleles)
+                assert list(pysam_sample.alleles) == pyvcf_alleles
 
     def verify(self, ts):
         for indivs, _num_indivs in example_individuals(ts):
@@ -399,7 +399,7 @@ class TestRecordsEqual(unittest.TestCase, ExamplesMixin):
                 self.verify_records(pyvcf_records, pysam_records)
 
 
-class TestContigLengths(unittest.TestCase):
+class TestContigLengths:
     """
     Tests that we create sensible contig lengths under a variety of conditions.
     """
@@ -411,27 +411,27 @@ class TestContigLengths(unittest.TestCase):
 
     def test_no_mutations(self):
         ts = msprime.simulate(10, length=1)
-        self.assertEqual(ts.num_mutations, 0)
+        assert ts.num_mutations == 0
         contig_length = self.get_contig_length(ts)
-        self.assertEqual(contig_length, 1)
+        assert contig_length == 1
 
     def test_long_sequence(self):
         # Nominal case where we expect the positions to map within the original
         # sequence length
         ts = msprime.simulate(10, length=100, mutation_rate=0.01, random_seed=3)
-        self.assertGreater(ts.num_mutations, 0)
+        assert ts.num_mutations > 0
         contig_length = self.get_contig_length(ts)
-        self.assertEqual(contig_length, 100)
+        assert contig_length == 100
 
     def test_short_sequence(self):
         # Degenerate case where the positions cannot map into the sequence length
         ts = msprime.simulate(10, length=1, mutation_rate=10)
-        self.assertGreater(ts.num_mutations, 1)
+        assert ts.num_mutations > 1
         contig_length = self.get_contig_length(ts)
-        self.assertEqual(contig_length, 1)
+        assert contig_length == 1
 
 
-class TestInterface(unittest.TestCase):
+class TestInterface:
     """
     Tests for the interface.
     """
@@ -439,17 +439,19 @@ class TestInterface(unittest.TestCase):
     def test_bad_ploidy(self):
         ts = msprime.simulate(10, mutation_rate=0.1, random_seed=2)
         for bad_ploidy in [-1, 0, 20]:
-            self.assertRaises(ValueError, ts.write_vcf, io.StringIO, bad_ploidy)
+            with pytest.raises(ValueError):
+                ts.write_vcf(io.StringIO, bad_ploidy)
         # Non divisible
         for bad_ploidy in [3, 7]:
-            self.assertRaises(ValueError, ts.write_vcf, io.StringIO, bad_ploidy)
+            with pytest.raises(ValueError):
+                ts.write_vcf(io.StringIO, bad_ploidy)
 
     def test_individuals_no_nodes(self):
         ts = msprime.simulate(10, mutation_rate=0.1, random_seed=2)
         tables = ts.dump_tables()
         tables.individuals.add_row()
         ts = tables.tree_sequence()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO())
 
     def test_ploidy_with_individuals(self):
@@ -457,19 +459,19 @@ class TestInterface(unittest.TestCase):
         tables = ts.dump_tables()
         tables.individuals.add_row()
         ts = tables.tree_sequence()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO(), ploidy=2)
 
     def test_bad_individuals(self):
         ts = msprime.simulate(10, mutation_rate=0.1, random_seed=2)
         ts = tsutil.insert_individuals(ts, ploidy=2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO(), individuals=[0, -1])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO(), individuals=[1, 2, ts.num_individuals])
 
 
-class TestRoundTripIndividuals(unittest.TestCase, ExamplesMixin):
+class TestRoundTripIndividuals(ExamplesMixin):
     """
     Tests that we can round-trip genotype data through VCF using pyvcf.
     """
@@ -485,25 +487,23 @@ class TestRoundTripIndividuals(unittest.TestCase, ExamplesMixin):
                 for variant, vcf_row in itertools.zip_longest(
                     ts.variants(samples=samples), vcf_reader
                 ):
-                    self.assertEqual(vcf_row.POS, np.round(variant.site.position))
-                    self.assertEqual(variant.alleles[0], vcf_row.REF)
-                    self.assertEqual(list(variant.alleles[1:]), vcf_row.ALT)
+                    assert vcf_row.POS == np.round(variant.site.position)
+                    assert variant.alleles[0] == vcf_row.REF
+                    assert list(variant.alleles[1:]) == vcf_row.ALT
                     j = 0
                     for individual, sample in itertools.zip_longest(
                         map(ts.individual, indivs), vcf_row.samples
                     ):
                         calls = sample.data.GT.split("|")
                         allele_calls = sample.gt_bases.split("|")
-                        self.assertEqual(len(calls), len(individual.nodes))
+                        assert len(calls) == len(individual.nodes)
                         for allele_call, call in zip(allele_calls, calls):
-                            self.assertEqual(int(call), variant.genotypes[j])
-                            self.assertEqual(
-                                allele_call, variant.alleles[variant.genotypes[j]]
-                            )
+                            assert int(call) == variant.genotypes[j]
+                            assert allele_call == variant.alleles[variant.genotypes[j]]
                             j += 1
 
 
-class TestLimitations(unittest.TestCase):
+class TestLimitations:
     """
     Verify the correct error behaviour in cases we don't support.
     """
@@ -520,7 +520,7 @@ class TestLimitations(unittest.TestCase):
         for j in range(9, 15):
             tables.mutations.add_row(0, node=j, derived_state=str(j))
             ts = tables.tree_sequence()
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.write_vcf(io.StringIO())
 
     def test_missing_data(self):
@@ -528,11 +528,11 @@ class TestLimitations(unittest.TestCase):
         tables = ts.dump_tables()
         tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
         ts = tables.tree_sequence()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO())
 
 
-class TestPositionTransformRoundTrip(unittest.TestCase, ExamplesMixin):
+class TestPositionTransformRoundTrip(ExamplesMixin):
     """
     Tests that the position transform method is working correctly.
     """
@@ -541,52 +541,52 @@ class TestPositionTransformRoundTrip(unittest.TestCase, ExamplesMixin):
         for transform in [np.round, np.ceil, lambda x: list(map(int, x))]:
             with ts_to_pyvcf(ts, position_transform=transform) as vcf_reader:
                 values = [record.POS for record in vcf_reader]
-                self.assertEqual(values, list(transform(ts.tables.sites.position)))
+                assert values == list(transform(ts.tables.sites.position))
 
 
-class TestPositionTransformErrors(unittest.TestCase):
+class TestPositionTransformErrors:
     """
     Tests what happens when we provide bad position transforms
     """
 
     def get_example_ts(self):
         ts = msprime.simulate(11, mutation_rate=1, random_seed=11)
-        self.assertGreater(ts.num_sites, 1)
+        assert ts.num_sites > 1
         return ts
 
     def test_wrong_output_dimensions(self):
         ts = self.get_example_ts()
         for bad_func in [np.sum, lambda x: []]:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 ts.write_vcf(io.StringIO(), position_transform=bad_func)
 
     def test_bad_func(self):
         ts = self.get_example_ts()
         for bad_func in ["", Exception]:
-            with self.assertRaises(TypeError):
+            with pytest.raises(TypeError):
                 ts.write_vcf(io.StringIO(), position_transform=bad_func)
 
 
-class TestIndividualNames(unittest.TestCase):
+class TestIndividualNames:
     """
     Tests for the individual names argument.
     """
 
     def test_bad_length_individuals(self):
         ts = msprime.simulate(6, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         ts = tsutil.insert_individuals(ts, ploidy=2)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO(), individual_names=[])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO(), individual_names=["x" for _ in range(4)])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(
                 io.StringIO(),
                 individuals=list(range(ts.num_individuals)),
                 individual_names=["x" for _ in range(ts.num_individuals - 1)],
             )
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(
                 io.StringIO(),
                 individuals=list(range(ts.num_individuals - 1)),
@@ -595,29 +595,29 @@ class TestIndividualNames(unittest.TestCase):
 
     def test_bad_length_ploidy(self):
         ts = msprime.simulate(6, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
-        with self.assertRaises(ValueError):
+        assert ts.num_sites > 0
+        with pytest.raises(ValueError):
             ts.write_vcf(io.StringIO(), ploidy=2, individual_names=[])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ts.write_vcf(
                 io.StringIO(), ploidy=2, individual_names=["x" for _ in range(4)]
             )
 
     def test_bad_type(self):
         ts = msprime.simulate(2, mutation_rate=2, random_seed=1)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ts.write_vcf(io.StringIO(), individual_names=[None, "b"])
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ts.write_vcf(io.StringIO(), individual_names=[b"a", "b"])
 
     def test_round_trip(self):
         ts = msprime.simulate(2, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         with ts_to_pyvcf(ts, individual_names=["a", "b"]) as vcf_reader:
-            self.assertEqual(vcf_reader.samples, ["a", "b"])
+            assert vcf_reader.samples == ["a", "b"]
 
     def test_defaults(self):
         ts = msprime.simulate(2, mutation_rate=2, random_seed=1)
-        self.assertGreater(ts.num_sites, 0)
+        assert ts.num_sites > 0
         with ts_to_pyvcf(ts) as vcf_reader:
-            self.assertEqual(vcf_reader.samples, ["tsk_0", "tsk_1"])
+            assert vcf_reader.samples == ["tsk_0", "tsk_1"]

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -22,17 +22,15 @@
 """
 Test python package versioning
 """
-import unittest
-
 from packaging.version import Version
 
 from tskit import _version
 
 
-class TestPythonVersion(unittest.TestCase):
+class TestPythonVersion:
     """
     Test that the version is PEP440 compliant
     """
 
     def test_version(self):
-        self.assertEqual(str(Version(_version.tskit_version)), _version.tskit_version)
+        assert str(Version(_version.tskit_version)) == _version.tskit_version

--- a/python/tests/test_wright_fisher.py
+++ b/python/tests/test_wright_fisher.py
@@ -25,11 +25,11 @@ Test various functions using messy tables output by a forwards-time simulator.
 """
 import itertools
 import random
-import unittest
 
 import msprime
 import numpy as np
 import numpy.testing as nt
+import pytest
 
 import tests as tests
 import tests.tsutil as tsutil
@@ -216,7 +216,7 @@ def wf_sim(
     return sim.run(ngens)
 
 
-class TestSimulation(unittest.TestCase):
+class TestSimulation:
     """
     Tests that the simulations produce the output we expect.
     """
@@ -233,9 +233,9 @@ class TestSimulation(unittest.TestCase):
             seed=self.random_seed,
             record_migrations=True,
         )
-        self.assertEqual(tables.nodes.num_rows, 5 * 4 * (1 + 1))
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, 5 * 4)
+        assert tables.nodes.num_rows == 5 * 4 * (1 + 1)
+        assert tables.edges.num_rows > 0
+        assert tables.migrations.num_rows == 5 * 4
 
     def test_multipop_mig_deep(self):
         N = 10
@@ -249,12 +249,12 @@ class TestSimulation(unittest.TestCase):
             seed=self.random_seed,
             record_migrations=True,
         )
-        self.assertGreater(tables.nodes.num_rows, (num_pops * N * ngens) + N)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertGreaterEqual(tables.migrations.num_rows, N * num_pops * ngens)
-        self.assertEqual(tables.populations.num_rows, num_pops)
+        assert tables.nodes.num_rows > (num_pops * N * ngens) + N
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows >= N * num_pops * ngens
+        assert tables.populations.num_rows == num_pops
         # sort does not support mig
         tables.migrations.clear()
         # making sure trees are valid
@@ -262,7 +262,7 @@ class TestSimulation(unittest.TestCase):
         tables.simplify()
         ts = tables.tree_sequence()
         sample_pops = tables.nodes.population[ts.samples()]
-        self.assertEqual(np.unique(sample_pops).size, num_pops)
+        assert np.unique(sample_pops).size == num_pops
 
     def test_multipop_mig_no_deep(self):
         N = 5
@@ -277,12 +277,12 @@ class TestSimulation(unittest.TestCase):
             seed=self.random_seed,
             record_migrations=True,
         )
-        self.assertEqual(tables.nodes.num_rows, num_pops * N * (ngens + 1))
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, N * num_pops * ngens)
-        self.assertEqual(tables.populations.num_rows, num_pops)
+        assert tables.nodes.num_rows == num_pops * N * (ngens + 1)
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows == N * num_pops * ngens
+        assert tables.populations.num_rows == num_pops
         # sort does not support mig
         tables.migrations.clear()
         # making sure trees are valid
@@ -290,81 +290,81 @@ class TestSimulation(unittest.TestCase):
         tables.simplify()
         ts = tables.tree_sequence()
         sample_pops = tables.nodes.population[ts.samples()]
-        self.assertEqual(np.unique(sample_pops).size, num_pops)
+        assert np.unique(sample_pops).size == num_pops
 
     def test_non_overlapping_generations(self):
         tables = wf_sim(N=10, ngens=10, survival=0.0, seed=self.random_seed)
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, 0)
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows == 0
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
         # All trees should have exactly one root and all internal nodes should
         # have arity > 1
         for tree in ts.trees():
-            self.assertEqual(tree.num_roots, 1)
+            assert tree.num_roots == 1
             leaves = set(tree.leaves(tree.root))
-            self.assertEqual(leaves, set(ts.samples()))
+            assert leaves == set(ts.samples())
             for u in tree.nodes():
                 if tree.is_internal(u):
-                    self.assertGreater(len(tree.children(u)), 1)
+                    assert len(tree.children(u)) > 1
 
     def test_overlapping_generations(self):
         tables = wf_sim(N=30, ngens=10, survival=0.85, seed=self.random_seed)
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, 0)
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows == 0
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
         for tree in ts.trees():
-            self.assertEqual(tree.num_roots, 1)
+            assert tree.num_roots == 1
 
     def test_one_generation_no_deep_history(self):
         N = 20
         tables = wf_sim(N=N, ngens=1, deep_history=False, seed=self.random_seed)
-        self.assertEqual(tables.nodes.num_rows, 2 * N)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, 0)
+        assert tables.nodes.num_rows == 2 * N
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows == 0
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
         ts = tables.tree_sequence()
         for tree in ts.trees():
             all_samples = set()
             for root in tree.roots:
                 root_samples = set(tree.samples(root))
-                self.assertEqual(len(root_samples & all_samples), 0)
+                assert len(root_samples & all_samples) == 0
                 all_samples |= root_samples
-            self.assertEqual(all_samples, set(ts.samples()))
+            assert all_samples == set(ts.samples())
 
     def test_many_generations_no_deep_history(self):
         N = 10
         ngens = 100
         tables = wf_sim(N=N, ngens=ngens, deep_history=False, seed=self.random_seed)
-        self.assertEqual(tables.nodes.num_rows, N * (ngens + 1))
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 0)
-        self.assertEqual(tables.mutations.num_rows, 0)
-        self.assertEqual(tables.migrations.num_rows, 0)
+        assert tables.nodes.num_rows == N * (ngens + 1)
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 0
+        assert tables.mutations.num_rows == 0
+        assert tables.migrations.num_rows == 0
         tables.sort()
         tables.simplify()
         ts = tables.tree_sequence()
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
         ts = tables.tree_sequence()
         # We are assuming that everything has coalesced and we have single-root trees
         for tree in ts.trees():
-            self.assertEqual(tree.num_roots, 1)
+            assert tree.num_roots == 1
 
     def test_with_mutations(self):
         N = 10
@@ -374,23 +374,23 @@ class TestSimulation(unittest.TestCase):
         ts = tables.tree_sequence()
         ts = tsutil.jukes_cantor(ts, 10, 0.1, seed=self.random_seed)
         tables = ts.tables
-        self.assertGreater(tables.sites.num_rows, 0)
-        self.assertGreater(tables.mutations.num_rows, 0)
+        assert tables.sites.num_rows > 0
+        assert tables.mutations.num_rows > 0
         samples = np.where(tables.nodes.flags == tskit.NODE_IS_SAMPLE)[0].astype(
             np.int32
         )
         tables.sort()
         tables.simplify(samples)
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertGreater(tables.sites.num_rows, 0)
-        self.assertGreater(tables.mutations.num_rows, 0)
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows > 0
+        assert tables.mutations.num_rows > 0
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sample_size, N)
+        assert ts.sample_size == N
         for hap in ts.haplotypes():
-            self.assertEqual(len(hap), ts.num_sites)
+            assert len(hap) == ts.num_sites
 
     def test_with_recurrent_mutations(self):
         # actually with only ONE site, at 0.0
@@ -401,32 +401,32 @@ class TestSimulation(unittest.TestCase):
         ts = tables.tree_sequence()
         ts = tsutil.jukes_cantor(ts, 1, 10, seed=self.random_seed)
         tables = ts.tables
-        self.assertEqual(tables.sites.num_rows, 1)
-        self.assertGreater(tables.mutations.num_rows, 0)
+        assert tables.sites.num_rows == 1
+        assert tables.mutations.num_rows > 0
         # before simplify
         for h in ts.haplotypes():
-            self.assertEqual(len(h), 1)
+            assert len(h) == 1
         # after simplify
         tables.sort()
         tables.simplify()
-        self.assertGreater(tables.nodes.num_rows, 0)
-        self.assertGreater(tables.edges.num_rows, 0)
-        self.assertEqual(tables.sites.num_rows, 1)
-        self.assertGreater(tables.mutations.num_rows, 0)
+        assert tables.nodes.num_rows > 0
+        assert tables.edges.num_rows > 0
+        assert tables.sites.num_rows == 1
+        assert tables.mutations.num_rows > 0
         ts = tables.tree_sequence()
-        self.assertEqual(ts.sample_size, N)
+        assert ts.sample_size == N
         for hap in ts.haplotypes():
-            self.assertEqual(len(hap), ts.num_sites)
+            assert len(hap) == ts.num_sites
 
 
-class TestIncrementalBuild(unittest.TestCase):
+class TestIncrementalBuild:
     """
     Tests for incrementally building a tree sequence from forward time
     simulations.
     """
 
 
-class TestSimplify(unittest.TestCase):
+class TestSimplify:
     """
     Tests for simplify on cases generated by the Wright-Fisher simulator.
     """
@@ -435,17 +435,17 @@ class TestSimplify(unittest.TestCase):
         nt.assert_equal(x, y)
 
     def assertTreeSequencesEqual(self, ts1, ts2):
-        self.assertEqual(list(ts1.samples()), list(ts2.samples()))
-        self.assertEqual(ts1.sequence_length, ts2.sequence_length)
+        assert list(ts1.samples()) == list(ts2.samples())
+        assert ts1.sequence_length == ts2.sequence_length
         ts1_tables = ts1.dump_tables()
         ts2_tables = ts2.dump_tables()
         # print("compare")
         # print(ts1_tables.nodes)
         # print(ts2_tables.nodes)
-        self.assertEqual(ts1_tables.nodes, ts2_tables.nodes)
-        self.assertEqual(ts1_tables.edges, ts2_tables.edges)
-        self.assertEqual(ts1_tables.sites, ts2_tables.sites)
-        self.assertEqual(ts1_tables.mutations, ts2_tables.mutations)
+        assert ts1_tables.nodes == ts2_tables.nodes
+        assert ts1_tables.edges == ts2_tables.edges
+        assert ts1_tables.sites == ts2_tables.sites
+        assert ts1_tables.mutations == ts2_tables.mutations
 
     def get_wf_sims(self, seed):
         """
@@ -480,10 +480,10 @@ class TestSimplify(unittest.TestCase):
                     k += 1
                 lefts.sort()
                 rights.sort()
-                self.assertEqual(lefts[0], 0.0)
-                self.assertEqual(rights[-1], 1.0)
+                assert lefts[0] == 0.0
+                assert rights[-1] == 1.0
                 for k in range(len(lefts) - 1):
-                    self.assertEqual(lefts[k + 1], rights[k])
+                    assert lefts[k + 1] == rights[k]
 
     def verify_simplify(self, ts, new_ts, samples, node_map):
         """
@@ -517,10 +517,10 @@ class TestSimplify(unittest.TestCase):
             for pair in pairs:
                 mapped_pair = [node_map[u] for u in pair]
                 mrca1 = old_tree.get_mrca(*pair)
-                self.assertNotEqual(mrca1, tskit.NULL)
+                assert mrca1 != tskit.NULL
                 mrca2 = new_tree.get_mrca(*mapped_pair)
-                self.assertNotEqual(mrca2, tskit.NULL)
-                self.assertEqual(node_map[mrca1], mrca2)
+                assert mrca2 != tskit.NULL
+                assert node_map[mrca1] == mrca2
         mut_parent = tsutil.compute_mutation_parent(ts=ts)
         self.assertArrayEqual(mut_parent, ts.tables.mutations.parent)
 
@@ -532,17 +532,18 @@ class TestSimplify(unittest.TestCase):
             samples, map_nodes=True, filter_zero_mutation_sites=False
         )
         # Sites tables should be equal
-        self.assertEqual(ts.tables.sites, sub_ts.tables.sites)
+        assert ts.tables.sites == sub_ts.tables.sites
         sub_haplotypes = dict(zip(sub_ts.samples(), sub_ts.haplotypes()))
         all_haplotypes = dict(zip(ts.samples(), ts.haplotypes()))
         mapped_ids = []
         for node_id, h in all_haplotypes.items():
             mapped_node_id = node_map[node_id]
             if mapped_node_id in sub_haplotypes:
-                self.assertEqual(h, sub_haplotypes[mapped_node_id])
+                assert h == sub_haplotypes[mapped_node_id]
                 mapped_ids.append(mapped_node_id)
-        self.assertEqual(sorted(mapped_ids), sorted(sub_ts.samples()))
+        assert sorted(mapped_ids) == sorted(sub_ts.samples())
 
+    @pytest.mark.slow
     def test_simplify(self):
         #  check that simplify(big set) -> simplify(subset) equals simplify(subset)
         seed = 23
@@ -551,7 +552,7 @@ class TestSimplify(unittest.TestCase):
             s = tests.Simplifier(ts, ts.samples())
             py_full_ts, py_full_map = s.simplify()
             full_ts, full_map = ts.simplify(ts.samples(), map_nodes=True)
-            self.assertTrue(all(py_full_map == full_map))
+            assert all(py_full_map == full_map)
             self.assertTreeSequencesEqual(full_ts, py_full_ts)
 
             for nsamples in [2, 5, 10]:
@@ -565,6 +566,7 @@ class TestSimplify(unittest.TestCase):
                 self.verify_simplify(ts, small_ts, sub_samples, small_map)
                 self.verify_haplotypes(ts, samples=sub_samples)
 
+    @pytest.mark.slow
     def test_simplify_tables(self):
         seed = 71
         for ts in self.get_wf_sims(seed=seed):
@@ -578,5 +580,5 @@ class TestSimplify(unittest.TestCase):
                 other_tables = small_ts.dump_tables()
                 tables.provenances.clear()
                 other_tables.provenances.clear()
-                self.assertEqual(tables, other_tables)
+                assert tables == other_tables
                 self.verify_simplify(ts, small_ts, sub_samples, node_map)

--- a/python/tests/test_wright_fisher.py
+++ b/python/tests/test_wright_fisher.py
@@ -528,9 +528,7 @@ class TestSimplify:
         """
         Check that haplotypes are unchanged by simplify.
         """
-        sub_ts, node_map = ts.simplify(
-            samples, map_nodes=True, filter_zero_mutation_sites=False
-        )
+        sub_ts, node_map = ts.simplify(samples, map_nodes=True, filter_sites=False)
         # Sites tables should be equal
         assert ts.tables.sites == sub_ts.tables.sites
         sub_haplotypes = dict(zip(sub_ts.samples(), sub_ts.haplotypes()))

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -147,7 +147,7 @@ class TopologyCounter:
 
     @staticmethod
     def _to_key(sample_set_indexes):
-        if not isinstance(sample_set_indexes, collections.Iterable):
+        if not isinstance(sample_set_indexes, collections.abc.Iterable):
             sample_set_indexes = (sample_set_indexes,)
         return tuple(sorted(sample_set_indexes))
 

--- a/python/tskit/formats.py
+++ b/python/tskit/formats.py
@@ -47,11 +47,11 @@ def _get_v2_provenance(command, attrs):
     try:
         environment = json.loads(str(attrs["environment"]))
     except ValueError:
-        logging.warn("Failed to convert environment provenance")
+        logging.warning("Failed to convert environment provenance")
     try:
         parameters = json.loads(str(attrs["parameters"]))
     except ValueError:
-        logging.warn("Failed to convert parameters provenance")
+        logging.warning("Failed to convert parameters provenance")
     parameters["command"] = command
     provenance_dict = provenance.get_provenance_dict(parameters)
     provenance_dict["version"] = environment.get("msprime_version", "Unknown_version")

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -46,7 +46,7 @@ attr_options = {"slots": True, "frozen": True, "auto_attribs": True}
 
 
 # note: soon attrs will deprecate cmp; we just need to change this argument to eq
-@attr.s(cmp=False, **attr_options)
+@attr.s(eq=False, **attr_options)
 class IndividualTableRow:
     flags: int
     location: np.ndarray

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3833,7 +3833,7 @@ class TreeSequence:
                     alleles[i] = allele_int8
             H[:, var.site.id] = alleles[var.genotypes]
         for h in H:
-            yield h.tostring().decode("ascii")
+            yield h.tobytes().decode("ascii")
 
     def variants(
         self,


### PR DESCRIPTION
I've tagged a load of people for comments, ignore if you're not interested or busy!

For some time now the `nose` homepage has had this message:

"Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using Nose2, py.test, or just plain unittest/unittest2."

https://pytest.org/ seems to be the most capable and popular replacement, for example it gives better error messages than `nose`. Our test suite is already compatible, but is not idiomatic pytest. The main change for that is to use plain `assert`s rather than `self.assert*`.  This PR shows what that would look like - I'm a fan of the cleaner style. One could go further and use `pytest`'s fixtures and class-less tests.

This is a big change to the test code, but also a change to people's workflow. I don't think it will be disruptive however.

PS I haven't converted `self.assertAlmostEqual` as that is a bit more work.

PPS This PR speeds up circle CI from ~22 min to 6 min! (Circle CI gives you 22 cores! Who knew!)
