### PR TITLE
Allow newicks to be output without branch lengths

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,9 @@
 
 **Features**
 
+- ``Tree.newick()`` now has extra option ``include_branch_lengths`` to allow branch
+  lengths to be omitted (:user:`hyanwong`, :pr:`931`).
+
 - Added ``Tree.generate_star`` static method to create star-topologies (:user:`hyanwong`,
   :pr:`934`).
 
@@ -28,6 +31,7 @@
 **Breaking changes**
 
 - The argument to ``ts.dump`` and ``tskit.load`` has been renamed `file` from `path`.
+- All arguments to ``Tree.newick()`` except precision are now keyword-only.
 
 --------------------
 [0.3.2] - 2020-09-29


### PR DESCRIPTION
As discussed on slack. This only changes the Python newick generator. I also took the opportunity to make all the parameters keyword-only (which is a breaking change), but it's really not obvious to me what `tree.newick(8)` means - I think we should force `tree.newick(precision=8)`.

Incidentally, I was wondering if `__build_newick` should be `_build_newick` (single underscore) for consistency. But perhaps the double underscore was deliberate? 