### PR TITLE
Add KEEP_UNARY_IN_INDIVIDUALS option to simplify()

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -6,6 +6,10 @@
 
 **Features**
 
+- Add ``TSK_KEEP_UNARY_IN_INDIVIDUALS`` flag to simplify, which allows the user to
+  keep unary nodes only if they belong to a tabled individual. This is useful for
+  simplification in forwards simulations (:user:`hyanwong`, :issue:`1113`, :pr:`1119`).
+
 **Bugfixes**
 
 

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -470,6 +470,11 @@ tsk_strerror_internal(int err)
         case TSK_ERR_DUPLICATE_SAMPLE_PAIRS:
             ret = "There are duplicate sample pairs.";
             break;
+
+        /* Simplify errors */
+        case TSK_ERR_KEEP_UNARY_MUTUALLY_EXCLUSIVE:
+            ret = "You cannot specify both KEEP_UNARY and KEEP_UNARY_IN_INDIVDUALS.";
+            break;
     }
     return ret;
 }

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -320,6 +320,9 @@ not found in the file.
 #define TSK_ERR_NO_SAMPLE_PAIRS                                    -1500
 #define TSK_ERR_DUPLICATE_SAMPLE_PAIRS                             -1501
 
+/* Simplify errors */
+#define TSK_ERR_KEEP_UNARY_MUTUALLY_EXCLUSIVE                      -1600
+
 // clang-format on
 
 /* This bit is 0 for any errors originating from kastore */

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -693,6 +693,7 @@ typedef struct {
 #define TSK_REDUCE_TO_SITE_TOPOLOGY (1 << 3)
 #define TSK_KEEP_UNARY (1 << 4)
 #define TSK_KEEP_INPUT_ROOTS (1 << 5)
+#define TSK_KEEP_UNARY_IN_INDIVIDUALS (1 << 6)
 
 /* Flags for check_integrity */
 #define TSK_CHECK_EDGE_ORDERING (1 << 0)
@@ -2671,6 +2672,9 @@ TSK_KEEP_INPUT_ROOTS
     By default simplify removes all topology ancestral the MRCAs of the samples.
     This option inserts edges from these MRCAs back to the roots of the input
     trees.
+TSK_KEEP_UNARY_IN_INDIVDUALS
+    This acts like TSK_KEEP_UNARY (and is mutually exclusive with that flag). It
+    keeps unary nodes, but only if the unary node is referenced from an individual.
 
 .. note:: Migrations are currently not supported by simplify, and an error will
     be raised if we attempt call simplify on a table collection with greater


### PR DESCRIPTION
## Description

Adds KEEP_UNARY_IN_INDIVIDUALS option to simplify()

Fixes #1113 

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
