### PR TITLE
Fix HTML for dicts

### DIFF
--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -377,21 +377,26 @@ def test_naturalsize(value, expected):
         (
             {"a": 1},
             '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
-            "t</summary>a:1</details></div>",
+            "t</summary>a:1<br/></details></div>",
         ),
         (
             {"b": [1, 2, 3]},
             '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
             't</summary><div><spanclass="tskit-details-label">b:</span><details><summary'
-            ">list</summary>1<br/>2<br/>3<br/></details></div></details></div>",
+            ">list</summary>1<br/>2<br/>3<br/></details></div><br/></details></div>",
         ),
         (
             {"b": [1, 2, {"c": 1}]},
             '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
             't</summary><div><spanclass="tskit-details-label">b:</span><details><summary'
             '>list</summary>1<br/>2<br/><div><spanclass="tskit-details-label"></span><de'
-            "tails><summary>dict</summary>c:1</details></div><br/></details></div></deta"
-            "ils></div>",
+            "tails><summary>dict</summary>c:1<br/></details></div><br/></details></div><"
+            "br/></details></div>",
+        ),
+        (
+            {"a": "1", "b": "2"},
+            '<div><spanclass="tskit-details-label">Test:</span><detailsopen><summary>dic'
+            "t</summary>a:1<br/>b:2<br/></details></div>",
         ),
     ],
 )

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -306,7 +306,7 @@ def obj_to_collapsed_html(d, name=None, open_depth=0):
                   <span class="tskit-details-label">{name}</span>
                   <details {opened}>
                     <summary>dict</summary>
-                    {"".join(obj_to_collapsed_html(val, key, open_depth)
+                    {"".join(f"{obj_to_collapsed_html(val, key, open_depth)}<br/>"
                              for key, val in d.items())}
                   </details>
                 </div>


### PR DESCRIPTION
Found a small wrinkle in the HTML for metadata where dict entries were all on one line.