### PR TITLE
Ibd constant time pair lookup

### DIFF
--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -3166,6 +3166,7 @@ test_ibd_finder_errors(void)
     tsk_treeseq_t ts;
     tsk_table_collection_t tables;
     tsk_id_t samples[] = { 0, 1, 2, 0 };
+    tsk_id_t duplicate_samples[] = { 0, 1, 1, 0 };
     tsk_id_t samples2[] = { -1, 1 };
     tsk_id_t samples3[] = { 0 };
     tsk_ibd_finder_t ibd_finder;
@@ -3191,6 +3192,11 @@ test_ibd_finder_errors(void)
     tsk_ibd_finder_free(&ibd_finder);
     ret = ibd_finder_init_and_run(&ibd_finder, &tables, samples, 2, -1, 0.0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_PARAM_VALUE);
+    tsk_ibd_finder_free(&ibd_finder);
+
+    // Duplicate samples
+    ret = ibd_finder_init_and_run(&ibd_finder, &tables, duplicate_samples, 2, 0.0, -1);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE_PAIRS);
     tsk_ibd_finder_free(&ibd_finder);
 
     tsk_table_collection_free(&tables);

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -466,6 +466,10 @@ tsk_strerror_internal(int err)
         case TSK_ERR_NO_SAMPLE_PAIRS:
             ret = "There are no possible sample pairs.";
             break;
+
+        case TSK_ERR_DUPLICATE_SAMPLE_PAIRS:
+            ret = "There are duplicate sample pairs.";
+            break;
     }
     return ret;
 }

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -318,6 +318,7 @@ not found in the file.
 
 /* IBD errors */
 #define TSK_ERR_NO_SAMPLE_PAIRS                                    -1500
+#define TSK_ERR_DUPLICATE_SAMPLE_PAIRS                             -1501
 
 // clang-format on
 

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -644,12 +644,15 @@ typedef struct {
     tsk_id_t *pairs;
     size_t num_pairs;
     size_t num_nodes;
+    size_t num_unique_nodes_in_pair;
+    int64_t *pair_map;
     double sequence_length;
     tsk_table_collection_t *tables;
     tsk_segment_t **ibd_segments_head;
     tsk_segment_t **ibd_segments_tail;
     tsk_blkalloc_t segment_heap;
     bool *is_sample;
+    tsk_id_t *paired_nodes_index;
     double min_length;
     double max_time;
     tsk_segment_t **ancestor_map_head;

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -727,6 +727,13 @@ class TestIbdPolytomies:
         }
         assert ibd_is_equal(ibd_segs, true_segs)
 
+    def test_duplicate_input_sample_pairs(self):
+        with pytest.raises(tskit.LibraryError):
+            self.ts.tables.find_ibd([(0, 1), (0, 1)])
+
+        with pytest.raises(tskit.LibraryError):
+            self.ts.tables.find_ibd([(0, 1), (1, 0)])
+
 
 class TestIbdInternalSamples:
     #


### PR DESCRIPTION
The current IBD algorithm spends most of its time looking up to which, if any, input pair a pair of nodes belongs.

This PR adds a matrix to `tsk_ibd_finder_t` that allows `tsk_ibd_finder_find_sample_pair_index2` to operate in constant time, at the cost of some extra memory.

To make this work, I add a new error code that gets raised when duplicate pairs are passed to the ibd finding code.

In addition to the existing tests, I ran the following stochastic test:

```py
import pickle
import time

import msprime

print(msprime.tskit.__version__)

ts = msprime.simulate(1000, recombination_rate=25.0, random_seed=420)


def make_pairs(n):
    rv = []
    for i in range(n):
        for j in range(i + 1, n):
            rv.append([i, j])

    return rv


for i in range(100, ts.num_samples + 1, 100):
    pairs = make_pairs(i)
    then = time.time()
    ibd = ts.tables.find_ibd(pairs)
    now = time.time()
    elapsed = now - then
    print(i, elapsed)
    with open(f"ibd_output_{i}.pickle", "wb") as f:
        pickle.dump(ibd, f)
    if elapsed > 5e3:
        break
```

The output for the current stable release is:

```
0.3.2
100 23.053314208984375
200 370.5223250389099
300 1860.3008773326874
400 5864.632394313812
```

The output for the code in this PR is:

```
0.3.3.dev1
100 0.11817097663879395
200 0.5299818515777588
300 1.2625401020050049
400 2.2465524673461914
500 3.626859188079834
600 5.582508087158203
700 7.96460223197937
800 11.132724046707153
900 14.832526206970215
1000 19.45262336730957
```

The speedup is over 2000x!

The following code compared the IBD outputs:

```py
import os
import pickle

import numpy as np

for i in range(100, 1000 + 1, 100):
    fn = f"ibd_output_{i}.pickle"
    fn2 = f"/home/kevin/src/tskit/python/ibd_output_{i}.pickle"
    if os.path.exists(fn) and os.path.exists(fn2):
        with open(fn, "rb") as f:
            stable_results = pickle.load(f)
        with open(fn2, "rb") as f:
            pr_results = pickle.load(f)
        assert len(stable_results) == len(pr_results)

        for k in stable_results.keys():
            assert k in pr_results
        for k in pr_results.keys():
            assert k in stable_results

        for key, value in stable_results.items():
            pr_value = pr_results[key]
            for x in ["left", "right", "node"]:
                assert np.array_equal(value[x], pr_value[x])
        print(f"{i} passed")
```

They all passed.


# PR Checklist:

- [X] Tests that fully cover new/changed functionality.

