### PR TITLE
Add html notebook display for TreeSequence

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -19,6 +19,9 @@
 - Added ``TableCollection.indexes`` for access to the edge insertion/removal order indexes.
   (:user:`benjeffery`, :issue:`4`, :pr:`916`)
 
+- Added ``TreeSequence._repr_html_`` for use in jupyter notebooks.
+  (:user:`benjeffery`, :issue:`872`, :pr:`923`)
+
 **Breaking changes**
 
 - The argument to ``ts.dump`` and ``tskit.load`` has been renamed `file` from `path`.

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1452,6 +1452,14 @@ class TestTreeSequence(HighLevelTestCase):
             # Tables in tc, and rebuilt
             assert tskit.TreeSequence.load_tables(tables).dump_tables().has_index()
 
+    def test_html_repr(self):
+        for ts in get_example_tree_sequences():
+            html = ts._repr_html_()
+            assert len(html) > 4300
+            assert f"<tr><td>Trees</td><td>{ts.num_trees}</td></tr>" in html
+            for table in ts.tables.name_map:
+                assert f"<td>{table.capitalize()}</td>" in html
+
 
 class TestTreeSequenceMethodSignatures:
     ts = msprime.simulate(10, random_seed=1234)

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -349,3 +349,54 @@ class TestArrayPacking:
             self.verify_packing(data)
             data = [1 / (1 + np.arange(n)) for _ in range(n)]
             self.verify_packing(data)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, "0 Bytes"),
+        (1, "1 Byte"),
+        (300, "300 Bytes"),
+        (3000, "2.9 KiB"),
+        (3000000, "2.9 MiB"),
+        (10 ** 26 * 30, "2481.5 YiB"),
+    ],
+)
+def test_naturalsize(value, expected):
+    assert util.naturalsize(value) == expected
+    if value != 0:
+        assert util.naturalsize(-value) == "-" + expected
+    else:
+        assert util.naturalsize(-value) == expected
+
+
+@pytest.mark.parametrize(
+    "obj, expected",
+    [
+        (0, "Test:0"),
+        (
+            {"a": 1},
+            '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
+            "t</summary>a:1</details></div>",
+        ),
+        (
+            {"b": [1, 2, 3]},
+            '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
+            't</summary><div><spanclass="tskit-details-label">b:</span><details><summary'
+            ">list</summary>1<br/>2<br/>3<br/></details></div></details></div>",
+        ),
+        (
+            {"b": [1, 2, {"c": 1}]},
+            '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
+            't</summary><div><spanclass="tskit-details-label">b:</span><details><summary'
+            '>list</summary>1<br/>2<br/><div><spanclass="tskit-details-label"></span><de'
+            "tails><summary>dict</summary>c:1</details></div><br/></details></div></deta"
+            "ils></div>",
+        ),
+    ],
+)
+def test_obj_to_collapsed_html(obj, expected):
+    assert (
+        util.obj_to_collapsed_html(obj, "Test", 1).replace(" ", "").replace("\n", "")
+        == expected
+    )

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3259,6 +3259,12 @@ class TreeSequence:
                 )
                 print(row, file=provenances)
 
+    def _repr_html_(self):
+        """
+        Called by jupyter notebooks to render a TreeSequence
+        """
+        return util.tree_sequence_html(self)
+
     # num_samples was originally called sample_size, and so we must keep sample_size
     # around as a deprecated alias.
     @property


### PR DESCRIPTION
## Description

Adds an html display in notebooks:
![Screenshot from 2020-10-23 15-03-55](https://user-images.githubusercontent.com/8552/97013508-08d27580-1541-11eb-8ef9-2d748d397168.png)


Fixes #872 

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
