### PR TITLE
Add nbytes to Table and TableCollection.

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -38,6 +38,10 @@
   collections that are not valid tree sequences to be manipulated.
   (:user:`benjeffery`, :issue:`14`, :pr:`986`)
 
+- Added ``nbytes`` method to tables, ``TableCollection`` and ``TreeSequence`` which
+  reports the size in bytes of those objects.
+  (:user:`jeromekelleher`, :user:`benjeffery`, :issue:`54`, :pr:`871`)
+
 **Breaking changes**
 
 - The argument to ``ts.dump`` and ``tskit.load`` has been renamed `file` from `path`.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3098,6 +3098,15 @@ class TreeSequence:
         """
         return self.dump_tables()
 
+    @property
+    def nbytes(self):
+        """
+        Returns the total number of bytes required to store the data
+        in this tree sequence. Note that this may not be equal to
+        the actual memory footprint.
+        """
+        return self.tables.nbytes
+
     def dump_tables(self):
         """
         A copy of the tables defining this tree sequence.
@@ -3290,7 +3299,7 @@ class TreeSequence:
             ["Trees", str(self.num_trees)],
             ["Sequence Length", str(self.sequence_length)],
             ["Sample Nodes", str(self.num_samples)],
-            ["Total Size TODO", util.naturalsize(99999)],
+            ["Total Size", util.naturalsize(self.nbytes)],
         ]
         header = ["Table", "Rows", "Size", "Has Metadata"]
         table_rows = []
@@ -3301,7 +3310,7 @@ class TreeSequence:
                     for s in [
                         name.capitalize(),
                         table.num_rows,
-                        "TODO",
+                        util.naturalsize(table.nbytes),
                         "Yes"
                         if hasattr(table, "metadata") and len(table.metadata) > 0
                         else "No",

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -377,7 +377,7 @@ def tree_sequence_html(ts):
                   <tr>
                     <td>{name.capitalize()}</td>
                       <td>{table.num_rows}</td>
-                      <td>TODO! {naturalsize(99999)}</td>
+                      <td>{naturalsize(table.nbytes)}</td>
                       <td style="text-align: center;">
                         {'✅' if hasattr(table, "metadata") and len(table.metadata) > 0
         else ''}
@@ -412,7 +412,7 @@ def tree_sequence_html(ts):
                       <tr><td>Trees</td><td>{ts.num_trees}</td></tr>
                       <tr><td>Sequence Length</td><td>{ts.sequence_length}</td></tr>
                       <tr><td>Sample Nodes</td><td>{ts.num_samples}</td></tr>
-                      <tr><td>Total Size</td><td>TODO! {naturalsize(99999)}</td></tr>
+                      <tr><td>Total Size</td><td>{naturalsize(ts.nbytes)}</td></tr>
                       <tr>
                         <td>Metadata</td><td style="text-align: left;">{obj_to_collapsed_html(ts.metadata, None, 1) if len(ts.tables.metadata_bytes) > 0 else "No Metadata"}</td></tr>
                     </tbody>


### PR DESCRIPTION
It's pretty useful to have a summary of the number of bytes used by a table collection. This uses a definition based on the total bytes used to encode the data, which seems like as good a definition as any. Trying to capture the actual memory used seems like a fiddly waste of time.

However, this currently doesn't work because of a few limitations:

- We can't dump a TableCollection #14 
- We can't dump to a File object #657 (This isnt' strictly necessary, but testing would be a lot handier if we could avoid making a TemporaryDirectory, etc)
- We don't have any information about the indexes in the dict encoding #870

Closes #54 