### PR TITLE
Add options to table collection clear

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -11,6 +11,11 @@
   current behaviour. (:user:`mufernando`, :user:`jeromekelleher`,
   :issue:`896`, :pr:`897`, :issue:`913`, :pr:`917`).
 
+- Changed default behaviour of ``tsk_table_collection_clear`` to not clear
+  provenances and added ``options`` argument to optionally clear provenances
+  and schemas.
+  (:user:`benjeffery`, :issue:`929`, :pr:`1001`)
+
 - Exposed ``tsk_table_collection_set_indexes`` to the API.
   (:user:`benjeffery`, :issue:`870`, :pr:`921`)
 

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -727,6 +727,11 @@ typedef struct {
 #define TSK_CMP_IGNORE_METADATA (1 << 2)
 #define TSK_CMP_IGNORE_TIMESTAMPS (1 << 3)
 
+/* Flags for tables collection clear */
+#define TSK_CLEAR_METADATA_SCHEMAS (1 << 0)
+#define TSK_CLEAR_TS_METADATA_AND_SCHEMA (1 << 1)
+#define TSK_CLEAR_PROVENANCE (1 << 2)
+
 /****************************************************************************/
 /* Function signatures */
 /****************************************************************************/
@@ -2251,17 +2256,34 @@ int tsk_table_collection_init(tsk_table_collection_t *self, tsk_flags_t options)
 int tsk_table_collection_free(tsk_table_collection_t *self);
 
 /**
-@brief Clears all tables in this table collection.
+@brief Clears data tables (and optionally provenances and metadata) in
+this table collection.
 
 @rst
+By default this operation clears all tables except the provenance table, retaining
+table metadata schemas and the tree-sequnce level metadata and schema.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_CLEAR_PROVENANCE
+    Additionally clear the provenance table
+TSK_CLEAR_METADATA_SCHEMAS
+    Additionally clear the table metadata schemas
+TSK_CLEAR_TS_METADATA_AND_SCHEMA
+    Additionally clear the tree-sequence metadata and schema
+
 No memory is freed as a result of this operation; please use
 :c:func:`tsk_table_collection_free` to free internal resources.
 @endrst
 
 @param self A pointer to a tsk_table_collection_t object.
+@param options Bitwise clearing options
 @return Return 0 on success or a negative value on failure.
 */
-int tsk_table_collection_clear(tsk_table_collection_t *self);
+int tsk_table_collection_clear(tsk_table_collection_t *self, tsk_flags_t options);
 
 /**
 @brief Returns true if the data in the specified table collection is equal

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -45,6 +45,10 @@
   reports the size in bytes of those objects.
   (:user:`jeromekelleher`, :user:`benjeffery`, :issue:`54`, :pr:`871`)
 
+- Added ``TableCollection.clear`` to clear data table rows and optionally
+  provenances, table schemas and tree-sequence level metadata and schema.
+  (:user:`benjeffery`, :issue:`929`, :pr:`1001`)
+
 **Breaking changes**
 
 - The argument to ``ts.dump`` and ``tskit.load`` has been renamed `file` from `path`.

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -5470,6 +5470,45 @@ out:
 }
 
 static PyObject *
+TableCollection_clear(TableCollection *self, PyObject *args, PyObject *kwds)
+{
+    int err;
+    PyObject *ret = NULL;
+    tsk_flags_t options = 0;
+    int clear_provenance = false;
+    int clear_metadata_schemas = false;
+    int clear_ts_metadata = false;
+    static char *kwlist[] = { "clear_provenance", "clear_metadata_schemas",
+        "clear_ts_metadata_and_schema", NULL };
+
+    if (TableCollection_check_state(self)) {
+        goto out;
+    }
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iii", kwlist, &clear_provenance,
+            &clear_metadata_schemas, &clear_ts_metadata)) {
+        goto out;
+    }
+    if (clear_provenance) {
+        options |= TSK_CLEAR_PROVENANCE;
+    }
+    if (clear_metadata_schemas) {
+        options |= TSK_CLEAR_METADATA_SCHEMAS;
+    }
+    if (clear_ts_metadata) {
+        options |= TSK_CLEAR_TS_METADATA_AND_SCHEMA;
+    }
+
+    err = tsk_table_collection_clear(self->tables, options);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 TableCollection_dump(TableCollection *self, PyObject *args, PyObject *kwds)
 {
     int err;
@@ -5649,6 +5688,10 @@ static PyMethodDef TableCollection_methods[] = {
         .ml_meth = (PyCFunction) TableCollection_has_index,
         .ml_flags = METH_NOARGS,
         .ml_doc = "Returns True if the TableCollection is indexed." },
+    { .ml_name = "clear",
+        .ml_meth = (PyCFunction) TableCollection_clear,
+        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_doc = "Clears table contents, and optionally provenances and metadata" },
     { .ml_name = "dump",
         .ml_meth = (PyCFunction) TableCollection_dump,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -865,6 +865,45 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
             ts4.dump_tables(tables4)
             assert tables4.has_index()
 
+    def test_clear_table(self, ts_fixture):
+        tables = _tskit.TableCollection(
+            sequence_length=ts_fixture.get_sequence_length()
+        )
+        ts_fixture.ll_tree_sequence.dump_tables(tables)
+        tables.clear()
+        data_tables = [
+            "individuals",
+            "nodes",
+            "edges",
+            "migrations",
+            "sites",
+            "mutations",
+            "populations",
+        ]
+        for table in data_tables:
+            assert getattr(tables, f"{table}").num_rows == 0
+            assert len(getattr(tables, f"{table}").metadata_schema) != 0
+        assert tables.provenances.num_rows > 0
+        assert len(tables.metadata) > 0
+        assert len(tables.metadata_schema) > 0
+
+        tables.clear(clear_provenance=True)
+        assert tables.provenances.num_rows == 0
+        for table in data_tables:
+            assert len(getattr(tables, f"{table}").metadata_schema) != 0
+        assert len(tables.metadata) > 0
+        assert len(tables.metadata_schema) > 0
+
+        tables.clear(clear_metadata_schemas=True)
+        for table in data_tables:
+            assert len(getattr(tables, f"{table}").metadata_schema) == 0
+        assert len(tables.metadata) > 0
+        assert len(tables.metadata_schema) > 0
+
+        tables.clear(clear_ts_metadata_and_schema=True)
+        assert len(tables.metadata) == 0
+        assert len(tables.metadata_schema) == 0
+
 
 class StatsInterfaceMixin:
     """

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -2369,6 +2369,42 @@ class TestTableCollection:
         t1.edges.clear()
         assert t1 != t2
 
+    def test_clear_table(self, ts_fixture):
+        tables = ts_fixture.dump_tables()
+        tables.clear()
+        data_tables = [
+            "individuals",
+            "nodes",
+            "edges",
+            "migrations",
+            "sites",
+            "mutations",
+            "populations",
+        ]
+        for table in data_tables:
+            assert getattr(tables, f"{table}").num_rows == 0
+            assert str(getattr(tables, f"{table}").metadata_schema) != ""
+        assert tables.provenances.num_rows > 0
+        assert len(tables.metadata) > 0
+        assert str(tables.metadata_schema) != ""
+
+        tables.clear(clear_provenance=True)
+        assert tables.provenances.num_rows == 0
+        for table in data_tables:
+            assert str(getattr(tables, f"{table}").metadata_schema) != ""
+        assert len(tables.metadata) > 0
+        assert str(tables.metadata_schema) != ""
+
+        tables.clear(clear_metadata_schemas=True)
+        for table in data_tables:
+            assert str(getattr(tables, f"{table}").metadata_schema) == ""
+        assert len(tables.metadata) > 0
+        assert str(tables.metadata_schema) != 0
+
+        tables.clear(clear_ts_metadata_and_schema=True)
+        assert len(tables.metadata) == 0
+        assert str(tables.metadata_schema) == ""
+
     def test_equals(self):
         pop_configs = [msprime.PopulationConfiguration(5) for _ in range(2)]
         migration_matrix = [[0, 1], [1, 0]]

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -576,14 +576,7 @@ def py_subset(tables, nodes, record_provenance=True):
     if np.any(nodes > tables.nodes.num_rows) or np.any(nodes < 0):
         raise ValueError("Nodes out of bounds.")
     full = tables.copy()
-    # there is no table collection clear in the py API
-    tables.nodes.clear()
-    tables.individuals.clear()
-    tables.populations.clear()
-    tables.edges.clear()
-    tables.migrations.clear()
-    tables.sites.clear()
-    tables.mutations.clear()
+    tables.clear()
     # mapping from old to new ids
     node_map = {}
     ind_map = {tskit.NULL: tskit.NULL}

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2879,6 +2879,29 @@ class TableCollection:
                 record=json.dumps(provenance.get_provenance_dict(parameters))
             )
 
+    def clear(
+        self,
+        clear_provenance=False,
+        clear_metadata_schemas=False,
+        clear_ts_metadata_and_schema=False,
+    ):
+        """
+        Remove all rows of the data tables, optionally remove provenance, metadata
+        schemas and ts-level metadata.
+
+        :param bool clear_provenance: If ``True``, remove all rows of the provenance
+            table. (Default: ``False``).
+        :param bool clear_metadata_schemas: If ``True``, clear the table metadata
+            schemas. (Default: ``False``).
+        :param bool clear_ts_metadata_and_schema: If ``True``, clear the tree-sequence
+            level metadata and schema (Default: ``False``).
+        """
+        self._ll_tables.clear(
+            clear_provenance=clear_provenance,
+            clear_metadata_schemas=clear_metadata_schemas,
+            clear_ts_metadata_and_schema=clear_ts_metadata_and_schema,
+        )
+
     def has_index(self):
         """
         Returns True if this TableCollection is indexed.


### PR DESCRIPTION
## Description

Adds options to `tsk_table_collection_clear`. Also changes the default behaviour by not clearing the provenance table. In the original issue I thought clear should wipe everything - but I've come round to the idea that the most common clearing operation is where you want to retain the provenance and metadata schemas. We should encourage retaining these by default in a table-modifying operation.

Fixes #929 

# PR Checklist:

- [X] Tests that fully cover new/changed functionality.
- [X] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
