### PR TITLE
Fix crashes on circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             libgsl-dev
             # Install meson to the system packages so we can run it as root
             sudo pip install meson==0.55
-            pip install numpy==1.19.5
+            pip install numpy==1.18.5
             pip install --user -r python/requirements/CI-complete/requirements.txt
             pip install twine --user
             # Remove tskit installed by msprime
@@ -125,7 +125,7 @@ jobs:
           name: Run Python tests
           command: |
             cd python
-            python -m pytest --cov=tskit  --cov-report=xml --cov-branch -n16 tests
+            python -m pytest --cov=tskit  --cov-report=xml --cov-branch -n4 tests
 
       - run:
           name: Upload Python coverage

--- a/python/requirements/CI-complete/requirements.txt
+++ b/python/requirements/CI-complete/requirements.txt
@@ -9,7 +9,7 @@ msgpack==1.0.2
 msprime==1.0.0a6
 networkx==2.5
 newick==1.0.0
-numpy==1.19.5
+numpy==1.18.5
 portion==2.1.5
 pyparsing==2.4.7
 pysam==0.16.0.1

--- a/python/requirements/CI-tests-conda/requirements.txt
+++ b/python/requirements/CI-tests-conda/requirements.txt
@@ -1,2 +1,2 @@
-numpy<=1.19.5 #Pinned as we get build errors - check again after 3.6 dropped
+numpy<=1.19.5 #Pinned as we get compatibility warnings.
 #msprime==0.7.4 # Pre-release is installed manually, re-instate after msprime 1.0


### PR DESCRIPTION
Downgrade numpy for testing, fixes #1280 

Reduce concurrency, should stop crashes.