### PR TITLE
regression -> linear model (closes #990)

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -14,6 +14,8 @@
 - Exposed ``tsk_table_collection_set_indexes`` to the API.
   (:user:`benjeffery`, :issue:`870`, :pr:`921`)
 
+- Renamed ``ts.trait_regression`` to ``ts.trait_linear_model``.
+
 ---------------------
 [0.99.7] - 2020-09-29
 ---------------------

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -1181,18 +1181,18 @@ test_paper_ex_trait_correlation(void)
 }
 
 static void
-test_paper_ex_trait_regression_errors(void)
+test_paper_ex_trait_linear_model_errors(void)
 {
     tsk_treeseq_t ts;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
-    verify_one_way_weighted_covariate_func_errors(&ts, tsk_treeseq_trait_regression);
+    verify_one_way_weighted_covariate_func_errors(&ts, tsk_treeseq_trait_linear_model);
     tsk_treeseq_free(&ts);
 }
 
 static void
-test_paper_ex_trait_regression(void)
+test_paper_ex_trait_linear_model(void)
 {
     tsk_treeseq_t ts;
     double result;
@@ -1211,7 +1211,7 @@ test_paper_ex_trait_regression(void)
     covariates[4] = covariates[6] = 0.0;
     covariates[5] = covariates[7] = 1.0;
 
-    ret = tsk_treeseq_trait_regression(
+    ret = tsk_treeseq_trait_linear_model(
         &ts, 1, weights, 2, covariates, 0, NULL, &result, TSK_STAT_SITE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 0.0, 1e-6);
@@ -1697,9 +1697,9 @@ main(int argc, char **argv)
         { "test_paper_ex_trait_correlation_errors",
             test_paper_ex_trait_correlation_errors },
         { "test_paper_ex_trait_correlation", test_paper_ex_trait_correlation },
-        { "test_paper_ex_trait_regression_errors",
-            test_paper_ex_trait_regression_errors },
-        { "test_paper_ex_trait_regression", test_paper_ex_trait_regression },
+        { "test_paper_ex_trait_linear_model_errors",
+            test_paper_ex_trait_linear_model_errors },
+        { "test_paper_ex_trait_linear_model", test_paper_ex_trait_linear_model },
         { "test_paper_ex_diversity_errors", test_paper_ex_diversity_errors },
         { "test_paper_ex_diversity", test_paper_ex_diversity },
         { "test_paper_ex_segregating_sites_errors",

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -2518,7 +2518,7 @@ out:
 }
 
 static int
-trait_regression_summary_func(size_t state_dim, const double *state, size_t result_dim,
+trait_linear_model_summary_func(size_t state_dim, const double *state, size_t result_dim,
     double *result, void *params)
 {
     covariates_stat_params_t args = *(covariates_stat_params_t *) params;
@@ -2564,7 +2564,7 @@ trait_regression_summary_func(size_t state_dim, const double *state, size_t resu
 }
 
 int
-tsk_treeseq_trait_regression(const tsk_treeseq_t *self, tsk_size_t num_weights,
+tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights,
     const double *weights, tsk_size_t num_covariates, const double *covariates,
     tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
 {
@@ -2622,8 +2622,8 @@ tsk_treeseq_trait_regression(const tsk_treeseq_t *self, tsk_size_t num_weights,
     }
 
     ret = tsk_treeseq_general_stat(self, num_weights + num_covariates + 1, new_weights,
-        num_weights, trait_regression_summary_func, &args, num_windows, windows, result,
-        options);
+        num_weights, trait_linear_model_summary_func, &args, num_windows, windows,
+        result, options);
 
 out:
     tsk_safe_free(V);

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -313,7 +313,7 @@ typedef int one_way_covariates_method(const tsk_treeseq_t *self, tsk_size_t num_
     const double *weights, tsk_size_t num_covariates, const double *covariates,
     tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
 
-int tsk_treeseq_trait_regression(const tsk_treeseq_t *self, tsk_size_t num_weights,
+int tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights,
     const double *weights, tsk_size_t num_covariates, const double *covariates,
     tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
 

--- a/docs/stats.rst
+++ b/docs/stats.rst
@@ -77,10 +77,11 @@ Trait correlations
 
 These methods compute correlations and covariances of traits (i.e., an
 arbitrary vector) with allelic state, possibly in the context of a multivariate
-regression with other covariates (as in GWAS).
+linear model with other covariates (as in GWAS).
 
 - :meth:`TreeSequence.trait_covariance`
 - :meth:`TreeSequence.trait_correlation`
+- :meth:`TreeSequence.trait_linear_model`
 
 ------------------
 Derived statistics
@@ -614,7 +615,7 @@ and boolean expressions (e.g., :math:`(x > 0)`) are interpreted as 0/1.
    where as before :math:`x` is the total number of samples below the node,
    and :math:`n` is the total number of samples.
 
-``trait_regression``
+``trait_linear_model``
    :math:`f(w, z, x) = \frac{1}{2}\left( \frac{w - \sum_{j=1}^k z_j v_j}{x - \sum_{j=1}^k z_j^2} \right)^2`,
 
    where :math:`w` and :math:`x` are as before,

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -46,6 +46,7 @@
 
 - The argument to ``ts.dump`` and ``tskit.load`` has been renamed `file` from `path`.
 - All arguments to ``Tree.newick()`` except precision are now keyword-only.
+- Renamed ``ts.trait_regression`` to ``ts.trait_linear_model``.
 
 --------------------
 [0.3.2] - 2020-09-29

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7166,10 +7166,10 @@ TreeSequence_trait_correlation(TreeSequence *self, PyObject *args, PyObject *kwd
 }
 
 static PyObject *
-TreeSequence_trait_regression(TreeSequence *self, PyObject *args, PyObject *kwds)
+TreeSequence_trait_linear_model(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     return TreeSequence_one_way_covariates_method(
-        self, args, kwds, tsk_treeseq_trait_regression);
+        self, args, kwds, tsk_treeseq_trait_linear_model);
 }
 
 static PyObject *
@@ -7589,10 +7589,10 @@ static PyMethodDef TreeSequence_methods[] = {
         .ml_meth = (PyCFunction) TreeSequence_trait_correlation,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,
         .ml_doc = "Computes correlation with traits." },
-    { .ml_name = "trait_regression",
-        .ml_meth = (PyCFunction) TreeSequence_trait_regression,
+    { .ml_name = "trait_linear_model",
+        .ml_meth = (PyCFunction) TreeSequence_trait_linear_model,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,
-        .ml_doc = "Computes regression coefficients of each trait." },
+        .ml_doc = "Computes coefficients of a linear model for each trait." },
     { .ml_name = "segregating_sites",
         .ml_meth = (PyCFunction) TreeSequence_segregating_sites,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1117,14 +1117,14 @@ class TestTraitCorrelation(LowLevelTestCase, WeightMixin):
         return ts, ts.trait_correlation
 
 
-class TestTraitRegression(LowLevelTestCase, WeightCovariateMixin):
+class TestTraitLinearModel(LowLevelTestCase, WeightCovariateMixin):
     """
     Tests for trait correlation.
     """
 
     def get_method(self):
         ts = self.get_example_tree_sequence()
-        return ts, ts.trait_regression
+        return ts, ts.trait_linear_model
 
 
 class TestSegregatingSites(LowLevelTestCase, OneWaySampleStatsMixin):

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5725,15 +5725,27 @@ class TreeSequence:
             span_normalise=span_normalise,
         )
 
-    def trait_regression(
+    def trait_regression(self, *args, **kwargs):
+        """
+        Deprecated synonym for
+        :meth:`trait_linear_model <.TreeSequence.trait_linear_model>`.
+        """
+        warnings.warn(
+            "This is deprecated: please use trait_linear_model( ) instead.",
+            FutureWarning,
+        )
+        return self.trait_linear_model(*args, **kwargs)
+
+    def trait_linear_model(
         self, W, Z=None, windows=None, mode="site", span_normalise=True
     ):
         """
-        For each trait w (i.e., each column of W), performs the least-squares
-        linear regression :math:`w \\sim g + Z`,
-        where :math:`g` is inheritance in the tree sequence and the columns of :math:`Z`
-        are covariates, and computes the squared coefficient of :math:`g` in this
-        regression.
+        Finds the relationship between trait and genotype after accounting for
+        covariates.  Concretely, for each trait w (i.e., each column of W),
+        this does a least-squares fit of the linear model :math:`w \\sim g + Z`,
+        where :math:`g` is inheritance in the tree sequence (e.g., genotype)
+        and the columns of :math:`Z` are covariates, and returns the squared
+        coefficient of :math:`g` in this linear model.
         See the :ref:`statistics interface <sec_stats_interface>` section for details on
         :ref:`windows <sec_stats_windows>`,
         :ref:`mode <sec_stats_mode>`,
@@ -5741,13 +5753,13 @@ class TreeSequence:
         and :ref:`return value <sec_stats_output_format>`.
         Operates on all samples in the tree sequence.
 
-        Concretely, if `g` is a binary vector that indicates inheritance from an allele,
+        To do this, if `g` is a binary vector that indicates inheritance from an allele,
         branch, or node and `w` is a column of W, there are :math:`k` columns of
         :math:`Z`, and the :math:`k+2`-vector :math:`b` minimises
         :math:`\\sum_i (w_i - b_0 - b_1 g_i - b_2 z_{2,i} - ... b_{k+2} z_{k+2,i})^2`
         then this returns the number :math:`b_1^2`. If :math:`g` lies in the linear span
-        of the columns of :math:`Z`, then :math:`b_1` is set to 0. To perform the
-        regression without covariates (only the intercept), set `Z = None`.
+        of the columns of :math:`Z`, then :math:`b_1` is set to 0. To fit the
+        linear model without covariates (only the intercept), set `Z = None`.
 
         What is computed depends on ``mode``:
 
@@ -5801,7 +5813,7 @@ class TreeSequence:
         Z = np.matmul(Z, np.linalg.inv(K))
         return self.__run_windowed_stat(
             windows,
-            self._ll_tree_sequence.trait_regression,
+            self._ll_tree_sequence.trait_linear_model,
             W,
             Z,
             mode=mode,


### PR DESCRIPTION
This renames `trait_regression` -> `trait_linear_model`, but keeps the old thing with a FutureWarning. We probably don't need to even do that because I doubt anyone is using it.