### PR TITLE
Make tc.equals kwargs only

### DIFF
--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -2502,6 +2502,9 @@ class TestTableCollection:
         assert t1.equals(t2)
         assert t2.equals(t1)
 
+        with pytest.raises(TypeError):
+            t1.equals(t2, True)
+
     def test_sequence_length(self):
         for sequence_length in [0, 1, 100.1234]:
             tables = tskit.TableCollection(sequence_length=sequence_length)

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2247,6 +2247,7 @@ class TableCollection:
     def equals(
         self,
         other,
+        *,
         ignore_metadata=False,
         ignore_ts_metadata=False,
         ignore_provenance=False,


### PR DESCRIPTION
## Description

Makes TableCollection equals options kwargs only


Fixes #896 

# PR Checklist:

- [X] Tests that fully cover new/changed functionality.
- [X] Documentation including tutorial content if appropriate.
- [X] Changelogs, if there are API changes.
