### PR TITLE
Fix typo in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Description
 
 Thanks for contributing to tskit! :heart:
-A guide to the PR process is [here]](https://tskit.readthedocs.io/en/latest/development.html#development_workflow_git)
+A guide to the PR process is [here](https://tskit.readthedocs.io/en/latest/development.html#development_workflow_git)
 Please replace this text with a summary of the change and which issue is fixed, if any. Please also include relevant motivation and context.
 
 Fixes #(issue) <- Putting the issue number here will auto-close the issue when this PR is merged 


### PR DESCRIPTION
Remove extra ] in markdown link

## Description

The existing template doesn't render links correctly because of an extra closing bracket.
Fairly meta using the old template in the proposal of a new template.

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
