### PR TITLE
Don't draw empty flanks

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -12,6 +12,11 @@
 - Add ``Table.append`` method for adding rows from classes such as ``SiteTableRow`` and
   ``Site`` (:user:`benjeffery`, :issue:`1111`, :pr:`1254`).
 
+- SVG visualization of a tree sequence can be restricted to displaying between left
+  and right genomic coordinates using the ``x_lim`` parameter. The default settings
+  now mean that if the left or right flanks of a tree sequence are entirely empty, 
+  these regions will not be plotted in the SVG (:user:`hyanwong`, :pr:`1288`).
+
 - SVG visualization of a single tree allows all mutations on an edge to be plotted
   via the ``all_edge_mutations`` param (:user:`hyanwong`,:issue:`1253`, :pr:`1258`).
 

--- a/python/tests/data/svg/ts_x_lim.svg
+++ b/python/tests/data/svg/ts_x_lim.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="600">
+	<defs>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+	</defs>
+	<g class="tree-sequence">
+		<g class="background">
+			<path d="M20,0 l186.667,0 l0,138.2 l-180.894,25 l0,5 l-5.7731,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M206.667,0 l186.667,0 l0,138.2 l115.817,25 l0,5 l-483.377,0 l0,-5 l180.894,-25 l0,-138.2z"/>
+			<path d="M393.333,0 l186.667,0 l0,138.2 l0,25 l0,5 l-70.8501,0 l0,-5 l-115.817,-25 l0,-138.2z"/>
+		</g>
+		<g class="axes">
+			<g class="x-axis">
+				<g class="lab" transform="translate(300,200)">
+					<text text-anchor="middle">Genome position</text>
+				</g>
+				<line x1="20" x2="580" y1="163.2" y2="163.2"/>
+				<g class="tick" transform="translate(25.7731 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.06</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(509.15 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.79</text>
+					</g>
+				</g>
+				<g class="site s0" transform="translate(25.9364 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m1">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+					<g class="mut m0">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+				</g>
+				<g class="site s1" transform="translate(184.24 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m3">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+					<g class="mut m2">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+				</g>
+				<g class="site s2" transform="translate(316.16 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+				</g>
+			</g>
+		</g>
+		<g class="plotbox trees">
+			<g class="tree t1" transform="translate(20 0)">
+				<g class="plotbox">
+					<g class="node n9 p0 root" transform="translate(93.3333 22.3778)">
+						<g class="a9 node n4 p0" transform="translate(-36.6667 97.7739)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.3333 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.3333 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -97.7739 H 36.6667"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a9 node n5 p0" transform="translate(36.6667 86.9138)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(18.3333 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -86.9138 H -36.6667"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+					</g>
+				</g>
+			</g>
+			<g class="tree t2" transform="translate(206.667 0)">
+				<g class="plotbox">
+					<g class="m2 node n7 p0 root s1" transform="translate(93.3333 63.504)">
+						<g class="a7 m0 m1 node n4 p0 s0" transform="translate(-36.6667 56.6478)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.3333 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.3333 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -56.6478 H 36.6667"/>
+							<g class="mut m0 s0 unknown_time" transform="translate(0 -37.7652)">
+								<line x1="0" x2="0" y1="0" y2="37.7652"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">0</text>
+							</g>
+							<g class="mut m1 s0 unknown_time" transform="translate(0 -18.8826)">
+								<line x1="0" x2="0" y1="0" y2="18.8826"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">1</text>
+							</g>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(36.6667 45.7876)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf m3 node n3 p0 s1 sample" transform="translate(18.3333 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -18.3333"/>
+								<g class="mut m3 s1 unknown_time" transform="translate(0 -6.05422)">
+									<line x1="0" x2="0" y1="0" y2="6.05422"/>
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">3</text>
+								</g>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -45.7876 H -36.6667"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<g class="mut m2 s1 unknown_time" transform="translate(0 -6.18889)">
+							<line x1="0" x2="0" y1="0" y2="6.18889"/>
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">2</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="tree t3" transform="translate(393.333 0)">
+				<g class="plotbox">
+					<g class="node n6 p0 root" transform="translate(93.3333 102.321)">
+						<g class="a6 node n4 p0" transform="translate(-36.6667 17.8305)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.3333 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.3333 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -17.8305 H 36.6667"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a6 node n5 p0" transform="translate(36.6667 6.97033)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(18.3333 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -18.3333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -6.97033 H -36.6667"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1541,8 +1541,8 @@ class Tree:
         force_root_branch=None,
         symbol_size=None,
         x_axis=None,
-        y_axis=None,
         x_label=None,
+        y_axis=None,
         y_label=None,
         y_ticks=None,
         y_gridlines=None,
@@ -1698,11 +1698,11 @@ class Tree:
         :param bool x_axis: Should the plot have an X axis line, showing the start and
             end position of this tree along the genome. If ``None`` (default) do not
             plot an X axis.
+        :param str x_label: Place a label under the plot. If ``None`` (default) and
+            there is an X axis, create and place an appropriate label.
         :param bool y_axis: Should the plot have an Y axis line, showing time (or
             ranked node time if ``tree_height_scale="rank"``). If ``None`` (default)
             do not plot a Y axis.
-        :param str x_label: Place a label under the plot. If ``None`` (default) and
-            there is an X axis, create and place an appropriate label.
         :param str y_label: Place a label to the left of the plot. If ``None`` (default)
             and there is a Y axis,  create and place an appropriate label.
         :param list y_ticks: A list of Y values at which to plot tickmarks (``[]``
@@ -1735,8 +1735,8 @@ class Tree:
             force_root_branch=force_root_branch,
             symbol_size=symbol_size,
             x_axis=x_axis,
-            y_axis=y_axis,
             x_label=x_label,
+            y_axis=y_axis,
             y_label=y_label,
             y_ticks=y_ticks,
             y_gridlines=y_gridlines,
@@ -5465,8 +5465,9 @@ class TreeSequence:
         force_root_branch=None,
         symbol_size=None,
         x_axis=None,
-        y_axis=None,
         x_label=None,
+        x_lim=None,
+        y_axis=None,
         y_label=None,
         y_ticks=None,
         y_gridlines=None,
@@ -5539,11 +5540,20 @@ class TreeSequence:
         :param bool x_axis: Should the plot have an X axis line, showing the positions
             of trees along the genome. The scale used is determined by the ``x_scale``
             parameter. If ``None`` (default) plot an X axis.
+        :param str x_label: Place a label under the plot. If ``None`` (default) and
+            there is an X axis, create and place an appropriate label.
+        :param list x_lim: A list of size two giving the genomic positions between which
+            trees should be plotted. If the first is ``None``, then plot from the first
+            non-empty region of the tree sequence. If the second is ``None``, then plot
+            up to the end of the last non-empty region of the tree sequence. The default
+            value ``x_lim=None`` is shorthand for the list [``None``, ``None``]. If
+            numerical values are given, then regions outside the interval have all
+            information discarded: this means that mutations outside the interval will
+            not be shown. To force display of the entire tree sequence, including empty
+            flanking regions, specify ``x_lim=[0, ts.sequence_length]``.
         :param bool y_axis: Should the plot have an Y axis line, showing time (or
             ranked node time if ``tree_height_scale="rank"``. If ``None`` (default)
             do not plot a Y axis.
-        :param str x_label: Place a label under the plot. If ``None`` (default) and
-            there is an X axis, create and place an appropriate label.
         :param str y_label: Place a label to the left of the plot. If ``None`` (default)
             and there is a Y axis, create and place an appropriate label.
         :param list y_ticks: A list of Y values at which to plot tickmarks (``[]``
@@ -5554,6 +5564,17 @@ class TreeSequence:
 
         :return: An SVG representation of a tree sequence.
         :rtype: str
+
+        .. note::
+            Technically, x_lim[0] specifies a *minimum* value for the start of the X
+            axis, and x_lim[1] specifies a *maximum* value for the end. This is only
+            relevant if the tree sequence contains "empty" regions with no edges or
+            mutations. In this case if x_lim[0] lies strictly within an empty region
+            (i.e. ``empty_tree.interval.left < x_lim[0] < empty_tree.interval.right``)
+            then that tree will not be plotted on the left hand side, and the X axis
+            will start at ``empty_tree.interval.right``. Similarly, if x_lim[1] lies
+            strictly within an empty region then that tree will not be plotted on the
+            right hand side, and the X axis will end at ``empty_tree.interval.left``
         """
         draw = drawing.SvgTreeSequence(
             self,
@@ -5568,8 +5589,9 @@ class TreeSequence:
             force_root_branch=force_root_branch,
             symbol_size=symbol_size,
             x_axis=x_axis,
-            y_axis=y_axis,
             x_label=x_label,
+            x_lim=x_lim,
+            y_axis=y_axis,
             y_label=y_label,
             y_ticks=y_ticks,
             y_gridlines=y_gridlines,


### PR DESCRIPTION
## Description

A draft for being able to specify only a certain genomic region to display on an SVG plot, using e.g. `x_lim=[1000, 2000]` to display only trees within the regions 1000-2000 base pairs. This is implemented by deleting the flanking intervals but keeping the coordinate system. As part of this, we want to make sure that we don't display the missing flanks in a tree sequence. This is of general benefit, as such sequences are likely to be generated e.g. by https://github.com/tskit-dev/msprime/pull/1599. Therefore this PR also changes the default behaviour of `ts.draw_svg()` so that if there are tree(s) to left or right that are completely empty (no edges and no mutations) they are not displayed. I think that's usually what will be wanted anyway.

As a nice addition, if a tree has been chopped off by specifying an x_lim, that tick won't be plotted, to imply that the tree continues to the left or right (and is simply not displayed). Here's the example in the tests:

<img width="590" alt="Screenshot 2021-03-31 at 21 59 18" src="https://user-images.githubusercontent.com/4699014/113210634-5aa7c600-926c-11eb-8449-bd36de95550c.png">


# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
