### PR TITLE
Test pickle with a fully populated tree sequence

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1649,38 +1649,8 @@ class TestTreeSequenceMetadata:
                 }
 
 
-class TestPickle(HighLevelTestCase):
-    """
-    Test pickling of a TreeSequence.
-    """
-
-    def verify_round_trip(self, ts):
-        pkl = pickle.dumps(ts)
-        tsp = pickle.loads(pkl)
-        assert ts.tables == tsp.tables
-
-    def test_simple(self):
-        self.verify_round_trip(msprime.simulate(10, random_seed=2))
-
-    def test_recombination(self):
-        self.verify_round_trip(
-            msprime.simulate(10, recombination_rate=1, random_seed=2)
-        )
-
-    def test_mutations(self):
-        self.verify_round_trip(msprime.simulate(10, mutation_rate=1, random_seed=2))
-
-    def test_migrations(self):
-        ts = msprime.simulate(
-            population_configurations=[
-                msprime.PopulationConfiguration(10),
-                msprime.PopulationConfiguration(10),
-            ],
-            migration_matrix=[[0, 1], [1, 0]],
-            record_migrations=True,
-            random_seed=2,
-        )
-        self.verify_round_trip(ts)
+def test_pickle_round_trip(ts_fixture):
+    assert ts_fixture.tables == pickle.loads(pickle.dumps(ts_fixture)).tables
 
 
 class TestFileUuid(HighLevelTestCase):


### PR DESCRIPTION
#994 pointed out that the test for pickling a tree sequence did not use metadata. This PR changes the test to use the fully populated tree sequence.