### PR TITLE
swap deprecated np.int and np.float for int & float

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -1853,7 +1853,7 @@ def branch_genetic_relatedness(
                 area = tr.branch_length(v) * span
                 haps = np.zeros(len(all_samples))
                 for x, u in enumerate(all_samples):
-                    haps[x] = np.int(tr.is_descendant(u, v))
+                    haps[x] = int(tr.is_descendant(u, v))
                 haps_mean = haps.mean()
                 haps_centered = haps - haps_mean
                 for i, (ix, iy) in enumerate(indexes):
@@ -1899,7 +1899,7 @@ def node_genetic_relatedness(
             for v in tr.nodes():
                 haps = np.zeros(len(all_samples))
                 for x, u in enumerate(all_samples):
-                    haps[x] = np.int(tr.is_descendant(u, v))
+                    haps[x] = int(tr.is_descendant(u, v))
                 haps_mean = haps.mean()
                 haps_centered = haps - haps_mean
                 for i, (ix, iy) in enumerate(indexes):

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -159,7 +159,7 @@ class TestNumpyArrayCasting:
                 ["str"],
                 {},
                 [{}],
-                np.array([0, 1], dtype=np.float),
+                np.array([0, 1], dtype=float),
             ]:
                 with pytest.raises(TypeError):
                     util.safe_np_int_cast(bad_type, dtype)


### PR DESCRIPTION
Recent versions of numpy deprecate np.int and np.float for simply `int` and `float`.