### PR TITLE
add convenience data member samples for vargen

### DIFF
--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -159,6 +159,7 @@ tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
     memset(self, 0, sizeof(tsk_vargen_t));
 
     if (samples == NULL) {
+        self->samples = tsk_treeseq_get_samples(tree_sequence);
         self->num_samples = tsk_treeseq_get_num_samples(tree_sequence);
         self->sample_index_map = tsk_treeseq_get_sample_index_map(tree_sequence);
         num_samples_alloc = self->num_samples;
@@ -171,6 +172,7 @@ tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
         if (ret != 0) {
             goto out;
         }
+        self->samples = samples;
         self->num_samples = num_samples;
         self->sample_index_map = self->alt_sample_index_map;
     }

--- a/c/tskit/genotypes.h
+++ b/c/tskit/genotypes.h
@@ -52,9 +52,8 @@ typedef struct {
     size_t num_samples;
     size_t num_sites;
     const tsk_treeseq_t *tree_sequence;
-    const tsk_id_t *sample_index_map;
-    tsk_id_t *alt_samples;
-    tsk_id_t *alt_sample_index_map;
+    const tsk_id_t *samples;          /* samples being used */
+    const tsk_id_t *sample_index_map; /* reverse index map being used */
     bool user_alleles;
     char *user_alleles_mem;
     size_t tree_site_index;
@@ -63,6 +62,9 @@ typedef struct {
     tsk_tree_t tree;
     tsk_flags_t options;
     tsk_variant_t variant;
+    // private: the following data members are not intended to be used externally
+    tsk_id_t *alt_samples; /* alternative subset of samples to use */
+    tsk_id_t *alt_sample_index_map;
 } tsk_vargen_t;
 
 int tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,


### PR DESCRIPTION
This is a follow up to compile problem discussed in #slim Slack channel.

The `sample` data member of `tsk_vargen_t` was removed during the 'consitifcation' of the codebase. This breaks some code in SLiM and might break other code that expects this data member to be present. This PR should fix this breaking of backwards of compatibility.

HOWEVER, technically, the SLiM code that got broken probably doesn't need this data member and probably doesn't want to use using `tsk_vargen_t` in the way it's been using it which expects a `sample` data member. @bhaller is considering what change, *if any*, to make in SLiM based on this new info.

Regardless, this breaking of backwards compatibility begs the question whether this PR should get merged regardless of what SLiM does in this particular case.

This issue gets slightly more complicated regarding the renaming of the original data member to `alt_samples` but I think thsi is actually an orthogonal issue. The `alt_samples` data member is essentially a private implementation detail of vargen and it would be ideal if clients do not rely on it.

Additional tasks to likely add to this PR:

- [x] comments about what the heck is `alt_samples` etc...
- [x] some kind of indication that `alt_sample` should be private

