### PR TITLE
Change metadata schemas to use repr for the encoded schema, making str pretty print

### DIFF
--- a/python/lwt_interface/dict_encoding_testlib.py
+++ b/python/lwt_interface/dict_encoding_testlib.py
@@ -217,13 +217,13 @@ class TestMissingData:
             tables.metadata
 
     def test_missing_metadata_schema(self, tables):
-        assert str(tables.metadata_schema) != ""
+        assert repr(tables.metadata_schema) != ""
         d = tables.asdict()
         del d["metadata_schema"]
         lwt = lwt_module.LightweightTableCollection()
         lwt.fromdict(d)
         tables = tskit.TableCollection.fromdict(lwt.asdict())
-        assert str(tables.metadata_schema) == ""
+        assert repr(tables.metadata_schema) == ""
 
     def test_missing_tables(self, tables):
         d = tables.asdict()
@@ -466,7 +466,7 @@ class TestRequiredAndOptionalColumns:
         out = lwt.asdict()
         assert "metadata_schema" not in out[table_name]
         tables = tskit.TableCollection.fromdict(out)
-        assert str(getattr(tables, table_name).metadata_schema) == ""
+        assert repr(getattr(tables, table_name).metadata_schema) == ""
 
     def test_individuals(self, tables):
         self.verify_required_columns(tables, "individuals", ["flags"])
@@ -595,7 +595,7 @@ class TestRequiredAndOptionalColumns:
         out = lwt.asdict()
         assert "metadata_schema" not in out
         tables = tskit.TableCollection.fromdict(out)
-        assert str(tables.metadata_schema) == ""
+        assert repr(tables.metadata_schema) == ""
         # Missing is tested in TestMissingData above
 
 

--- a/python/tests/test_file_format.py
+++ b/python/tests/test_file_format.py
@@ -569,7 +569,7 @@ class TestDumpFormat(TestFileFormat):
         assert format_version[0] == CURRENT_FILE_MAJOR
         assert format_version[1] == CURRENT_FILE_MINOR
         assert ts.sequence_length == store["sequence_length"][0]
-        assert str(ts.metadata_schema) == "".join(store["metadata_schema"].astype("U"))
+        assert repr(ts.metadata_schema) == "".join(store["metadata_schema"].astype("U"))
 
         # Load another copy from file so we can check the uuid.
         other_ts = tskit.load(self.temp_file)
@@ -591,7 +591,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.individuals.metadata_offset, store["individuals/metadata_offset"]
         )
-        assert str(tables.individuals.metadata_schema) == "".join(
+        assert repr(tables.individuals.metadata_schema) == "".join(
             store["individuals/metadata_schema"].astype("U")
         )
 
@@ -603,7 +603,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.nodes.metadata_offset, store["nodes/metadata_offset"]
         )
-        assert str(tables.nodes.metadata_schema) == "".join(
+        assert repr(tables.nodes.metadata_schema) == "".join(
             store["nodes/metadata_schema"].astype("U")
         )
 
@@ -615,7 +615,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.edges.metadata_offset, store["edges/metadata_offset"]
         )
-        assert str(tables.edges.metadata_schema) == "".join(
+        assert repr(tables.edges.metadata_schema) == "".join(
             store["edges/metadata_schema"].astype("U")
         )
 
@@ -650,7 +650,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.migrations.metadata_offset, store["migrations/metadata_offset"]
         )
-        assert str(tables.migrations.metadata_schema) == "".join(
+        assert repr(tables.migrations.metadata_schema) == "".join(
             store["migrations/metadata_schema"].astype("U")
         )
 
@@ -666,7 +666,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.sites.metadata_offset, store["sites/metadata_offset"]
         )
-        assert str(tables.sites.metadata_schema) == "".join(
+        assert repr(tables.sites.metadata_schema) == "".join(
             store["sites/metadata_schema"].astype("U")
         )
 
@@ -687,7 +687,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.mutations.metadata_offset, store["mutations/metadata_offset"]
         )
-        assert str(tables.mutations.metadata_schema) == "".join(
+        assert repr(tables.mutations.metadata_schema) == "".join(
             store["mutations/metadata_schema"].astype("U")
         )
 
@@ -697,7 +697,7 @@ class TestDumpFormat(TestFileFormat):
         assert np.array_equal(
             tables.populations.metadata_offset, store["populations/metadata_offset"]
         )
-        assert str(tables.populations.metadata_schema) == "".join(
+        assert repr(tables.populations.metadata_schema) == "".join(
             store["populations/metadata_schema"].astype("U")
         )
 

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1641,10 +1641,10 @@ class TestTreeSequenceMetadata:
     def test_tree_sequence_metadata_schema(self):
         tc = tskit.TableCollection(1)
         ts = tc.tree_sequence()
-        assert str(ts.metadata_schema) == str(tskit.MetadataSchema(None))
+        assert repr(ts.metadata_schema) == repr(tskit.MetadataSchema(None))
         tc.metadata_schema = self.metadata_schema
         ts = tc.tree_sequence()
-        assert str(ts.metadata_schema) == str(self.metadata_schema)
+        assert repr(ts.metadata_schema) == repr(self.metadata_schema)
         with pytest.raises(AttributeError):
             del ts.metadata_schema
         with pytest.raises(AttributeError):
@@ -1676,17 +1676,19 @@ class TestTreeSequenceMetadata:
             schema = tskit.MetadataSchema({"codec": "json", "TEST": f"{table}-SCHEMA"})
             # Check via table API
             getattr(tables, f"{table}s").metadata_schema = schema
-            assert str(getattr(tables, f"{table}s").metadata_schema) == str(schema)
-            for other_table in self.metadata_tables:
-                if other_table != table:
-                    assert str(getattr(tables, f"{other_table}s").metadata_schema) == ""
-            # Check via tree-sequence API
-            new_ts = tskit.TreeSequence.load_tables(tables)
-            assert str(getattr(new_ts.table_metadata_schemas, table)) == str(schema)
+            assert repr(getattr(tables, f"{table}s").metadata_schema) == repr(schema)
             for other_table in self.metadata_tables:
                 if other_table != table:
                     assert (
-                        str(getattr(new_ts.table_metadata_schemas, other_table)) == ""
+                        repr(getattr(tables, f"{other_table}s").metadata_schema) == ""
+                    )
+            # Check via tree-sequence API
+            new_ts = tskit.TreeSequence.load_tables(tables)
+            assert repr(getattr(new_ts.table_metadata_schemas, table)) == repr(schema)
+            for other_table in self.metadata_tables:
+                if other_table != table:
+                    assert (
+                        repr(getattr(new_ts.table_metadata_schemas, other_table)) == ""
                     )
             # Can't set schema via this API
             with pytest.raises(AttributeError):

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -28,6 +28,7 @@ import io
 import json
 import os
 import pickle
+import pprint
 import struct
 import tempfile
 import unittest
@@ -318,10 +319,21 @@ class TestMetadataModule:
             "additionalProperties": False,
         }
         ms = metadata.MetadataSchema(schema)
-        assert str(ms) == tskit.canonical_json(schema)
+        assert repr(ms) == tskit.canonical_json(schema)
         # Missing required properties
         with pytest.raises(exceptions.MetadataValidationError):
             ms.validate_and_encode_row({})
+
+    def test_schema_str(self):
+        schema = {
+            "codec": "json",
+            "title": "Example Metadata",
+            "type": "object",
+            "properties": {"one": {"type": "string"}, "two": {"type": "number"}},
+            "required": ["one", "two"],
+            "additionalProperties": False,
+        }
+        assert str(metadata.MetadataSchema(schema)) == pprint.pformat(schema)
 
     def test_register_codec(self):
         class TestCodec(metadata.AbstractMetadataCodec):
@@ -367,7 +379,7 @@ class TestMetadataModule:
             codec="json",
         )
         assert json.dumps(schema) != json.dumps(schema2)
-        assert str(metadata.MetadataSchema(schema)) == str(
+        assert repr(metadata.MetadataSchema(schema)) == repr(
             metadata.MetadataSchema(schema2)
         )
 
@@ -433,7 +445,7 @@ class TestMetadataModule:
 
     def test_null_codec(self):
         ms = metadata.MetadataSchema(None)
-        assert str(ms) == ""
+        assert repr(ms) == ""
         row = b"Some binary data that tskit can't interpret "
         # Encode/decode are no-ops
         assert row == ms.validate_and_encode_row(row)

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -725,19 +725,19 @@ class MetadataTestsMixin:
         metadata_schema2 = metadata.MetadataSchema({"codec": "json"})
         table = self.table_class()
         # Default is no-op metadata codec
-        assert str(table.metadata_schema) == str(metadata.MetadataSchema(None))
+        assert repr(table.metadata_schema) == repr(metadata.MetadataSchema(None))
         # Set
         table.metadata_schema = self.metadata_schema
-        assert str(table.metadata_schema) == str(self.metadata_schema)
+        assert repr(table.metadata_schema) == repr(self.metadata_schema)
         # Overwrite
         table.metadata_schema = metadata_schema2
-        assert str(table.metadata_schema) == str(metadata_schema2)
+        assert repr(table.metadata_schema) == repr(metadata_schema2)
         # Remove
-        table.metadata_schema = ""
-        assert str(table.metadata_schema) == str(metadata.MetadataSchema(None))
+        table.metadata_schema = metadata.MetadataSchema(None)
+        assert repr(table.metadata_schema) == repr(metadata.MetadataSchema(None))
         # Set after remove
         table.metadata_schema = self.metadata_schema
-        assert str(table.metadata_schema) == str(self.metadata_schema)
+        assert repr(table.metadata_schema) == repr(self.metadata_schema)
         # Del should fail
         with pytest.raises(AttributeError):
             del table.metadata_schema
@@ -2289,7 +2289,7 @@ class TestTableCollection:
         d1 = {
             "encoding_version": (1, 2),
             "sequence_length": t.sequence_length,
-            "metadata_schema": str(t.metadata_schema),
+            "metadata_schema": repr(t.metadata_schema),
             "metadata": t.metadata_schema.encode_row(t.metadata),
             "individuals": t.individuals.asdict(),
             "populations": t.populations.asdict(),
@@ -2320,7 +2320,7 @@ class TestTableCollection:
         d = {
             "encoding_version": (1, 1),
             "sequence_length": t1.sequence_length,
-            "metadata_schema": str(t1.metadata_schema),
+            "metadata_schema": repr(t1.metadata_schema),
             "metadata": t1.metadata_schema.encode_row(t1.metadata),
             "individuals": t1.individuals.asdict(),
             "populations": t1.populations.asdict(),
@@ -2389,27 +2389,27 @@ class TestTableCollection:
         ]
         for table in data_tables:
             assert getattr(tables, f"{table}").num_rows == 0
-            assert str(getattr(tables, f"{table}").metadata_schema) != ""
+            assert repr(getattr(tables, f"{table}").metadata_schema) != ""
         assert tables.provenances.num_rows > 0
         assert len(tables.metadata) > 0
-        assert str(tables.metadata_schema) != ""
+        assert repr(tables.metadata_schema) != ""
 
         tables.clear(clear_provenance=True)
         assert tables.provenances.num_rows == 0
         for table in data_tables:
-            assert str(getattr(tables, f"{table}").metadata_schema) != ""
+            assert repr(getattr(tables, f"{table}").metadata_schema) != ""
         assert len(tables.metadata) > 0
-        assert str(tables.metadata_schema) != ""
+        assert repr(tables.metadata_schema) != ""
 
         tables.clear(clear_metadata_schemas=True)
         for table in data_tables:
-            assert str(getattr(tables, f"{table}").metadata_schema) == ""
+            assert repr(getattr(tables, f"{table}").metadata_schema) == ""
         assert len(tables.metadata) > 0
-        assert str(tables.metadata_schema) != 0
+        assert repr(tables.metadata_schema) != 0
 
         tables.clear(clear_ts_metadata_and_schema=True)
         assert len(tables.metadata) == 0
-        assert str(tables.metadata_schema) == ""
+        assert repr(tables.metadata_schema) == ""
 
     def test_equals(self):
         # Here we don't use the fixture as we'd like to run the same sim twice
@@ -2840,19 +2840,19 @@ class TestTableCollectionMetadata:
         tc = tskit.TableCollection(1)
         metadata_schema2 = metadata.MetadataSchema({"codec": "json"})
         # Default is no-op metadata codec
-        assert str(tc.metadata_schema) == str(metadata.MetadataSchema(None))
+        assert repr(tc.metadata_schema) == repr(metadata.MetadataSchema(None))
         # Set
         tc.metadata_schema = self.metadata_schema
-        assert str(tc.metadata_schema) == str(self.metadata_schema)
+        assert repr(tc.metadata_schema) == repr(self.metadata_schema)
         # Overwrite
         tc.metadata_schema = metadata_schema2
-        assert str(tc.metadata_schema) == str(metadata_schema2)
+        assert repr(tc.metadata_schema) == repr(metadata_schema2)
         # Remove
-        tc.metadata_schema = ""
-        assert str(tc.metadata_schema) == str(metadata.MetadataSchema(None))
+        tc.metadata_schema = metadata.MetadataSchema(None)
+        assert repr(tc.metadata_schema) == repr(metadata.MetadataSchema(None))
         # Set after remove
         tc.metadata_schema = self.metadata_schema
-        assert str(tc.metadata_schema) == str(self.metadata_schema)
+        assert repr(tc.metadata_schema) == repr(self.metadata_schema)
         # Del should fail
         with pytest.raises(AttributeError):
             del tc.metadata_schema

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -26,6 +26,7 @@ import abc
 import collections
 import copy
 import json
+import pprint
 import struct
 from itertools import islice
 from typing import Any
@@ -530,8 +531,11 @@ class MetadataSchema:
             self.encode_row = codec_instance.encode
             self.decode_row = codec_instance.decode
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return self._string
+
+    def __str__(self) -> str:
+        return pprint.pformat(self._schema)
 
     def __eq__(self, other) -> bool:
         return self._string == other._string

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -326,7 +326,7 @@ class BaseTable:
         ret = {col: getattr(self, col) for col in self.column_names}
         # Not all tables have metadata
         try:
-            ret["metadata_schema"] = str(self.metadata_schema)
+            ret["metadata_schema"] = repr(self.metadata_schema)
         except AttributeError:
             pass
         return ret
@@ -411,7 +411,8 @@ class MetadataMixin:
 
     @metadata_schema.setter
     def metadata_schema(self, schema: metadata.MetadataSchema) -> None:
-        self.ll_table.metadata_schema = str(schema)
+        self.ll_table.metadata_schema = repr(schema)
+        self._update_metadata_schema_cache_from_ll()
         self._update_metadata_schema_cache_from_ll()
 
     def decode_row(self, row: Tuple[Any]) -> Tuple:
@@ -2135,8 +2136,8 @@ class TableCollection:
     @metadata_schema.setter
     def metadata_schema(self, schema: metadata.MetadataSchema) -> None:
         # Check the schema is a valid schema instance by roundtripping it.
-        metadata.parse_metadata_schema(str(schema))
-        self._ll_tables.metadata_schema = str(schema)
+        metadata.parse_metadata_schema(repr(schema))
+        self._ll_tables.metadata_schema = repr(schema)
 
     @property
     def metadata(self) -> Any:
@@ -2168,7 +2169,7 @@ class TableCollection:
         ret = {
             "encoding_version": (1, 2),
             "sequence_length": self.sequence_length,
-            "metadata_schema": str(self.metadata_schema),
+            "metadata_schema": repr(self.metadata_schema),
             "metadata": self.metadata_schema.encode_row(self.metadata),
             "individuals": self.individuals.asdict(),
             "nodes": self.nodes.asdict(),
@@ -2211,7 +2212,7 @@ class TableCollection:
             (
                 8,  # sequence_length takes 8 bytes
                 len(self.metadata_bytes),
-                len(str(self.metadata_schema).encode()),
+                len(repr(self.metadata_schema).encode()),
                 self.indexes.nbytes,
                 sum(table.nbytes for table in self.name_map.values()),
             )


### PR DESCRIPTION
Fixes #1074

This didn't quite seem to warrant a changelog, happy to add one though if anyone thinks otherwise.