### PR TITLE
Use defaults when decoding JSON metadata

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -65,8 +65,9 @@ JSON
 When ``json`` is specified as the ``codec`` in the schema the metadata is encoded in
 the human readable `JSON <https://www.json.org/json-en.html>`_ format. As this format
 is human readable and encodes numbers as text it uses more bytes than the ``struct``
-format. However it is simpler to configure as it doesn't have any specific constraints and
-doesn't require any format specifiers for each type in the schema.
+format. However it is simpler to configure as it doesn't require any format specifier
+for each type in the schema. Default values for properties can be specified for only
+the shallowest level of the metadata object.
 
 ------
 struct

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -526,6 +526,47 @@ class TestMetadataModule:
         assert ms.decode_row(ms.validate_and_encode_row(row_data)) == row_data
 
 
+class TestJSONCodec:
+    def test_simple_default(self):
+        schema = {
+            "codec": "json",
+            "type": "object",
+            "properties": {"number": {"type": "number", "default": 5}},
+        }
+        ms = tskit.MetadataSchema(schema)
+        assert ms.decode_row(ms.validate_and_encode_row({})) == {"number": 5}
+        assert ms.decode_row(ms.validate_and_encode_row({"number": 42})) == {
+            "number": 42
+        }
+
+    def test_nested_default_error(self):
+        schema = {
+            "codec": "json",
+            "type": "object",
+            "properties": {
+                "obj": {
+                    "type": "object",
+                    "properties": {
+                        "nested_obj_no_default": {
+                            "type": "object",
+                            "properties": {},
+                        },
+                        "nested_obj": {
+                            "type": "object",
+                            "properties": {},
+                            "default": {"foo": "bar"},
+                        },
+                    },
+                }
+            },
+        }
+        with pytest.raises(
+            tskit.MetadataSchemaValidationError,
+            match="Defaults can only be specified at the top level for JSON codec",
+        ):
+            tskit.MetadataSchema(schema)
+
+
 class TestStructCodec:
     def encode_decode(self, method_name, sub_schema, obj, buffer):
         assert (


### PR DESCRIPTION
Fixes #1073 

Only uses defaults for the first-level of objects. Raises error if the schema specifies deeper defaults.