### PR TITLE
Print actual time values for ranked times

### DIFF
--- a/python/tests/data/svg/tree_both_axes.svg
+++ b/python/tests/data/svg/tree_both_axes.svg
@@ -28,6 +28,12 @@
 					<text text-anchor="middle">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="131.4" y2="10"/>
+				<g class="tick" transform="translate(56.8 26.8)">
+					<line x1="0" x2="-5" y1="0" y2="0"/>
+					<g class="lab" transform="translate(-5,0)">
+						<text text-anchor="end">6.57</text>
+					</g>
+				</g>
 				<g class="tick" transform="translate(56.8 129.578)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
@@ -44,12 +50,6 @@
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
 						<text text-anchor="end">1.11</text>
-					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 26.8)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.57</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/tree_y_axis_rank.svg
+++ b/python/tests/data/svg/tree_y_axis_rank.svg
@@ -10,6 +10,20 @@
 					<text text-anchor="middle">Time (relative steps)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="168.2" y2="10"/>
+				<g class="tick" transform="translate(56.8 49.55)">
+					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+					<line x1="0" x2="-5" y1="0" y2="0"/>
+					<g class="lab" transform="translate(-5,0)">
+						<text text-anchor="end">5.31</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(56.8 128.65)">
+					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+					<line x1="0" x2="-5" y1="0" y2="0"/>
+					<g class="lab" transform="translate(-5,0)">
+						<text text-anchor="end">0.11</text>
+					</g>
+				</g>
 				<g class="tick" transform="translate(56.8 168.2)">
 					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
@@ -17,25 +31,11 @@
 						<text text-anchor="end">0.00</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(56.8 128.65)">
-					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.00</text>
-					</g>
-				</g>
 				<g class="tick" transform="translate(56.8 89.1)">
 					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">2.00</text>
-					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 49.55)">
-					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">3.00</text>
+						<text text-anchor="end">1.11</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_nonbinary.svg
+++ b/python/tests/data/svg/ts_nonbinary.svg
@@ -5,38 +5,38 @@
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
-			<path d="M20,0 l198.75,0 l0,138.2 l171.606,25 l0,5 l-370.356,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M218.75,0 l198.75,0 l0,138.2 l428.211,25 l0,5 l-455.355,0 l0,-5 l-171.606,-25 l0,-138.2z"/>
-			<path d="M417.5,0 l198.75,0 l0,138.2 l263.426,25 l0,5 l-33.9651,0 l0,-5 l-428.211,-25 l0,-138.2z"/>
-			<path d="M616.25,0 l198.75,0 l0,138.2 l106.244,25 l0,5 l-41.5682,0 l0,-5 l-263.426,-25 l0,-138.2z"/>
-			<path d="M815,0 l198.75,0 l0,138.2 l57.9426,25 l0,5 l-150.449,0 l0,-5 l-106.244,-25 l0,-138.2z"/>
-			<path d="M1013.75,0 l198.75,0 l0,138.2 l-87.7192,25 l0,5 l-53.0881,0 l0,-5 l-57.9426,-25 l0,-138.2z"/>
-			<path d="M1212.5,0 l198.75,0 l0,138.2 l-204.349,25 l0,5 l-82.1205,0 l0,-5 l87.7192,-25 l0,-138.2z"/>
-			<path d="M1411.25,0 l198.75,0 l0,138.2 l-331.212,25 l0,5 l-71.8872,0 l0,-5 l204.349,-25 l0,-138.2z"/>
-			<path d="M1610,0 l198.75,0 l0,138.2 l-496.112,25 l0,5 l-33.849,0 l0,-5 l331.212,-25 l0,-138.2z"/>
-			<path d="M1808.75,0 l198.75,0 l0,138.2 l-507.036,25 l0,5 l-187.827,0 l0,-5 l496.112,-25 l0,-138.2z"/>
-			<path d="M2007.5,0 l198.75,0 l0,138.2 l-506.42,25 l0,5 l-199.366,0 l0,-5 l507.036,-25 l0,-138.2z"/>
-			<path d="M2206.25,0 l198.75,0 l0,138.2 l-361.46,25 l0,5 l-343.71,0 l0,-5 l506.42,-25 l0,-138.2z"/>
-			<path d="M2405,0 l198.75,0 l0,138.2 l-142.405,25 l0,5 l-417.805,0 l0,-5 l361.46,-25 l0,-138.2z"/>
-			<path d="M2603.75,0 l198.75,0 l0,138.2 l-288.604,25 l0,5 l-52.5506,0 l0,-5 l142.405,-25 l0,-138.2z"/>
-			<path d="M2802.5,0 l198.75,0 l0,138.2 l26.9572,25 l0,5 l-514.311,0 l0,-5 l288.604,-25 l0,-138.2z"/>
-			<path d="M3001.25,0 l198.75,0 l0,138.2 l310.2,25 l0,5 l-481.992,0 l0,-5 l-26.9572,-25 l0,-138.2z"/>
-			<path d="M3200,0 l198.75,0 l0,138.2 l120.094,25 l0,5 l-8.6445,0 l0,-5 l-310.2,-25 l0,-138.2z"/>
-			<path d="M3398.75,0 l198.75,0 l0,138.2 l37.5886,25 l0,5 l-116.245,0 l0,-5 l-120.094,-25 l0,-138.2z"/>
-			<path d="M3597.5,0 l198.75,0 l0,138.2 l-138.488,25 l0,5 l-22.6733,0 l0,-5 l-37.5886,-25 l0,-138.2z"/>
-			<path d="M3796.25,0 l198.75,0 l0,138.2 l-322.968,25 l0,5 l-14.2697,0 l0,-5 l138.488,-25 l0,-138.2z"/>
-			<path d="M3995,0 l198.75,0 l0,138.2 l-438.619,25 l0,5 l-83.099,0 l0,-5 l322.968,-25 l0,-138.2z"/>
-			<path d="M4193.75,0 l198.75,0 l0,138.2 l-547.338,25 l0,5 l-90.0312,0 l0,-5 l438.619,-25 l0,-138.2z"/>
-			<path d="M4392.5,0 l198.75,0 l0,138.2 l-664.575,25 l0,5 l-81.5129,0 l0,-5 l547.338,-25 l0,-138.2z"/>
-			<path d="M4591.25,0 l198.75,0 l0,138.2 l-841.558,25 l0,5 l-21.7675,0 l0,-5 l664.575,-25 l0,-138.2z"/>
-			<path d="M4790,0 l198.75,0 l0,138.2 l-603.373,25 l0,5 l-436.935,0 l0,-5 l841.558,-25 l0,-138.2z"/>
-			<path d="M4988.75,0 l198.75,0 l0,138.2 l-716.328,25 l0,5 l-85.7947,0 l0,-5 l603.373,-25 l0,-138.2z"/>
-			<path d="M5187.5,0 l198.75,0 l0,138.2 l-840.966,25 l0,5 l-74.1124,0 l0,-5 l716.328,-25 l0,-138.2z"/>
-			<path d="M5386.25,0 l198.75,0 l0,138.2 l-699.119,25 l0,5 l-340.597,0 l0,-5 l840.966,-25 l0,-138.2z"/>
-			<path d="M5585,0 l198.75,0 l0,138.2 l-321.681,25 l0,5 l-576.188,0 l0,-5 l699.119,-25 l0,-138.2z"/>
-			<path d="M5783.75,0 l198.75,0 l0,138.2 l-209.842,25 l0,5 l-310.589,0 l0,-5 l321.681,-25 l0,-138.2z"/>
-			<path d="M5982.5,0 l198.75,0 l0,138.2 l83.0852,25 l0,5 l-491.677,0 l0,-5 l209.842,-25 l0,-138.2z"/>
-			<path d="M6181.25,0 l198.75,0 l0,138.2 l0,25 l0,5 l-115.665,0 l0,-5 l-83.0852,-25 l0,-138.2z"/>
+			<path d="M20,0 l198.75,0 l0,138.2 l171.593,25 l0,5 l-370.343,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M218.75,0 l198.75,0 l0,138.2 l428.219,25 l0,5 l-455.376,0 l0,-5 l-171.593,-25 l0,-138.2z"/>
+			<path d="M417.5,0 l198.75,0 l0,138.2 l263.431,25 l0,5 l-33.9624,0 l0,-5 l-428.219,-25 l0,-138.2z"/>
+			<path d="M616.25,0 l198.75,0 l0,138.2 l106.276,25 l0,5 l-41.5944,0 l0,-5 l-263.431,-25 l0,-138.2z"/>
+			<path d="M815,0 l198.75,0 l0,138.2 l57.9396,25 l0,5 l-150.414,0 l0,-5 l-106.276,-25 l0,-138.2z"/>
+			<path d="M1013.75,0 l198.75,0 l0,138.2 l-87.7044,25 l0,5 l-53.106,0 l0,-5 l-57.9396,-25 l0,-138.2z"/>
+			<path d="M1212.5,0 l198.75,0 l0,138.2 l-204.347,25 l0,5 l-82.1076,0 l0,-5 l87.7044,-25 l0,-138.2z"/>
+			<path d="M1411.25,0 l198.75,0 l0,138.2 l-331.229,25 l0,5 l-71.868,0 l0,-5 l204.347,-25 l0,-138.2z"/>
+			<path d="M1610,0 l198.75,0 l0,138.2 l-496.144,25 l0,5 l-33.8352,0 l0,-5 l331.229,-25 l0,-138.2z"/>
+			<path d="M1808.75,0 l198.75,0 l0,138.2 l-507.019,25 l0,5 l-187.874,0 l0,-5 l496.144,-25 l0,-138.2z"/>
+			<path d="M2007.5,0 l198.75,0 l0,138.2 l-506.447,25 l0,5 l-199.322,0 l0,-5 l507.019,-25 l0,-138.2z"/>
+			<path d="M2206.25,0 l198.75,0 l0,138.2 l-361.439,25 l0,5 l-343.758,0 l0,-5 l506.447,-25 l0,-138.2z"/>
+			<path d="M2405,0 l198.75,0 l0,138.2 l-142.4,25 l0,5 l-417.788,0 l0,-5 l361.439,-25 l0,-138.2z"/>
+			<path d="M2603.75,0 l198.75,0 l0,138.2 l-288.617,25 l0,5 l-52.5336,0 l0,-5 l142.4,-25 l0,-138.2z"/>
+			<path d="M2802.5,0 l198.75,0 l0,138.2 l26.9664,25 l0,5 l-514.333,0 l0,-5 l288.617,-25 l0,-138.2z"/>
+			<path d="M3001.25,0 l198.75,0 l0,138.2 l310.177,25 l0,5 l-481.961,0 l0,-5 l-26.9664,-25 l0,-138.2z"/>
+			<path d="M3200,0 l198.75,0 l0,138.2 l120.077,25 l0,5 l-8.6496,0 l0,-5 l-310.177,-25 l0,-138.2z"/>
+			<path d="M3398.75,0 l198.75,0 l0,138.2 l37.5876,25 l0,5 l-116.261,0 l0,-5 l-120.077,-25 l0,-138.2z"/>
+			<path d="M3597.5,0 l198.75,0 l0,138.2 l-138.457,25 l0,5 l-22.7052,0 l0,-5 l-37.5876,-25 l0,-138.2z"/>
+			<path d="M3796.25,0 l198.75,0 l0,138.2 l-322.961,25 l0,5 l-14.2464,0 l0,-5 l138.457,-25 l0,-138.2z"/>
+			<path d="M3995,0 l198.75,0 l0,138.2 l-438.649,25 l0,5 l-83.0616,0 l0,-5 l322.961,-25 l0,-138.2z"/>
+			<path d="M4193.75,0 l198.75,0 l0,138.2 l-547.342,25 l0,5 l-90.0576,0 l0,-5 l438.649,-25 l0,-138.2z"/>
+			<path d="M4392.5,0 l198.75,0 l0,138.2 l-664.556,25 l0,5 l-81.5352,0 l0,-5 l547.342,-25 l0,-138.2z"/>
+			<path d="M4591.25,0 l198.75,0 l0,138.2 l-841.555,25 l0,5 l-21.7512,0 l0,-5 l664.556,-25 l0,-138.2z"/>
+			<path d="M4790,0 l198.75,0 l0,138.2 l-603.373,25 l0,5 l-436.932,0 l0,-5 l841.555,-25 l0,-138.2z"/>
+			<path d="M4988.75,0 l198.75,0 l0,138.2 l-716.327,25 l0,5 l-85.7964,0 l0,-5 l603.373,-25 l0,-138.2z"/>
+			<path d="M5187.5,0 l198.75,0 l0,138.2 l-840.983,25 l0,5 l-74.094,0 l0,-5 l716.327,-25 l0,-138.2z"/>
+			<path d="M5386.25,0 l198.75,0 l0,138.2 l-699.091,25 l0,5 l-340.642,0 l0,-5 l840.983,-25 l0,-138.2z"/>
+			<path d="M5585,0 l198.75,0 l0,138.2 l-321.689,25 l0,5 l-576.152,0 l0,-5 l699.091,-25 l0,-138.2z"/>
+			<path d="M5783.75,0 l198.75,0 l0,138.2 l-209.816,25 l0,5 l-310.622,0 l0,-5 l321.689,-25 l0,-138.2z"/>
+			<path d="M5982.5,0 l198.75,0 l0,138.2 l83.0616,25 l0,5 l-491.628,0 l0,-5 l209.816,-25 l0,-138.2z"/>
+			<path d="M6181.25,0 l198.75,0 l0,138.2 l0,25 l0,5 l-115.688,0 l0,-5 l-83.0616,-25 l0,-138.2z"/>
 		</g>
 		<g class="axes">
 			<g class="x-axis">
@@ -50,25 +50,25 @@
 						<text>0.00</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(390.356 163.2)">
+				<g class="tick" transform="translate(390.343 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.06</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(845.711 163.2)">
+				<g class="tick" transform="translate(845.719 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.13</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(879.676 163.2)">
+				<g class="tick" transform="translate(879.681 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.14</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(921.244 163.2)">
+				<g class="tick" transform="translate(921.276 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.14</text>
@@ -80,7 +80,7 @@
 						<text>0.17</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(1124.78 163.2)">
+				<g class="tick" transform="translate(1124.8 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.17</text>
@@ -92,31 +92,31 @@
 						<text>0.19</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(1278.79 163.2)">
+				<g class="tick" transform="translate(1278.77 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.20</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(1312.64 163.2)">
+				<g class="tick" transform="translate(1312.61 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.20</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(1500.46 163.2)">
+				<g class="tick" transform="translate(1500.48 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.23</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(1699.83 163.2)">
+				<g class="tick" transform="translate(1699.8 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.26</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(2043.54 163.2)">
+				<g class="tick" transform="translate(2043.56 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.32</text>
@@ -128,25 +128,25 @@
 						<text>0.38</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(2513.9 163.2)">
+				<g class="tick" transform="translate(2513.88 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.39</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3028.21 163.2)">
+				<g class="tick" transform="translate(3028.22 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.47</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3510.2 163.2)">
+				<g class="tick" transform="translate(3510.18 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.55</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3518.84 163.2)">
+				<g class="tick" transform="translate(3518.83 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.55</text>
@@ -158,19 +158,19 @@
 						<text>0.57</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3657.76 163.2)">
+				<g class="tick" transform="translate(3657.79 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.57</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3672.03 163.2)">
+				<g class="tick" transform="translate(3672.04 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.57</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3755.13 163.2)">
+				<g class="tick" transform="translate(3755.1 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.59</text>
@@ -182,7 +182,7 @@
 						<text>0.60</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(3926.67 163.2)">
+				<g class="tick" transform="translate(3926.69 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.61</text>
@@ -206,31 +206,31 @@
 						<text>0.70</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(4545.28 163.2)">
+				<g class="tick" transform="translate(4545.27 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.71</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(4885.88 163.2)">
+				<g class="tick" transform="translate(4885.91 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.77</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(5462.07 163.2)">
+				<g class="tick" transform="translate(5462.06 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.86</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(5772.66 163.2)">
+				<g class="tick" transform="translate(5772.68 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.90</text>
 					</g>
 				</g>
-				<g class="tick" transform="translate(6264.34 163.2)">
+				<g class="tick" transform="translate(6264.31 163.2)">
 					<line x1="0" x2="0" y1="0" y2="5"/>
 					<g class="lab" transform="translate(0,5)">
 						<text>0.98</text>
@@ -878,7 +878,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 								<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -899,7 +899,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+								<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
@@ -909,8 +909,8 @@
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">0</text>
 							</g>
-							<g class="mut m1 s1 unknown_time" transform="translate(0 -15.8489)">
-								<line x1="0" x2="0" y1="0" y2="15.8489"/>
+							<g class="mut m1 s1 unknown_time" transform="translate(0 -15.8488)">
+								<line x1="0" x2="0" y1="0" y2="15.8488"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">1</text>
 							</g>
@@ -924,33 +924,33 @@
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
 							<g class="a17 node n12 p0" transform="translate(16.8672 23.7186)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
@@ -976,7 +976,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a15 m10 node n13 p0 s10" transform="translate(-19.8438 15.0885)">
+							<g class="a15 m10 node n13 p0 s10" transform="translate(-19.8438 15.0886)">
 								<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -997,9 +997,9 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
-								<g class="mut m10 s10 unknown_time" transform="translate(0 -8.24547)">
-									<line x1="0" x2="0" y1="0" y2="8.24547"/>
+								<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
+								<g class="mut m10 s10 unknown_time" transform="translate(0 -8.24548)">
+									<line x1="0" x2="0" y1="0" y2="8.24548"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">10</text>
 								</g>
@@ -1007,8 +1007,8 @@
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
 							<path class="edge" d="M 0 0 V -47.3547 H 26.293"/>
-							<g class="mut m2 s2 unknown_time" transform="translate(0 -42.4195)">
-								<line x1="0" x2="0" y1="0" y2="42.4195"/>
+							<g class="mut m2 s2 unknown_time" transform="translate(0 -42.4196)">
+								<line x1="0" x2="0" y1="0" y2="42.4196"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">2</text>
 							</g>
@@ -1042,33 +1042,33 @@
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
 							<g class="a17 m7 node n12 p0 s7" transform="translate(16.8672 23.7186)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
@@ -1109,33 +1109,33 @@
 				<g class="plotbox">
 					<g class="node n34 p0 root" transform="translate(115.25 55.1109)">
 						<g class="a34 node n12 p0" transform="translate(25.7969 65.1238)">
-							<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-								<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+								<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-								<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-									<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+							<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+								<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+									<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">8</text>
 								</g>
-								<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-									<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-										<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+								<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+									<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+										<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">6</text>
 									</g>
-									<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-										<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+									<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+										<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">9</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+									<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 								</g>
-								<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+								<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 							</g>
@@ -1155,7 +1155,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+								<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 									<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 										<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -1176,7 +1176,7 @@
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">4</text>
 									</g>
-									<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+									<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 								</g>
@@ -1202,7 +1202,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 								<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -1223,7 +1223,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+								<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
@@ -1253,33 +1253,33 @@
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
 							<g class="a25 node n12 p0" transform="translate(16.8672 47.3087)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
@@ -1300,33 +1300,33 @@
 				<g class="plotbox">
 					<g class="node n25 p0 root" transform="translate(115.25 72.926)">
 						<g class="a25 node n12 p0" transform="translate(25.7969 47.3087)">
-							<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-								<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+								<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-								<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-									<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+							<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+								<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+									<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">8</text>
 								</g>
-								<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-									<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-										<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+								<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+									<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+										<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">6</text>
 									</g>
-									<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-										<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+									<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+										<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">9</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+									<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 								</g>
-								<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+								<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 							</g>
@@ -1334,16 +1334,16 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 						</g>
-						<g class="a25 node n24 p0" transform="translate(-25.7969 1.0642)">
+						<g class="a25 node n24 p0" transform="translate(-25.7969 1.06427)">
 							<g class="a24 leaf m15 m16 m17 node n2 p0 s15 s16 s17 sample" transform="translate(17.8594 47.4098)">
 								<path class="edge" d="M 0 0 V -47.4098 H -17.8594"/>
-								<g class="mut m15 s15 unknown_time" transform="translate(0 -39.7554)">
-									<line x1="0" x2="0" y1="0" y2="39.7554"/>
+								<g class="mut m15 s15 unknown_time" transform="translate(0 -39.7553)">
+									<line x1="0" x2="0" y1="0" y2="39.7553"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab rgt" transform="translate(5 0)">15</text>
 								</g>
-								<g class="mut m16 s16 unknown_time" transform="translate(0 -30.3008)">
-									<line x1="0" x2="0" y1="0" y2="30.3008"/>
+								<g class="mut m16 s16 unknown_time" transform="translate(0 -30.3007)">
+									<line x1="0" x2="0" y1="0" y2="30.3007"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab rgt" transform="translate(5 0)">16</text>
 								</g>
@@ -1361,7 +1361,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+								<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 									<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 										<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -1382,7 +1382,7 @@
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">4</text>
 									</g>
-									<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+									<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 								</g>
@@ -1390,7 +1390,7 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">15</text>
 							</g>
-							<path class="edge" d="M 0 0 V -1.0642 H 25.7969"/>
+							<path class="edge" d="M 0 0 V -1.06427 H 25.7969"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">24</text>
 						</g>
@@ -1408,7 +1408,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 								<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -1429,7 +1429,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+								<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
@@ -1439,33 +1439,33 @@
 						</g>
 						<g class="a34 node n25 p0" transform="translate(26.293 17.8151)">
 							<g class="a25 node n12 p0" transform="translate(16.8672 47.3087)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
@@ -1501,7 +1501,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 								<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -1522,7 +1522,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+								<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
@@ -1535,11 +1535,11 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">15</text>
 						</g>
-						<g class="a34 node n18 p0" transform="translate(26.293 31.7394)">
+						<g class="a34 node n18 p0" transform="translate(26.293 31.7396)">
 							<g class="a18 leaf m19 m20 node n2 p0 s19 s20 sample" transform="translate(-16.8672 34.5496)">
 								<path class="edge" d="M 0 0 V -34.5496 H 16.8672"/>
-								<g class="mut m19 s19 unknown_time" transform="translate(0 -25.9598)">
-									<line x1="0" x2="0" y1="0" y2="25.9598"/>
+								<g class="mut m19 s19 unknown_time" transform="translate(0 -25.9597)">
+									<line x1="0" x2="0" y1="0" y2="25.9597"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">19</text>
 								</g>
@@ -1552,33 +1552,33 @@
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
 							<g class="a18 node n12 p0" transform="translate(16.8672 33.3843)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
@@ -1586,7 +1586,7 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -31.7394 H -26.293"/>
+							<path class="edge" d="M 0 0 V -31.7396 H -26.293"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">18</text>
 						</g>
@@ -1597,14 +1597,14 @@
 			</g>
 			<g class="tree t7" transform="translate(1411.25 0)">
 				<g class="plotbox">
-					<g class="node n35 p0 root" transform="translate(97.8867 50.8136)">
+					<g class="node n35 p0 root" transform="translate(97.8867 50.8135)">
 						<g class="a35 node n15 p0" transform="translate(-26.293 51.6521)">
 							<g class="a15 leaf node n7 p0 sample" transform="translate(19.8438 18.9344)">
 								<path class="edge" d="M 0 0 V -18.9344 H -19.8438"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0885)">
+							<g class="a15 node n13 p0" transform="translate(-19.8438 15.0886)">
 								<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -1625,7 +1625,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.0885 H 19.8438"/>
+								<path class="edge" d="M 0 0 V -15.0886 H 19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
@@ -1633,7 +1633,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">15</text>
 						</g>
-						<g class="a35 m23 node n18 p0 s23" transform="translate(26.293 36.0368)">
+						<g class="a35 m23 node n18 p0 s23" transform="translate(26.293 36.0369)">
 							<g class="a18 leaf m24 node n2 p0 s24 sample" transform="translate(-16.8672 34.5496)">
 								<path class="edge" d="M 0 0 V -34.5496 H 16.8672"/>
 								<g class="mut m24 s24 unknown_time" transform="translate(0 -20.8649)">
@@ -1645,48 +1645,48 @@
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
 							<g class="a18 m22 node n12 p0 s22" transform="translate(16.8672 33.3843)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
 								<path class="edge" d="M 0 0 V -33.3843 H -16.8672"/>
-								<g class="mut m22 s22 unknown_time" transform="translate(0 -20.0506)">
-									<line x1="0" x2="0" y1="0" y2="20.0506"/>
+								<g class="mut m22 s22 unknown_time" transform="translate(0 -20.0505)">
+									<line x1="0" x2="0" y1="0" y2="20.0505"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab rgt" transform="translate(5 0)">22</text>
 								</g>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -36.0368 H -26.293"/>
-							<g class="mut m23 s23 unknown_time" transform="translate(0 -21.9144)">
-								<line x1="0" x2="0" y1="0" y2="21.9144"/>
+							<path class="edge" d="M 0 0 V -36.0369 H -26.293"/>
+							<g class="mut m23 s23 unknown_time" transform="translate(0 -21.9145)">
+								<line x1="0" x2="0" y1="0" y2="21.9145"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">23</text>
 							</g>
@@ -1700,7 +1700,7 @@
 			</g>
 			<g class="tree t8" transform="translate(1610 0)">
 				<g class="plotbox">
-					<g class="node n35 p0 root" transform="translate(95.6543 50.8136)">
+					<g class="node n35 p0 root" transform="translate(95.6543 50.8135)">
 						<g class="a35 node n13 p0" transform="translate(-43.9043 66.7406)">
 							<g class="a13 leaf node n0 p0 sample" transform="translate(-23.8125 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -1726,46 +1726,46 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
-						<g class="a35 node n20 p0" transform="translate(43.9043 31.2832)">
-							<g class="a20 leaf node n7 p0 sample" transform="translate(31.2539 39.3032)">
-								<path class="edge" d="M 0 0 V -39.3032 H -31.2539"/>
+						<g class="a35 node n20 p0" transform="translate(43.9043 31.2831)">
+							<g class="a20 leaf node n7 p0 sample" transform="translate(31.2539 39.3033)">
+								<path class="edge" d="M 0 0 V -39.3033 H -31.2539"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a20 node n18 p0" transform="translate(-31.2539 4.7536)">
+							<g class="a20 node n18 p0" transform="translate(-31.2539 4.75375)">
 								<g class="a18 leaf node n2 p0 sample" transform="translate(-16.8672 34.5496)">
 									<path class="edge" d="M 0 0 V -34.5496 H 16.8672"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">2</text>
 								</g>
 								<g class="a18 node n12 p0" transform="translate(16.8672 33.3843)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
@@ -1773,11 +1773,11 @@
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -4.7536 H 31.2539"/>
+								<path class="edge" d="M 0 0 V -4.75375 H 31.2539"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">18</text>
 							</g>
-							<path class="edge" d="M 0 0 V -31.2832 H -43.9043"/>
+							<path class="edge" d="M 0 0 V -31.2831 H -43.9043"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">20</text>
 						</g>
@@ -1788,7 +1788,7 @@
 			</g>
 			<g class="tree t9" transform="translate(1808.75 0)">
 				<g class="plotbox">
-					<g class="node n35 p0 root" transform="translate(103.84 50.8136)">
+					<g class="node n35 p0 root" transform="translate(103.84 50.8135)">
 						<g class="a35 m25 m27 m29 node n13 p0 s25 s27 s29" transform="translate(-44.1523 66.7406)">
 							<g class="a13 leaf node n0 p0 sample" transform="translate(-31.75 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 31.75"/>
@@ -1821,8 +1821,8 @@
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
 							<path class="edge" d="M 0 0 V -66.7406 H 44.1523"/>
-							<g class="mut m25 s25 unknown_time" transform="translate(0 -57.6265)">
-								<line x1="0" x2="0" y1="0" y2="57.6265"/>
+							<g class="mut m25 s25 unknown_time" transform="translate(0 -57.6266)">
+								<line x1="0" x2="0" y1="0" y2="57.6266"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">25</text>
 							</g>
@@ -1831,61 +1831,61 @@
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">27</text>
 							</g>
-							<g class="mut m29 s29 unknown_time" transform="translate(0 -29.1025)">
-								<line x1="0" x2="0" y1="0" y2="29.1025"/>
+							<g class="mut m29 s29 unknown_time" transform="translate(0 -29.1026)">
+								<line x1="0" x2="0" y1="0" y2="29.1026"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">29</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
-						<g class="a35 m30 node n20 p0 s30" transform="translate(44.1523 31.2832)">
-							<g class="a20 leaf m28 node n7 p0 s28 sample" transform="translate(22.8203 39.3032)">
-								<path class="edge" d="M 0 0 V -39.3032 H -22.8203"/>
-								<g class="mut m28 s28 unknown_time" transform="translate(0 -24.259)">
-									<line x1="0" x2="0" y1="0" y2="24.259"/>
+						<g class="a35 m30 node n20 p0 s30" transform="translate(44.1523 31.2831)">
+							<g class="a20 leaf m28 node n7 p0 s28 sample" transform="translate(22.8203 39.3033)">
+								<path class="edge" d="M 0 0 V -39.3033 H -22.8203"/>
+								<g class="mut m28 s28 unknown_time" transform="translate(0 -24.2591)">
+									<line x1="0" x2="0" y1="0" y2="24.2591"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab rgt" transform="translate(5 0)">28</text>
 								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a20 node n12 p0" transform="translate(-22.8203 38.1379)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a20 node n12 p0" transform="translate(-22.8203 38.138)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -38.1379 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -38.138 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -31.2832 H -44.1523"/>
+							<path class="edge" d="M 0 0 V -31.2831 H -44.1523"/>
 							<g class="mut m30 s30 unknown_time" transform="translate(0 -18.6002)">
 								<line x1="0" x2="0" y1="0" y2="18.6002"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -1901,7 +1901,7 @@
 			</g>
 			<g class="tree t10" transform="translate(2007.5 0)">
 				<g class="plotbox">
-					<g class="node n35 p0 root" transform="translate(103.84 50.8136)">
+					<g class="node n35 p0 root" transform="translate(103.84 50.8135)">
 						<g class="a35 m31 m35 node n13 p0 s31 s35" transform="translate(-44.1523 66.7406)">
 							<g class="a13 leaf node n0 p0 sample" transform="translate(-31.75 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 31.75"/>
@@ -1948,50 +1948,50 @@
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
 						<g class="a35 node n16 p0" transform="translate(44.1523 47.8554)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 m34 node n12 p0 s34" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 m34 node n12 p0 s34" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf m32 node n8 p0 s32 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
-										<g class="mut m32 s32 unknown_time" transform="translate(0 -0.358532)">
-											<line x1="0" x2="0" y1="0" y2="0.358532"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf m32 node n8 p0 s32 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
+										<g class="mut m32 s32 unknown_time" transform="translate(0 -0.358531)">
+											<line x1="0" x2="0" y1="0" y2="0.358531"/>
 											<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 											<text class="lab rgt" transform="translate(5 0)">32</text>
 										</g>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
-								<g class="mut m34 s34 unknown_time" transform="translate(0 -12.2067)">
-									<line x1="0" x2="0" y1="0" y2="12.2067"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
+								<g class="mut m34 s34 unknown_time" transform="translate(0 -12.2068)">
+									<line x1="0" x2="0" y1="0" y2="12.2068"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">34</text>
 								</g>
@@ -2055,48 +2055,48 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
-						<g class="a33 m38 node n16 p0 s38" transform="translate(44.1523 40.5273)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+						<g class="a33 m38 node n16 p0 s38" transform="translate(44.1523 40.5272)">
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -40.5273 H -44.1523"/>
+							<path class="edge" d="M 0 0 V -40.5272 H -44.1523"/>
 							<g class="mut m38 s38 unknown_time" transform="translate(0 -25.1512)">
 								<line x1="0" x2="0" y1="0" y2="25.1512"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -2112,7 +2112,7 @@
 			</g>
 			<g class="tree t12" transform="translate(2405 0)">
 				<g class="plotbox">
-					<g class="node n28 p0 root" transform="translate(103.84 67.5219)">
+					<g class="node n28 p0 root" transform="translate(103.84 67.522)">
 						<g class="a28 m42 m45 node n13 p0 s42 s45" transform="translate(-44.1523 50.0322)">
 							<g class="a13 leaf node n0 p0 sample" transform="translate(-31.75 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 31.75"/>
@@ -2153,70 +2153,70 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
-						<g class="a28 m40 m43 node n16 p0 s40 s43" transform="translate(44.1523 31.1471)">
-							<g class="a16 leaf m46 node n7 p0 s46 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
-								<g class="mut m46 s46 unknown_time" transform="translate(0 -12.9454)">
-									<line x1="0" x2="0" y1="0" y2="12.9454"/>
+						<g class="a28 m40 m43 node n16 p0 s40 s43" transform="translate(44.1523 31.1469)">
+							<g class="a16 leaf m46 node n7 p0 s46 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
+								<g class="mut m46 s46 unknown_time" transform="translate(0 -12.9455)">
+									<line x1="0" x2="0" y1="0" y2="12.9455"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab rgt" transform="translate(5 0)">46</text>
 								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 m41 m44 node n12 p0 s41 s44" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 m41 m44 node n12 p0 s41 s44" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
-								<g class="mut m41 s41 unknown_time" transform="translate(0 -15.5734)">
-									<line x1="0" x2="0" y1="0" y2="15.5734"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
+								<g class="mut m41 s41 unknown_time" transform="translate(0 -15.5735)">
+									<line x1="0" x2="0" y1="0" y2="15.5735"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">41</text>
 								</g>
-								<g class="mut m44 s44 unknown_time" transform="translate(0 -8.53341)">
-									<line x1="0" x2="0" y1="0" y2="8.53341"/>
+								<g class="mut m44 s44 unknown_time" transform="translate(0 -8.53348)">
+									<line x1="0" x2="0" y1="0" y2="8.53348"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">44</text>
 								</g>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -31.1471 H -44.1523"/>
-							<g class="mut m40 s40 unknown_time" transform="translate(0 -23.1744)">
-								<line x1="0" x2="0" y1="0" y2="23.1744"/>
+							<path class="edge" d="M 0 0 V -31.1469 H -44.1523"/>
+							<g class="mut m40 s40 unknown_time" transform="translate(0 -23.1742)">
+								<line x1="0" x2="0" y1="0" y2="23.1742"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">40</text>
 							</g>
-							<g class="mut m43 s43 unknown_time" transform="translate(0 -13.2285)">
-								<line x1="0" x2="0" y1="0" y2="13.2285"/>
+							<g class="mut m43 s43 unknown_time" transform="translate(0 -13.2284)">
+								<line x1="0" x2="0" y1="0" y2="13.2284"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">43</text>
 							</g>
@@ -2261,48 +2261,48 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
-						<g class="a33 node n16 p0" transform="translate(44.1523 40.5273)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+						<g class="a33 node n16 p0" transform="translate(44.1523 40.5272)">
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -40.5273 H -44.1523"/>
+							<path class="edge" d="M 0 0 V -40.5272 H -44.1523"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 						</g>
@@ -2313,7 +2313,7 @@
 			</g>
 			<g class="tree t14" transform="translate(2802.5 0)">
 				<g class="plotbox">
-					<g class="node n35 p0 root" transform="translate(103.84 50.8136)">
+					<g class="node n35 p0 root" transform="translate(103.84 50.8135)">
 						<g class="a35 m47 m48 m50 m51 m53 node n13 p0 s47 s48 s50 s51 s53" transform="translate(-44.1523 66.7406)">
 							<g class="a13 leaf node n0 p0 sample" transform="translate(-31.75 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 31.75"/>
@@ -2370,43 +2370,43 @@
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
 						<g class="a35 m49 m52 node n16 p0 s49 s52" transform="translate(44.1523 47.8554)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
@@ -2431,7 +2431,7 @@
 			</g>
 			<g class="tree t15" transform="translate(3001.25 0)">
 				<g class="plotbox">
-					<g class="node n19 p0 root" transform="translate(103.84 86.0222)">
+					<g class="node n19 p0 root" transform="translate(103.84 86.0223)">
 						<g class="a19 m55 node n13 p0 s55" transform="translate(-44.1523 31.5319)">
 							<g class="a13 leaf node n0 p0 sample" transform="translate(-31.75 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 31.75"/>
@@ -2467,50 +2467,50 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 						</g>
-						<g class="a19 m54 node n16 p0 s54" transform="translate(44.1523 12.6468)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+						<g class="a19 m54 node n16 p0 s54" transform="translate(44.1523 12.6466)">
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -12.6468 H -44.1523"/>
-							<g class="mut m54 s54 unknown_time" transform="translate(0 -6.81685)">
-								<line x1="0" x2="0" y1="0" y2="6.81685"/>
+							<path class="edge" d="M 0 0 V -12.6466 H -44.1523"/>
+							<g class="mut m54 s54 unknown_time" transform="translate(0 -6.81677)">
+								<line x1="0" x2="0" y1="0" y2="6.81677"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">54</text>
 							</g>
@@ -2530,7 +2530,7 @@
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a38 node n19 p0" transform="translate(39.9355 47.273)">
+						<g class="a38 node n19 p0" transform="translate(39.9355 47.2731)">
 							<g class="a19 node n13 p0" transform="translate(-40.1836 31.5319)">
 								<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -2556,57 +2556,57 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
-							<g class="a19 node n16 p0" transform="translate(40.1836 12.6468)">
-								<g class="a16 leaf m56 node n7 p0 s56 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
-									<g class="mut m56 s56 unknown_time" transform="translate(0 -12.9454)">
-										<line x1="0" x2="0" y1="0" y2="12.9454"/>
+							<g class="a19 node n16 p0" transform="translate(40.1836 12.6466)">
+								<g class="a16 leaf m56 node n7 p0 s56 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
+									<g class="mut m56 s56 unknown_time" transform="translate(0 -12.9455)">
+										<line x1="0" x2="0" y1="0" y2="12.9455"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">56</text>
 									</g>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -12.6468 H -40.1836"/>
+								<path class="edge" d="M 0 0 V -12.6466 H -40.1836"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 							</g>
-							<path class="edge" d="M 0 0 V -47.273 H -39.9355"/>
+							<path class="edge" d="M 0 0 V -47.2731 H -39.9355"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">19</text>
 						</g>
@@ -2654,53 +2654,53 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
-							<g class="a19 node n16 p0" transform="translate(40.1836 12.6468)">
-								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+							<g class="a19 node n16 p0" transform="translate(40.1836 12.6466)">
+								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 m58 node n12 p0 s58" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 m58 node n12 p0 s58" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
-									<g class="mut m58 s58 unknown_time" transform="translate(0 -12.2067)">
-										<line x1="0" x2="0" y1="0" y2="12.2067"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
+									<g class="mut m58 s58 unknown_time" transform="translate(0 -12.2068)">
+										<line x1="0" x2="0" y1="0" y2="12.2068"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab lft" transform="translate(-5 0)">58</text>
 									</g>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -12.6468 H -40.1836"/>
+								<path class="edge" d="M 0 0 V -12.6466 H -40.1836"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 							</g>
@@ -2731,7 +2731,7 @@
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a37 node n19 p0" transform="translate(39.9355 45.7708)">
+						<g class="a37 node n19 p0" transform="translate(39.9355 45.7709)">
 							<g class="a19 node n13 p0" transform="translate(-40.1836 31.5319)">
 								<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -2757,52 +2757,52 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
-							<g class="a19 node n16 p0" transform="translate(40.1836 12.6468)">
-								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+							<g class="a19 node n16 p0" transform="translate(40.1836 12.6466)">
+								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -12.6468 H -40.1836"/>
+								<path class="edge" d="M 0 0 V -12.6466 H -40.1836"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 							</g>
-							<path class="edge" d="M 0 0 V -45.7708 H -39.9355"/>
+							<path class="edge" d="M 0 0 V -45.7709 H -39.9355"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">19</text>
 						</g>
@@ -2819,7 +2819,7 @@
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a40 node n19 p0" transform="translate(39.9355 59.2222)">
+						<g class="a40 node n19 p0" transform="translate(39.9355 59.2223)">
 							<g class="a19 node n13 p0" transform="translate(-40.1836 31.5319)">
 								<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -2845,52 +2845,52 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
-							<g class="a19 node n16 p0" transform="translate(40.1836 12.6468)">
-								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+							<g class="a19 node n16 p0" transform="translate(40.1836 12.6466)">
+								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -12.6468 H -40.1836"/>
+								<path class="edge" d="M 0 0 V -12.6466 H -40.1836"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 							</g>
-							<path class="edge" d="M 0 0 V -59.2222 H -39.9355"/>
+							<path class="edge" d="M 0 0 V -59.2223 H -39.9355"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">19</text>
 						</g>
@@ -2907,7 +2907,7 @@
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a40 m62 node n31 p0 s62" transform="translate(39.9355 39.3941)">
+						<g class="a40 m62 node n31 p0 s62" transform="translate(39.9355 39.394)">
 							<g class="a31 node n13 p0" transform="translate(-40.1836 51.3601)">
 								<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -2933,62 +2933,62 @@
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">13</text>
 							</g>
-							<g class="a31 m63 node n16 p0 s63" transform="translate(40.1836 32.475)">
-								<g class="a16 leaf m61 node n7 p0 s61 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
-									<g class="mut m61 s61 unknown_time" transform="translate(0 -12.9454)">
-										<line x1="0" x2="0" y1="0" y2="12.9454"/>
+							<g class="a31 m63 node n16 p0 s63" transform="translate(40.1836 32.4749)">
+								<g class="a16 leaf m61 node n7 p0 s61 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
+									<g class="mut m61 s61 unknown_time" transform="translate(0 -12.9455)">
+										<line x1="0" x2="0" y1="0" y2="12.9455"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">61</text>
 									</g>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -32.475 H -40.1836"/>
-								<g class="mut m63 s63 unknown_time" transform="translate(0 -19.42)">
-									<line x1="0" x2="0" y1="0" y2="19.42"/>
+								<path class="edge" d="M 0 0 V -32.4749 H -40.1836"/>
+								<g class="mut m63 s63 unknown_time" transform="translate(0 -19.4199)">
+									<line x1="0" x2="0" y1="0" y2="19.4199"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab rgt" transform="translate(5 0)">63</text>
 								</g>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 							</g>
-							<path class="edge" d="M 0 0 V -39.3941 H -39.9355"/>
+							<path class="edge" d="M 0 0 V -39.394 H -39.9355"/>
 							<g class="mut m62 s62 unknown_time" transform="translate(0 -24.3249)">
 								<line x1="0" x2="0" y1="0" y2="24.3249"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -3056,48 +3056,48 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a32 m68 node n16 p0 s68" transform="translate(28.2773 36.1101)">
-								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+							<g class="a32 m68 node n16 p0 s68" transform="translate(28.2773 36.11)">
+								<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -36.1101 H -28.2773"/>
+								<path class="edge" d="M 0 0 V -36.11 H -28.2773"/>
 								<g class="mut m68 s68 unknown_time" transform="translate(0 -21.9664)">
 									<line x1="0" x2="0" y1="0" y2="21.9664"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -3118,50 +3118,50 @@
 			<g class="tree t22" transform="translate(4392.5 0)">
 				<g class="plotbox">
 					<g class="node n40 p0 root" transform="translate(97.8867 26.8)">
-						<g class="a40 m72 node n16 p0 s72" transform="translate(50.1055 71.869)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+						<g class="a40 m72 node n16 p0 s72" transform="translate(50.1055 71.8689)">
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -71.869 H -50.1055"/>
-							<g class="mut m72 s72 unknown_time" transform="translate(0 -50.1818)">
-								<line x1="0" x2="0" y1="0" y2="50.1818"/>
+							<path class="edge" d="M 0 0 V -71.8689 H -50.1055"/>
+							<g class="mut m72 s72 unknown_time" transform="translate(0 -50.1817)">
+								<line x1="0" x2="0" y1="0" y2="50.1817"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">72</text>
 							</g>
@@ -3174,7 +3174,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a23 node n13 p0" transform="translate(19.8438 41.8335)">
+							<g class="a23 node n13 p0" transform="translate(19.8438 41.8336)">
 								<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -3195,13 +3195,13 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">2</text>
 								</g>
-								<path class="edge" d="M 0 0 V -41.8335 H -19.8438"/>
+								<path class="edge" d="M 0 0 V -41.8336 H -19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 							</g>
 							<path class="edge" d="M 0 0 V -48.9206 H 50.1055"/>
-							<g class="mut m69 s69 unknown_time" transform="translate(0 -41.1276)">
-								<line x1="0" x2="0" y1="0" y2="41.1276"/>
+							<g class="mut m69 s69 unknown_time" transform="translate(0 -41.1275)">
+								<line x1="0" x2="0" y1="0" y2="41.1275"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">69</text>
 							</g>
@@ -3226,50 +3226,50 @@
 			<g class="tree t23" transform="translate(4591.25 0)">
 				<g class="plotbox">
 					<g class="node n39 p0 root" transform="translate(97.8867 34.4472)">
-						<g class="a39 m73 node n16 p0 s73" transform="translate(50.1055 64.2218)">
-							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.731)">
-								<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
+						<g class="a39 m73 node n16 p0 s73" transform="translate(50.1055 64.2217)">
+							<g class="a16 leaf node n7 p0 sample" transform="translate(22.8203 22.7311)">
+								<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">7</text>
 							</g>
-							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+							<g class="a16 node n12 p0" transform="translate(-22.8203 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
+								<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 							</g>
-							<path class="edge" d="M 0 0 V -64.2218 H -50.1055"/>
-							<g class="mut m73 s73 unknown_time" transform="translate(0 -43.7306)">
-								<line x1="0" x2="0" y1="0" y2="43.7306"/>
+							<path class="edge" d="M 0 0 V -64.2217 H -50.1055"/>
+							<g class="mut m73 s73 unknown_time" transform="translate(0 -43.7305)">
+								<line x1="0" x2="0" y1="0" y2="43.7305"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">73</text>
 							</g>
@@ -3282,7 +3282,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a23 node n13 p0" transform="translate(19.8438 41.8335)">
+							<g class="a23 node n13 p0" transform="translate(19.8438 41.8336)">
 								<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 									<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -3303,7 +3303,7 @@
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">2</text>
 								</g>
-								<path class="edge" d="M 0 0 V -41.8335 H -19.8438"/>
+								<path class="edge" d="M 0 0 V -41.8336 H -19.8438"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 							</g>
@@ -3369,90 +3369,90 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a39 m80 m81 m83 node n22 p0 s80 s81 s83" transform="translate(-45.3926 42.5755)">
+						<g class="a39 m80 m81 m83 node n22 p0 s80 s81 s83" transform="translate(-45.3926 42.5754)">
 							<g class="a22 leaf m76 node n0 p0 s76 sample" transform="translate(-28.2773 44.3773)">
 								<path class="edge" d="M 0 0 V -44.3773 H 28.2773"/>
-								<g class="mut m76 s76 unknown_time" transform="translate(0 -28.0046)">
-									<line x1="0" x2="0" y1="0" y2="28.0046"/>
+								<g class="mut m76 s76 unknown_time" transform="translate(0 -28.0047)">
+									<line x1="0" x2="0" y1="0" y2="28.0047"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">76</text>
 								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a22 node n16 p0" transform="translate(28.2773 21.6463)">
-								<g class="a16 leaf m74 m75 node n7 p0 s74 s75 sample" transform="translate(22.8203 22.731)">
-									<path class="edge" d="M 0 0 V -22.731 H -22.8203"/>
-									<g class="mut m74 s74 unknown_time" transform="translate(0 -16.4776)">
-										<line x1="0" x2="0" y1="0" y2="16.4776"/>
+							<g class="a22 node n16 p0" transform="translate(28.2773 21.6462)">
+								<g class="a16 leaf m74 m75 node n7 p0 s74 s75 sample" transform="translate(22.8203 22.7311)">
+									<path class="edge" d="M 0 0 V -22.7311 H -22.8203"/>
+									<g class="mut m74 s74 unknown_time" transform="translate(0 -16.4777)">
+										<line x1="0" x2="0" y1="0" y2="16.4777"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">74</text>
 									</g>
-									<g class="mut m75 s75 unknown_time" transform="translate(0 -9.07412)">
-										<line x1="0" x2="0" y1="0" y2="9.07412"/>
+									<g class="mut m75 s75 unknown_time" transform="translate(0 -9.07417)">
+										<line x1="0" x2="0" y1="0" y2="9.07417"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">75</text>
 									</g>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<g class="a16 m77 m82 node n12 p0 s77 s82" transform="translate(-22.8203 21.5657)">
-									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-										<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+								<g class="a16 m77 m82 node n12 p0 s77 s82" transform="translate(-22.8203 21.5658)">
+									<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+										<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">5</text>
 									</g>
-									<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-											<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+									<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+										<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+											<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">8</text>
 										</g>
-										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+										<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+											<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">6</text>
 											</g>
-											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-												<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+											<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+												<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 												<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 												<text class="lab" transform="translate(0 11)">9</text>
 											</g>
-											<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+											<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 											<circle class="sym" cx="0" cy="0" r="3"/>
 											<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+										<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 									</g>
-									<path class="edge" d="M 0 0 V -21.5657 H 22.8203"/>
-									<g class="mut m77 s77 unknown_time" transform="translate(0 -15.5734)">
-										<line x1="0" x2="0" y1="0" y2="15.5734"/>
+									<path class="edge" d="M 0 0 V -21.5658 H 22.8203"/>
+									<g class="mut m77 s77 unknown_time" transform="translate(0 -15.5735)">
+										<line x1="0" x2="0" y1="0" y2="15.5735"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab lft" transform="translate(-5 0)">77</text>
 									</g>
-									<g class="mut m82 s82 unknown_time" transform="translate(0 -8.53341)">
-										<line x1="0" x2="0" y1="0" y2="8.53341"/>
+									<g class="mut m82 s82 unknown_time" transform="translate(0 -8.53348)">
+										<line x1="0" x2="0" y1="0" y2="8.53348"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab lft" transform="translate(-5 0)">82</text>
 									</g>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab lft" transform="translate(-3 -7.0)">12</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.6463 H -28.2773"/>
+								<path class="edge" d="M 0 0 V -21.6462 H -28.2773"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">16</text>
 							</g>
-							<path class="edge" d="M 0 0 V -42.5755 H 45.3926"/>
+							<path class="edge" d="M 0 0 V -42.5754 H 45.3926"/>
 							<g class="mut m80 s80 unknown_time" transform="translate(0 -35.3976)">
 								<line x1="0" x2="0" y1="0" y2="35.3976"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">80</text>
 							</g>
-							<g class="mut m81 s81 unknown_time" transform="translate(0 -26.6605)">
-								<line x1="0" x2="0" y1="0" y2="26.6605"/>
+							<g class="mut m81 s81 unknown_time" transform="translate(0 -26.6604)">
+								<line x1="0" x2="0" y1="0" y2="26.6604"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab lft" transform="translate(-5 0)">81</text>
 							</g>
@@ -3502,58 +3502,58 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a39 node n16 p0" transform="translate(-45.1445 64.2218)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a39 node n16 p0" transform="translate(-45.1445 64.2217)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
+								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -64.2218 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -64.2217 H 45.1445"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
 						</g>
@@ -3564,7 +3564,7 @@
 			</g>
 			<g class="tree t26" transform="translate(5187.5 0)">
 				<g class="plotbox">
-					<g class="node n27 p0 root" transform="translate(101.855 68.7104)">
+					<g class="node n27 p0 root" transform="translate(101.855 68.7105)">
 						<g class="a27 node n13 p0" transform="translate(45.1445 48.8437)">
 							<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -3590,58 +3590,58 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a27 node n16 p0" transform="translate(-45.1445 29.9586)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a27 node n16 p0" transform="translate(-45.1445 29.9584)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
+								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -29.9586 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -29.9584 H 45.1445"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
 						</g>
@@ -3653,7 +3653,7 @@
 			<g class="tree t27" transform="translate(5386.25 0)">
 				<g class="plotbox">
 					<g class="node n26 p0 root" transform="translate(101.855 71.724)">
-						<g class="a26 m89 m90 node n13 p0 s89 s90" transform="translate(45.1445 45.8301)">
+						<g class="a26 m89 m90 node n13 p0 s89 s90" transform="translate(45.1445 45.8302)">
 							<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -3674,7 +3674,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<path class="edge" d="M 0 0 V -45.8301 H -45.1445"/>
+							<path class="edge" d="M 0 0 V -45.8302 H -45.1445"/>
 							<g class="mut m89 s89 unknown_time" transform="translate(0 -35.4785)">
 								<line x1="0" x2="0" y1="0" y2="35.4785"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -3688,68 +3688,68 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a26 node n16 p0" transform="translate(-45.1445 26.945)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a26 node n16 p0" transform="translate(-45.1445 26.9449)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf m88 m91 node n7 p0 s88 s91 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
-									<g class="mut m88 s88 unknown_time" transform="translate(0 -5.12778)">
-										<line x1="0" x2="0" y1="0" y2="5.12778"/>
+								<g class="a14 leaf m88 m91 node n7 p0 s88 s91 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
+									<g class="mut m88 s88 unknown_time" transform="translate(0 -5.12771)">
+										<line x1="0" x2="0" y1="0" y2="5.12771"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">88</text>
 									</g>
-									<g class="mut m91 s91 unknown_time" transform="translate(0 -2.64529)">
-										<line x1="0" x2="0" y1="0" y2="2.64529"/>
+									<g class="mut m91 s91 unknown_time" transform="translate(0 -2.64525)">
+										<line x1="0" x2="0" y1="0" y2="2.64525"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">91</text>
 									</g>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -26.945 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -26.9449 H 45.1445"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
 						</g>
@@ -3760,7 +3760,7 @@
 			</g>
 			<g class="tree t28" transform="translate(5585 0)">
 				<g class="plotbox">
-					<g class="node n27 p0 root" transform="translate(101.855 68.7104)">
+					<g class="node n27 p0 root" transform="translate(101.855 68.7105)">
 						<g class="a27 m94 m95 m96 node n13 p0 s94 s95 s96" transform="translate(45.1445 48.8437)">
 							<g class="a13 leaf node n1 p0 sample" transform="translate(-23.8125 3.84582)">
 								<path class="edge" d="M 0 0 V -3.84582 H 23.8125"/>
@@ -3801,68 +3801,68 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a27 node n16 p0" transform="translate(-45.1445 29.9586)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a27 node n16 p0" transform="translate(-45.1445 29.9584)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 m93 node n14 p0 s93" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 m93 node n14 p0 s93" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf m92 node n7 p0 s92 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
-									<g class="mut m92 s92 unknown_time" transform="translate(0 -3.90562)">
-										<line x1="0" x2="0" y1="0" y2="3.90562"/>
+								<g class="a14 leaf m92 node n7 p0 s92 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
+									<g class="mut m92 s92 unknown_time" transform="translate(0 -3.90557)">
+										<line x1="0" x2="0" y1="0" y2="3.90557"/>
 										<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 										<text class="lab rgt" transform="translate(5 0)">92</text>
 									</g>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
-								<g class="mut m93 s93 unknown_time" transform="translate(0 -8.34988)">
-									<line x1="0" x2="0" y1="0" y2="8.34988"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
+								<g class="mut m93 s93 unknown_time" transform="translate(0 -8.35001)">
+									<line x1="0" x2="0" y1="0" y2="8.35001"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 									<text class="lab lft" transform="translate(-5 0)">93</text>
 								</g>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -29.9586 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -29.9584 H 45.1445"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
 						</g>
@@ -3904,58 +3904,58 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a32 m97 m98 m99 node n16 p0 s97 s98 s99" transform="translate(-45.1445 36.1101)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a32 m97 m98 m99 node n16 p0 s97 s98 s99" transform="translate(-45.1445 36.11)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
+								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -36.1101 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -36.11 H 45.1445"/>
 							<g class="mut m97 s97 unknown_time" transform="translate(0 -29.6548)">
 								<line x1="0" x2="0" y1="0" y2="29.6548"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -4017,58 +4017,58 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a21 node n16 p0" transform="translate(-45.1445 18.6181)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a21 node n16 p0" transform="translate(-45.1445 18.618)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
+								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -18.6181 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -18.618 H 45.1445"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
 						</g>
@@ -4110,58 +4110,58 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">13</text>
 						</g>
-						<g class="a32 node n16 p0" transform="translate(-45.1445 36.1101)">
-							<g class="a16 node n12 p0" transform="translate(20.8359 21.5657)">
-								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16532)">
-									<path class="edge" d="M 0 0 V -1.16532 H 17.8594"/>
+						<g class="a32 node n16 p0" transform="translate(-45.1445 36.11)">
+							<g class="a16 node n12 p0" transform="translate(20.8359 21.5658)">
+								<g class="a12 leaf node n5 p0 sample" transform="translate(-17.8594 1.16528)">
+									<path class="edge" d="M 0 0 V -1.16528 H 17.8594"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">5</text>
 								</g>
-								<g class="a12 node n11 p0" transform="translate(17.8594 0.451409)">
-									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713906)">
-										<path class="edge" d="M 0 0 V -0.713906 H -11.9062"/>
+								<g class="a12 node n11 p0" transform="translate(17.8594 0.451377)">
+									<g class="a11 leaf node n8 p0 sample" transform="translate(11.9062 0.713905)">
+										<path class="edge" d="M 0 0 V -0.713905 H -11.9062"/>
 										<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 										<text class="lab" transform="translate(0 11)">8</text>
 									</g>
-									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280605)">
-										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H 7.9375"/>
+									<g class="a11 node n10 p0" transform="translate(-11.9062 0.280455)">
+										<g class="a10 leaf node n6 p0 sample" transform="translate(-7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H 7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">6</text>
 										</g>
-										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.433301)">
-											<path class="edge" d="M 0 0 V -0.433301 H -7.9375"/>
+										<g class="a10 leaf node n9 p0 sample" transform="translate(7.9375 0.43345)">
+											<path class="edge" d="M 0 0 V -0.43345 H -7.9375"/>
 											<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 											<text class="lab" transform="translate(0 11)">9</text>
 										</g>
-										<path class="edge" d="M 0 0 V -0.280605 H 11.9062"/>
+										<path class="edge" d="M 0 0 V -0.280455 H 11.9062"/>
 										<circle class="sym" cx="0" cy="0" r="3"/>
 										<text class="lab lft" transform="translate(-3 -7.0)">10</text>
 									</g>
-									<path class="edge" d="M 0 0 V -0.451409 H -17.8594"/>
+									<path class="edge" d="M 0 0 V -0.451377 H -17.8594"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
 									<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 								</g>
-								<path class="edge" d="M 0 0 V -21.5657 H -20.8359"/>
+								<path class="edge" d="M 0 0 V -21.5658 H -20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab rgt" transform="translate(3 -7.0)">12</text>
 							</g>
-							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2646)">
-								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H 7.9375"/>
+							<g class="a16 node n14 p0" transform="translate(-20.8359 15.2648)">
+								<g class="a14 leaf node n0 p0 sample" transform="translate(-7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H 7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">0</text>
 								</g>
-								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46635)">
-									<path class="edge" d="M 0 0 V -7.46635 H -7.9375"/>
+								<g class="a14 leaf node n7 p0 sample" transform="translate(7.9375 7.46625)">
+									<path class="edge" d="M 0 0 V -7.46625 H -7.9375"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">7</text>
 								</g>
-								<path class="edge" d="M 0 0 V -15.2646 H 20.8359"/>
+								<path class="edge" d="M 0 0 V -15.2648 H 20.8359"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">14</text>
 							</g>
-							<path class="edge" d="M 0 0 V -36.1101 H 45.1445"/>
+							<path class="edge" d="M 0 0 V -36.11 H 45.1445"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
 						</g>

--- a/python/tests/data/svg/ts_rank.svg
+++ b/python/tests/data/svg/ts_rank.svg
@@ -95,7 +95,7 @@
 			</g>
 			<g class="y-axis">
 				<g class="lab" transform="translate(0,65.7)">
-					<text text-anchor="middle">Ranked node time</text>
+					<text text-anchor="middle">Node time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
 				<g class="tick" transform="translate(56.8 121.4)">
@@ -107,37 +107,37 @@
 				<g class="tick" transform="translate(56.8 105.486)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.00</text>
+						<text text-anchor="end">0.11</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 89.5714)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">2.00</text>
+						<text text-anchor="end">1.11</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 73.6571)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">3.00</text>
+						<text text-anchor="end">1.75</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 57.7429)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">4.00</text>
+						<text text-anchor="end">5.31</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 41.8286)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.00</text>
+						<text text-anchor="end">6.57</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 25.9143)">
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.00</text>
+						<text text-anchor="end">9.08</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -58,13 +58,14 @@ class TestTreeDraw:
         demographic_events = [
             msprime.SimpleBottleneck(time=0.1, population=0, proportion=0.5)
         ]
-        return msprime.simulate(
+        ts = msprime.simulate(
             10,
             recombination_rate=5,
             mutation_rate=10,
             demographic_events=demographic_events,
             random_seed=1,
         )
+        return ts
 
     def get_nonbinary_tree(self):
         for t in self.get_nonbinary_ts().trees():
@@ -1494,7 +1495,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         with pytest.raises(NotImplementedError):
             plot.draw_x_axis(tick_positions=ts.breakpoints(as_array=True))
         with pytest.raises(NotImplementedError):
-            plot.draw_y_axis(tick_positions=[0])
+            plot.draw_y_axis(ticks={0: "0"})
 
     def test_bad_tick_spacing(self):
         # Integer y_ticks to give auto-generated tick locs is not currently implemented
@@ -1948,7 +1949,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
             (None, "Time"),
             ("time", "Time"),
             ("log_time", "Time"),
-            ("rank", "Ranked node time"),
+            ("rank", "Node time"),
         ]:
             svg = tree.draw_svg(y_axis=True, tree_height_scale=hscale)
             svg_no_css = svg[svg.find("</style>") :]
@@ -2092,7 +2093,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         assert svg_no_css.count("y-axis") == 0
         self.verify_known_svg(svg, "tree_x_axis.svg", overwrite_viz, width=400)
 
-    def test_known_svg_tree_y_axis(self, overwrite_viz, draw_plotbox):
+    def test_known_svg_tree_y_axis_rank(self, overwrite_viz, draw_plotbox):
         tree = self.get_simple_ts().at_index(1)
         label = "Time (relative steps)"
         svg = tree.draw_svg(
@@ -2110,7 +2111,7 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         assert svg_no_css.count("axes") == 1
         assert svg_no_css.count("x-axis") == 0
         assert svg_no_css.count("y-axis") == 1
-        self.verify_known_svg(svg, "tree_y_axis.svg", overwrite_viz)
+        self.verify_known_svg(svg, "tree_y_axis_rank.svg", overwrite_viz)
 
     def test_known_svg_tree_both_axes(self, overwrite_viz, draw_plotbox):
         tree = self.get_simple_ts().at_index(-1)


### PR DESCRIPTION
Fixes https://github.com/tskit-dev/tskit/issues/1263

Note that the `y_ticks` param now allows either a list of positions (as before) *or* a dict of `{pos1: label1, pos2: label2}`. The dict use is not documented, and neither is the fact that the position used when placing bespoke labels with `scale="rank"` is the rank position, not the actual time.

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
