### PR TITLE
Add a Tree.generate_star method

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,9 @@
 
 **Features**
 
+- Added ``Tree.generate_star`` static method to create star-topologies (:user:`hyanwong`,
+  :pr:`934`).
+
 - Added ``equals`` method to TableCollection and each of the tables which
   provides more flexible equality comparisons, for example, allowing
   users to ignore metadata or provenance in the comparison.

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -7917,3 +7917,37 @@ class TestMissingData:
                 tree.is_isolated("abc")
             with pytest.raises(TypeError):
                 tree.is_isolated(1.1)
+
+
+class TestExampleTrees:
+    """
+    Test hard-coded example tree (sequence) generation
+    """
+
+    def test_star_equivalent(self):
+        for extra_params in [{}, {"span": 2.5}]:
+            for n in range(2, 6):
+                ts = tskit.Tree.generate_star(n, **extra_params).tree_sequence
+                equiv_ts = tskit.Tree.unrank((0, 0), n, **extra_params).tree_sequence
+                assert ts.tables.equals(equiv_ts.tables, ignore_provenance=True)
+
+    def test_star_bad_params(self):
+        for n in [-1, 0, 1, np.array([1, 2])]:
+            with pytest.raises(ValueError):
+                tskit.Tree.generate_star(n)
+        for n in [None, "", []]:
+            with pytest.raises(TypeError):
+                tskit.Tree.generate_star(n)
+        with pytest.raises(tskit.LibraryError):
+            tskit.Tree.generate_star(2, span=0)
+        with pytest.raises(tskit.LibraryError):
+            tskit.Tree.generate_star(2, branch_length=0)
+
+    def test_star_branch_length(self):
+        branch_length = 10
+        n = 7
+        ts = tskit.Tree.generate_star(n, branch_length=branch_length).tree_sequence
+        topological_equiv_ts = tskit.Tree.unrank((0, 0), n).tree_sequence
+
+        assert ts.node(ts.first().root).time == branch_length
+        assert ts.kc_distance(topological_equiv_ts) == 0


### PR DESCRIPTION
## Description

Add `Tree.create_star`, `Tree.create_balanced`, and `Tree.create_empty` methods, as discussed on Slack.

The `Tree.create_empty` method is perhaps unlikely to be widely used, but I think is useful for completeness, and will also come in handy for testing (for example, I only just noticed that we currently bomb out with a non-obvious message when trying to plot an empty TS).

Happy to make these class methods if that is preferred.