### PR TITLE
Mock out signal.signal for tests.

### DIFF
--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -60,7 +60,10 @@ def capture_output(func, *args, **kwargs):
     sys.stderr = buffer_class()
 
     try:
-        func(*args, **kwargs)
+        # Recent versions of MacOS seem to have issues with us calling signal
+        # during tests.
+        with mock.patch("signal.signal"):
+            func(*args, **kwargs)
         stdout_output = sys.stdout.getvalue()
         stderr_output = sys.stderr.getvalue()
     finally:


### PR DESCRIPTION
Closes #1216

Hit this problem in msprime recently as well, this is the simplest fix.