### PR TITLE
Change default in split_polytomies to use nextafter.

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,4 +1,14 @@
 --------------------
+[0.3.5] - 2021-XX-XX
+--------------------
+
+**Features**
+
+- Change the default behaviour of Tree.split_polytomies to generate
+  the shortest possible branch lengths instead of a fixed epsilon of
+  1e-10. (:user:`jeromekelleher`, :issue:`1089`, :pr:`1090`)
+
+--------------------
 [0.3.4] - 2020-12-02
 --------------------
 

--- a/python/tskit/_version.py
+++ b/python/tskit/_version.py
@@ -1,4 +1,4 @@
 # Definitive location for the version number.
 # During development, should be x.y.z.devN
 # For beta should be x.y.zbN
-tskit_version = "0.3.4"
+tskit_version = "0.3.5.dev1"

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2398,8 +2398,25 @@ class Tree:
         Return a new :class:`.Tree` where extra nodes and edges have been inserted
         so that any any node ``u`` with greater than 2 children --- a multifurcation
         or "polytomy" --- is resolved into successive bifurcations. New nodes are
-        inserted at times fractionally less than than the time of node ``u``
-        (controlled by the ``epsilon`` parameter).
+        inserted at times fractionally less than than the time of node ``u``.
+        Times are allocated to different levels of the tree, such that any newly
+        inserted sibling nodes will have the same time.
+
+        By default, the times of the newly generated children of a particular
+        node are the minimum representable distance in floating point arithmetic
+        from their parents (using the `nextafter
+        <https://numpy.org/doc/stable/reference/generated/numpy.nextafter.html>`_
+        function). Thus, the generated branches have the shortest possible nonzero
+        length. A fixed branch length between inserted nodes and their parents
+        can also be specified by using the ``epsilon`` parameter.
+
+        .. note::
+            A tree sequence :ref:`requires<sec_valid_tree_sequence_requirements>` that
+            parents be older than children and that mutations are younger than the
+            parent of the edge on which they lie. If a fixed ``epsilon`` is specifed
+            and is not small enough compared to the distance between a polytomy and
+            its oldest child (or oldest child mutation) these requirements may not
+            be met. In this case an error will be raised.
 
         If the ``method`` is ``"random"`` (currently the only option, and the default
         when no method is specified), then for a node with :math:`n` children, the
@@ -2412,20 +2429,9 @@ class Tree:
         tree sequence that contains only one non-degenerate tree, that is, where
         edges cover only the interval spanned by this tree.
 
-        .. note::
-            A tree sequence :ref:`requires<sec_valid_tree_sequence_requirements>` that
-            parents be older than children and that mutations are younger than the
-            parent of the edge on which they lie. If ``epsilon`` is not small enough,
-            compared to the distance between a polytomy and its oldest child (or oldest
-            child mutation) these requirements may not be met. In this case an error is
-            raised, recommending a smaller epsilon value be used.
-
-        :param epsilon: A small time period used to separate each newly inserted node.
-            For a given polytomy of degree :math:`n`, the :math:`n-2` extra nodes are
-            inserted with the oldest at time ``epsilon`` less than the original parent,
-            ``u``, and successive nodes at time ``epsilon`` from each other. Times
-            are allocated to different levels of the tree, such that any newly
-            inserted sibling nodes will have the same time. (Default :math:`1e-10`).
+        :param epsilon: If specified, the fixed branch length between inserted
+            nodes and their parents. If None (the default), the minimal possible
+            nonzero branch length is generated for each node.
         :param str method: The method used to break polytomies. Currently only "random"
             is supported, which can also be specified by ``method=None``
             (Default: ``None``).


### PR DESCRIPTION
Generate the shortest possible branches when splitting polytomies, by default. This will be much more robust to different scales than the old fixed-size default, and, think, is about as good as you can do, ever.

I've also put some effort into making good error messages to allow people debug what happens when this goes wrong, which is extremely fiddly. Having worked with this a bit now and pushed it to it's limits, I don't really see a good reason for ever using the fixed epsilon, unless that's really what you want to do and you intend to put multiple mutations on the branches.

Supersedes #1089

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
