### PR TITLE
Fix python version for docs to 3.8 as default is now 3.9 which has no wheels for h5py.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
             submodules: true
 
       - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
 
       - name: Install deps
         run: |


### PR DESCRIPTION
… 