### PR TITLE
Test stats when not all samples are included.

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -881,8 +881,12 @@ def example_sample_sets(ts, min_size=1):
         yield [samples[:1]]
     if ts.num_samples > 2 and min_size <= 2:
         yield [samples[:2], samples[2:]]
+    if ts.num_samples > 4 and min_size <= 2:
+        yield [samples[:2], samples[2:4]]
     if ts.num_samples > 7 and min_size <= 4:
         yield [samples[:2], samples[2:4], samples[4:6], samples[6:]]
+    if ts.num_samples > 8 and min_size <= 4:
+        yield [samples[:2], samples[2:4], samples[4:6], samples[6:8]]
 
 
 def example_sample_set_index_pairs(sample_sets):


### PR DESCRIPTION
Over in #1023 I noticed that some tests were passing that shouldn't, because all of our tests in `test_tree_stats.py` had the property that the union of all sample sets was equal to the set of all samples. This fixes this oversight (and hopefully everything still works, eek!).

I've also set (temporarily!!) it to run *all* the tests in `test_tree_stats.py`, but will need to change that back so that testing doesn't take forever.