### PR TITLE
Add `x_label` parameter for the X axis

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,8 +4,8 @@
 
 **Features**
 
-- SVG visualization now uses red crosses for mutations, and squares for sample nodes
-  (:user:`hyanwong`,:issue:`1155`, :pr:`1182`).
+- SVG visualization now uses red crosses for mutations and squares for sample nodes, and
+  an x-axis label can be set (:user:`hyanwong`,:issue:`1155`, :pr:`1182`, :pr:`1213`).
 
 - Add ``parents`` column to the individual table to allow recording of pedigrees
   (:user:`ivan-krukov`, :user:`benjeffery`, :issue:`852`, :pr:`1125`, :pr:`866`, :pr:`1153`, :pr:`1177` :pr:`1192`).

--- a/python/tests/data/svg/mut_tree.svg
+++ b/python/tests/data/svg/mut_tree.svg
@@ -1,41 +1,41 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-size: 14px}.tree-sequence .x-tick-label {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree t0">
-		<g class="m0 m1 node n9 p0 root s0" transform="translate(100.0 50.0)">
-			<g class="a9 m2 node n4 p0 s0" transform="translate(-36.0 119.677)">
-				<g class="a4 leaf node n0 p0 sample" transform="translate(-18.0 0.32302)">
-					<path class="edge" d="M 0 0 V -0.32302 H 18.0"/>
+		<g class="m0 m1 node n9 p0 root s0" transform="translate(100.0 42.0)">
+			<g class="a9 m2 node n4 p0 s0" transform="translate(-36.0 135.634)">
+				<g class="a4 leaf node n0 p0 sample" transform="translate(-18.0 0.366089)">
+					<path class="edge" d="M 0 0 V -0.366089 H 18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">0</text>
 				</g>
-				<g class="a4 leaf node n1 p0 sample" transform="translate(18.0 0.32302)">
-					<path class="edge" d="M 0 0 V -0.32302 H -18.0"/>
+				<g class="a4 leaf node n1 p0 sample" transform="translate(18.0 0.366089)">
+					<path class="edge" d="M 0 0 V -0.366089 H -18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">1</text>
 				</g>
-				<path class="edge" d="M 0 0 V -119.677 H 36.0"/>
+				<path class="edge" d="M 0 0 V -135.634 H 36.0"/>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab lft" transform="translate(-3 -6)">4</text>
-				<g class="mut m2 s0" transform="translate(0 -59.8385)">
+				<g class="mut m2 s0" transform="translate(0 -67.817)">
 					<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 					<text class="lab lft" transform="translate(-5 0)">2</text>
 				</g>
 			</g>
-			<g class="a9 node n5 p0" transform="translate(36.0 118.538)">
-				<g class="a5 leaf node n2 p0 sample" transform="translate(-18.0 1.46223)">
-					<path class="edge" d="M 0 0 V -1.46223 H 18.0"/>
+			<g class="a9 node n5 p0" transform="translate(36.0 134.343)">
+				<g class="a5 leaf node n2 p0 sample" transform="translate(-18.0 1.65719)">
+					<path class="edge" d="M 0 0 V -1.65719 H 18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">2</text>
 				</g>
-				<g class="a5 leaf node n3 p0 sample" transform="translate(18.0 1.46223)">
-					<path class="edge" d="M 0 0 V -1.46223 H -18.0"/>
+				<g class="a5 leaf node n3 p0 sample" transform="translate(18.0 1.65719)">
+					<path class="edge" d="M 0 0 V -1.65719 H -18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">3</text>
 				</g>
-				<path class="edge" d="M 0 0 V -118.538 H -36.0"/>
+				<path class="edge" d="M 0 0 V -134.343 H -36.0"/>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab rgt" transform="translate(3 -6)">5</text>
 			</g>

--- a/python/tests/data/svg/tree.svg
+++ b/python/tests/data/svg/tree.svg
@@ -1,37 +1,37 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-size: 14px}.tree-sequence .x-tick-label {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree t1">
-		<g class="node n7 p0 root" transform="translate(100.0 30.0)">
-			<g class="a7 node n4 p0" transform="translate(-36.0 138.519)">
-				<g class="a4 leaf node n0 p0 sample" transform="translate(-18.0 1.4814)">
-					<path class="edge" d="M 0 0 V -1.4814 H 18.0"/>
+		<g class="node n7 p0 root" transform="translate(100.0 22.0)">
+			<g class="a7 node n4 p0" transform="translate(-36.0 154.349)">
+				<g class="a4 leaf node n0 p0 sample" transform="translate(-18.0 1.6507)">
+					<path class="edge" d="M 0 0 V -1.6507 H 18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">0</text>
 				</g>
-				<g class="a4 leaf node n1 p0 sample" transform="translate(18.0 1.4814)">
-					<path class="edge" d="M 0 0 V -1.4814 H -18.0"/>
+				<g class="a4 leaf node n1 p0 sample" transform="translate(18.0 1.6507)">
+					<path class="edge" d="M 0 0 V -1.6507 H -18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">1</text>
 				</g>
-				<path class="edge" d="M 0 0 V -138.519 H 36.0"/>
+				<path class="edge" d="M 0 0 V -154.349 H 36.0"/>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab lft" transform="translate(-3 -6)">4</text>
 			</g>
-			<g class="a7 node n5 p0" transform="translate(36.0 133.294)">
-				<g class="a5 leaf node n2 p0 sample" transform="translate(-18.0 6.70591)">
-					<path class="edge" d="M 0 0 V -6.70591 H 18.0"/>
+			<g class="a7 node n5 p0" transform="translate(36.0 148.528)">
+				<g class="a5 leaf node n2 p0 sample" transform="translate(-18.0 7.4723)">
+					<path class="edge" d="M 0 0 V -7.4723 H 18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">2</text>
 				</g>
-				<g class="a5 leaf node n3 p0 sample" transform="translate(18.0 6.70591)">
-					<path class="edge" d="M 0 0 V -6.70591 H -18.0"/>
+				<g class="a5 leaf node n3 p0 sample" transform="translate(18.0 7.4723)">
+					<path class="edge" d="M 0 0 V -7.4723 H -18.0"/>
 					<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 					<text class="lab" transform="translate(0 12)">3</text>
 				</g>
-				<path class="edge" d="M 0 0 V -133.294 H -36.0"/>
+				<path class="edge" d="M 0 0 V -148.528 H -36.0"/>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab rgt" transform="translate(3 -6)">5</text>
 			</g>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-size: 14px}.tree-sequence .x-tick-label {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -10,208 +10,208 @@
 			<path d="M788,0 l192,0 l0,160 l0,20 l0,5 l-86.1174,0 l0,-5 l-105.883,-20 l0,-160z"/>
 		</g>
 		<g class="trees">
-			<g class="treebox t0" transform="translate(20 30)">
+			<g class="treebox t0" transform="translate(20 0)">
 				<g class="tree t0">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96.0 44.0)">
-						<g class="a9 m2 node n4 p0 s0" transform="translate(-34.4 65.8223)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+					<g class="m0 m1 node n9 p0 root s0" transform="translate(96.0 38.0)">
+						<g class="a9 m2 node n4 p0 s0" transform="translate(-34.4 99.7308)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
-							<path class="edge" d="M 0 0 V -65.8223 H 34.4"/>
+							<path class="edge" d="M 0 0 V -99.7308 H 34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -6)">4</text>
-							<g class="mut m2 s0" transform="translate(0 -32.9112)">
+							<g class="mut m2 s0" transform="translate(0 -49.8654)">
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">2</text>
 							</g>
 						</g>
-						<g class="a9 node n5 p0" transform="translate(34.4 65.1958)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+						<g class="a9 node n5 p0" transform="translate(34.4 98.7815)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -65.1958 H -34.4"/>
+							<path class="edge" d="M 0 0 V -98.7815 H -34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -6)">5</text>
 						</g>
-						<path class="edge" d="M 0 0 V -14.0 H 0"/>
+						<path class="edge" d="M 0 0 V -16.0 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab rgt" transform="translate(3 -6)">9</text>
-						<g class="mut m1 s0" transform="translate(0 -4.66667)">
+						<g class="mut m1 s0" transform="translate(0 -5.33333)">
 							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
-						<g class="mut m0 s0" transform="translate(0 -9.33333)">
+						<g class="mut m0 s0" transform="translate(0 -10.6667)">
 							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 							<text class="lab rgt" transform="translate(5 0)">0</text>
 						</g>
 					</g>
 				</g>
 			</g>
-			<g class="treebox t1" transform="translate(212.0 30)">
+			<g class="treebox t1" transform="translate(212.0 0)">
 				<g class="tree t1">
-					<g class="node n7 p0 root" transform="translate(96.0 93.2101)">
-						<g class="a7 node n4 p0" transform="translate(-34.4 16.6123)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+					<g class="node n7 p0 root" transform="translate(96.0 112.561)">
+						<g class="a7 node n4 p0" transform="translate(-34.4 25.1701)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
-							<path class="edge" d="M 0 0 V -16.6123 H 34.4"/>
+							<path class="edge" d="M 0 0 V -25.1701 H 34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -6)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(34.4 15.9857)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+						<g class="a7 node n5 p0" transform="translate(34.4 24.2208)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -15.9857 H -34.4"/>
+							<path class="edge" d="M 0 0 V -24.2208 H -34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -6)">5</text>
 						</g>
-						<path class="edge" d="M 0 0 V -14.0 H 0"/>
+						<path class="edge" d="M 0 0 V -16.0 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab rgt" transform="translate(3 -6)">7</text>
 					</g>
 				</g>
 			</g>
-			<g class="treebox t2" transform="translate(404.0 30)">
+			<g class="treebox t2" transform="translate(404.0 0)">
 				<g class="tree t2">
-					<g class="node n6 p0 root" transform="translate(96.0 97.2837)">
-						<g class="a6 node n4 p0" transform="translate(-34.4 12.5387)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+					<g class="node n6 p0 root" transform="translate(96.0 118.733)">
+						<g class="a6 node n4 p0" transform="translate(-34.4 18.998)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
-							<path class="edge" d="M 0 0 V -12.5387 H 34.4"/>
+							<path class="edge" d="M 0 0 V -18.998 H 34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -6)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(34.4 11.9121)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+						<g class="a6 node n5 p0" transform="translate(34.4 18.0486)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -11.9121 H -34.4"/>
+							<path class="edge" d="M 0 0 V -18.0486 H -34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -6)">5</text>
 						</g>
-						<path class="edge" d="M 0 0 V -14.0 H 0"/>
+						<path class="edge" d="M 0 0 V -16.0 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab rgt" transform="translate(3 -6)">6</text>
 					</g>
 				</g>
 			</g>
-			<g class="treebox t3" transform="translate(596.0 30)">
+			<g class="treebox t3" transform="translate(596.0 0)">
 				<g class="tree t3">
-					<g class="node n7 p0 root" transform="translate(96.0 93.2101)">
-						<g class="a7 node n4 p0" transform="translate(-34.4 16.6123)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+					<g class="node n7 p0 root" transform="translate(96.0 112.561)">
+						<g class="a7 node n4 p0" transform="translate(-34.4 25.1701)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
-							<path class="edge" d="M 0 0 V -16.6123 H 34.4"/>
+							<path class="edge" d="M 0 0 V -25.1701 H 34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -6)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(34.4 15.9857)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+						<g class="a7 node n5 p0" transform="translate(34.4 24.2208)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -15.9857 H -34.4"/>
+							<path class="edge" d="M 0 0 V -24.2208 H -34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -6)">5</text>
 						</g>
-						<path class="edge" d="M 0 0 V -14.0 H 0"/>
+						<path class="edge" d="M 0 0 V -16.0 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab rgt" transform="translate(3 -6)">7</text>
 					</g>
 				</g>
 			</g>
-			<g class="treebox t4" transform="translate(788.0 30)">
+			<g class="treebox t4" transform="translate(788.0 0)">
 				<g class="tree t4">
-					<g class="node n8 p0 root" transform="translate(96.0 84.0354)">
-						<g class="a8 node n4 p0" transform="translate(-34.4 25.7869)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H 17.2"/>
+					<g class="node n8 p0 root" transform="translate(96.0 98.6597)">
+						<g class="a8 node n4 p0" transform="translate(-34.4 39.0711)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.177661)">
-								<path class="edge" d="M 0 0 V -0.177661 H -17.2"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.269183)">
+								<path class="edge" d="M 0 0 V -0.269183 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">1</text>
 							</g>
-							<path class="edge" d="M 0 0 V -25.7869 H 34.4"/>
+							<path class="edge" d="M 0 0 V -39.0711 H 34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -6)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(34.4 25.1604)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H 17.2"/>
+						<g class="a8 node n5 p0" transform="translate(34.4 38.1218)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H 17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 0.804227)">
-								<path class="edge" d="M 0 0 V -0.804227 H -17.2"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.21853)">
+								<path class="edge" d="M 0 0 V -1.21853 H -17.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 12)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -25.1604 H -34.4"/>
+							<path class="edge" d="M 0 0 V -38.1218 H -34.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -6)">5</text>
 						</g>
-						<path class="edge" d="M 0 0 V -14.0 H 0"/>
+						<path class="edge" d="M 0 0 V -16.0 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab rgt" transform="translate(3 -6)">8</text>
 					</g>
@@ -221,28 +221,28 @@
 		<g class="axis">
 			<line x1="20" x2="980" y1="180" y2="180"/>
 			<line x1="20" x2="20" y1="180" y2="185"/>
-			<g transform="translate(20, 200)">
-				<text font-size="14" font-weight="bold" text-anchor="middle">0.00</text>
+			<g transform="translate(20, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.00</text>
 			</g>
 			<line x1="77.3623" x2="77.3623" y1="180" y2="185"/>
-			<g transform="translate(77.3623, 200)">
-				<text font-size="14" font-weight="bold" text-anchor="middle">0.06</text>
+			<g transform="translate(77.3623, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.06</text>
 			</g>
 			<line x1="780.883" x2="780.883" y1="180" y2="185"/>
-			<g transform="translate(780.883, 200)">
-				<text font-size="14" font-weight="bold" text-anchor="middle">0.79</text>
+			<g transform="translate(780.883, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.79</text>
 			</g>
 			<line x1="890.091" x2="890.091" y1="180" y2="185"/>
-			<g transform="translate(890.091, 200)">
-				<text font-size="14" font-weight="bold" text-anchor="middle">0.91</text>
+			<g transform="translate(890.091, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.91</text>
 			</g>
 			<line x1="893.883" x2="893.883" y1="180" y2="185"/>
-			<g transform="translate(893.883, 200)">
-				<text font-size="14" font-weight="bold" text-anchor="middle">0.91</text>
+			<g transform="translate(893.883, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.91</text>
 			</g>
 			<line x1="980.0" x2="980.0" y1="180" y2="185"/>
-			<g transform="translate(980.0, 200)">
-				<text font-size="14" font-weight="bold" text-anchor="middle">1.00</text>
+			<g transform="translate(980.0, 198)">
+				<text class="x-tick-label" text-anchor="middle">1.00</text>
 			</g>
 		</g>
 	</g>

--- a/python/tests/data/svg/ts_plain.svg
+++ b/python/tests/data/svg/ts_plain.svg
@@ -1,0 +1,244 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
+	<defs>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-size: 14px}.tree-sequence .x-tick-label {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}]]></style>
+	</defs>
+	<g class="tree-sequence">
+		<g class="trees">
+			<g class="treebox t0" transform="translate(20 0)">
+				<g class="tree t0">
+					<g class="m0 m1 node n9 p0 root s0" transform="translate(96.0 39.5)">
+						<g class="a9 m2 node n4 p0 s0" transform="translate(-34.4 113.194)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -113.194 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+							<g class="mut m2 s0" transform="translate(0 -56.5972)">
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">2</text>
+							</g>
+						</g>
+						<g class="a9 node n5 p0" transform="translate(34.4 112.117)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -112.117 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -17.5 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">9</text>
+						<g class="mut m1 s0" transform="translate(0 -5.83333)">
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">1</text>
+						</g>
+						<g class="mut m0 s0" transform="translate(0 -11.6667)">
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">0</text>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t1" transform="translate(212.0 0)">
+				<g class="tree t1">
+					<g class="node n7 p0 root" transform="translate(96.0 124.126)">
+						<g class="a7 node n4 p0" transform="translate(-34.4 28.5681)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -28.5681 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(34.4 27.4906)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -27.4906 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -17.5 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t2" transform="translate(404.0 0)">
+				<g class="tree t2">
+					<g class="node n6 p0 root" transform="translate(96.0 131.132)">
+						<g class="a6 node n4 p0" transform="translate(-34.4 21.5627)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -21.5627 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a6 node n5 p0" transform="translate(34.4 20.4852)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -20.4852 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -17.5 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">6</text>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t3" transform="translate(596.0 0)">
+				<g class="tree t3">
+					<g class="node n7 p0 root" transform="translate(96.0 124.126)">
+						<g class="a7 node n4 p0" transform="translate(-34.4 28.5681)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -28.5681 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(34.4 27.4906)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -27.4906 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -17.5 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t4" transform="translate(788.0 0)">
+				<g class="tree t4">
+					<g class="node n8 p0 root" transform="translate(96.0 108.349)">
+						<g class="a8 node n4 p0" transform="translate(-34.4 44.3457)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.305523)">
+								<path class="edge" d="M 0 0 V -0.305523 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -44.3457 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a8 node n5 p0" transform="translate(34.4 43.2682)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.38303)">
+								<path class="edge" d="M 0 0 V -1.38303 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -43.2682 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -17.5 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">8</text>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g class="axis">
+			<line x1="20" x2="980" y1="180" y2="180"/>
+			<line x1="20" x2="20" y1="175" y2="185"/>
+			<g transform="translate(20, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.00</text>
+			</g>
+			<line x1="212.0" x2="212.0" y1="175" y2="185"/>
+			<g transform="translate(212.0, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.06</text>
+			</g>
+			<line x1="404.0" x2="404.0" y1="175" y2="185"/>
+			<g transform="translate(404.0, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.79</text>
+			</g>
+			<line x1="596.0" x2="596.0" y1="175" y2="185"/>
+			<g transform="translate(596.0, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.91</text>
+			</g>
+			<line x1="788.0" x2="788.0" y1="175" y2="185"/>
+			<g transform="translate(788.0, 198)">
+				<text class="x-tick-label" text-anchor="middle">0.91</text>
+			</g>
+			<line x1="980.0" x2="980.0" y1="175" y2="185"/>
+			<g transform="translate(980.0, 198)">
+				<text class="x-tick-label" text-anchor="middle">1.00</text>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tests/data/svg/ts_xlabel.svg
+++ b/python/tests/data/svg/ts_xlabel.svg
@@ -1,0 +1,252 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
+	<defs>
+		<style type="text/css"><![CDATA[.tree-sequence .background path {fill: #808080; fill-opacity:.1}.tree-sequence .axis {font-size: 14px}.tree-sequence .x-tick-label {font-weight: bold}.tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}.tree-sequence .axis line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.node .mut text {fill: red; font-style: italic}.node .mut .sym {stroke: red; stroke-width: 1.5px}.tree text {dominant-baseline: middle}.tree .lab.lft {text-anchor: end}.tree .lab.rgt {text-anchor: start}]]></style>
+	</defs>
+	<g class="tree-sequence">
+		<g class="background">
+			<path d="M20,0 l192,0 l0,146 l-134.638,20 l0,5 l-57.3623,0 l0,-5 l0,-20 l0,-146z"/>
+			<path d="M404,0 l192,0 l0,146 l294.091,20 l0,5 l-109.208,0 l0,-5 l-376.883,-20 l0,-146z"/>
+			<path d="M788,0 l192,0 l0,146 l0,20 l0,5 l-86.1174,0 l0,-5 l-105.883,-20 l0,-146z"/>
+		</g>
+		<g class="trees">
+			<g class="treebox t0" transform="translate(20 0)">
+				<g class="tree t0">
+					<g class="m0 m1 node n9 p0 root s0" transform="translate(96.0 36.6)">
+						<g class="a9 m2 node n4 p0 s0" transform="translate(-34.4 87.1647)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -87.1647 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+							<g class="mut m2 s0" transform="translate(0 -43.5824)">
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">2</text>
+							</g>
+						</g>
+						<g class="a9 node n5 p0" transform="translate(34.4 86.335)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -86.335 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -14.6 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">9</text>
+						<g class="mut m1 s0" transform="translate(0 -4.86667)">
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">1</text>
+						</g>
+						<g class="mut m0 s0" transform="translate(0 -9.73333)">
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">0</text>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t1" transform="translate(212.0 0)">
+				<g class="tree t1">
+					<g class="node n7 p0 root" transform="translate(96.0 101.766)">
+						<g class="a7 node n4 p0" transform="translate(-34.4 21.9987)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -21.9987 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(34.4 21.1689)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -21.1689 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -14.6 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t2" transform="translate(404.0 0)">
+				<g class="tree t2">
+					<g class="node n6 p0 root" transform="translate(96.0 107.16)">
+						<g class="a6 node n4 p0" transform="translate(-34.4 16.6042)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -16.6042 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a6 node n5 p0" transform="translate(34.4 15.7745)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -15.7745 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -14.6 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">6</text>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t3" transform="translate(596.0 0)">
+				<g class="tree t3">
+					<g class="node n7 p0 root" transform="translate(96.0 101.766)">
+						<g class="a7 node n4 p0" transform="translate(-34.4 21.9987)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -21.9987 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(34.4 21.1689)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -21.1689 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -14.6 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="treebox t4" transform="translate(788.0 0)">
+				<g class="tree t4">
+					<g class="node n8 p0 root" transform="translate(96.0 89.6166)">
+						<g class="a8 node n4 p0" transform="translate(-34.4 34.1482)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(17.2 0.235266)">
+								<path class="edge" d="M 0 0 V -0.235266 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -34.1482 H 34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -6)">4</text>
+						</g>
+						<g class="a8 node n5 p0" transform="translate(34.4 33.3184)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H 17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(17.2 1.06499)">
+								<path class="edge" d="M 0 0 V -1.06499 H -17.2"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 12)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -33.3184 H -34.4"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -6)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -14.6 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -6)">8</text>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g class="axis">
+			<line x1="20" x2="980" y1="166" y2="166"/>
+			<line x1="20" x2="20" y1="166" y2="171"/>
+			<g transform="translate(20, 184)">
+				<text class="x-tick-label" text-anchor="middle">0.00</text>
+			</g>
+			<line x1="77.3623" x2="77.3623" y1="166" y2="171"/>
+			<g transform="translate(77.3623, 184)">
+				<text class="x-tick-label" text-anchor="middle">0.06</text>
+			</g>
+			<line x1="780.883" x2="780.883" y1="166" y2="171"/>
+			<g transform="translate(780.883, 184)">
+				<text class="x-tick-label" text-anchor="middle">0.79</text>
+			</g>
+			<line x1="890.091" x2="890.091" y1="166" y2="171"/>
+			<g transform="translate(890.091, 184)">
+				<text class="x-tick-label" text-anchor="middle">0.91</text>
+			</g>
+			<line x1="893.883" x2="893.883" y1="166" y2="171"/>
+			<g transform="translate(893.883, 184)">
+				<text class="x-tick-label" text-anchor="middle">0.91</text>
+			</g>
+			<line x1="980.0" x2="980.0" y1="166" y2="171"/>
+			<g transform="translate(980.0, 184)">
+				<text class="x-tick-label" text-anchor="middle">1.00</text>
+			</g>
+			<g transform="translate(500.0, 196)">
+				<text class="x-label" text-anchor="middle">genomic position (bp)</text>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -1918,6 +1918,36 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
             expected_svg = file.read()
         self.assertXmlEquivalentOutputs(svg, expected_svg)
 
+    def test_known_svg_ts_plain(self):
+        """
+        Plain style, with no background shading and a variable X axis
+        """
+        ts = self.get_simple_ts()
+        svg = ts.draw_svg(x_scale="treewise")
+        # Prettify the SVG code for easy inspection
+        svg = xml.dom.minidom.parseString(svg).toprettyxml()
+        svg_fn = pathlib.Path(__file__).parent / "data" / "svg" / "ts_plain.svg"
+        self.verify_basic_svg(svg, width=200 * ts.num_trees)
+        with open(svg_fn, "rb") as file:
+            expected_svg = file.read()
+        self.assertXmlEquivalentOutputs(svg, expected_svg)
+
+    def test_known_svg_ts_with_xlabel(self):
+        """
+        Style with X axis label
+        """
+        ts = self.get_simple_ts()
+        x_label = "genomic position (bp)"
+        svg = ts.draw_svg(x_label=x_label)
+        # Prettify the SVG code for easy inspection
+        svg = xml.dom.minidom.parseString(svg).toprettyxml()
+        svg_fn = pathlib.Path(__file__).parent / "data" / "svg" / "ts_xlabel.svg"
+        self.verify_basic_svg(svg, width=200 * ts.num_trees)
+        assert x_label in svg
+        with open(svg_fn, "rb") as file:
+            expected_svg = file.read()
+        self.assertXmlEquivalentOutputs(svg, expected_svg)
+
 
 class TestRounding:
     def test_rnd(self):

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -247,6 +247,7 @@ class SvgTreeSequence:
         order=None,
         force_root_branch=None,
         symbol_size=None,
+        x_label=None,
     ):
         self.ts = ts
         if size is None:
@@ -278,11 +279,11 @@ class SvgTreeSequence:
             )
         # TODO add general padding arguments following matplotlib's terminology.
         self.axes_x_offset = 15
-        self.axes_y_offset = 10
+        self.axes_y_offset = 20 if x_label is None else 34
         self.treebox_x_offset = self.axes_x_offset + 5
         self.treebox_y_offset = self.axes_y_offset + axis_top_pad
         treebox_width = size[0] - 2 * self.treebox_x_offset
-        treebox_height = size[1] - 2 * self.treebox_y_offset
+        treebox_height = size[1] - self.treebox_y_offset
         tree_width = treebox_width / ts.num_trees
         svg_trees = [
             SvgTree(
@@ -305,7 +306,7 @@ class SvgTreeSequence:
         ]
 
         ticks = []  # svg_x_pos of drawn trees, svg_x_pos of breakpoints, & labels
-        y = self.treebox_y_offset
+        y = 0
         trees = root_group.add(dwg.g(class_="trees"))
         drawing_scale = float(tree_width * ts.num_trees) / ts.sequence_length
         tree_x = self.treebox_x_offset
@@ -336,7 +337,7 @@ class SvgTreeSequence:
 
         axes_left = self.treebox_x_offset
         axes_right = self.image_size[0] - self.treebox_x_offset
-        y = self.image_size[1] - 2 * self.axes_y_offset
+        y = self.image_size[1] - self.axes_y_offset
         axis = root_group.add(dwg.g(class_="axis"))
         axis.add(dwg.line((axes_left, y), (axes_right, y)))
         integer_ticks = all(round(label) == label for _, _, label in ticks)
@@ -377,11 +378,20 @@ class SvgTreeSequence:
                 dwg,
                 axis,
                 x,
-                y + 20,
+                y + 18,
                 f"{genome_coord:.{label_precision}f}",
-                font_size=14,
+                class_="x-tick-label",
                 text_anchor="middle",
-                font_weight="bold",
+            )
+        if x_label is not None:
+            add_text_in_group(
+                dwg,
+                axis,
+                (axes_left + axes_right) / 2,
+                y + 30,
+                x_label,
+                class_="x-label",
+                text_anchor="middle",
             )
 
 
@@ -394,7 +404,8 @@ class SvgTree:
 
     standard_style = (
         ".tree-sequence .background path {fill: #808080; fill-opacity:.1}"
-        ".tree-sequence .axis {font-weight: bold}"
+        ".tree-sequence .axis {font-size: 14px}"
+        ".tree-sequence .x-tick-label {font-weight: bold}"
         ".tree-sequence .axis, .tree {font-size: 14px; text-anchor:middle}"
         ".tree-sequence .axis line, .edge {stroke:black; fill:none}"
         ".node > .sym {fill: black; stroke: none}"
@@ -569,7 +580,7 @@ class SvgTree:
 
         # TODO should make this a parameter somewhere. This is padding to keep the
         # node labels within the treebox
-        label_padding = 10
+        label_padding = 6
         y_padding = self.treebox_y_offset + 2 * label_padding
         height = self.image_size[1]
         self.root_branch_length = 0

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5276,6 +5276,7 @@ class TreeSequence:
         style=None,
         order=None,
         force_root_branch=None,
+        x_label=None,
         **kwargs,
     ):
         """
@@ -5338,8 +5339,10 @@ class TreeSequence:
         :param bool force_root_branch: If ``True`` plot a branch (edge) above every tree
             root in the tree sequence. If ``None`` (default) then only plot such
             root branches if any root in the tree sequence has a mutation above it.
+        :param str x_label: A string to display on the X axis, e.g. "Genomic position".
+            If ``None`` (default) do not label the X axis in this tree sequence.
 
-        :return: An SVG representation of a tree.
+        :return: An SVG representation of a tree sequence.
         :rtype: str
         """
         draw = drawing.SvgTreeSequence(
@@ -5353,6 +5356,7 @@ class TreeSequence:
             style=style,
             order=order,
             force_root_branch=force_root_branch,
+            x_label=x_label,
             **kwargs,
         )
         output = draw.drawing.tostring()


### PR DESCRIPTION
And correct some alignment bugs in SVG placement of trees in a tree sequence, where we accidentally padded the top of the trees in the tree sequence, rather than just the bottom.

This will result in nicer diagrams for the tutorial, and is an obvious addition. The only question is whether we want a label by default or not. It's less of a change, and less language-specific if we simply have no X label by default, so I just left it that way for the time being.

Visual representations to check this is what we want are in the `tests/data/svg` directory.

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
