### PR TITLE
Do not set samples in TreeSequence.simplify()

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1106,10 +1106,19 @@ class TestTreeSequence(HighLevelTestCase):
                 a2 = [variant.alleles[g] for g in variant.genotypes]
                 assert a1 == a2
 
+    def verify_tables_api_equality(self, ts):
+        for samples in [None, list(ts.samples()), ts.samples()]:
+            tables = ts.dump_tables()
+            tables.simplify(samples=samples)
+            assert tables.equals(
+                ts.simplify(samples=samples).tables, ignore_timestamps=True
+            )
+
     @pytest.mark.slow
     def test_simplify(self):
         num_mutations = 0
         for ts in get_example_tree_sequences():
+            self.verify_tables_api_equality(ts)
             self.verify_simplify_provenance(ts)
             n = ts.get_sample_size()
             num_mutations += ts.get_num_mutations()

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5036,8 +5036,6 @@ class TreeSequence:
         :rtype: .TreeSequence or (.TreeSequence, numpy.ndarray)
         """
         tables = self.dump_tables()
-        if samples is None:
-            samples = self.get_samples()
         assert tables.sequence_length == self.sequence_length
         node_map = tables.simplify(
             samples=samples,


### PR DESCRIPTION
I just noticed this: if `samples` is None, I think we should probably pass it straight through to Tables.simplify(), rather than have 2 bits of code, one in `TreeSequence.simplify()` and one in `Tables.simplify()` that do the same thing? That way we are also sure that the methods always do the same thing.
