### PR TITLE
Add kwargs to tree creation functions

### DIFF
--- a/python/tests/test_combinatorics.py
+++ b/python/tests/test_combinatorics.py
@@ -1255,6 +1255,11 @@ class TestPolytomySplitting:
         record = json.loads(ts_split.provenance(ts_split.num_provenances - 1).record)
         assert record["parameters"]["command"] != "split_polytomies"
 
+    def test_kwargs(self):
+        tree = self.tree_polytomy_4()
+        split_tree = tree.split_polytomies(random_seed=14, tracked_samples=[0, 1])
+        assert split_tree.num_tracked_samples() == 2
+
 
 class TreeGeneratorTestBase:
     """
@@ -1315,6 +1320,10 @@ class TreeGeneratorTestBase:
         tables1 = tree1.tree_sequence.tables
         tables2 = tree2.tree_sequence.tables
         assert tables1.equals(tables2, ignore_provenance=True)
+
+    def test_kwargs(self):
+        tree = self.method(3, tracked_samples=[0, 1])
+        assert tree.num_tracked_samples() == 2
 
 
 class TestGenerateStar(TreeGeneratorTestBase):

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -127,7 +127,7 @@ class TreeNode:
         return root
 
 
-def generate_star(num_leaves, *, span, branch_length, record_provenance):
+def generate_star(num_leaves, *, span, branch_length, record_provenance, **kwargs):
     """
     Generate a star tree for the specified number of leaves.
 
@@ -155,10 +155,10 @@ def generate_star(num_leaves, *, span, branch_length, record_provenance):
         tables.provenances.add_row(
             record=json.dumps(tskit.provenance.get_provenance_dict(parameters))
         )
-    return tables.tree_sequence().first()
+    return tables.tree_sequence().first(**kwargs)
 
 
-def generate_comb(num_leaves, *, span, branch_length, record_provenance):
+def generate_comb(num_leaves, *, span, branch_length, record_provenance, **kwargs):
     """
     Generate a comb tree for the specified number of leaves.
 
@@ -188,10 +188,12 @@ def generate_comb(num_leaves, *, span, branch_length, record_provenance):
         tables.provenances.add_row(
             record=json.dumps(tskit.provenance.get_provenance_dict(parameters))
         )
-    return tables.tree_sequence().first()
+    return tables.tree_sequence().first(**kwargs)
 
 
-def generate_balanced(num_leaves, *, arity, span, branch_length, record_provenance):
+def generate_balanced(
+    num_leaves, *, arity, span, branch_length, record_provenance, **kwargs
+):
     """
     Generate a balanced tree for the specified number of leaves.
 
@@ -233,7 +235,7 @@ def generate_balanced(num_leaves, *, arity, span, branch_length, record_provenan
             record=json.dumps(tskit.provenance.get_provenance_dict(parameters))
         )
 
-    return tables.tree_sequence().first()
+    return tables.tree_sequence().first(**kwargs)
 
 
 def split_polytomies(
@@ -243,6 +245,7 @@ def split_polytomies(
     method=None,
     record_provenance=True,
     random_seed=None,
+    **kwargs,
 ):
     """
     Return a new tree where extra nodes and edges have been inserted
@@ -306,7 +309,7 @@ def split_polytomies(
             )
 
         raise e
-    return ts.at(tree.interval[0])
+    return ts.at(tree.interval[0], **kwargs)
 
 
 def treeseq_count_topologies(ts, sample_sets):

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2392,6 +2392,7 @@ class Tree:
         method=None,
         record_provenance=True,
         random_seed=None,
+        **kwargs,
     ):
         """
         Return a new :class:`.Tree` where extra nodes and edges have been inserted
@@ -2433,6 +2434,10 @@ class Tree:
         :param int random_seed: The random seed. If this is None, a random seed will
             be automatically generated. Valid random seeds must be between 1 and
             :math:`2^32 − 1`.
+        :param \\**kwargs: Further arguments used as parameters when constructing the
+            returned :class:`Tree`. For example
+            ``tree.split_polytomies(sample_lists=True)`` will
+            return a :class:`Tree` created with ``sample_lists=True``.
         :return: A new tree with polytomies split into random bifurcations.
         :rtype: tskit.Tree
         """
@@ -2442,10 +2447,13 @@ class Tree:
             method=method,
             record_provenance=record_provenance,
             random_seed=random_seed,
+            **kwargs,
         )
 
     @staticmethod
-    def generate_star(num_leaves, *, span=1, branch_length=1, record_provenance=True):
+    def generate_star(
+        num_leaves, *, span=1, branch_length=1, record_provenance=True, **kwargs
+    ):
         """
         Generate a :class:<Tree> whose leaf nodes all have the same parent (i.e.
         a "star" tree). The leaf nodes are all at time 0 and are marked as sample nodes.
@@ -2460,6 +2468,12 @@ class Tree:
             property of the returned :class:<Tree>.
         :param float branch_length: The length of every branch in the tree (equivalent
             to the time of the root node).
+        :param bool record_provenance: If True, add details of this operation to the
+            provenance information of the returned tree sequence. (Default: True).
+        :param \\**kwargs: Further arguments used as parameters when constructing the
+            returned :class:`Tree`. For example
+            ``tskit.Tree.generate_star(sample_lists=True)`` will
+            return a :class:`Tree` created with ``sample_lists=True``.
         :return: A star-shaped tree. Its corresponding :class:`TreeSequence` is available
             via the :attr:`.tree_sequence` attribute.
         :rtype: Tree
@@ -2469,11 +2483,18 @@ class Tree:
             span=span,
             branch_length=branch_length,
             record_provenance=record_provenance,
+            **kwargs,
         )
 
     @staticmethod
     def generate_balanced(
-        num_leaves, *, arity=2, span=1, branch_length=1, record_provenance=True
+        num_leaves,
+        *,
+        arity=2,
+        span=1,
+        branch_length=1,
+        record_provenance=True,
+        **kwargs,
     ):
         """
         Generate a :class:<Tree> with the specified number of leaves that is maximally
@@ -2498,6 +2519,12 @@ class Tree:
             property of the returned :class:<Tree>.
         :param float branch_length: The minimum length of a branch in the tree (see
             above for details on how internal node times are assigned).
+        :param bool record_provenance: If True, add details of this operation to the
+            provenance information of the returned tree sequence. (Default: True).
+        :param \\**kwargs: Further arguments used as parameters when constructing the
+            returned :class:`Tree`. For example
+            ``tskit.Tree.generate_balanced(sample_lists=True)`` will
+            return a :class:`Tree` created with ``sample_lists=True``.
         :return: A balanced tree. Its corresponding :class:`TreeSequence` is available
             via the :attr:`.tree_sequence` attribute.
         :rtype: Tree
@@ -2508,10 +2535,13 @@ class Tree:
             span=span,
             branch_length=branch_length,
             record_provenance=record_provenance,
+            **kwargs,
         )
 
     @staticmethod
-    def generate_comb(num_leaves, *, span=1, branch_length=1, record_provenance=True):
+    def generate_comb(
+        num_leaves, *, span=1, branch_length=1, record_provenance=True, **kwargs
+    ):
         """
         Generate a :class:<Tree> in which all internal nodes have two children
         and the left child is a leaf. This is a "comb", "ladder" or "pectinate"
@@ -2530,6 +2560,12 @@ class Tree:
             property of the returned :class:<Tree>.
         :param float branch_length: The branch length between each internal node; the
             root node is therefore placed at time ``branch_length * (num_leaves - 1)``.
+        :param bool record_provenance: If True, add details of this operation to the
+            provenance information of the returned tree sequence. (Default: True).
+        :param \\**kwargs: Further arguments used as parameters when constructing the
+            returned :class:`Tree`. For example
+            ``tskit.Tree.generate_comb(sample_lists=True)`` will
+            return a :class:`Tree` created with ``sample_lists=True``.
         :return: A comb-shaped bifurcating tree. Its corresponding :class:`TreeSequence`
             is available via the :attr:`.tree_sequence` attribute.
         :rtype: Tree
@@ -2539,6 +2575,7 @@ class Tree:
             span=span,
             branch_length=branch_length,
             record_provenance=record_provenance,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
## Description

Add kwargs to `tskit.Tree.generate_XXX` and `tskit.Tree.split_polytomies()` functions. Probably not worth a changelog entry?
Also noticed that the documentation for record_provenance in generate_XXX was missing, so I added that too.

Fixes #1082
# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
