### PR TITLE
Skip flakey test on OS X

### DIFF
--- a/python/tests/test_fileobj.py
+++ b/python/tests/test_fileobj.py
@@ -242,6 +242,7 @@ def stream(fifo, ts_list):
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="No FIFOs on Windows")
+@pytest.mark.skipif(IS_OSX, reason="FIFO flakey on OS X, issue #1170")
 class TestFIFO:
     @fixture
     def fifo(self):


### PR DESCRIPTION
Fixes #1170

I have only seen this in CI on OS X python 3.9, so I'm dropping it for that platform first. If we see it occurring on Linux CI we can drop the test altogether.