### PR TITLE
Replace interval numbers with attr names

### DIFF
--- a/python/tests/test_combinatorics.py
+++ b/python/tests/test_combinatorics.py
@@ -1169,11 +1169,11 @@ class TestPolytomySplitting:
             resolved_ts = binary_tree.tree_sequence
             assert resolved_ts.sequence_length == ts.sequence_length
             assert resolved_ts.num_trees <= 3
-            if tree.interval[0] == 0:
+            if tree.interval.left == 0:
                 assert resolved_ts.num_trees == 2
                 null_tree = resolved_ts.last()
                 assert null_tree.num_roots == ts.num_samples
-            elif tree.interval[1] == ts.sequence_length:
+            elif tree.interval.right == ts.sequence_length:
                 assert resolved_ts.num_trees == 2
                 null_tree = resolved_ts.first()
                 assert null_tree.num_roots == ts.num_samples

--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -765,9 +765,9 @@ class ViterbiMatrix(CompressedMatrix):
 
         rr_index = len(self.recombination_required) - 1
         for site in reversed(self.ts.sites()):
-            while tree.interval[0] > site.position:
+            while tree.interval.left > site.position:
                 tree.prev()
-            assert tree.interval[0] <= site.position < tree.interval[1]
+            assert tree.interval.left <= site.position < tree.interval.right
 
             # Fill in the recombination tree
             j = rr_index

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -135,8 +135,8 @@ def get_gap_examples():
         ts = insert_gap(ts, x, gap)
         found = False
         for t in ts.trees():
-            if t.interval[0] == x:
-                assert t.interval[1] == x + gap
+            if t.interval.left == x:
+                assert t.interval.right == x + gap
                 assert len(t.parent_dict) == 0
                 found = True
         assert found
@@ -638,7 +638,7 @@ class TestTreeSequence(HighLevelTestCase):
                 edge_ids.append(edge.id)
                 assert edge == ts.edge(edge.id)
                 children[edge.parent].add(edge.child)
-            while tree.interval[1] <= left:
+            while tree.interval.right <= left:
                 tree = next(trees)
             assert left >= tree.interval.left
             assert right <= tree.interval.right
@@ -729,7 +729,9 @@ class TestTreeSequence(HighLevelTestCase):
         for ts in get_example_tree_sequences():
             breakpoints = ts.breakpoints(as_array=True)
             assert breakpoints.shape == (ts.num_trees + 1,)
-            other = np.fromiter(iter([0] + [t.interval[1] for t in ts.trees()]), float)
+            other = np.fromiter(
+                iter([0] + [t.interval.right for t in ts.trees()]), float
+            )
             assert np.array_equal(other, breakpoints)
             # in case downstream code has
             for j, x in enumerate(ts.breakpoints()):
@@ -2498,7 +2500,7 @@ class TestTree(HighLevelTestCase):
         assert t1.get_num_mutations() == t1.num_mutations
         assert t1.get_parent_dict() == t1.parent_dict
         assert t1.get_total_branch_length() == t1.total_branch_length
-        assert t1.span == t1.interval[1] - t1.interval[0]
+        assert t1.span == t1.interval.right - t1.interval.left
         # node properties
         root = t1.get_root()
         for node in t1.nodes():
@@ -2608,15 +2610,15 @@ class TestTree(HighLevelTestCase):
             for j in range(L):
                 tree.seek(j)
                 index = tree.index
-                assert tree.interval[0] <= j < tree.interval[1]
-                tree.seek(tree.interval[0])
+                assert tree.interval.left <= j < tree.interval.right
+                tree.seek(tree.interval.left)
                 assert tree.index == index
-                if tree.interval[1] < L:
-                    tree.seek(tree.interval[1])
+                if tree.interval.right < L:
+                    tree.seek(tree.interval.right)
                     assert tree.index == index + 1
             for j in reversed(range(L)):
                 tree.seek(j)
-                assert tree.interval[0] <= j < tree.interval[1]
+                assert tree.interval.left <= j < tree.interval.right
         for bad_position in [-1, L, L + 1, -L]:
             with pytest.raises(ValueError):
                 tree.seek(bad_position)
@@ -2628,9 +2630,9 @@ class TestTree(HighLevelTestCase):
         assert breakpoints[0] == 0
         assert breakpoints[-1] == ts.sequence_length
         for i, tree in enumerate(ts.trees()):
-            assert tree.interval[0] == pytest.approx(breakpoints[i])
             assert tree.interval.left == pytest.approx(breakpoints[i])
-            assert tree.interval[1] == pytest.approx(breakpoints[i + 1])
+            assert tree.interval.left == pytest.approx(breakpoints[i])
+            assert tree.interval.right == pytest.approx(breakpoints[i + 1])
             assert tree.interval.right == pytest.approx(breakpoints[i + 1])
             assert tree.interval.span == pytest.approx(
                 breakpoints[i + 1] - breakpoints[i]

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -106,7 +106,7 @@ def get_ibd(
             prev_dict = t.get_parent_dict()
 
         for interval in interval_list:
-            if min_length == 0 or interval[1] - interval[0] > min_length:
+            if min_length == 0 or interval.right - interval.left > min_length:
                 orig_id = node_map.index(node_id)
                 ibd_list.append(ibd.Segment(interval[0], interval[1], orig_id))
 

--- a/python/tests/test_phylo_formats.py
+++ b/python/tests/test_phylo_formats.py
@@ -283,8 +283,8 @@ class TestNexus(TreeExamples):
             assert len(split_name) == 2
             start = float(split_name[0][4:])
             end = float(split_name[1])
-            self.assertAlmostEqual(tree.interval[0], start)
-            self.assertAlmostEqual(tree.interval[1], end)
+            self.assertAlmostEqual(tree.interval.left, start)
+            self.assertAlmostEqual(tree.interval.right, end)
 
             self.verify_tree(nexus_tree, tree)
 

--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -356,7 +356,7 @@ def naive_genealogical_nearest_neighbours(ts, focal, reference_sets):
     ]
     for _ in range(ts.num_trees):
         trees = list(map(next, tree_iters))
-        length = trees[0].interval[1] - trees[0].interval[0]
+        length = trees[0].interval.right - trees[0].interval.left
         for j, u in enumerate(focal):
             focal_node_set = reference_set_map[u]
             # delta(u) = 1 if u exists in any of the reference sets; 0 otherwise
@@ -687,7 +687,7 @@ def exact_genealogical_nearest_neighbours(ts, focal, reference_sets):
             v = trees[0].parent(v)
         if v != tskit.NULL:
             # The length is only reported where the statistic is defined.
-            L[trees[0].index] = trees[0].interval[1] - trees[0].interval[0]
+            L[trees[0].index] = trees[0].interval.right - trees[0].interval.left
             for k, tree in enumerate(trees):
                 # If the focal node is in the current set, we subtract its
                 # contribution from the numerator
@@ -763,8 +763,8 @@ class TestExactGenealogicalNearestNeighbours(TestGenealogicalNearestNeighbours):
 
         G, lefts, rights = local_gnn(ts, focal, reference_sets)
         for tree in ts.trees():
-            assert lefts[tree.index] == tree.interval[0]
-            assert rights[tree.index] == tree.interval[1]
+            assert lefts[tree.index] == tree.interval.left
+            assert rights[tree.index] == tree.interval.right
 
         for j, u in enumerate(focal):
             T, L = exact_genealogical_nearest_neighbours(ts, u, reference_sets)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -1163,9 +1163,9 @@ def branch_diversity(ts, sample_sets, windows=None, span_normalise=True):
             denom = np.float64(len(X) * (len(X) - 1))
             has_trees = False
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
@@ -1173,7 +1173,7 @@ def branch_diversity(ts, sample_sets, windows=None, span_normalise=True):
                 for x in X:
                     for y in set(X) - {x}:
                         SS += path_length(tr, x, y)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             if has_trees:
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
@@ -1195,16 +1195,16 @@ def node_diversity(ts, sample_sets, windows=None, span_normalise=True):
             denom = np.float64(len(X) * (len(X) - 1))
             S = np.zeros(ts.num_nodes)
             for tr in ts.trees(tracked_samples=X):
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in tr.nodes():
                     # count number of pairwise paths going through u
                     n = tr.num_tracked_samples(u)
                     SS[u] += 2 * n * (tX - n)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, k] = S / denom
             if span_normalise:
@@ -1287,9 +1287,9 @@ def branch_segregating_sites(ts, sample_sets, windows=None, span_normalise=True)
         for i, X in enumerate(sample_sets):
             tX = len(X)
             for tr in ts.trees(tracked_samples=X):
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = 0
                 for u in tr.nodes():
@@ -1297,7 +1297,7 @@ def branch_segregating_sites(ts, sample_sets, windows=None, span_normalise=True)
                     if nX > 0 and nX < tX:
                         SS += tr.branch_length(u)
                 out[j][i] += SS * (
-                    min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                    min(end, tr.interval.right) - max(begin, tr.interval.left)
                 )
             if span_normalise:
                 out[j][i] /= end - begin
@@ -1316,15 +1316,15 @@ def node_segregating_sites(ts, sample_sets, windows=None, span_normalise=True):
             tX = len(X)
             S = np.zeros(ts.num_nodes)
             for tr in ts.trees(tracked_samples=X):
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in tr.nodes():
                     nX = tr.num_tracked_samples(u)
                     SS[u] = (nX > 0) and (nX < tX)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             out[j, :, k] = S
             if span_normalise:
                 out[j, :, k] /= end - begin
@@ -1489,13 +1489,13 @@ def branch_Y1(ts, sample_sets, windows=None, span_normalise=True):
             denom = np.float64(len(X) * (len(X) - 1) * (len(X) - 2))
             has_trees = False
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
-                this_length = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                this_length = min(end, tr.interval.right) - max(begin, tr.interval.left)
                 for x in X:
                     for y in set(X) - {x}:
                         for z in set(X) - {x, y}:
@@ -1575,16 +1575,16 @@ def node_Y1(ts, sample_sets, windows=None, span_normalise=True):
             denom = np.float64(tX * (tX - 1) * (tX - 2))
             S = np.zeros(ts.num_nodes)
             for tr in ts.trees(tracked_samples=X):
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in tr.nodes():
                     # count number of paths above a but not b,c
                     n = tr.num_tracked_samples(u)
                     SS[u] += n * (tX - n) * (tX - n - 1) + (tX - n) * n * (n - 1)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, k] = S / denom
             if span_normalise:
@@ -1676,9 +1676,9 @@ def branch_divergence(ts, sample_sets, indexes, windows=None, span_normalise=Tru
             has_trees = False
             S = 0
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
@@ -1686,7 +1686,7 @@ def branch_divergence(ts, sample_sets, indexes, windows=None, span_normalise=Tru
                 for x in X:
                     for y in Y:
                         SS += path_length(tr, x, y)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             if has_trees:
                 with suppress_division_by_zero_warning():
                     out[j][i] = S / denom
@@ -1708,9 +1708,9 @@ def node_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True)
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
             for t1, t2 in zip(ts.trees(tracked_samples=X), ts.trees(tracked_samples=Y)):
-                if t1.interval[1] <= begin:
+                if t1.interval.right <= begin:
                     continue
-                if t1.interval[0] >= end:
+                if t1.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in t1.nodes():
@@ -1718,7 +1718,7 @@ def node_divergence(ts, sample_sets, indexes, windows=None, span_normalise=True)
                     nX = t1.num_tracked_samples(u)
                     nY = t2.num_tracked_samples(u)
                     SS[u] += nX * (tY - nY) + (tX - nX) * nY
-                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval.right) - max(begin, t1.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
@@ -1847,12 +1847,12 @@ def branch_genetic_relatedness(
         begin = windows[j]
         end = windows[j + 1]
         for tr in ts.trees():
-            if tr.interval[1] <= begin:
+            if tr.interval.right <= begin:
                 continue
-            if tr.interval[0] >= end:
+            if tr.interval.left >= end:
                 break
             branches = [(c, tr.parent(c)) for c in tr.nodes()]
-            span = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+            span = min(end, tr.interval.right) - max(begin, tr.interval.left)
             for B in branches:
                 v = B[0]
                 area = tr.branch_length(v) * span
@@ -1896,10 +1896,10 @@ def node_genetic_relatedness(
         begin = windows[j]
         end = windows[j + 1]
         for tr in ts.trees():
-            span = min(end, tr.interval[1]) - max(begin, tr.interval[0])
-            if tr.interval[1] <= begin:
+            span = min(end, tr.interval.right) - max(begin, tr.interval.left)
+            if tr.interval.right <= begin:
                 continue
-            if tr.interval[0] >= end:
+            if tr.interval.left >= end:
                 break
             for v in tr.nodes():
                 haps = np.zeros(len(all_samples))
@@ -2200,13 +2200,13 @@ def branch_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
             has_trees = False
             S = 0
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
-                this_length = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                this_length = min(end, tr.interval.right) - max(begin, tr.interval.left)
                 for x in X:
                     for y in Y:
                         for z in set(Y) - {y}:
@@ -2288,9 +2288,9 @@ def node_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
             for t1, t2 in zip(ts.trees(tracked_samples=X), ts.trees(tracked_samples=Y)):
-                if t1.interval[1] <= begin:
+                if t1.interval.right <= begin:
                     continue
-                if t1.interval[0] >= end:
+                if t1.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in t1.nodes():
@@ -2298,7 +2298,7 @@ def node_Y2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     nX = t1.num_tracked_samples(u)
                     nY = t2.num_tracked_samples(u)
                     SS[u] += nX * (tY - nY) * (tY - nY - 1) + (tX - nX) * nY * (nY - 1)
-                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval.right) - max(begin, t1.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
@@ -2366,13 +2366,13 @@ def branch_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
             denom = np.float64(len(X) * len(Y) * len(Z))
             has_trees = False
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
-                this_length = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                this_length = min(end, tr.interval.right) - max(begin, tr.interval.left)
                 for x in X:
                     for y in Y:
                         for z in Z:
@@ -2460,9 +2460,9 @@ def node_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 ts.trees(tracked_samples=Y),
                 ts.trees(tracked_samples=Z),
             ):
-                if t1.interval[1] <= begin:
+                if t1.interval.right <= begin:
                     continue
-                if t1.interval[0] >= end:
+                if t1.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in t1.nodes():
@@ -2471,7 +2471,7 @@ def node_Y3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                     nY = t2.num_tracked_samples(u)
                     nZ = t3.num_tracked_samples(u)
                     SS[u] += nX * (tY - nY) * (tZ - nZ) + (tX - nX) * nY * nZ
-                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval.right) - max(begin, t1.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
@@ -2538,13 +2538,13 @@ def branch_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
             has_trees = False
             S = 0
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
-                this_length = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                this_length = min(end, tr.interval.right) - max(begin, tr.interval.left)
                 SS = 0
                 for a in A:
                     for b in B:
@@ -2623,9 +2623,9 @@ def node_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
             end = windows[j + 1]
             S = np.zeros(ts.num_nodes)
             for t1, t2 in zip(ts.trees(tracked_samples=A), ts.trees(tracked_samples=B)):
-                if t1.interval[1] <= begin:
+                if t1.interval.right <= begin:
                     continue
-                if t1.interval[0] >= end:
+                if t1.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in t1.nodes():
@@ -2637,7 +2637,7 @@ def node_f2(ts, sample_sets, indexes, windows=None, span_normalise=True):
                         tA - nA - 1
                     ) * nB * (nB - 1)
                     SS[u] -= 2 * nA * nB * (tA - nA) * (tB - nB)
-                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval.right) - max(begin, t1.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
@@ -2713,13 +2713,13 @@ def branch_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
             has_trees = False
             S = 0
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
-                this_length = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                this_length = min(end, tr.interval.right) - max(begin, tr.interval.left)
                 SS = 0
                 for a in A:
                     for b in B:
@@ -2804,9 +2804,9 @@ def node_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 ts.trees(tracked_samples=B),
                 ts.trees(tracked_samples=C),
             ):
-                if t1.interval[1] <= begin:
+                if t1.interval.right <= begin:
                     continue
-                if t1.interval[0] >= end:
+                if t1.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in t1.nodes():
@@ -2823,7 +2823,7 @@ def node_f3(ts, sample_sets, indexes, windows=None, span_normalise=True):
                         nA * nC * (tA - nA) * (tB - nB)
                         + (tA - nA) * (tC - nC) * nA * nB
                     )
-                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval.right) - max(begin, t1.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
@@ -2898,13 +2898,13 @@ def branch_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
             has_trees = False
             S = 0
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
-                this_length = min(end, tr.interval[1]) - max(begin, tr.interval[0])
+                this_length = min(end, tr.interval.right) - max(begin, tr.interval.left)
                 SS = 0
                 for a in A:
                     for b in B:
@@ -2995,9 +2995,9 @@ def node_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
                 ts.trees(tracked_samples=C),
                 ts.trees(tracked_samples=D),
             ):
-                if t1.interval[1] <= begin:
+                if t1.interval.right <= begin:
                     continue
-                if t1.interval[0] >= end:
+                if t1.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in t1.nodes():
@@ -3015,7 +3015,7 @@ def node_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
                         nA * nD * (tB - nB) * (tC - nC)
                         + (tA - nA) * (tD - nD) * nB * nC
                     )
-                S += SS * (min(end, t1.interval[1]) - max(begin, t1.interval[0]))
+                S += SS * (min(end, t1.interval.right) - max(begin, t1.interval.left))
             with suppress_division_by_zero_warning():
                 out[j, :, i] = S / denom
             if span_normalise:
@@ -3219,7 +3219,7 @@ def naive_branch_allele_frequency_spectrum(
         ]
         t = trees[0]
         while True:
-            tr_len = min(end, t.interval[1]) - max(begin, t.interval[0])
+            tr_len = min(end, t.interval.right) - max(begin, t.interval.left)
             if tr_len > 0:
                 for node in t.nodes():
                     if 0 < t.num_samples(node) < ts.num_samples:
@@ -4250,9 +4250,9 @@ def branch_trait_covariance(ts, W, windows=None, span_normalise=True):
             S = 0
             has_trees = False
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
@@ -4261,7 +4261,7 @@ def branch_trait_covariance(ts, W, windows=None, span_normalise=True):
                     below = np.in1d(samples, list(tr.samples(u)))
                     branch_length = tr.branch_length(u)
                     SS += covsq(w, below) * branch_length
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             if has_trees:
                 out[j, i] = S
                 if span_normalise:
@@ -4287,15 +4287,15 @@ def node_trait_covariance(ts, W, windows=None, span_normalise=True):
             w -= np.mean(w)
             S = np.zeros(ts.num_nodes)
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in range(ts.num_nodes):
                     below = np.in1d(samples, list(tr.samples(u)))
                     SS[u] += covsq(w, below)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             out[j, :, i] = S
             if span_normalise:
                 out[j, :, i] /= end - begin
@@ -4461,9 +4461,9 @@ def branch_trait_correlation(ts, W, windows=None, span_normalise=True):
             S = 0
             has_trees = False
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
@@ -4477,7 +4477,7 @@ def branch_trait_correlation(ts, W, windows=None, span_normalise=True):
                         #         sum(w[np.logical_not(below)])**2) * branch_length
                         #        / (2 * (p * (1 - p))))
                         SS += corsq(w, below) * branch_length
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             if has_trees:
                 out[j, i] = S
                 if span_normalise:
@@ -4504,9 +4504,9 @@ def node_trait_correlation(ts, W, windows=None, span_normalise=True):
             w /= np.std(w) * np.sqrt(len(w) / (len(w) - 1))
             S = np.zeros(ts.num_nodes)
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in range(ts.num_nodes):
@@ -4517,7 +4517,7 @@ def node_trait_correlation(ts, W, windows=None, span_normalise=True):
                         # SS[u] += sum(w[np.logical_not(below)])**2 / 2
                         # SS[u] /= (p * (1 - p))
                         SS[u] += corsq(w, below)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             out[j, :, i] = S
             if span_normalise:
                 out[j, :, i] /= end - begin
@@ -4708,9 +4708,9 @@ def branch_trait_linear_model(ts, W, Z, windows=None, span_normalise=True):
             S = 0
             has_trees = False
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 if tr.total_branch_length > 0:
                     has_trees = True
@@ -4719,7 +4719,7 @@ def branch_trait_linear_model(ts, W, Z, windows=None, span_normalise=True):
                     below = np.in1d(samples, list(tr.samples(u)))
                     branch_length = tr.branch_length(u)
                     SS += linear_model(w, below, Z) * branch_length
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             if has_trees:
                 out[j, i] = S
                 if span_normalise:
@@ -4745,15 +4745,15 @@ def node_trait_linear_model(ts, W, Z, windows=None, span_normalise=True):
             w = W[:, i]
             S = np.zeros(ts.num_nodes)
             for tr in ts.trees():
-                if tr.interval[1] <= begin:
+                if tr.interval.right <= begin:
                     continue
-                if tr.interval[0] >= end:
+                if tr.interval.left >= end:
                     break
                 SS = np.zeros(ts.num_nodes)
                 for u in range(ts.num_nodes):
                     below = np.in1d(samples, list(tr.samples(u)))
                     SS[u] += linear_model(w, below, Z)
-                S += SS * (min(end, tr.interval[1]) - max(begin, tr.interval[0]))
+                S += SS * (min(end, tr.interval.right) - max(begin, tr.interval.left))
             out[j, :, i] = S
             if span_normalise:
                 out[j, :, i] /= end - begin

--- a/python/tests/test_wright_fisher.py
+++ b/python/tests/test_wright_fisher.py
@@ -608,7 +608,7 @@ class TestSimplify:
             # keep_unary_in_individuals then also nodes in individuals; if
             # keep_unary then all such nodes.
             for t in ts.trees(tracked_samples=sub_samples):
-                st = sts.at(t.interval[0])
+                st = sts.at(t.interval.left)
                 visited = [False for _ in sts.nodes()]
                 for n, sn in zip(sub_samples, sts.samples()):
                     last_n = t.num_tracked_samples(n)

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -111,7 +111,7 @@ def insert_branch_mutations(ts, mutations_per_branch=1):
     tables.sites.clear()
     tables.mutations.clear()
     for tree in ts.trees():
-        site = tables.sites.add_row(position=tree.interval[0], ancestral_state="0")
+        site = tables.sites.add_row(position=tree.interval.left, ancestral_state="0")
         for root in tree.roots:
             state = {tskit.NULL: 0}
             mutation = {tskit.NULL: -1}
@@ -206,7 +206,7 @@ def insert_multichar_mutations(ts, seed=1, max_len=10):
     for tree in ts.trees():
         ancestral_state = rng.choice(letters) * rng.randint(0, max_len)
         site = tables.sites.add_row(
-            position=tree.interval[0], ancestral_state=ancestral_state
+            position=tree.interval.left, ancestral_state=ancestral_state
         )
         nodes = list(tree.nodes())
         nodes.remove(tree.root)
@@ -501,7 +501,7 @@ def generate_site_mutations(
     information are recorded in the specified tables.  Note that this records
     more than one mutation per edge.
     """
-    assert tree.interval[0] <= position < tree.interval[1]
+    assert tree.interval.left <= position < tree.interval.right
     states = ["A", "C", "G", "T"]
     ancestral_state = random.choice(states)
     site_table.add_row(position, ancestral_state)
@@ -544,7 +544,7 @@ def jukes_cantor(ts, num_sites, mu, multiple_per_node=True, seed=None):
     trees = ts.trees()
     t = next(trees)
     for position in positions:
-        while position >= t.interval[1]:
+        while position >= t.interval.right:
             t = next(trees)
         generate_site_mutations(
             t,

--- a/python/tskit/cli.py
+++ b/python/tskit/cli.py
@@ -70,8 +70,11 @@ def run_trees(args):
     for tree in ts.trees():
         print(f"tree {tree.index}:")
         print(f"  num_sites: {tree.num_sites}")
-        left, right = tree.interval
-        print("  interval:  ({0:.{2}f}, {1:.{2}f})".format(left, right, args.precision))
+        print(
+            "  interval:  ({0:.{2}f}, {1:.{2}f})".format(
+                tree.interval.left, tree.interval.right, args.precision
+            )
+        )
         if args.draw:
             print(tree.draw(format="unicode"))
 

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -409,7 +409,7 @@ def split_polytomies(
                 )
             e.args += (msg,)
         raise e
-    return ts.at(tree.interval[0], **kwargs)
+    return ts.at(tree.interval.left, **kwargs)
 
 
 def treeseq_count_topologies(ts, sample_sets):

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4199,12 +4199,12 @@ class TreeSequence:
         right = 0
         while right != L:
             left = right
-            right = min(tree1.interval[1], tree2.interval[1])
+            right = min(tree1.interval.right, tree2.interval.right)
             yield Interval(left, right), tree1, tree2
             # Advance
-            if tree1.interval[1] == right:
+            if tree1.interval.right == right:
                 tree1 = next(trees1, None)
-            if tree2.interval[1] == right:
+            if tree2.interval.right == right:
                 tree2 = next(trees2, None)
 
     def haplotypes(


### PR DESCRIPTION
I looked into replacing `Interval` with a dataclass, but we iterate on it a lot, so left it as is. I thought it worth keeping these changes from `[0]` to `.left`.
