### PR TITLE
Fix flakey test

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -492,7 +492,7 @@ class HighLevelTestCase:
             next(iter2)
         assert ts.get_num_trees() == num_trees
         assert breakpoints == list(ts.breakpoints())
-        assert length == ts.get_sequence_length()
+        assert length == pytest.approx(ts.get_sequence_length())
 
 
 class TestNumpySamples:


### PR DESCRIPTION
Just got this in github actions:
```
>       assert length == ts.get_sequence_length()
E       assert 3.9999999999999996 == 4.0
E         +3.9999999999999996
E         -4.0

tests\test_highlevel.py:495: AssertionError
```
Added `pytest.approx` to fix.