### PR TITLE
Svg improvements

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,9 @@
 
 **Features**
 
+- SVG visualization now uses red crosses for mutations, and squares for sample nodes
+  (:user:`hyanwong`,:issue:`1155`, :pr:`1182`).
+
 - Add ``parents`` column to the individual table to allow recording of pedigrees
   (:user:`ivan-krukov`, :user:`benjeffery`, :issue:`852`, :pr:`1125`, :pr:`866`, :pr:`1153`, :pr:`1177`).
 

--- a/python/tests/data/svg/internal_sample_ts.svg
+++ b/python/tests/data/svg/internal_sample_ts.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="123" version="1.1" width="200">
+	<defs>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.mut text {fill: red; font-style: italic}.mut .sym {stroke: red; stroke-width: 1.5px}.leaf .sym {fill: green} .sample .sym {fill: cyan}]]></style>
+	</defs>
+	<g class="tree-sequence">
+		<g class="background">
+			<path d="M20,0 l160,0 l0,160 l0,20 l0,5 l-160,0 l0,-5 l0,-20 l0,-160z"/>
+		</g>
+		<g class="trees">
+			<g class="treebox t0" transform="translate(20 30)">
+				<g class="tree t0">
+					<g class="node n8 p0 root" transform="translate(82.9167 30.0)">
+						<g class="a8 m3 node n6 p0 s3 sample" transform="translate(32.0833 66.9136)">
+							<g class="a6 leaf m1 node n1 p0 s1" transform="translate(-11.6667 13.0864)">
+								<path class="edge" d="M 0 0 V -13.0864 H 11.6667"/>
+								<circle class="sym" cx="0" cy="0" r="3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+								<g class="mut m1 s1" transform="translate(0 -6.54322)">
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab lft" transform="translate(-5 0)">1</text>
+								</g>
+							</g>
+							<g class="a6 leaf node n2 p0 sample" transform="translate(11.6667 13.0864)">
+								<path class="edge" d="M 0 0 V -13.0864 H -11.6667"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<path class="edge" d="M 0 0 V -66.9136 H -32.0833"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab rgt" transform="translate(3 -6)">6</text>
+							<g class="mut m3 s3" transform="translate(0 -33.4568)">
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab rgt" transform="translate(5 0)">3</text>
+							</g>
+						</g>
+						<g class="a8 m5 node n7 p0 s5" transform="translate(-32.0833 43.8482)">
+							<g class="a7 leaf node n0 p0" transform="translate(-17.5 36.1518)">
+								<path class="edge" d="M 0 0 V -36.1518 H 17.5"/>
+								<circle class="sym" cx="0" cy="0" r="3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a7 m0 m2 m4 node n5 p0 s0 s2 s4 sample" transform="translate(17.5 28.7618)">
+								<g class="a5 leaf node n3 p0 sample" transform="translate(-11.6667 7.39)">
+									<path class="edge" d="M 0 0 V -7.39 H 11.6667"/>
+									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+									<text class="lab" transform="translate(0 12)">3</text>
+								</g>
+								<g class="a5 leaf node n4 p0 sample" transform="translate(11.6667 7.39)">
+									<path class="edge" d="M 0 0 V -7.39 H -11.6667"/>
+									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+									<text class="lab" transform="translate(0 12)">4</text>
+								</g>
+								<path class="edge" d="M 0 0 V -28.7618 H -17.5"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab rgt" transform="translate(3 -6)">5</text>
+								<g class="mut m4 s4" transform="translate(0 -7.19046)">
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">4</text>
+								</g>
+								<g class="mut m2 s2" transform="translate(0 -14.3809)">
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">2</text>
+								</g>
+								<g class="mut m0 s0" transform="translate(0 -21.5714)">
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">0</text>
+								</g>
+							</g>
+							<path class="edge" d="M 0 0 V -43.8482 H 32.0833"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">7</text>
+							<g class="mut m5 s5" transform="translate(0 -21.9241)">
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">5</text>
+							</g>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab" transform="translate(0 -10)">8</text>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g class="axis">
+			<line x1="20" x2="180" y1="180" y2="180"/>
+			<line x1="20" x2="20" y1="180" y2="185"/>
+			<g transform="translate(20, 200)">
+				<text font-size="14" font-weight="bold" text-anchor="middle">0</text>
+			</g>
+			<line x1="180.0" x2="180.0" y1="180" y2="185"/>
+			<g transform="translate(180.0, 200)">
+				<text font-size="14" font-weight="bold" text-anchor="middle">1</text>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tests/data/svg/mut_tree.svg
+++ b/python/tests/data/svg/mut_tree.svg
@@ -1,39 +1,38 @@
 <?xml version="1.0" ?>
-<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="200">
 	<defs>
-		<style type="text/css">
-<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle}.edge {stroke: black; fill: none}.node > .sym {fill: black; stroke: none}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.mut {fill: red; font-style: italic}.edge {stroke: blue}]]>		</style>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree t0">
 		<g class="m0 m1 node n9 p0 root s0" transform="translate(100.0 50.0)">
 			<g class="a9 m2 node n4 p0 s0" transform="translate(-36.0 119.677)">
 				<g class="a4 leaf node n0 p0 sample" transform="translate(-18.0 0.32302)">
 					<path class="edge" d="M 0 0 V -0.32302 H 18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">0</text>
 				</g>
 				<g class="a4 leaf node n1 p0 sample" transform="translate(18.0 0.32302)">
 					<path class="edge" d="M 0 0 V -0.32302 H -18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">1</text>
 				</g>
 				<path class="edge" d="M 0 0 V -119.677 H 36.0"/>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab lft" transform="translate(-3 -6)">4</text>
 				<g class="mut m2 s0" transform="translate(0 -59.8385)">
-					<rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+					<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 					<text class="lab lft" transform="translate(-5 0)">2</text>
 				</g>
 			</g>
 			<g class="a9 node n5 p0" transform="translate(36.0 118.538)">
 				<g class="a5 leaf node n2 p0 sample" transform="translate(-18.0 1.46223)">
 					<path class="edge" d="M 0 0 V -1.46223 H 18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">2</text>
 				</g>
 				<g class="a5 leaf node n3 p0 sample" transform="translate(18.0 1.46223)">
 					<path class="edge" d="M 0 0 V -1.46223 H -18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">3</text>
 				</g>
 				<path class="edge" d="M 0 0 V -118.538 H -36.0"/>
@@ -44,11 +43,11 @@
 			<circle class="sym" cx="0" cy="0" r="3"/>
 			<text class="lab rgt" transform="translate(3 -6)">9</text>
 			<g class="mut m1 s0" transform="translate(0 -6.66667)">
-				<rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+				<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 				<text class="lab rgt" transform="translate(5 0)">1</text>
 			</g>
 			<g class="mut m0 s0" transform="translate(0 -13.3333)">
-				<rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+				<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 				<text class="lab rgt" transform="translate(5 0)">0</text>
 			</g>
 		</g>

--- a/python/tests/data/svg/tree.svg
+++ b/python/tests/data/svg/tree.svg
@@ -1,20 +1,19 @@
 <?xml version="1.0" ?>
-<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="200">
 	<defs>
-		<style type="text/css">
-<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle}.edge {stroke: black; fill: none}.node > .sym {fill: black; stroke: none}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.mut {fill: red; font-style: italic}.edge {stroke: blue}]]>		</style>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree t1">
 		<g class="node n7 p0 root" transform="translate(100.0 30.0)">
 			<g class="a7 node n4 p0" transform="translate(-36.0 138.519)">
 				<g class="a4 leaf node n0 p0 sample" transform="translate(-18.0 1.4814)">
 					<path class="edge" d="M 0 0 V -1.4814 H 18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">0</text>
 				</g>
 				<g class="a4 leaf node n1 p0 sample" transform="translate(18.0 1.4814)">
 					<path class="edge" d="M 0 0 V -1.4814 H -18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">1</text>
 				</g>
 				<path class="edge" d="M 0 0 V -138.519 H 36.0"/>
@@ -24,12 +23,12 @@
 			<g class="a7 node n5 p0" transform="translate(36.0 133.294)">
 				<g class="a5 leaf node n2 p0 sample" transform="translate(-18.0 6.70591)">
 					<path class="edge" d="M 0 0 V -6.70591 H 18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">2</text>
 				</g>
 				<g class="a5 leaf node n3 p0 sample" transform="translate(18.0 6.70591)">
 					<path class="edge" d="M 0 0 V -6.70591 H -18.0"/>
-					<circle class="sym" cx="0" cy="0" r="3"/>
+					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">3</text>
 				</g>
 				<path class="edge" d="M 0 0 V -133.294 H -36.0"/>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -1,14 +1,13 @@
 <?xml version="1.0" ?>
-<svg baseProfile="full" height="200" id="XYZ" version="1.1" width="1000" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="1000">
 	<defs>
-		<style type="text/css">
-<![CDATA[.axis {font-weight: bold}.tree, .axis {font-size: 14px; text-anchor:middle}.edge {stroke: black; fill: none}.node > .sym {fill: black; stroke: none}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.mut {fill: red; font-style: italic}.edge {stroke: blue}]]>		</style>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
-			<polygon fill="#F1F1F1" points="20,185 20,180 20,160 20,0 212.0,0 212.0,160 77.3623,180 77.3623,185"/>
-			<polygon fill="#F1F1F1" points="780.883,185 780.883,180 404.0,160 404.0,0 596.0,0 596.0,160 890.091,180 890.091,185"/>
-			<polygon fill="#F1F1F1" points="893.883,185 893.883,180 788.0,160 788.0,0 980.0,0 980.0,160 980.0,180 980.0,185"/>
+			<path d="M20,0 l192,0 l0,160 l-134.638,20 l0,5 l-57.3623,0 l0,-5 l0,-20 l0,-160z"/>
+			<path d="M404,0 l192,0 l0,160 l294.091,20 l0,5 l-109.208,0 l0,-5 l-376.883,-20 l0,-160z"/>
+			<path d="M788,0 l192,0 l0,160 l0,20 l0,5 l-86.1174,0 l0,-5 l-105.883,-20 l0,-160z"/>
 		</g>
 		<g class="trees">
 			<g class="treebox t0" transform="translate(20 30)">
@@ -17,31 +16,31 @@
 						<g class="a9 m2 node n4 p0 s0" transform="translate(-34.4 65.8223)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
 							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
 							<path class="edge" d="M 0 0 V -65.8223 H 34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -6)">4</text>
 							<g class="mut m2 s0" transform="translate(0 -32.9112)">
-								<rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">2</text>
 							</g>
 						</g>
 						<g class="a9 node n5 p0" transform="translate(34.4 65.1958)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
 							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
 							<path class="edge" d="M 0 0 V -65.1958 H -34.4"/>
@@ -52,11 +51,11 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab rgt" transform="translate(3 -6)">9</text>
 						<g class="mut m1 s0" transform="translate(0 -4.66667)">
-							<rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<g class="mut m0 s0" transform="translate(0 -9.33333)">
-							<rect class="sym" height="6" transform="translate(-3 -3)" width="6" x="0" y="0"/>
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 							<text class="lab rgt" transform="translate(5 0)">0</text>
 						</g>
 					</g>
@@ -68,12 +67,12 @@
 						<g class="a7 node n4 p0" transform="translate(-34.4 16.6123)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
 							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
 							<path class="edge" d="M 0 0 V -16.6123 H 34.4"/>
@@ -83,12 +82,12 @@
 						<g class="a7 node n5 p0" transform="translate(34.4 15.9857)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
 							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
 							<path class="edge" d="M 0 0 V -15.9857 H -34.4"/>
@@ -107,12 +106,12 @@
 						<g class="a6 node n4 p0" transform="translate(-34.4 12.5387)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
 							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
 							<path class="edge" d="M 0 0 V -12.5387 H 34.4"/>
@@ -122,12 +121,12 @@
 						<g class="a6 node n5 p0" transform="translate(34.4 11.9121)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
 							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
 							<path class="edge" d="M 0 0 V -11.9121 H -34.4"/>
@@ -146,12 +145,12 @@
 						<g class="a7 node n4 p0" transform="translate(-34.4 16.6123)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
 							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
 							<path class="edge" d="M 0 0 V -16.6123 H 34.4"/>
@@ -161,12 +160,12 @@
 						<g class="a7 node n5 p0" transform="translate(34.4 15.9857)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
 							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
 							<path class="edge" d="M 0 0 V -15.9857 H -34.4"/>
@@ -185,12 +184,12 @@
 						<g class="a8 node n4 p0" transform="translate(-34.4 25.7869)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
 							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
 								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
 							<path class="edge" d="M 0 0 V -25.7869 H 34.4"/>
@@ -200,12 +199,12 @@
 						<g class="a8 node n5 p0" transform="translate(34.4 25.1604)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
 							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
 								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
-								<circle class="sym" cx="0" cy="0" r="3"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
 							<path class="edge" d="M 0 0 V -25.1604 H -34.4"/>
@@ -220,28 +219,28 @@
 			</g>
 		</g>
 		<g class="axis">
-			<line stroke="black" x1="20" x2="980" y1="180" y2="180"/>
-			<line stroke="black" x1="20" x2="20" y1="180" y2="185"/>
+			<line x1="20" x2="980" y1="180" y2="180"/>
+			<line x1="20" x2="20" y1="180" y2="185"/>
 			<g transform="translate(20, 200)">
 				<text font-size="14" font-weight="bold" text-anchor="middle">0.00</text>
 			</g>
-			<line stroke="black" x1="77.3623" x2="77.3623" y1="180" y2="185"/>
+			<line x1="77.3623" x2="77.3623" y1="180" y2="185"/>
 			<g transform="translate(77.3623, 200)">
 				<text font-size="14" font-weight="bold" text-anchor="middle">0.06</text>
 			</g>
-			<line stroke="black" x1="780.883" x2="780.883" y1="180" y2="185"/>
+			<line x1="780.883" x2="780.883" y1="180" y2="185"/>
 			<g transform="translate(780.883, 200)">
 				<text font-size="14" font-weight="bold" text-anchor="middle">0.79</text>
 			</g>
-			<line stroke="black" x1="890.091" x2="890.091" y1="180" y2="185"/>
+			<line x1="890.091" x2="890.091" y1="180" y2="185"/>
 			<g transform="translate(890.091, 200)">
 				<text font-size="14" font-weight="bold" text-anchor="middle">0.91</text>
 			</g>
-			<line stroke="black" x1="893.883" x2="893.883" y1="180" y2="185"/>
+			<line x1="893.883" x2="893.883" y1="180" y2="185"/>
 			<g transform="translate(893.883, 200)">
 				<text font-size="14" font-weight="bold" text-anchor="middle">0.91</text>
 			</g>
-			<line stroke="black" x1="980.0" x2="980.0" y1="180" y2="185"/>
+			<line x1="980.0" x2="980.0" y1="180" y2="185"/>
 			<g transform="translate(980.0, 200)">
 				<text font-size="14" font-weight="bold" text-anchor="middle">1.00</text>
 			</g>

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -363,7 +363,8 @@ class SvgTreeSequence:
                                 (rnd(break_x), rnd(y)),
                                 (rnd(break_x), rnd(y + tick_len[1])),
                             ],
-                            fill="#F1F1F1",
+                            fill="#808080",
+                            fill_opacity=0.1,
                         )
                     )
 

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -338,7 +338,7 @@ class SvgTreeSequence:
         axes_right = self.image_size[0] - self.treebox_x_offset
         y = self.image_size[1] - 2 * self.axes_y_offset
         axis = root_group.add(dwg.g(class_="axis"))
-        axis.add(dwg.line((axes_left, y), (axes_right, y), stroke="black"))
+        axis.add(dwg.line((axes_left, y), (axes_right, y)))
         integer_ticks = all(round(label) == label for _, _, label in ticks)
         label_precision = 0 if integer_ticks else 2
 
@@ -372,7 +372,6 @@ class SvgTreeSequence:
                 dwg.line(
                     (rnd(x), rnd(y - tick_len[0])),
                     (rnd(x), rnd(y + tick_len[1])),
-                    stroke="black",
                 )
             )
             add_text_in_group(
@@ -397,7 +396,8 @@ class SvgTree:
     standard_style = (
         ".axis {font-weight: bold}"
         ".tree, .axis {font-size: 14px; text-anchor:middle}"
-        ".edge {stroke: black; fill: none}"
+        "line, path {stroke:black}"
+        ".edge {fill:none}"
         ".node > .sym {fill: black; stroke: none}"
         ".tree text {dominant-baseline: middle}"  # NB: not inherited in css 1.1
         ".tree .lab.lft {text-anchor: end}"

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1465,7 +1465,12 @@ class Tree:
         **kwargs,
     ):
         """
-        Return an SVG representation of a single tree.
+        Return an SVG representation of a single tree. Sample nodes are represented as
+        black squares, other nodes are black circles, and mutations are red crosses,
+        although these default styles can be altered (see below). By default, numeric
+        labels are drawn beside nodes and mutations: these can be altered using the
+        ``node_labels`` and ``mutation_labels`` parameters.
+
 
         When working in a Jupyter notebook, use the ``IPython.display.SVG`` function
         to display the SVG output from this function inline in the notebook::
@@ -1489,8 +1494,8 @@ class Tree:
         to the tree structure. Any particular node in the tree will have a corresponding
         group containing child groups (if any) followed by the edge above that node, a
         node symbol, and (potentially) text containing the node label. For example, a
-        simple two tip tree, with tip node ids 0 and 1, and a root node id of 2 will have
-        a structure similar to the following:
+        simple two tip tree, with tip node ids 0 and 1, and a root node id of 2, and with
+        some bespoke labels, will have a structure similar to the following:
 
         .. code-block::
 
@@ -1498,16 +1503,16 @@ class Tree:
               <g class="node n2 root">
                 <g class="node n1 a2 i1 p1 sample leaf">
                   <path class="edge" ... />
-                  <circle class="sym" ... />
+                  <rect class="sym" ... />
                   <text class="lab" ...>Node 1</text>
                 </g>
                 <g class="node n0 a2 i2 p1 sample leaf">
                   <path class="edge" ... />
-                  <circle class="sym" .../>
+                  <rect class="sym" .../>
                   <text class="lab" ...>Node 0</text>
                 </g>
                 <path class="edge" ... />
-                <circle />
+                <circle class="sym" ... />
                 <text class="lab">Root (Node 2)</text>
               </g>
             </g>


### PR DESCRIPTION
Make samples nodes square, use a translucent background for light/dark modes, and place line colours in the style file for ease of changing. Also use pytest tmp_path so we can look at saved output files.

Fixes #1155

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
