### PR TITLE
Make metadata lazy for table row classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -307,6 +307,7 @@ nitpick_ignore = [
     ("c:type", "uint32_t"),
     ("c:type", "bool"),
     ("py:class", "tskit.metadata.AbstractMetadataCodec"),
+    ("py:class", "tskit.trees.Site"),
     # TODO these have been triaged here to make the docs compile, but we should
     # sort them out properly. https://github.com/tskit-dev/tskit/issues/336
     ("py:class", "array_like"),

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,10 +4,19 @@
 
 **Breaking changes**
 
+- `Mutation.position` and `Mutation.index` which were deprecated in 0.2.2 (Sep '19) have
+  been removed.
+
 **Features**
 
 - SVG visualization of a single tree allows all mutations on an edge to be plotted
   via the ``all_edge_mutations`` param (:user:`hyanwong`,:issue:`1253`, :pr:`1258`).
+
+- Entity classes such as `Mutation`, `Node` are now python dataclasses
+  (:user:`benjeffery`, :pr:`1261`).
+
+- Metadata decoding for table row access is now lazy (:user:`benjeffery`, :pr:`1261`).
+
 
 **Fixes**
 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -234,13 +234,13 @@ class PythonTreeSequence:
         def make_mutation(id_):
             site, node, derived_state, parent, metadata, time = ll_ts.get_mutation(id_)
             return tskit.Mutation(
-                id_=id_,
+                id=id_,
                 site=site,
                 node=node,
                 time=time,
                 derived_state=derived_state,
                 parent=parent,
-                encoded_metadata=metadata,
+                metadata=metadata,
                 metadata_decoder=tskit.metadata.parse_metadata_schema(
                     ll_ts.get_table_metadata_schemas().mutation
                 ).decode_row,
@@ -250,11 +250,11 @@ class PythonTreeSequence:
             pos, ancestral_state, ll_mutations, id_, metadata = ll_ts.get_site(j)
             self._sites.append(
                 tskit.Site(
-                    id_=id_,
+                    id=id_,
                     position=pos,
                     ancestral_state=ancestral_state,
                     mutations=[make_mutation(ll_mut) for ll_mut in ll_mutations],
-                    encoded_metadata=metadata,
+                    metadata=metadata,
                     metadata_decoder=tskit.metadata.parse_metadata_schema(
                         ll_ts.get_table_metadata_schemas().site
                     ).decode_row,

--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -108,11 +108,17 @@ class TestLdCalculator(unittest.TestCase):
         A = ldc.get_r2_matrix()
         j = len(mutations) // 2
         for k in range(j):
-            x = mutations[j + k].position - mutations[j].position
+            x = (
+                ts.site(mutations[j + k].site).position
+                - ts.site(mutations[j].site).position
+            )
             a = ldc.get_r2_array(j, max_distance=x)
             assert a.shape[0] == k
             assert np.allclose(A[j, j + 1 : j + 1 + k], a)
-            x = mutations[j].position - mutations[j - k].position
+            x = (
+                ts.site(mutations[j].site).position
+                - ts.site(mutations[j - k].site).position
+            )
             a = ldc.get_r2_array(j, max_distance=x, direction=tskit.REVERSE)
             assert a.shape[0] == k
             assert np.allclose(A[j, j - k : j], a[::-1])

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -23,11 +23,13 @@
 Classes for metadata decoding, encoding and validation
 """
 import abc
+import builtins
 import collections
 import copy
 import json
 import pprint
 import struct
+import types
 from itertools import islice
 from typing import Any
 from typing import Mapping
@@ -38,6 +40,8 @@ import jsonschema
 
 import tskit
 import tskit.exceptions as exceptions
+
+__builtins__object__setattr__ = builtins.object.__setattr__
 
 
 def replace_root_refs(obj):
@@ -656,3 +660,56 @@ def parse_metadata_schema(encoded_schema: str) -> MetadataSchema:
         except json.decoder.JSONDecodeError:
             raise ValueError(f"Metadata schema is not JSON, found {encoded_schema}")
         return MetadataSchema(decoded)
+
+
+class _CachedMetadata:
+    """
+    Descriptor for lazy decoding of metadata on attribute access.
+    """
+
+    def __get__(self, row, owner):
+        if row._metadata_decoder is not None:
+            # Some classes that use this are frozen so we need to directly setattr.
+            __builtins__object__setattr__(
+                row, "_metadata", row._metadata_decoder(row._metadata)
+            )
+            # Decoder being None indicates that metadata is decoded
+            __builtins__object__setattr__(row, "_metadata_decoder", None)
+        return row._metadata
+
+    def __set__(self, row, value):
+        __builtins__object__setattr__(row, "_metadata", value)
+
+
+def lazy_decode(cls):
+    """
+    Modifies a dataclass such that it lazily decodes metadata, if it is encoded.
+    If the metadata passed to the constructor is encoded a `metadata_decoder` parameter
+    must be also be passed.
+    """
+    wrapped_init = cls.__init__
+
+    # Intercept the init to record the decoder
+    def new_init(self, *args, metadata_decoder=None, **kwargs):
+        __builtins__object__setattr__(self, "_metadata_decoder", metadata_decoder)
+        wrapped_init(self, *args, **kwargs)
+
+    cls.__init__ = new_init
+
+    # Add a descriptor to the class to decode and cache metadata
+    cls.metadata = _CachedMetadata()
+
+    # Add slots needed to the class
+    slots = cls.__slots__
+    slots.extend(["_metadata", "_metadata_decoder"])
+    dict_ = dict()
+    sloted_members = dict()
+    for k, v in cls.__dict__.items():
+        if k not in slots:
+            dict_[k] = v
+        elif not isinstance(v, types.MemberDescriptorType):
+            sloted_members[k] = v
+    new_cls = type(cls.__name__, cls.__bases__, dict_)
+    for k, v in sloted_members.items():
+        setattr(new_cls, k, v)
+    return new_cls

--- a/python/tskit/vcf.py
+++ b/python/tskit/vcf.py
@@ -203,8 +203,7 @@ class VcfWriter:
                 end="\t",
                 file=output,
             )
-            variant.genotypes += ord("0")
-            gt_array[indexes] = variant.genotypes
+            gt_array[indexes] = variant.genotypes + ord("0")
             g_bytes = memoryview(gt_array).tobytes()
             g_str = g_bytes.decode()
             print(g_str, end="", file=output)


### PR DESCRIPTION
We were decoding metadata on every table row access previously, this makes that lazy. This same method will be applied to the container classes that get returned from e.g. `ts.node(u)` when they are dataclasses.

Note this also gives table row objects a `.table` attribute (@hyanwong might be interested) This attribute does not get put into the result of `dataclasses.asdict` or used in the auto dataclasses methods such as `__eq__` or `__repr__`. These auto methods also only see decoded metadata. The dataclasses are still "frozen".

Needs a couple of extra tests and and one optimisation for the null schema case before merging. Also thinking the schema reference should be stored, as otherwise it could be modified before use by the row.