### PR TITLE
clarification to keep_intervals docs

### DIFF
--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4589,14 +4589,17 @@ class TreeSequence:
         Returns a copy of this tree sequence for which information in the
         specified list of genomic intervals has been deleted. Edges spanning these
         intervals are truncated or deleted, and sites and mutations falling within
-        them are discarded.
+        them are discarded. Note that it is the information in the intervals that
+        is deleted, not the intervals themselves, so in particular, all samples
+        will be isolated in the deleted intervals.
 
         Note that node IDs may change as a result of this operation,
         as by default :meth:`.simplify` is called on the returned tree sequence
         to remove redundant nodes. If you wish to map node IDs onto the same
         nodes before and after this method has been called, specify ``simplify=False``.
 
-        See also :meth:`.keep_intervals`.
+        See also :meth:`.keep_intervals`, :meth:`.ltrim`, :meth:`.rtrim`, and
+        :ref:`missing data<sec_data_model_missing_data>`.
 
         :param array_like intervals: A list (start, end) pairs describing the
             genomic intervals to delete. Intervals must be non-overlapping and
@@ -4617,14 +4620,17 @@ class TreeSequence:
         Returns a copy of this tree sequence which includes only information in
         the specified list of genomic intervals. Edges are truncated to lie within
         these intervals, and sites and mutations falling outside these intervals
-        are discarded.
+        are discarded.  Note that it is the information outside the intervals that
+        is deleted, not the intervals themselves, so in particular, all samples
+        will be isolated outside of the retained intervals.
 
         Note that node IDs may change as a result of this operation,
         as by default :meth:`.simplify` is called on the returned tree sequence
         to remove redundant nodes. If you wish to map node IDs onto the same
         nodes before and after this method has been called, specify ``simplify=False``.
 
-        See also :meth:`.delete_intervals`.
+        See also :meth:`.keep_intervals`, :meth:`.ltrim`, :meth:`.rtrim`, and
+        :ref:`missing data<sec_data_model_missing_data>`.
 
         :param array_like intervals: A list (start, end) pairs describing the
             genomic intervals to keep. Intervals must be non-overlapping and


### PR DESCRIPTION
On the msprime mailing list, @mnavascues rightly asks:

``` 
I am using SLiM and pyslim+msprime (for recapitation) for simulating
whole human genomes. I want to apply msprime independently to smaller
chuncks of genome (e.g. chromosome arms) and wanted to use
keep_interval() as suggested by Peter Ralph
(https://groups.google.com/forum/#!topic/slim-discuss/UIwmOPuv9Ww).

However, I am not sure I am doing it right, the resulting tree sequence
seems to be of the same size of the original sequence:

 >>> import msprime
 >>> tree_sequence = msprime.simulate(sample_size=6, length=50e3, Ne=1000)
 >>> tree_sequence.sequence_length
50000.0
 >>> tree_sequence.keep_intervals(np.array([[0,10]])).sequence_length
50000.0

Shouldn't this give me a sequence length of 10?
```

But, no: this is something that [we discussed]( https://github.com/tskit-dev/tskit/pull/261#issuecomment-511207084). Hopefully, this change should clear up this confusion?