### PR TITLE
AFS clarification (closes #863) and add pre-commit troubleshooting

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -914,6 +914,99 @@ the C and Python APIs.
     latest/development.html#rebasing>`_ if necessary!) and let the community check
     your work.
 
+***************
+Troubleshooting
+***************
+
+--------------------------
+pre-commit is blocking me!
+--------------------------
+
+You might be having a hard time committing because of the "pre-commit" checks
+(described above). First, consider: the pre-commit hooks are supposed to make your life *easier*,
+not add a layer of frustration to contributing.
+So, you should feel free to just ask git to skip the pre-commit!
+There's no shame in a broken build - you can get it fixed up (and we'll help)
+before it's merged into the rest of the project.
+To skip, just append `--no-verify` to the `git commit` command.
+Below are some more specific situations.
+
+----------------------------------------------
+pre-commit complains about files I didn't edit
+----------------------------------------------
+
+For instance, suppose you have *not* edited `util.py` and yet:
+
+.. code-block:: bash
+
+   > git commit -a -m 'dev docs'
+   python/tskit/util.py:117:26: E203 whitespace before ':'
+   python/tskit/util.py:135:31: E203 whitespace before ':'
+   python/tskit/util.py:195:23: E203 whitespace before ':'
+   python/tskit/util.py:213:36: E203 whitespace before ':'
+   ... lots more, gah, what is this ...
+
+First, check (with `git status`) that you didn't actually edit `util.py`.
+Then, you should **not** try to fix these errors; this is **not your problem**.
+You might first try restarting your pre-commit, by running
+
+.. code-block:: bash
+
+   pre-commit clean
+   pre-commit gc
+
+You might also check you don't have other pre-commit hook files in `.git/hooks`.
+If this doesn't fix the problem,
+then you should just *skip* the pre-commit (but alert us to the problem),
+by appending `--no-verify`:
+
+.. code-block:: bash
+
+   > git commit -a -m 'dev docs' --no-verify
+   [main 46f3f2e] dev docs
+    1 file changed, 43 insertions(+)
+
+Now you can go ahead and push your changes!
+
+
+--------------------
+pre-commit won't run
+--------------------
+
+For instance:
+
+.. code-block:: bash
+
+   > git commit -a -m 'fixed all the things'
+   /usr/bin/env: ‘python3.7’: No such file or directory
+
+What the heck? Why is this even looking for python3.7?
+This is because of the "pre-commit hook", mentioned above.
+As above, you can proceed by just appending `--no-verify`:
+
+.. code-block:: bash
+
+   > git commit -a -m 'fixed all the things' --no-verify
+   [main 99a01da] fixed all the things
+    1 file changed, 10 insertions(+)
+
+We'll help you sort it out in the PR.
+But, you should fix the problem at some point. In this case,
+uninstalling and reinstalling the pre-commit hooks fixed the problem:
+
+.. code-block:: bash
+
+   > pre-commit uninstall
+   pre-commit uninstalled
+   Restored previous hooks to .git/hooks/pre-commit
+   > pre-commit install -f
+   pre-commit installed at .git/hooks/pre-commit
+   > # do some more edits
+   > git commit -a -m 'wrote the docs'
+   [main 79b81ff] fixed all the things
+    1 file changed, 42 insertions(+)
+      
+
 ***********************
 Releasing a new version
 ***********************

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5691,6 +5691,16 @@ class TreeSequence:
         "node"
             Not supported for this method (raises a ValueError).
 
+        For example, suppose that `S0` is a list of 5 sample IDs, and `S1` is
+        a list of 3 other sample IDs. Then `afs = ts.allele_frequency_spectrum([S0, S1],
+        mode="site", span_normalise=False)` will be a 5x3 numpy array, and if
+        there are six alleles that are present in only one sample of `S0` but
+        two samples of `S1`, then `afs[1,2]` will be equal to 6.  Similarly,
+        `branch_afs = ts.allele_frequency_spectrum([S0, S1], mode="branch",
+        span_normalise=False)` will also be a 5x3 array, and `branch_afs[1,2]`
+        will be the total area (i.e., length times span) of all branches that
+        are above exactly one sample of `S0` and two samples of `S1`.
+
         :param list sample_sets: A list of lists of Node IDs, specifying the
             groups of samples to compute the joint allele frequency
         :param list windows: An increasing list of breakpoints between windows


### PR DESCRIPTION
As discussed over in #863, make the AFS a bit more concrete.

In doing this I ran into some issues with `pre-commit`, yet again. I'm worried that pre-commit could be a significant deterrant to new folks, so I want to at least start documenting these things. The first problem was that my system updated to python3.8, and so the previous hook's shebang went looking for python3.7 but couldn't find it. Reinstalling the pre-commit hook fixed it. But, then I've got some formatting errors (black?) on files I didn't change -- see my additions to `docs/development.rst`. My advice here is just do `--no-verify`... but, what's the right way to fix this?