### PR TITLE
add keep_unary_in_individuals to python and test

### DIFF
--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -4960,16 +4960,17 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     int filter_individuals = false;
     int filter_populations = false;
     int keep_unary = false;
+    int keep_unary_in_individuals = false;
     int keep_input_roots = false;
     int reduce_to_site_topology = false;
-    static char *kwlist[]
-        = { "samples", "filter_sites", "filter_populations", "filter_individuals",
-              "reduce_to_site_topology", "keep_unary", "keep_input_roots", NULL };
+    static char *kwlist[] = { "samples", "filter_sites", "filter_populations",
+        "filter_individuals", "reduce_to_site_topology", "keep_unary",
+        "keep_unary_in_indivdiuals", "keep_input_roots", NULL };
 
     if (TableCollection_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiiii", kwlist, &samples,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiiiii", kwlist, &samples,
             &filter_sites, &filter_populations, &filter_individuals,
             &reduce_to_site_topology, &keep_unary, &keep_input_roots)) {
         goto out;
@@ -4995,6 +4996,9 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     if (keep_unary) {
         options |= TSK_KEEP_UNARY;
+    }
+    if (keep_unary_in_individuals) {
+        options |= TSK_KEEP_UNARY_IN_INDIVIDUALS;
     }
     if (keep_input_roots) {
         options |= TSK_KEEP_INPUT_ROOTS;

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -264,6 +264,8 @@ class TestTableCollection(LowLevelTestCase):
         with pytest.raises(TypeError):
             tc.simplify([0, 1], keep_unary="sdf")
         with pytest.raises(TypeError):
+            tc.simplify([0, 1], keep_unary_in_individuals="abc")
+        with pytest.raises(TypeError):
             tc.simplify([0, 1], keep_input_roots="sdf")
         with pytest.raises(TypeError):
             tc.simplify([0, 1], filter_populations="x")

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2455,6 +2455,7 @@ class TableCollection:
         filter_individuals=True,
         filter_sites=True,
         keep_unary=False,
+        keep_unary_in_individuals=False,
         keep_input_roots=False,
         record_provenance=True,
         filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
@@ -2503,6 +2504,7 @@ class TableCollection:
         :param bool keep_unary: If True, any unary nodes (i.e. nodes with exactly
             one child) that exist on the path from samples to root will be preserved
             in the output. (Default: False)
+        :param bool keep_unary_in_individuals: TODO DOCUMENT
         :param bool keep_input_roots: If True, insert edges from the MRCAs of the
             samples to the roots in the input trees. If False, no topology older
             than the MRCAs of the samples will be included. (Default: False)
@@ -2535,6 +2537,7 @@ class TableCollection:
             filter_populations=filter_populations,
             reduce_to_site_topology=reduce_to_site_topology,
             keep_unary=keep_unary,
+            keep_unary_in_individuals=keep_unary_in_individuals,
             keep_input_roots=keep_input_roots,
         )
         if record_provenance:

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4897,6 +4897,7 @@ class TreeSequence:
         filter_individuals=True,
         filter_sites=True,
         keep_unary=False,
+        keep_unary_in_individuals=False,
         keep_input_roots=False,
         record_provenance=True,
         filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
@@ -4982,6 +4983,7 @@ class TreeSequence:
             filter_individuals=filter_individuals,
             filter_sites=filter_sites,
             keep_unary=keep_unary,
+            keep_unary_in_individuals=keep_unary_in_individuals,
             keep_input_roots=keep_input_roots,
             record_provenance=record_provenance,
             filter_zero_mutation_sites=filter_zero_mutation_sites,


### PR DESCRIPTION
Will close #1120; see discussion there; just getting things started.

In particular, I like the idea of having `keep_unary=(True|False|"individuals")`, though - seems appropriate, given that keep_unary_individuals should give a strict subset of keep_unary, and extensible.  Were I to do this, I'd keep the low-level interface the same, and just do the translation in the python `TableCollection.simplify` code.