### PR TITLE
Make returned values for edge diffs a namedtuple

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -92,8 +92,15 @@ def draw_plotbox(request):
 
 
 @fixture(scope="session")
-def simple_ts_fixture():
+def simple_degree1_ts_fixture():
     return msprime.simulate(10, random_seed=42)
+
+
+@fixture(scope="session")
+def simple_degree2_ts_fixture():
+    ts = msprime.simulate(10, recombination_rate=0.2, random_seed=42)
+    assert ts.num_trees == 2
+    return ts
 
 
 @fixture(scope="session")

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -653,6 +653,13 @@ class TestTreeSequence(HighLevelTestCase):
         for ts in get_example_tree_sequences():
             self.verify_edge_diffs(ts)
 
+    def test_edge_diffs_names(self, simple_degree2_ts_fixture):
+        for val in simple_degree2_ts_fixture.edge_diffs():
+            assert len(val) == 3
+            assert val[0] == val.interval
+            assert val[1] == val.edges_out
+            assert val[2] == val.edges_in
+
     def test_edge_diffs_include_terminal(self):
         for ts in get_example_tree_sequences():
             edges = set()

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -2680,8 +2680,8 @@ class TestSimplifyTables:
                 assert ts.individual(node.individual).metadata == node.metadata
         assert set(tables.individuals.parents) != {tskit.NULL}
 
-    def test_bad_individuals(self, simple_ts_fixture):
-        tables = simple_ts_fixture.dump_tables()
+    def test_bad_individuals(self, simple_degree1_ts_fixture):
+        tables = simple_degree1_ts_fixture.dump_tables()
         tables.individuals.clear()
         tables.individuals.add_row(parents=[-2])
         with pytest.raises(tskit.LibraryError, match="Individual out of bounds"):
@@ -2693,8 +2693,8 @@ class TestSimplifyTables:
         ):
             tables.simplify()
 
-    def test_unsorted_individuals_ok(self, simple_ts_fixture):
-        tables = simple_ts_fixture.dump_tables()
+    def test_unsorted_individuals_ok(self, simple_degree1_ts_fixture):
+        tables = simple_degree1_ts_fixture.dump_tables()
         tables.individuals.clear()
         tables.individuals.clear()
         tables.individuals.add_row(parents=[1])
@@ -3110,10 +3110,10 @@ class TestTableCollection:
         tree = next(trees)
         assert len(tree.parent_dict) == 0
 
-    def test_indexes(self, simple_ts_fixture):
+    def test_indexes(self, simple_degree1_ts_fixture):
         tc = tskit.TableCollection(sequence_length=1)
         assert tc.indexes == tskit.TableCollectionIndexes()
-        tc = simple_ts_fixture.tables
+        tc = simple_degree1_ts_fixture.tables
         assert np.array_equal(
             tc.indexes.edge_insertion_order, np.arange(18, dtype=np.int32)
         )
@@ -3142,13 +3142,13 @@ class TestTableCollection:
             tc.indexes.edge_removal_order, np.arange(4242, 4242 + 18, dtype=np.int32)
         )
 
-    def test_indexes_roundtrip(self, simple_ts_fixture):
+    def test_indexes_roundtrip(self, simple_degree1_ts_fixture):
         # Indexes shouldn't be made by roundtripping
         tables = tskit.TableCollection(sequence_length=1)
         assert not tables.has_index()
         assert not tskit.TableCollection.fromdict(tables.asdict()).has_index()
 
-        tables = simple_ts_fixture.dump_tables()
+        tables = simple_degree1_ts_fixture.dump_tables()
         tables.drop_index()
         assert not tskit.TableCollection.fromdict(tables.asdict()).has_index()
 


### PR DESCRIPTION
I always have to force myself to remember that the returned values from the `edge_diffs` iterator are `(intvl, out, in)` not `(intvl, in, out)` - I think it's because the Hokey Cokey goes in, out, in , out before shaking it all about.

This trivial addition should make it much clearer and stop mistakes down the line.

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
