### PR TITLE
Use str instead of repr for terminal use

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -44,7 +44,7 @@
 - Added ``TreeSequence._repr_html_`` for use in jupyter notebooks.
   (:user:`benjeffery`, :issue:`872`, :pr:`923`)
 
-- Added ``TreeSequence.__repr__`` to display a summary for terminal usage.
+- Added ``TreeSequence.__str__`` to display a summary for terminal usage.
   (:user:`benjeffery`, :issue:`938`, :pr:`985`)
 
 - Added ``TableCollection.dump`` and ``TableCollection.load``. This allows table

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1456,9 +1456,9 @@ class TestTreeSequence(HighLevelTestCase):
             for table in ts.tables.name_map:
                 assert f"<td>{table.capitalize()}</td>" in html
 
-    def test_repr(self):
+    def test_str(self):
         for ts in get_example_tree_sequences():
-            s = repr(ts)
+            s = str(ts)
             assert len(s) > 999
             assert re.search(rf"║Trees *│ *{ts.num_trees}║", s)
             for table in ts.tables.name_map:

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3443,7 +3443,7 @@ class TreeSequence:
                 )
                 print(row, file=provenances)
 
-    def __repr__(self):
+    def __str__(self):
         ts_rows = [
             ["Trees", str(self.num_trees)],
             ["Sequence Length", str(self.sequence_length)],


### PR DESCRIPTION
Change `__repr__` to `__str__` for unicode table printing.

Fixes #1032 
