### PR TITLE
Change refs in map mutation docs from Fitch to Hartigan

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1211,7 +1211,7 @@ The output is::
 Missing data
 ++++++++++++
 
-The Fitch parsimony algorithm in :meth:`Tree.map_mutations` can also take missing data
+The Hartigan parsimony algorithm in :meth:`Tree.map_mutations` can also take missing data
 into account when finding a set of parsimonious state transitions. We do this by
 specifying the special value ``-1`` as the state, which is treated by the algorithm as
 "could be anything".

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2312,7 +2312,7 @@ class Tree:
         one non-missing observation must be provided. A maximum of 64 alleles are
         supported.
 
-        The current implementation uses the Fitch parsimony algorithm to determine
+        The current implementation uses the Hartigan parsimony algorithm to determine
         the minimum number of state transitions required to explain the data. In this
         model, transitions between any of the non-missing states is equally likely.
 


### PR DESCRIPTION
Missed a few of these. Worth doing a `grep -r Fitch *` once the code in haplotypes.c is changed, so we are sure we've caught them all (bar some references in the test suite, which still uses Fitch for testing binary trees)