### PR TITLE
Use msprime alpha on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           # It's sometimes necessary to nuke the cache, and the simplest
           # way to do it is to change the key. We can increment this
           # version number when we want to do this.
-          key: tskit-{{ .Branch }}-v4
+          key: tskit-{{ .Branch }}-v5
       - run:
           name: Checkout submodules
           command: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
             /usr/share/miniconda/envs/anaconda-client-env
             ~/osx-conda
             ~/.profile
-          key: ${{ runner.os }}-${{ matrix.python}}-conda-v10-${{ hashFiles('python/requirements/CI-tests-conda/requirements.txt') }}-${{ hashFiles('python/requirements/CI-tests-pip/requirements.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python}}-conda-v11-${{ hashFiles('python/requirements/CI-tests-conda/requirements.txt') }}-${{ hashFiles('python/requirements/CI-tests-pip/requirements.txt') }}
 
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2
@@ -85,7 +85,11 @@ jobs:
       - name: Install conda deps
         if: steps.cache.outputs.cache-hit != 'true'
         shell: bash -l {0} #We need a login shell to get conda
-        run: conda install --yes --file=python/requirements/CI-tests-conda/requirements.txt
+        run: |
+          conda install --yes --file=python/requirements/CI-tests-conda/requirements.txt
+          # Install pre-release from non standard label until msprime
+          # 1.0 is tagged.
+          conda install -c conda-forge/label/msprime_rc msprime
 
       - name: Install pip deps
         if: steps.cache.outputs.cache-hit != 'true'

--- a/python/requirements/CI-complete/requirements.txt
+++ b/python/requirements/CI-complete/requirements.txt
@@ -6,7 +6,7 @@ h5py==3.1.0
 jsonschema==3.2.0
 kastore==0.3.1
 msgpack==1.0.2
-msprime==0.7.4
+msprime==1.0.0a6
 networkx==2.5
 newick==1.0.0
 numpy==1.19.5

--- a/python/requirements/CI-tests-conda/requirements.txt
+++ b/python/requirements/CI-tests-conda/requirements.txt
@@ -1,2 +1,2 @@
 numpy<=1.19.5 #Pinned as we get build errors - check again after 3.6 dropped
-msprime==0.7.4
+#msprime==0.7.4 # Pre-release is installed manually, re-instate after msprime 1.0


### PR DESCRIPTION
This works - although we get different SVGs, so we won't be able to get both versions of msprime to pass with the same expected SVG files.