### PR TITLE
Fix DeprecationWarning for collections.abc in test_ms

### DIFF
--- a/python/tests/test_ms.py
+++ b/python/tests/test_ms.py
@@ -89,7 +89,7 @@ class TestNumReplicates(unittest.TestCase):
     """
 
     def verify_num_replicates(self, tree_seq, num_replicates):
-        if isinstance(tree_seq, collections.Iterable):
+        if isinstance(tree_seq, collections.abc.Iterable):
             with tempfile.TemporaryDirectory() as temp_dir:
                 ms_file_path = os.path.join(temp_dir, "testing_ms_file.txt")
                 with open(ms_file_path, "w") as f:
@@ -133,7 +133,7 @@ class TestNumHaplotypes(unittest.TestCase):
     """
 
     def verify_num_haplotypes(self, tree_seq, tree_seq2, num_replicates):
-        if isinstance(tree_seq, collections.Iterable):
+        if isinstance(tree_seq, collections.abc.Iterable):
             with tempfile.TemporaryDirectory() as temp_dir:
                 ms_file_path = os.path.join(temp_dir, "testing_ms_file.txt")
                 with open(ms_file_path, "w") as f:
@@ -182,7 +182,7 @@ class TestNumSites(unittest.TestCase):
     """
 
     def verify_num_sites(self, tree_seq, tree_seq2, num_replicates):
-        if isinstance(tree_seq, collections.Iterable):
+        if isinstance(tree_seq, collections.abc.Iterable):
             with tempfile.TemporaryDirectory() as temp_dir:
                 ms_file_path = os.path.join(temp_dir, "testing_ms_file.txt")
                 with open(ms_file_path, "w") as f:
@@ -244,7 +244,7 @@ class TestGenotypes(unittest.TestCase):
         return gens_array
 
     def verify_genotypes(self, tree_seq, tree_seq2, num_replicates):
-        if isinstance(tree_seq, collections.Iterable):
+        if isinstance(tree_seq, collections.abc.Iterable):
             with tempfile.TemporaryDirectory() as temp_dir:
                 ms_file_path = os.path.join(temp_dir, "testing_ms_file.txt")
                 with open(ms_file_path, "w") as f:
@@ -302,7 +302,7 @@ class TestPositions(unittest.TestCase):
         return positions
 
     def verify_positions(self, tree_seq, tree_seq2, num_replicates):
-        if isinstance(tree_seq, collections.Iterable):
+        if isinstance(tree_seq, collections.abc.Iterable):
             with tempfile.TemporaryDirectory() as temp_dir:
                 ms_file_path = os.path.join(temp_dir, "testing_ms_file.txt")
                 with open(ms_file_path, "w") as f:

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6506,7 +6506,7 @@ def write_ms(
     are sample size and number of replicates. The second line has a 0 as a substitute
     for the random seed.
     """
-    if not isinstance(tree_sequence, collections.Iterable):
+    if not isinstance(tree_sequence, collections.abc.Iterable):
         tree_sequence = [tree_sequence]
 
     i = 0


### PR DESCRIPTION
Trivial fix for the following test warning:

```
tests/test_ms.py::TestNumReplicates::test_num_replicates
  /Users/yan/Documents/Research/BDI/tskit/python/tests/test_ms.py:92: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    if isinstance(tree_seq, collections.Iterable):
```