### PR TITLE
Allow span to be set when generating trees

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -484,9 +484,9 @@ Table functions
 
 .. _sec_metadata_api:
 
-********
-Metadata
-********
+************
+Metadata API
+************
 
 The ``metadata`` module provides validation, encoding and decoding of metadata
 using a schema. See :ref:`sec_metadata`, :ref:`sec_metadata_api_overview` and
@@ -498,16 +498,20 @@ using a schema. See :ref:`sec_metadata`, :ref:`sec_metadata_api_overview` and
 
 .. autofunction:: register_metadata_codec
 
-.. _sec_stats_api:
+.. _sec_combinatorics_api:
 
-*************
-Combinatorics
-*************
-The following are generators for fully enumerating unique tree topologies.
-The position of a tree in the enumeration ``all_trees`` is given by
-:meth:`Tree.rank`. Inversely, a :class:`Tree` can be constructed from a
-position in the enumeration with :meth:`Tree.unrank`.
-See :ref:`sec_combinatorics` for details.
+*****************
+Combinatorics API
+*****************
+
+The combinatorics API deals with tree topologies, allowing them to be counted,
+listed and generated: see :ref:`sec_combinatorics` for a detailed description. Briefly,
+the position of a tree in the enumeration ``all_trees`` can be obtained using the tree's
+:meth:`~Tree.rank` method. Inversely, a :class:`Tree` can be constructed from a position
+in the enumeration with :meth:`Tree.unrank`. Generated trees are associated with a new
+tree sequence containing only that tree for the entire genome (i.e. with
+:attr:`~TreeSequence.num_trees` = 1 and a :attr:`~TreeSequence.sequence_length` equal to
+the :attr:`~Tree.span` of the tree).
 
 .. autofunction:: all_trees
 

--- a/python/tests/test_combinatorics.py
+++ b/python/tests/test_combinatorics.py
@@ -182,6 +182,16 @@ class TestRankTree:
         for rank_tree, tsk_tree in zip(all_rank_trees, all_tsk_trees):
             assert rank_tree == RankTree.from_tsk_tree(tsk_tree)
 
+    def test_generate_treeseq_roundtrip(self):
+        n = 5
+        span = 9
+        all_rank_trees = RankTree.all_labelled_trees(n)
+        all_tsk_trees = tskit.all_trees(n, span=span)
+        for rank_tree, tsk_tree in zip(all_rank_trees, all_tsk_trees):
+            ts1 = tsk_tree.tree_sequence
+            ts2 = rank_tree.to_tsk_tree(span=span).tree_sequence
+            assert ts1.tables.equals(ts2.tables, ignore_provenance=True)
+
     def test_all_shapes_roundtrip(self):
         n = 5
         all_rank_tree_shapes = RankTree.all_unlabelled_trees(n)
@@ -388,6 +398,16 @@ class TestRankTree:
         ts = tables.tree_sequence()
         with pytest.raises(ValueError):
             ts.first().rank()
+
+    def test_span(self):
+        n = 5
+        span = 8
+        # Create a start tree, with a single root
+        tsk_tree = tskit.Tree.unrank((0, 0), n, span=span)
+        assert tsk_tree.num_nodes == n + 1
+        assert tsk_tree.interval.left == 0
+        assert tsk_tree.interval.right == span
+        assert tsk_tree.tree_sequence.sequence_length == span
 
     def test_big_trees(self):
         n = 14

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -847,7 +847,7 @@ class Tree:
         return combinatorics.RankTree.from_tsk_tree(self).rank()
 
     @staticmethod
-    def unrank(rank, num_leaves):
+    def unrank(rank, num_leaves, *, span=1):
         """
         Reconstruct the tree of the given ``rank``
         (see :meth:`tskit.Tree.rank`) with ``num_leaves`` leaves.
@@ -859,11 +859,15 @@ class Tree:
 
         :param tuple(int) rank: The rank of the tree to generate.
         :param int num_leaves: The number of leaves of the tree to generate.
+        :param float span: The genomic span of the returned tree. The tree will cover
+            the interval :math:`[0, \\text{span})` and the :attr:`~Tree.tree_sequence`
+            from which the tree is taken will have its
+            :attr:`~tskit.TreeSequence.sequence_length` equal to ``span``.
         :rtype: Tree
         :raises: ValueError: If the given rank is out of bounds for trees
             with ``num_leaves`` leaves.
         """
-        return combinatorics.RankTree.unrank(rank, num_leaves).to_tsk_tree()
+        return combinatorics.RankTree.unrank(rank, num_leaves).to_tsk_tree(span=span)
 
     def count_topologies(self, sample_sets=None):
         """


### PR DESCRIPTION
## Description

Extend the functionality of `Tree.unroot`, `tskit.all_trees` etc to allow trees with spans other than 1. Passing `**kwargs` means that we can also extends this if (for example) we want to be able to set node/root times on the generated trees. Also document that a new ts is created for each new tree, and change the API section titles "Metadata" and "Combinatorics" so they aren't confused with the pages of those names.
