### PR TITLE
Time join

### DIFF
--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2976,6 +2976,7 @@ class TableCollection:
         self,
         other,
         node_mapping,
+        offset_time=None,
         check_shared_equality=True,
         add_populations=True,
         record_provenance=True,
@@ -2994,6 +2995,7 @@ class TableCollection:
             should be the index of the equivalent node in ``self``, or
             ``tskit.NULL`` if the node is not present in ``self`` (in which case it
             will be added to self).
+        :param float offset_time: Time to offset ``other`` by
         :param bool check_shared_equality: If True, the shared portions of the
             table collections will be checked for equality.
         :param bool add_populations: If True, nodes new to ``self`` will be
@@ -3002,6 +3004,10 @@ class TableCollection:
             in the provenance table for this operation.
         """
         node_mapping = util.safe_np_int_cast(node_mapping, np.int32)
+
+        # adjust table time
+        # adjust sample flags
+
         self._ll_tables.union(
             other._ll_tables,
             node_mapping,


### PR DESCRIPTION
@petrelharp @jeromekelleher - here's the new PR

Initial implementation of the time join functionality in tskit (instead of msprime or pyslim). Posting as a draft so you can hopefully take a look as I work on the tests! And copying over my (slightly edited) description for others' reference (discussion can be found on [msprime here](https://github.com/tskit-dev/msprime/pull/1347) and [pyslim here](https://github.com/tskit-dev/pyslim/pull/118)). 

In using pyslim, I found the process described in ["Vignette: Following up with more coalescent simulation" ](https://pyslim.readthedocs.io/en/latest/vignette_continuing.html)incredibly useful. To make it more accessible for all tree sequences instead of just those generated using SLiM or msprime, I added it to tskit as a `TableCollection` method called `time_join`. It is all contained in the high level python right now, although a C implementation could be useful long term.

It takes in a "recent" and an "ancient" `TreeSequence` and the length of time to separate them by before joining. It outputs a complete tree sequence, containing the entirety of both `TreeSequence` objects. It uses two helper methods for now, `set_time`, which performs the time adjustment on the tables, and `set_flags`, which removes the sample flags on the "ancient" `TreeSequence` (and could also be used to place sample flags in other cases)

The initial use described in the example taking a tree sequence produced by SLiM, recapitating, adding mutations, and continuing the simulation, but this could be done with any tree sequences.