### PR TITLE
Take a copy when making arrays for asdict

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -56,6 +56,12 @@
   provenances, table schemas and tree-sequence level metadata and schema.
   (:user:`benjeffery`, :issue:`929`, :pr:`1001`)
 
+**Bugfixes**
+
+- ``LightWeightTableCollection.asdict`` and ``TableCollection.asdict`` now return copies
+  of arrays.
+  (:user:`benjeffery`, :issue:`1025`, :pr:`1029`)
+
 **Breaking changes**
 
 - The argument to ``ts.dump`` and ``tskit.load`` has been renamed `file` from `path`.

--- a/python/lwt_interface/tskit_lwt_interface.h
+++ b/python/lwt_interface/tskit_lwt_interface.h
@@ -1600,10 +1600,12 @@ write_table_arrays(tsk_table_collection_t *tables, PyObject *dict)
         }
         col = table_descs[j].cols;
         while (col->name != NULL) {
-            array = PyArray_SimpleNewFromData(1, &col->num_rows, col->type, col->data);
+            array = (PyObject *) PyArray_EMPTY(1, &col->num_rows, col->type, 0);
             if (array == NULL) {
                 goto out;
             }
+            memcpy(PyArray_DATA((PyArrayObject *) array), col->data,
+                col->num_rows * PyArray_ITEMSIZE((PyArrayObject *) array));
             if (PyDict_SetItemString(table_dict, col->name, array) != 0) {
                 goto out;
             }

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -2309,6 +2309,12 @@ class TestTableCollection:
         assert t1.has_index()
         assert t2.has_index()
 
+    def test_asdict_lifecycle(self, ts_fixture):
+        tables = ts_fixture.dump_tables()
+        tables_dict = tables.asdict()
+        del tables
+        assert tskit.TableCollection.fromdict(tables_dict) == ts_fixture.dump_tables()
+
     def test_from_dict(self, ts_fixture):
         t1 = ts_fixture.tables
         d = {


### PR DESCRIPTION
## Description

The `tskit.LightweightTableCollection` and `tskit.TableCollection` were not taking copies of arrays, leading to lifecycle errors where the array could be deallocated.

Fixes #1025 

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
