### PR TITLE
Tidy up genetic_relatedness

### DIFF
--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -1334,7 +1334,7 @@ test_paper_ex_divergence(void)
 }
 
 static void
-test_paper_ex_relatedness(void)
+test_paper_ex_genetic_relatedness(void)
 {
     tsk_treeseq_t ts;
     tsk_id_t samples[] = { 0, 1, 2, 3 };
@@ -1346,20 +1346,20 @@ test_paper_ex_relatedness(void)
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
-    ret = tsk_treeseq_relatedness(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0,
-        NULL, &result, TSK_STAT_SITE);
+    ret = tsk_treeseq_genetic_relatedness(&ts, 2, sample_set_sizes, samples, 1,
+        set_indexes, 0, NULL, &result, TSK_STAT_SITE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_treeseq_free(&ts);
 }
 
 static void
-test_paper_ex_relatedness_errors(void)
+test_paper_ex_genetic_relatedness_errors(void)
 {
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
-    verify_two_way_stat_func_errors(&ts, tsk_treeseq_relatedness);
+    verify_two_way_stat_func_errors(&ts, tsk_treeseq_genetic_relatedness);
     tsk_treeseq_free(&ts);
 }
 
@@ -1709,8 +1709,9 @@ main(int argc, char **argv)
         { "test_paper_ex_Y1", test_paper_ex_Y1 },
         { "test_paper_ex_divergence_errors", test_paper_ex_divergence_errors },
         { "test_paper_ex_divergence", test_paper_ex_divergence },
-        { "test_paper_ex_relatedness_errors", test_paper_ex_relatedness_errors },
-        { "test_paper_ex_relatedness", test_paper_ex_relatedness },
+        { "test_paper_ex_genetic_relatedness_errors",
+            test_paper_ex_genetic_relatedness_errors },
+        { "test_paper_ex_genetic_relatedness", test_paper_ex_genetic_relatedness },
         { "test_paper_ex_Y2_errors", test_paper_ex_Y2_errors },
         { "test_paper_ex_Y2", test_paper_ex_Y2 },
         { "test_paper_ex_f2_errors", test_paper_ex_f2_errors },

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -2753,8 +2753,8 @@ out:
 }
 
 static int
-relatedness_summary_func(size_t state_dim, const double *state, size_t result_dim,
-    double *result, void *params)
+genetic_relatedness_summary_func(size_t state_dim, const double *state,
+    size_t result_dim, double *result, void *params)
 {
     sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
     const double *x = state;
@@ -2771,13 +2771,13 @@ relatedness_summary_func(size_t state_dim, const double *state, size_t result_di
     for (k = 0; k < result_dim; k++) {
         i = args.set_indexes[2 * k];
         j = args.set_indexes[2 * k + 1];
-        result[k] = (x[i] - meanx) * (x[j] - meanx);
+        result[k] = (x[i] - meanx) * (x[j] - meanx) / 2;
     }
     return 0;
 }
 
 int
-tsk_treeseq_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
     const double *windows, double *result, tsk_flags_t options)
@@ -2788,7 +2788,7 @@ tsk_treeseq_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
         goto out;
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
-        sample_sets, num_index_tuples, index_tuples, relatedness_summary_func,
+        sample_sets, num_index_tuples, index_tuples, genetic_relatedness_summary_func,
         num_windows, windows, result, options);
 out:
     return ret;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -355,10 +355,11 @@ int tsk_treeseq_f2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
     const double *windows, double *result, tsk_flags_t options);
-int tsk_treeseq_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
-    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_index_tuples,
+    const tsk_id_t *index_tuples, tsk_size_t num_windows, const double *windows,
+    double *result, tsk_flags_t options);
 
 /* Three way sample set stats */
 int tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7035,7 +7035,8 @@ TreeSequence_divergence(TreeSequence *self, PyObject *args, PyObject *kwds)
 static PyObject *
 TreeSequence_genetic_relatedness(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
-    return TreeSequence_k_way_stat_method(self, args, kwds, 2, tsk_treeseq_genetic_relatedness);
+    return TreeSequence_k_way_stat_method(
+        self, args, kwds, 2, tsk_treeseq_genetic_relatedness);
 }
 
 static PyObject *

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7033,9 +7033,9 @@ TreeSequence_divergence(TreeSequence *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-TreeSequence_relatedness(TreeSequence *self, PyObject *args, PyObject *kwds)
+TreeSequence_genetic_relatedness(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
-    return TreeSequence_k_way_stat_method(self, args, kwds, 2, tsk_treeseq_relatedness);
+    return TreeSequence_k_way_stat_method(self, args, kwds, 2, tsk_treeseq_genetic_relatedness);
 }
 
 static PyObject *
@@ -7355,8 +7355,8 @@ static PyMethodDef TreeSequence_methods[] = {
         .ml_meth = (PyCFunction) TreeSequence_divergence,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,
         .ml_doc = "Computes diveregence between sample sets." },
-    { .ml_name = "relatedness",
-        .ml_meth = (PyCFunction) TreeSequence_relatedness,
+    { .ml_name = "genetic_relatedness",
+        .ml_meth = (PyCFunction) TreeSequence_genetic_relatedness,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,
         .ml_doc = "Computes genetic relatedness between sample sets." },
     { .ml_name = "Y1",

--- a/python/tests/test_covariance.py
+++ b/python/tests/test_covariance.py
@@ -33,7 +33,7 @@ import numpy as np
 import tskit
 
 
-def naive_genotype_covariance(ts, proportion=False):
+def naive_genetic_relatedness(ts, proportion=False):
     G = ts.genotype_matrix()
     denominator = ts.sequence_length
     if proportion:
@@ -44,7 +44,7 @@ def naive_genotype_covariance(ts, proportion=False):
     return G @ G.T / denominator
 
 
-def genotype_relatedness(ts, polarised=False, proportion=False):
+def genetic_relatedness(ts, polarised=False, proportion=False):
     n = ts.num_samples
     sample_sets = [[u] for u in ts.samples()]
 
@@ -75,7 +75,7 @@ def genotype_relatedness(ts, polarised=False, proportion=False):
     )
 
 
-def c_genotype_relatedness(ts, sample_sets, indexes, polarised=False, proportion=False):
+def c_genetic_relatedness(ts, sample_sets, indexes, polarised=False, proportion=False):
     m = len(indexes)
     state_dim = len(sample_sets)
 
@@ -116,8 +116,8 @@ class TestCovariance(unittest.TestCase):
     """
 
     def verify(self, ts):
-        cov1 = naive_genotype_covariance(ts)
-        cov2 = genotype_relatedness(ts)
+        cov1 = naive_genetic_relatedness(ts)
+        cov2 = genetic_relatedness(ts)
         sample_sets = [[u] for u in ts.samples()]
         n = len(sample_sets)
         indexes = [
@@ -126,7 +126,7 @@ class TestCovariance(unittest.TestCase):
         cov3 = np.zeros((n, n))
         cov4 = np.zeros((n, n))
         i_upper = np.triu_indices(n)
-        cov3[i_upper] = c_genotype_relatedness(ts, sample_sets, indexes)
+        cov3[i_upper] = c_genetic_relatedness(ts, sample_sets, indexes)
         cov3 = cov3 + cov3.T - np.diag(cov3.diagonal())
         cov4[i_upper] = ts.genetic_relatedness(
             sample_sets, indexes, mode="site", span_normalise=True

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5535,18 +5535,15 @@ class TreeSequence:
             segregating sites (defaults to True).
         :return: A ndarray with shape equal to (num windows, num statistics).
         """
-        return (
-            self.__k_way_sample_set_stat(
-                self._ll_tree_sequence.relatedness,
-                2,
-                sample_sets,
-                indexes=indexes,
-                windows=windows,
-                mode=mode,
-                span_normalise=span_normalise,
-                polarised=polarised,
-            )
-            / 2
+        return self.__k_way_sample_set_stat(
+            self._ll_tree_sequence.genetic_relatedness,
+            2,
+            sample_sets,
+            indexes=indexes,
+            windows=windows,
+            mode=mode,
+            span_normalise=span_normalise,
+            polarised=polarised,
         )
 
     def trait_covariance(self, W, windows=None, mode="site", span_normalise=True):


### PR DESCRIPTION
Small changes to naming of genetic_relatedness in the tests and the C implementation.

Moved the denominator 2 into the summary function.

Fixes #973 
