### PR TITLE
constify rest of public C API and tsk_tree_t types

### DIFF
--- a/c/dev-tools/dev-cli.c
+++ b/c/dev-tools/dev-cli.c
@@ -249,7 +249,7 @@ run_simplify(const char *input_filename,
     int verbose)
 {
     tsk_treeseq_t ts, subset;
-    tsk_id_t *samples;
+    const tsk_id_t *samples;
     int flags = 0;
     int ret;
 

--- a/c/examples/tree_traversal.c
+++ b/c/examples/tree_traversal.c
@@ -65,7 +65,7 @@ traverse_stack(tsk_tree_t *tree)
 static void
 traverse_upwards(tsk_tree_t *tree)
 {
-    tsk_id_t *samples = tsk_treeseq_get_samples(tree->tree_sequence);
+    const tsk_id_t *samples = tsk_treeseq_get_samples(tree->tree_sequence);
     tsk_size_t num_samples = tsk_treeseq_get_num_samples(tree->tree_sequence);
     tsk_size_t j;
     tsk_id_t u;

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -217,8 +217,8 @@ static void
 verify_genealogical_nearest_neighbours(tsk_treeseq_t *ts)
 {
     int ret;
-    tsk_id_t *samples;
-    tsk_id_t *sample_sets[2];
+    const tsk_id_t *samples;
+    const tsk_id_t *sample_sets[2];
     size_t sample_set_size[2];
     size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *A = malloc(2 * num_samples * sizeof(double));
@@ -257,13 +257,14 @@ verify_mean_descendants(tsk_treeseq_t *ts)
 {
     int ret;
     tsk_id_t *samples;
-    tsk_id_t *sample_sets[2];
+    const tsk_id_t *sample_sets[2];
     size_t sample_set_size[2];
     size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *C = malloc(2 * tsk_treeseq_get_num_nodes(ts) * sizeof(double));
     CU_ASSERT_FATAL(C != NULL);
 
-    samples = tsk_treeseq_get_samples(ts);
+    samples = malloc(num_samples * sizeof(*samples));
+    memcpy(samples, tsk_treeseq_get_samples(ts), num_samples * sizeof(*samples));
 
     sample_sets[0] = samples;
     sample_set_size[0] = num_samples / 2;
@@ -283,6 +284,7 @@ verify_mean_descendants(tsk_treeseq_t *ts)
     ret = tsk_treeseq_mean_descendants(ts, sample_sets, sample_set_size, 2, 0, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
+    free(samples);
     free(C);
 }
 
@@ -818,7 +820,7 @@ verify_afs(tsk_treeseq_t *ts)
     int ret;
     tsk_size_t n = tsk_treeseq_get_num_samples(ts);
     tsk_size_t sample_set_sizes[2];
-    tsk_id_t *samples = tsk_treeseq_get_samples(ts);
+    const tsk_id_t *samples = tsk_treeseq_get_samples(ts);
     double *result = malloc(n * n * sizeof(*result));
 
     CU_ASSERT_FATAL(sample_set_sizes != NULL);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -181,7 +181,7 @@ verify_trees(tsk_treeseq_t *ts, tsk_size_t num_trees, tsk_id_t *parents)
     tsk_id_t u, j, v;
     uint32_t mutation_index, site_index;
     tsk_size_t k, l, tree_sites_length;
-    tsk_site_t *sites = NULL;
+    const tsk_site_t *sites = NULL;
     tsk_tree_t tree;
     size_t num_nodes = tsk_treeseq_get_num_nodes(ts);
     size_t num_sites = tsk_treeseq_get_num_sites(ts);
@@ -474,8 +474,8 @@ verify_tree_diffs(tsk_treeseq_t *ts, tsk_flags_t options)
 /* When we keep all sites in simplify, the genotypes for the subset of the
  * samples should be the same as the original */
 static void
-verify_simplify_genotypes(
-    tsk_treeseq_t *ts, tsk_treeseq_t *subset, tsk_id_t *samples, size_t num_samples)
+verify_simplify_genotypes(tsk_treeseq_t *ts, tsk_treeseq_t *subset,
+    const tsk_id_t *samples, size_t num_samples)
 {
     int ret;
     size_t m = tsk_treeseq_get_num_sites(ts);
@@ -483,7 +483,7 @@ verify_simplify_genotypes(
     tsk_variant_t *variant, *subset_variant;
     size_t j, k;
     int8_t a1, a2;
-    tsk_id_t *sample_index_map;
+    const tsk_id_t *sample_index_map;
 
     sample_index_map = tsk_treeseq_get_sample_index_map(ts);
 
@@ -529,13 +529,13 @@ verify_simplify_genotypes(
 }
 
 static void
-verify_simplify_properties(tsk_treeseq_t *ts, tsk_treeseq_t *subset, tsk_id_t *samples,
-    size_t num_samples, tsk_id_t *node_map)
+verify_simplify_properties(tsk_treeseq_t *ts, tsk_treeseq_t *subset,
+    const tsk_id_t *samples, size_t num_samples, tsk_id_t *node_map)
 {
     int ret;
     tsk_node_t n1, n2;
     tsk_tree_t full_tree, subset_tree;
-    tsk_site_t *tree_sites;
+    const tsk_site_t *tree_sites;
     tsk_size_t tree_sites_length;
     uint32_t j, k;
     tsk_id_t u, mrca1, mrca2;
@@ -647,7 +647,7 @@ verify_simplify(tsk_treeseq_t *ts)
     tsk_size_t n = tsk_treeseq_get_num_samples(ts);
     tsk_size_t num_samples[] = { 0, 1, 2, 3, n / 2, n - 1, n };
     tsk_size_t j;
-    tsk_id_t *sample;
+    const tsk_id_t *sample;
     tsk_id_t *node_map = malloc(tsk_treeseq_get_num_nodes(ts) * sizeof(tsk_id_t));
     tsk_treeseq_t subset;
     tsk_flags_t options = TSK_FILTER_SITES;
@@ -695,7 +695,7 @@ verify_sample_counts(tsk_treeseq_t *ts, size_t num_tests, sample_count_test_t *t
     size_t j, num_samples, n, k;
     tsk_id_t stop, sample_index;
     tsk_tree_t tree;
-    tsk_id_t *samples;
+    const tsk_id_t *samples;
 
     n = tsk_treeseq_get_num_samples(ts);
     samples = tsk_treeseq_get_samples(ts);
@@ -822,7 +822,7 @@ verify_sample_sets_for_tree(tsk_tree_t *tree)
     tsk_id_t u, v;
     size_t tmp, n, num_nodes, num_samples;
     tsk_id_t *stack, *samples;
-    tsk_treeseq_t *ts = tree->tree_sequence;
+    const tsk_treeseq_t *ts = tree->tree_sequence;
     tsk_id_t *sample_index_map = ts->sample_index_map;
     const tsk_id_t *list_left = tree->left_sample;
     const tsk_id_t *list_right = tree->right_sample;
@@ -1402,8 +1402,8 @@ test_simplest_general_samples(void)
                         "0.75 0\n";
     const char *mutations = "0    2     1\n"
                             "1    0     1";
-    tsk_id_t samples[2] = { 0, 2 };
-    tsk_id_t *s;
+    const tsk_id_t samples[2] = { 0, 2 };
+    const tsk_id_t *s;
     int ret;
 
     tsk_treeseq_t ts, simplified;
@@ -3577,7 +3577,7 @@ test_single_tree_general_samples_iter(void)
                         "0  6   1   5,6\n"
                         "0  6   0   1,2\n";
     tsk_id_t parents[] = { TSK_NULL, 0, 0, 2, 2, 1, 1 };
-    tsk_id_t *samples;
+    const tsk_id_t *samples;
     tsk_treeseq_t ts;
     tsk_tree_t tree;
     tsk_id_t u, v, w;
@@ -5351,7 +5351,7 @@ test_genealogical_nearest_neighbours_errors(void)
 {
     int ret;
     tsk_treeseq_t ts;
-    tsk_id_t *reference_sets[2];
+    const tsk_id_t *reference_sets[2];
     tsk_id_t reference_set_0[4], reference_set_1[4];
     tsk_id_t focal[] = { 0, 1, 2, 3 };
     size_t reference_set_size[2];

--- a/c/tskit/convert.c
+++ b/c/tskit/convert.c
@@ -46,7 +46,7 @@ typedef struct {
     tsk_flags_t options;
     char *newick;
     tsk_id_t *traversal_stack;
-    tsk_tree_t *tree;
+    const tsk_tree_t *tree;
 } tsk_newick_converter_t;
 
 static int
@@ -54,7 +54,7 @@ tsk_newick_converter_run(
     tsk_newick_converter_t *self, tsk_id_t root, size_t buffer_size, char *buffer)
 {
     int ret = TSK_ERR_GENERIC;
-    tsk_tree_t *tree = self->tree;
+    const tsk_tree_t *tree = self->tree;
     tsk_id_t *stack = self->traversal_stack;
     const double *time = self->tree->tree_sequence->tables->nodes.time;
     int stack_top = 0;
@@ -144,7 +144,7 @@ out:
 }
 
 static int
-tsk_newick_converter_init(tsk_newick_converter_t *self, tsk_tree_t *tree,
+tsk_newick_converter_init(tsk_newick_converter_t *self, const tsk_tree_t *tree,
     size_t precision, tsk_flags_t options)
 {
     int ret = 0;
@@ -171,7 +171,7 @@ tsk_newick_converter_free(tsk_newick_converter_t *self)
 }
 
 int
-tsk_convert_newick(tsk_tree_t *tree, tsk_id_t root, size_t precision,
+tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
     tsk_flags_t options, size_t buffer_size, char *buffer)
 {
     int ret = 0;

--- a/c/tskit/convert.h
+++ b/c/tskit/convert.h
@@ -32,7 +32,7 @@ extern "C" {
 
 #include <tskit/trees.h>
 
-int tsk_convert_newick(tsk_tree_t *tree, tsk_id_t root, size_t precision,
+int tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
     tsk_flags_t options, size_t buffer_size, char *buffer);
 
 #ifdef __cplusplus

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -35,7 +35,7 @@
  * ======================================================== */
 
 void
-tsk_vargen_print_state(tsk_vargen_t *self, FILE *out)
+tsk_vargen_print_state(const tsk_vargen_t *self, FILE *out)
 {
     tsk_size_t j;
 
@@ -102,60 +102,77 @@ out:
     return ret;
 }
 
+static int
+vargen_init_samples_and_index_map(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
+    const tsk_id_t *samples, size_t num_samples, size_t num_samples_alloc,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    const tsk_flags_t *flags = tree_sequence->tables->nodes.flags;
+    size_t j, num_nodes;
+    bool impute_missing = !!(options & TSK_ISOLATED_NOT_MISSING);
+    tsk_id_t u;
+
+    num_nodes = tsk_treeseq_get_num_nodes(tree_sequence);
+    self->alt_samples = malloc(num_samples_alloc * sizeof(*samples));
+    self->alt_sample_index_map = malloc(num_nodes * sizeof(*self->alt_sample_index_map));
+    if (self->alt_samples == NULL || self->alt_sample_index_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(self->alt_samples, samples, num_samples * sizeof(*samples));
+    memset(self->alt_sample_index_map, 0xff,
+        num_nodes * sizeof(*self->alt_sample_index_map));
+    /* Create the reverse mapping */
+    for (j = 0; j < num_samples; j++) {
+        u = samples[j];
+        if (u < 0 || u >= (tsk_id_t) num_nodes) {
+            ret = TSK_ERR_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->alt_sample_index_map[u] != TSK_NULL) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        /* We can only detect missing data for samples */
+        if (!impute_missing && !(flags[u] & TSK_NODE_IS_SAMPLE)) {
+            ret = TSK_ERR_MUST_IMPUTE_NON_SAMPLES;
+            goto out;
+        }
+        self->alt_sample_index_map[samples[j]] = (tsk_id_t) j;
+    }
+out:
+    return ret;
+}
+
 int
-tsk_vargen_init(tsk_vargen_t *self, tsk_treeseq_t *tree_sequence, tsk_id_t *samples,
-    size_t num_samples, const char **alleles, tsk_flags_t options)
+tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
+    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    tsk_flags_t options)
 {
     int ret = TSK_ERR_NO_MEMORY;
     tsk_flags_t tree_options;
-    const tsk_flags_t *flags = tree_sequence->tables->nodes.flags;
-    size_t j, num_nodes, num_samples_alloc, max_alleles_limit;
-    bool impute_missing = !!(options & TSK_ISOLATED_NOT_MISSING);
+    size_t num_samples_alloc, max_alleles_limit;
     tsk_size_t max_alleles;
-    tsk_id_t u;
 
     tsk_bug_assert(tree_sequence != NULL);
     memset(self, 0, sizeof(tsk_vargen_t));
 
     if (samples == NULL) {
-        self->sample_index_map_allocated = false;
         self->num_samples = tsk_treeseq_get_num_samples(tree_sequence);
         self->sample_index_map = tsk_treeseq_get_sample_index_map(tree_sequence);
         num_samples_alloc = self->num_samples;
     } else {
-        self->sample_index_map_allocated = true;
         /* Take a copy of the samples for simplicity */
-        num_nodes = tsk_treeseq_get_num_nodes(tree_sequence);
         /* We can have num_samples = 0 here, so guard against malloc(0) */
         num_samples_alloc = num_samples + 1;
-        self->samples = malloc(num_samples_alloc * sizeof(*self->samples));
-        self->sample_index_map = malloc(num_nodes * sizeof(*self->sample_index_map));
-        if (self->samples == NULL || self->sample_index_map == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+        ret = vargen_init_samples_and_index_map(
+            self, tree_sequence, samples, num_samples, num_samples_alloc, options);
+        if (ret != 0) {
             goto out;
         }
-        memcpy(self->samples, samples, num_samples * sizeof(*self->samples));
-        memset(
-            self->sample_index_map, 0xff, num_nodes * sizeof(*self->sample_index_map));
-        /* Create the reverse mapping */
-        for (j = 0; j < num_samples; j++) {
-            u = samples[j];
-            if (u < 0 || u >= (tsk_id_t) num_nodes) {
-                ret = TSK_ERR_OUT_OF_BOUNDS;
-                goto out;
-            }
-            if (self->sample_index_map[u] != TSK_NULL) {
-                ret = TSK_ERR_DUPLICATE_SAMPLE;
-                goto out;
-            }
-            /* We can only detect missing data for samples */
-            if (!impute_missing && !(flags[u] & TSK_NODE_IS_SAMPLE)) {
-                ret = TSK_ERR_MUST_IMPUTE_NON_SAMPLES;
-                goto out;
-            }
-            self->sample_index_map[samples[j]] = (tsk_id_t) j;
-        }
         self->num_samples = num_samples;
+        self->sample_index_map = self->alt_sample_index_map;
     }
     self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
     self->tree_sequence = tree_sequence;
@@ -207,7 +224,7 @@ tsk_vargen_init(tsk_vargen_t *self, tsk_treeseq_t *tree_sequence, tsk_id_t *samp
     /* When a list of samples is given, we use the traversal based algorithm
      * and turn off the sample list tracking in the tree */
     tree_options = 0;
-    if (self->samples == NULL) {
+    if (self->alt_samples == NULL) {
         tree_options = TSK_SAMPLE_LISTS;
     } else {
         self->traversal_stack = malloc(
@@ -241,11 +258,9 @@ tsk_vargen_free(tsk_vargen_t *self)
     tsk_safe_free(self->variant.alleles);
     tsk_safe_free(self->variant.allele_lengths);
     tsk_safe_free(self->user_alleles_mem);
-    tsk_safe_free(self->samples);
+    tsk_safe_free(self->alt_samples);
+    tsk_safe_free(self->alt_sample_index_map);
     tsk_safe_free(self->traversal_stack);
-    if (self->sample_index_map_allocated) {
-        tsk_safe_free(self->sample_index_map);
-    }
     return 0;
 }
 
@@ -516,11 +531,11 @@ tsk_vargen_update_site(tsk_vargen_t *self)
     tsk_size_t j, num_missing;
     int no_longer_missing;
     tsk_variant_t *var = &self->variant;
-    tsk_site_t *site = var->site;
+    const tsk_site_t *site = var->site;
     tsk_mutation_t mutation;
     bool genotypes16 = !!(self->options & TSK_16_BIT_GENOTYPES);
     bool impute_missing = !!(self->options & TSK_ISOLATED_NOT_MISSING);
-    bool by_traversal = self->samples != NULL;
+    bool by_traversal = self->alt_samples != NULL;
     int (*update_genotypes)(tsk_vargen_t *, tsk_id_t, tsk_id_t);
     tsk_size_t (*mark_missing)(tsk_vargen_t *);
 

--- a/c/tskit/genotypes.h
+++ b/c/tskit/genotypes.h
@@ -36,7 +36,7 @@ extern "C" {
 #define TSK_ISOLATED_NOT_MISSING (1 << 1)
 
 typedef struct {
-    tsk_site_t *site;
+    const tsk_site_t *site;
     const char **alleles;
     tsk_size_t *allele_lengths;
     tsk_size_t num_alleles;
@@ -51,10 +51,10 @@ typedef struct {
 typedef struct {
     size_t num_samples;
     size_t num_sites;
-    tsk_treeseq_t *tree_sequence;
-    tsk_id_t *samples;
-    tsk_id_t *sample_index_map;
-    bool sample_index_map_allocated;
+    const tsk_treeseq_t *tree_sequence;
+    const tsk_id_t *sample_index_map;
+    tsk_id_t *alt_samples;
+    tsk_id_t *alt_sample_index_map;
     bool user_alleles;
     char *user_alleles_mem;
     size_t tree_site_index;
@@ -65,11 +65,12 @@ typedef struct {
     tsk_variant_t variant;
 } tsk_vargen_t;
 
-int tsk_vargen_init(tsk_vargen_t *self, tsk_treeseq_t *tree_sequence, tsk_id_t *samples,
-    size_t num_samples, const char **alleles, tsk_flags_t options);
+int tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
+    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    tsk_flags_t options);
 int tsk_vargen_next(tsk_vargen_t *self, tsk_variant_t **variant);
 int tsk_vargen_free(tsk_vargen_t *self);
-void tsk_vargen_print_state(tsk_vargen_t *self, FILE *out);
+void tsk_vargen_print_state(const tsk_vargen_t *self, FILE *out);
 
 #ifdef __cplusplus
 }

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -225,7 +225,7 @@ tsk_ls_hmm_reset(tsk_ls_hmm_t *self)
     double n = self->num_samples;
     tsk_size_t j;
     tsk_id_t u;
-    tsk_id_t *samples;
+    const tsk_id_t *samples;
     tsk_size_t N = self->num_nodes;
 
     memset(self->parent, 0xff, N * sizeof(*self->parent));
@@ -384,7 +384,7 @@ tsk_ls_hmm_get_allele_index(tsk_ls_hmm_t *self, tsk_id_t site, const char *allel
 
 static int
 tsk_ls_hmm_update_probabilities(
-    tsk_ls_hmm_t *self, tsk_site_t *site, int8_t haplotype_state)
+    tsk_ls_hmm_t *self, const tsk_site_t *site, int8_t haplotype_state)
 {
     int ret = 0;
     tsk_id_t root;
@@ -896,7 +896,8 @@ out:
 }
 
 static int
-tsk_ls_hmm_process_site(tsk_ls_hmm_t *self, tsk_site_t *site, int8_t haplotype_state)
+tsk_ls_hmm_process_site(
+    tsk_ls_hmm_t *self, const tsk_site_t *site, int8_t haplotype_state)
 {
     int ret = 0;
     double x, normalisation_factor;
@@ -941,7 +942,7 @@ tsk_ls_hmm_run(tsk_ls_hmm_t *self, int8_t *haplotype,
 {
     int ret = 0;
     int t_ret;
-    tsk_site_t *sites;
+    const tsk_site_t *sites;
     tsk_size_t j, num_sites;
 
     self->next_probability = next_probability;
@@ -1307,7 +1308,7 @@ tsk_compressed_matrix_decode(tsk_compressed_matrix_t *self, double *values)
     int t_ret;
     tsk_tree_t tree;
     tsk_size_t j, num_tree_sites;
-    tsk_site_t *sites = NULL;
+    const tsk_site_t *sites = NULL;
     tsk_id_t site_id;
     double *site_array;
 

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -31,7 +31,7 @@
 #include <tskit/stats.h>
 
 static void
-tsk_ld_calc_check_state(tsk_ld_calc_t *self)
+tsk_ld_calc_check_state(const tsk_ld_calc_t *self)
 {
     uint32_t u;
     uint32_t num_nodes = (uint32_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
@@ -48,9 +48,9 @@ tsk_ld_calc_check_state(tsk_ld_calc_t *self)
 }
 
 void
-tsk_ld_calc_print_state(tsk_ld_calc_t *self, FILE *out)
+tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out)
 {
-    fprintf(out, "tree_sequence = %p\n", (void *) self->tree_sequence);
+    fprintf(out, "tree_sequence = %p\n", (const void *) self->tree_sequence);
     fprintf(out, "outer tree index = %d\n", (int) self->outer_tree->index);
     fprintf(out, "outer tree interval = (%f, %f)\n", self->outer_tree->left,
         self->outer_tree->right);
@@ -61,7 +61,7 @@ tsk_ld_calc_print_state(tsk_ld_calc_t *self, FILE *out)
 }
 
 int TSK_WARN_UNUSED
-tsk_ld_calc_init(tsk_ld_calc_t *self, tsk_treeseq_t *tree_sequence)
+tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence)
 {
     int ret = TSK_ERR_GENERIC;
 

--- a/c/tskit/stats.h
+++ b/c/tskit/stats.h
@@ -37,12 +37,12 @@ typedef struct {
     tsk_tree_t *inner_tree;
     tsk_size_t num_sites;
     int tree_changed;
-    tsk_treeseq_t *tree_sequence;
+    const tsk_treeseq_t *tree_sequence;
 } tsk_ld_calc_t;
 
-int tsk_ld_calc_init(tsk_ld_calc_t *self, tsk_treeseq_t *tree_sequence);
+int tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence);
 int tsk_ld_calc_free(tsk_ld_calc_t *self);
-void tsk_ld_calc_print_state(tsk_ld_calc_t *self, FILE *out);
+void tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out);
 int tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2);
 int tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
     tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values);

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -719,7 +719,7 @@ tsk_individual_table_equals(const tsk_individual_table_t *self,
 }
 
 static int
-tsk_individual_table_dump(tsk_individual_table_t *self, kastore_t *store)
+tsk_individual_table_dump(const tsk_individual_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "individuals/flags", (void *) self->flags, self->num_rows, KAS_UINT32 },
@@ -1211,7 +1211,7 @@ out:
 }
 
 static int
-tsk_node_table_dump(tsk_node_table_t *self, kastore_t *store)
+tsk_node_table_dump(const tsk_node_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "nodes/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
@@ -1725,7 +1725,7 @@ tsk_edge_table_equals(
 }
 
 static int
-tsk_edge_table_dump(tsk_edge_table_t *self, kastore_t *store)
+tsk_edge_table_dump(const tsk_edge_table_t *self, kastore_t *store)
 {
     int ret = TSK_ERR_IO;
 
@@ -2330,7 +2330,7 @@ out:
 }
 
 static int
-tsk_site_table_dump(tsk_site_table_t *self, kastore_t *store)
+tsk_site_table_dump(const tsk_site_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "sites/position", (void *) self->position, self->num_rows, KAS_FLOAT64 },
@@ -2916,7 +2916,7 @@ out:
 }
 
 static int
-tsk_mutation_table_dump(tsk_mutation_table_t *self, kastore_t *store)
+tsk_mutation_table_dump(const tsk_mutation_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "mutations/site", (void *) self->site, self->num_rows, KAS_INT32 },
@@ -3413,7 +3413,7 @@ tsk_migration_table_equals(const tsk_migration_table_t *self,
 }
 
 static int
-tsk_migration_table_dump(tsk_migration_table_t *self, kastore_t *store)
+tsk_migration_table_dump(const tsk_migration_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "migrations/left", (void *) self->left, self->num_rows, KAS_FLOAT64 },
@@ -3848,7 +3848,7 @@ tsk_population_table_equals(const tsk_population_table_t *self,
 }
 
 static int
-tsk_population_table_dump(tsk_population_table_t *self, kastore_t *store)
+tsk_population_table_dump(const tsk_population_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "populations/metadata", (void *) self->metadata, self->metadata_length,
@@ -4330,7 +4330,7 @@ tsk_provenance_table_equals(const tsk_provenance_table_t *self,
 }
 
 static int
-tsk_provenance_table_dump(tsk_provenance_table_t *self, kastore_t *store)
+tsk_provenance_table_dump(const tsk_provenance_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "provenances/timestamp", (void *) self->timestamp, self->timestamp_length,
@@ -8216,7 +8216,7 @@ out:
 }
 
 static int TSK_WARN_UNUSED
-tsk_table_collection_dump_indexes(tsk_table_collection_t *self, kastore_t *store)
+tsk_table_collection_dump_indexes(const tsk_table_collection_t *self, kastore_t *store)
 {
     int ret = 0;
     write_table_col_t write_cols[] = {

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -585,14 +585,14 @@ tsk_treeseq_get_breakpoints(const tsk_treeseq_t *self)
     return self->breakpoints;
 }
 
-tsk_id_t *
-tsk_treeseq_get_samples(tsk_treeseq_t *self)
+const tsk_id_t *
+tsk_treeseq_get_samples(const tsk_treeseq_t *self)
 {
     return self->samples;
 }
 
-tsk_id_t *
-tsk_treeseq_get_sample_index_map(tsk_treeseq_t *self)
+const tsk_id_t *
+tsk_treeseq_get_sample_index_map(const tsk_treeseq_t *self)
 {
     return self->sample_index_map;
 }
@@ -642,7 +642,7 @@ increment_nd_array_value(double *array, tsk_size_t n, const tsk_size_t *shape,
  * in diversity, divergence, etc. */
 int TSK_WARN_UNUSED
 tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
-    const tsk_id_t *focal, size_t num_focal, tsk_id_t *const *reference_sets,
+    const tsk_id_t *focal, size_t num_focal, const tsk_id_t *const *reference_sets,
     const size_t *reference_set_size, size_t num_reference_sets,
     tsk_flags_t TSK_UNUSED(options), double *ret_array)
 {
@@ -824,9 +824,9 @@ out:
 }
 
 int TSK_WARN_UNUSED
-tsk_treeseq_mean_descendants(const tsk_treeseq_t *self, tsk_id_t *const *reference_sets,
-    const size_t *reference_set_size, size_t num_reference_sets,
-    tsk_flags_t TSK_UNUSED(options), double *ret_array)
+tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
+    const tsk_id_t *const *reference_sets, const size_t *reference_set_size,
+    size_t num_reference_sets, tsk_flags_t TSK_UNUSED(options), double *ret_array)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -3140,7 +3140,7 @@ tsk_tree_clear(tsk_tree_t *self)
 }
 
 int TSK_WARN_UNUSED
-tsk_tree_init(tsk_tree_t *self, tsk_treeseq_t *tree_sequence, tsk_flags_t options)
+tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options)
 {
     int ret = TSK_ERR_NO_MEMORY;
     tsk_size_t num_samples;
@@ -3266,7 +3266,7 @@ out:
 
 int TSK_WARN_UNUSED
 tsk_tree_set_tracked_samples(
-    tsk_tree_t *self, size_t num_tracked_samples, tsk_id_t *tracked_samples)
+    tsk_tree_t *self, size_t num_tracked_samples, const tsk_id_t *tracked_samples)
 {
     int ret = TSK_ERR_GENERIC;
     size_t j;
@@ -3626,7 +3626,8 @@ out:
 }
 
 int TSK_WARN_UNUSED
-tsk_tree_get_sites(tsk_tree_t *self, tsk_site_t **sites, tsk_size_t *sites_length)
+tsk_tree_get_sites(
+    const tsk_tree_t *self, const tsk_site_t **sites, tsk_size_t *sites_length)
 {
     *sites = self->sites;
     *sites_length = self->sites_length;
@@ -4130,7 +4131,7 @@ int TSK_WARN_UNUSED
 tsk_tree_last(tsk_tree_t *self)
 {
     int ret = 1;
-    tsk_treeseq_t *ts = self->tree_sequence;
+    const tsk_treeseq_t *ts = self->tree_sequence;
     const tsk_table_collection_t *tables = ts->tables;
 
     self->left = 0;
@@ -4167,7 +4168,7 @@ int TSK_WARN_UNUSED
 tsk_tree_next(tsk_tree_t *self)
 {
     int ret = 0;
-    tsk_treeseq_t *ts = self->tree_sequence;
+    const tsk_treeseq_t *ts = self->tree_sequence;
     const tsk_table_collection_t *tables = ts->tables;
     tsk_id_t num_trees = (tsk_id_t) tsk_treeseq_get_num_trees(ts);
 
@@ -4392,7 +4393,7 @@ out:
 
 int TSK_WARN_UNUSED
 tsk_diff_iter_init(
-    tsk_diff_iter_t *self, tsk_treeseq_t *tree_sequence, tsk_flags_t options)
+    tsk_diff_iter_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options)
 {
     int ret = 0;
 
@@ -4426,7 +4427,7 @@ tsk_diff_iter_free(tsk_diff_iter_t *self)
 }
 
 void
-tsk_diff_iter_print_state(tsk_diff_iter_t *self, FILE *out)
+tsk_diff_iter_print_state(const tsk_diff_iter_t *self, FILE *out)
 {
     fprintf(out, "tree_diff_iterator state\n");
     fprintf(out, "num_edges = %d\n", (int) self->num_edges);
@@ -4446,7 +4447,7 @@ tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
     double left = self->tree_left;
     double right = sequence_length;
     tsk_size_t next_edge_list_node = 0;
-    tsk_treeseq_t *s = self->tree_sequence;
+    const tsk_treeseq_t *s = self->tree_sequence;
     tsk_edge_list_node_t *out_head = NULL;
     tsk_edge_list_node_t *out_tail = NULL;
     tsk_edge_list_node_t *in_head = NULL;
@@ -4579,7 +4580,7 @@ kc_vectors_free(kc_vectors *self)
 
 static inline void
 update_kc_vectors_single_sample(
-    tsk_treeseq_t *ts, kc_vectors *kc_vecs, tsk_id_t u, double time)
+    const tsk_treeseq_t *ts, kc_vectors *kc_vecs, tsk_id_t u, double time)
 {
     const tsk_id_t *sample_index_map = ts->sample_index_map;
     tsk_id_t u_index = sample_index_map[u];
@@ -4589,7 +4590,7 @@ update_kc_vectors_single_sample(
 }
 
 static inline void
-update_kc_vectors_all_pairs(tsk_tree_t *tree, kc_vectors *kc_vecs, tsk_id_t u,
+update_kc_vectors_all_pairs(const tsk_tree_t *tree, kc_vectors *kc_vecs, tsk_id_t u,
     tsk_id_t v, tsk_size_t depth, double time)
 {
     tsk_id_t sample1_index, sample2_index, n1, n2, tmp, pair_index;
@@ -4635,7 +4636,7 @@ struct kc_stack_elmt {
 };
 
 static int
-fill_kc_vectors(tsk_tree_t *t, kc_vectors *kc_vecs)
+fill_kc_vectors(const tsk_tree_t *t, kc_vectors *kc_vecs)
 {
     int stack_top;
     tsk_size_t depth;
@@ -4644,7 +4645,7 @@ fill_kc_vectors(tsk_tree_t *t, kc_vectors *kc_vecs)
     struct kc_stack_elmt *stack;
     tsk_id_t root, u, c1, c2;
     int ret = 0;
-    tsk_treeseq_t *ts = t->tree_sequence;
+    const tsk_treeseq_t *ts = t->tree_sequence;
 
     stack = malloc(t->num_nodes * sizeof(*stack));
     if (stack == NULL) {
@@ -4706,7 +4707,7 @@ norm_kc_vectors(kc_vectors *self, kc_vectors *other, double lambda)
 }
 
 static int
-check_kc_distance_tree_inputs(tsk_tree_t *self)
+check_kc_distance_tree_inputs(const tsk_tree_t *self)
 {
     tsk_id_t u, num_nodes, left_child;
     int ret = 0;
@@ -4733,7 +4734,7 @@ out:
 }
 
 static int
-check_kc_distance_samples_inputs(tsk_treeseq_t *self, tsk_treeseq_t *other)
+check_kc_distance_samples_inputs(const tsk_treeseq_t *self, const tsk_treeseq_t *other)
 {
     const tsk_id_t *samples, *other_samples;
     tsk_id_t i, n;
@@ -4758,11 +4759,12 @@ out:
 }
 
 int
-tsk_tree_kc_distance(tsk_tree_t *self, tsk_tree_t *other, double lambda, double *result)
+tsk_tree_kc_distance(
+    const tsk_tree_t *self, const tsk_tree_t *other, double lambda, double *result)
 {
     tsk_id_t n, i;
     kc_vectors vecs[2];
-    tsk_tree_t *trees[2] = { self, other };
+    const tsk_tree_t *trees[2] = { self, other };
     int ret = 0;
 
     for (i = 0; i < 2; i++) {
@@ -4801,7 +4803,8 @@ out:
 }
 
 static int
-check_kc_distance_tree_sequence_inputs(tsk_treeseq_t *self, tsk_treeseq_t *other)
+check_kc_distance_tree_sequence_inputs(
+    const tsk_treeseq_t *self, const tsk_treeseq_t *other)
 {
     int ret = 0;
 
@@ -4820,7 +4823,7 @@ out:
 }
 
 static void
-update_kc_pair_with_sample(tsk_tree_t *self, kc_vectors *kc, tsk_id_t sample,
+update_kc_pair_with_sample(const tsk_tree_t *self, kc_vectors *kc, tsk_id_t sample,
     tsk_size_t *depths, double root_time)
 {
     tsk_id_t c, p, sib;
@@ -4930,14 +4933,14 @@ out:
 }
 
 int
-tsk_treeseq_kc_distance(
-    tsk_treeseq_t *self, tsk_treeseq_t *other, double lambda_, double *result)
+tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *other,
+    double lambda_, double *result)
 {
     int i;
     tsk_id_t n;
     tsk_size_t num_nodes;
     double left, span, total;
-    tsk_treeseq_t *treeseqs[2] = { self, other };
+    const tsk_treeseq_t *treeseqs[2] = { self, other };
     tsk_tree_t trees[2];
     kc_vectors kcs[2];
     tsk_diff_iter_t diff_iters[2];

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -119,7 +119,7 @@ typedef struct {
     /**
      * @brief The parent tree sequence.
      */
-    tsk_treeseq_t *tree_sequence;
+    const tsk_treeseq_t *tree_sequence;
     /**
      * @brief The leftmost root in the tree. Roots are siblings, and
      * other roots can be found using right_sib.
@@ -154,7 +154,7 @@ typedef struct {
     tsk_size_t num_nodes;
     tsk_flags_t options;
     tsk_size_t root_threshold;
-    tsk_id_t *samples;
+    const tsk_id_t *samples;
     /* TODO before documenting this should be change to interval. */
     /* Left and right physical coordinates of the tree */
     double left;
@@ -179,7 +179,7 @@ typedef struct {
     tsk_id_t *right_sample;
     tsk_id_t *next_sample;
     /* The sites on this tree */
-    tsk_site_t *sites;
+    const tsk_site_t *sites;
     tsk_size_t sites_length;
     /* Counters needed for next() and prev() transformations. */
     int direction;
@@ -204,7 +204,7 @@ typedef struct {
     tsk_size_t num_nodes;
     tsk_size_t num_edges;
     double tree_left;
-    tsk_treeseq_t *tree_sequence;
+    const tsk_treeseq_t *tree_sequence;
     tsk_id_t insertion_index;
     tsk_id_t removal_index;
     tsk_id_t tree_index;
@@ -252,8 +252,8 @@ tsk_size_t tsk_treeseq_get_metadata_schema_length(const tsk_treeseq_t *self);
 const char *tsk_treeseq_get_file_uuid(const tsk_treeseq_t *self);
 double tsk_treeseq_get_sequence_length(const tsk_treeseq_t *self);
 const double *tsk_treeseq_get_breakpoints(const tsk_treeseq_t *self);
-tsk_id_t *tsk_treeseq_get_samples(tsk_treeseq_t *self);
-tsk_id_t *tsk_treeseq_get_sample_index_map(tsk_treeseq_t *self);
+const tsk_id_t *tsk_treeseq_get_samples(const tsk_treeseq_t *self);
+const tsk_id_t *tsk_treeseq_get_sample_index_map(const tsk_treeseq_t *self);
 bool tsk_treeseq_is_sample(const tsk_treeseq_t *self, tsk_id_t u);
 
 int tsk_treeseq_get_node(const tsk_treeseq_t *self, tsk_id_t index, tsk_node_t *node);
@@ -274,15 +274,15 @@ int tsk_treeseq_simplify(const tsk_treeseq_t *self, const tsk_id_t *samples,
     tsk_size_t num_samples, tsk_flags_t options, tsk_treeseq_t *output,
     tsk_id_t *node_map);
 
-int tsk_treeseq_kc_distance(
-    tsk_treeseq_t *self, tsk_treeseq_t *other, double lambda_, double *result);
+int tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *other,
+    double lambda_, double *result);
 
 int tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
-    const tsk_id_t *focal, size_t num_focal, tsk_id_t *const *reference_sets,
+    const tsk_id_t *focal, size_t num_focal, const tsk_id_t *const *reference_sets,
     const size_t *reference_set_size, size_t num_reference_sets, tsk_flags_t options,
     double *ret_array);
 int tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
-    tsk_id_t *const *reference_sets, const size_t *reference_set_size,
+    const tsk_id_t *const *reference_sets, const size_t *reference_set_size,
     size_t num_reference_sets, tsk_flags_t options, double *ret_array);
 
 /* TODO change all these size_t's to tsk_size_t */
@@ -383,7 +383,8 @@ int tsk_treeseq_f4(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
 @{
 */
 
-int tsk_tree_init(tsk_tree_t *self, tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+int tsk_tree_init(
+    tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
 int tsk_tree_free(tsk_tree_t *self);
 
 tsk_id_t tsk_tree_get_index(const tsk_tree_t *self);
@@ -410,7 +411,7 @@ bool tsk_tree_is_sample(const tsk_tree_t *self, tsk_id_t u);
 
 int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options);
 int tsk_tree_set_tracked_samples(
-    tsk_tree_t *self, size_t num_tracked_samples, tsk_id_t *tracked_samples);
+    tsk_tree_t *self, size_t num_tracked_samples, const tsk_id_t *tracked_samples);
 int tsk_tree_set_tracked_samples_from_sample_list(
     tsk_tree_t *self, tsk_tree_t *other, tsk_id_t node);
 
@@ -420,7 +421,8 @@ int tsk_tree_get_mrca(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *
 int tsk_tree_get_num_samples(const tsk_tree_t *self, tsk_id_t u, size_t *num_samples);
 int tsk_tree_get_num_tracked_samples(
     const tsk_tree_t *self, tsk_id_t u, size_t *num_tracked_samples);
-int tsk_tree_get_sites(tsk_tree_t *self, tsk_site_t **sites, tsk_size_t *sites_length);
+int tsk_tree_get_sites(
+    const tsk_tree_t *self, const tsk_site_t **sites, tsk_size_t *sites_length);
 int tsk_tree_depth(const tsk_tree_t *self, tsk_id_t u, tsk_size_t *depth);
 
 typedef struct {
@@ -434,18 +436,18 @@ int tsk_tree_map_mutations(tsk_tree_t *self, int8_t *genotypes, double *cost_mat
     tsk_state_transition_t **transitions);
 
 int tsk_tree_kc_distance(
-    tsk_tree_t *self, tsk_tree_t *other, double lambda, double *result);
+    const tsk_tree_t *self, const tsk_tree_t *other, double lambda, double *result);
 
 /****************************************************************************/
 /* Diff iterator */
 /****************************************************************************/
 
 int tsk_diff_iter_init(
-    tsk_diff_iter_t *self, tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+    tsk_diff_iter_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
 int tsk_diff_iter_free(tsk_diff_iter_t *self);
 int tsk_diff_iter_next(tsk_diff_iter_t *self, double *left, double *right,
     tsk_edge_list_t *edges_out, tsk_edge_list_t *edges_in);
-void tsk_diff_iter_print_state(tsk_diff_iter_t *self, FILE *out);
+void tsk_diff_iter_print_state(const tsk_diff_iter_t *self, FILE *out);
 
 #ifdef __cplusplus
 }

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6088,7 +6088,7 @@ static PyObject *
 TreeSequence_get_samples(TreeSequence *self)
 {
     PyObject *ret = NULL;
-    tsk_id_t *samples;
+    const tsk_id_t *samples;
     PyArrayObject *samples_array = NULL;
     npy_intp dim;
 
@@ -6119,7 +6119,7 @@ TreeSequence_genealogical_nearest_neighbours(
 {
     PyObject *ret = NULL;
     static char *kwlist[] = { "focal", "reference_sets", NULL };
-    tsk_id_t **reference_sets = NULL;
+    const tsk_id_t **reference_sets = NULL;
     size_t *reference_set_size = NULL;
     PyObject *focal = NULL;
     PyObject *reference_sets_list = NULL;
@@ -6249,7 +6249,7 @@ TreeSequence_mean_descendants(TreeSequence *self, PyObject *args, PyObject *kwds
 {
     PyObject *ret = NULL;
     static char *kwlist[] = { "reference_sets", NULL };
-    tsk_id_t **reference_sets = NULL;
+    const tsk_id_t **reference_sets = NULL;
     size_t *reference_set_size = NULL;
     PyObject *reference_sets_list = NULL;
     PyArrayObject **reference_set_arrays = NULL;


### PR DESCRIPTION
Builds on top of #939 and final PR for #844.

Consitfies more or less everything else except haplotype_matching.h. Wasn't clear whether that header is used enough to be worth constifying. I've barely read it.

This the final PR for where a few final touches in trees.h cause a bunch of changes across many files.
