### PR TITLE
Change Tree.unrank order of arguments to feel more natural

### DIFF
--- a/docs/combinatorics.rst
+++ b/docs/combinatorics.rst
@@ -89,7 +89,7 @@ method.
 .. code-block:: python
 
     for rank in [(0, 0), (1, 0), (1, 1), (1, 2)]:
-        t = Tree.unrank(rank, num_leaves=3)
+        t = Tree.unrank(3, rank)
         display(SVG(t.draw(node_labels={0: 0, 1: 1, 2: 2}, order="tree")))
 
 .. image:: _static/topology_0_0.svg
@@ -116,7 +116,7 @@ samples are synonymous with leaves.
 
     rank_counts = collections.Counter(t.rank() for t in ts.trees())
     most_freq_rank, count = rank_counts.most_common(1)[0]
-    Tree.unrank(most_freq_rank, num_leaves=ts.num_samples())
+    Tree.unrank(ts.num_samples(), most_freq_rank)
 
 .. _sec_enumerating_topologies:
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -42,6 +42,10 @@
 
 **Breaking changes**
 
+- The argument order of ``Tree.unrank`` and ``combinatorics.num_labellings`` now
+  positions the number of leaves before the tree rank
+  (:user:`daniel-goldstein`, :issue:`950`, :pr:`978`)
+
 - Change several methods (``simplify()``, ``trees()``, ``Tree()``) so most parameters
   are keyword only, not positional. This allows reordering of parameters, so
   that deprecated parameters can be moved, and the parameter order in similar functions,

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -7928,7 +7928,7 @@ class TestExampleTrees:
         for extra_params in [{}, {"span": 2.5}]:
             for n in range(2, 6):
                 ts = tskit.Tree.generate_star(n, **extra_params).tree_sequence
-                equiv_ts = tskit.Tree.unrank((0, 0), n, **extra_params).tree_sequence
+                equiv_ts = tskit.Tree.unrank(n, (0, 0), **extra_params).tree_sequence
                 assert ts.tables.equals(equiv_ts.tables, ignore_provenance=True)
 
     def test_star_bad_params(self):
@@ -7947,7 +7947,7 @@ class TestExampleTrees:
         branch_length = 10
         n = 7
         ts = tskit.Tree.generate_star(n, branch_length=branch_length).tree_sequence
-        topological_equiv_ts = tskit.Tree.unrank((0, 0), n).tree_sequence
+        topological_equiv_ts = tskit.Tree.unrank(n, (0, 0)).tree_sequence
 
         assert ts.node(ts.first().root).time == branch_length
         assert ts.kc_distance(topological_equiv_ts) == 0

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -249,7 +249,7 @@ class PartialTopologyCounter:
         children = []
         for sample_set_indexes, rank in child_topologies:
             n = len(sample_set_indexes)
-            t = RankTree.unrank(rank, n, list(sample_set_indexes))
+            t = RankTree.unrank(n, rank, list(sample_set_indexes))
             children.append(t)
         children.sort(key=RankTree.canonical_order)
         return RankTree(children).rank()
@@ -432,7 +432,7 @@ class RankTree:
         return self._label_rank
 
     @staticmethod
-    def unrank(rank, num_leaves, labels=None):
+    def unrank(num_leaves, rank, labels=None):
         """
         Produce a ``RankTree`` of the given ``rank`` with ``num_leaves`` leaves,
         labelled with ``labels``. Labels must be sorted, and if ``None`` default
@@ -441,18 +441,18 @@ class RankTree:
         shape_rank, label_rank = rank
         if shape_rank < 0 or label_rank < 0:
             raise ValueError("Rank is out of bounds.")
-        unlabelled = RankTree.shape_unrank(shape_rank, num_leaves)
+        unlabelled = RankTree.shape_unrank(num_leaves, shape_rank)
         return unlabelled.label_unrank(label_rank, labels)
 
     @staticmethod
-    def shape_unrank(shape_rank, n):
+    def shape_unrank(n, shape_rank):
         """
         Generate an unlabelled tree with n leaves with a shape corresponding to
         the `shape_rank`.
         """
         part, child_shape_ranks = children_shape_ranks(shape_rank, n)
         children = [
-            RankTree.shape_unrank(rk, k) for rk, k in zip(child_shape_ranks, part)
+            RankTree.shape_unrank(k, rk) for k, rk in zip(part, child_shape_ranks)
         ]
 
         t = RankTree(children=children)
@@ -753,8 +753,8 @@ def num_tree_pairings(part):
     return total
 
 
-def num_labellings(shape_rk, n):
-    return RankTree.shape_unrank(shape_rk, n).num_labellings()
+def num_labellings(n, shape_rk):
+    return RankTree.shape_unrank(n, shape_rk).num_labellings()
 
 
 def children_shape_ranks(rank, n):

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -849,7 +849,7 @@ class Tree:
         return combinatorics.RankTree.from_tsk_tree(self).rank()
 
     @staticmethod
-    def unrank(rank, num_leaves, *, span=1):
+    def unrank(num_leaves, rank, *, span=1):
         """
         Reconstruct the tree of the given ``rank``
         (see :meth:`tskit.Tree.rank`) with ``num_leaves`` leaves.
@@ -859,8 +859,8 @@ class Tree:
         See the :ref:`sec_tree_ranks` section for details on ranking and
         unranking trees and what constitutes valid ranks.
 
-        :param tuple(int) rank: The rank of the tree to generate.
         :param int num_leaves: The number of leaves of the tree to generate.
+        :param tuple(int) rank: The rank of the tree to generate.
         :param float span: The genomic span of the returned tree. The tree will cover
             the interval :math:`[0, \\text{span})` and the :attr:`~Tree.tree_sequence`
             from which the tree is taken will have its
@@ -869,7 +869,7 @@ class Tree:
         :raises: ValueError: If the given rank is out of bounds for trees
             with ``num_leaves`` leaves.
         """
-        return combinatorics.RankTree.unrank(rank, num_leaves).to_tsk_tree(span=span)
+        return combinatorics.RankTree.unrank(num_leaves, rank).to_tsk_tree(span=span)
 
     def count_topologies(self, sample_sets=None):
         """
@@ -2378,7 +2378,7 @@ class Tree:
         a "star" tree). The leaf nodes are all at time 0 and are marked as sample nodes.
 
         .. note::
-            This is similar to ``tskit.Tree.unrank((0,0), n, span=span)`` but is more
+            This is similar to ``tskit.Tree.unrank(n, (0,0), span=span)`` but is more
             efficient for large n. However, the ``unrank`` method provides
             a concise way of generating alternative (non-star) topologies.
 


### PR DESCRIPTION
## Description

Changes the order of the arguments to ``Tree.unrank`` and ``combinatorics.num_labellings`` to take first the number of leaves and then the rank of the tree in question.

Fixes #950 

cc: @hyanwong @jeromekelleher 

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
