### PR TITLE
Overwrite docs instead of copying into existing folder.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,13 +46,16 @@ jobs:
         if: github.event.pull_request
         run: |
           cd tskit-docs
+          rm -rf ${{github.event.pull_request.number}}
           cp -r ../docs/_build/html ${{github.event.pull_request.number}}
 
       - name: Copy our docs to the tag specific location
         if: (!github.event.pull_request)
         run: |
           cd tskit-docs
-          cp -r ../docs/_build/html `echo ${GITHUB_REF} | sed -e "s/refs\/heads\///g" |  sed -e "s/refs\/tags\///g"`
+          export DEST=`echo ${GITHUB_REF} | sed -e "s/refs\/heads\///g" |  sed -e "s/refs\/tags\///g"`
+          rm -rf $DEST
+          cp -r ../docs/_build/html $DEST
 
       - name: Commit and push the docs
         run: |


### PR DESCRIPTION
Currently, the docs workflow will copy the built documentation with `cp -r ../docs/_build/html destination_folder`. This works fine for initial pull requests, but when additional commits are made to the PR branch, the destination folder will already exist. This results in a `html` folder in the intended destination folder (e.g. see folders and timestampts in https://github.com/tskit-dev/tskit-docs/tree/main/926). This bug also exists for the workflow code path for merging/pushing to the `main` branch (https://github.com/tskit-dev/tskit-docs/tree/main/main/).