### PR TITLE
Add the ability to set your own svg symbols

### DIFF
--- a/python/tests/data/svg/ts_alt_symbols.svg
+++ b/python/tests/data/svg/ts_alt_symbols.svg
@@ -1,0 +1,350 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
+	<defs>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+	</defs>
+	<g class="tree-sequence">
+		<g class="background">
+			<path d="M20,0 l192,0 l0,138.2 l-134.638,25 l0,5 l-57.3623,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M212,0 l192,0 l0,138.2 l376.883,25 l0,5 l-703.52,0 l0,-5 l134.638,-25 l0,-138.2z"/>
+			<path d="M404,0 l192,0 l0,138.2 l294.091,25 l0,5 l-109.208,0 l0,-5 l-376.883,-25 l0,-138.2z"/>
+			<path d="M596,0 l192,0 l0,138.2 l105.883,25 l0,5 l-3.79176,0 l0,-5 l-294.091,-25 l0,-138.2z"/>
+			<path d="M788,0 l192,0 l0,138.2 l0,25 l0,5 l-86.1174,0 l0,-5 l-105.883,-25 l0,-138.2z"/>
+		</g>
+		<g class="axes">
+			<g class="x-axis">
+				<g class="lab" transform="translate(500,200)">
+					<text text-anchor="middle">Genome position</text>
+				</g>
+				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
+				<g class="tick" transform="translate(20 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.00</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(77.3623 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.06</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(780.883 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.79</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(890.091 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.91</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(893.883 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>0.91</text>
+					</g>
+				</g>
+				<g class="tick" transform="translate(980 163.2)">
+					<line x1="0" x2="0" y1="0" y2="5"/>
+					<g class="lab" transform="translate(0,5)">
+						<text>1.00</text>
+					</g>
+				</g>
+				<g class="site s0" transform="translate(68 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m2">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+					<g class="mut m1">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+					<g class="mut m0">
+						<polyline class="sym" points="2.5,-14.5 0,-9.5 -2.5,-14.5"/>
+					</g>
+				</g>
+				<g class="site s1" transform="translate(77.6 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m4">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+					<g class="mut m3">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+				</g>
+				<g class="site s2" transform="translate(308 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m6">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+					<g class="mut m5">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+				</g>
+				<g class="site s3" transform="translate(500 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+				</g>
+				<g class="site s4" transform="translate(893.6 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m7">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g class="plotbox trees">
+			<g class="tree t0" transform="translate(20 0)">
+				<g class="plotbox">
+					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
+						<g class="a9 node n4 p0" transform="translate(-38 97.7739)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
+								<g class="sym">
+									<circle cx="0" cy="0" fill="yellow" r="10"/>
+									<text>Hello</text>
+								</g>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -97.7739 H 38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a9 m2 node n5 p0 s0" transform="translate(38 86.9138)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -86.9138 H -38"/>
+							<g class="mut m2 s0 unknown_time" transform="translate(0 -43.4569)">
+								<line x1="0" x2="0" y1="0" y2="43.4569"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab rgt" transform="translate(5 0)">2</text>
+							</g>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
+							<line x1="0" x2="0" y1="0" y2="8.25185"/>
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">0</text>
+						</g>
+						<g class="mut m1 s0 unknown_time" transform="translate(0 -4.12593)">
+							<line x1="0" x2="0" y1="0" y2="4.12593"/>
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">1</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+					</g>
+				</g>
+			</g>
+			<g class="tree t1" transform="translate(212 0)">
+				<g class="plotbox">
+					<g class="m5 node n7 p0 root s2" transform="translate(96 63.504)">
+						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
+								<g class="sym">
+									<circle cx="0" cy="0" fill="yellow" r="10"/>
+									<text>Hello</text>
+								</g>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -56.6478 H 38"/>
+							<g class="mut m3 s1 unknown_time" transform="translate(0 -37.7652)">
+								<line x1="0" x2="0" y1="0" y2="37.7652"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">3</text>
+							</g>
+							<g class="mut m4 s1 unknown_time" transform="translate(0 -18.8826)">
+								<line x1="0" x2="0" y1="0" y2="18.8826"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">4</text>
+							</g>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf m6 node n3 p0 s2 sample" transform="translate(19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -19"/>
+								<g class="mut m6 s2 unknown_time" transform="translate(0 -6.05422)">
+									<line x1="0" x2="0" y1="0" y2="6.05422"/>
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">6</text>
+								</g>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
+							<line x1="0" x2="0" y1="0" y2="6.18889"/>
+							<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+							<text class="lab rgt" transform="translate(5 0)">5</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="tree t2" transform="translate(404 0)">
+				<g class="plotbox">
+					<g class="node n6 p0 root" transform="translate(96 102.321)">
+						<g class="a6 node n4 p0" transform="translate(-38 17.8305)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
+								<g class="sym">
+									<circle cx="0" cy="0" fill="yellow" r="10"/>
+									<text>Hello</text>
+								</g>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -17.8305 H 38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a6 node n5 p0" transform="translate(38 6.97033)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -6.97033 H -38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+					</g>
+				</g>
+			</g>
+			<g class="tree t3" transform="translate(596 0)">
+				<g class="plotbox">
+					<g class="node n7 p0 root" transform="translate(96 63.504)">
+						<g class="a7 node n4 p0" transform="translate(-38 56.6478)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
+								<g class="sym">
+									<circle cx="0" cy="0" fill="yellow" r="10"/>
+									<text>Hello</text>
+								</g>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -56.6478 H 38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf m7 node n3 p0 s4 sample" transform="translate(19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -19"/>
+								<g class="mut m7 s4 unknown_time" transform="translate(0 -6.05422)">
+									<line x1="0" x2="0" y1="0" y2="6.05422"/>
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">7</text>
+								</g>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+					</g>
+				</g>
+			</g>
+			<g class="tree t4" transform="translate(788 0)">
+				<g class="plotbox">
+					<g class="node n8 p0 root" transform="translate(96 49.7389)">
+						<g class="a8 node n4 p0" transform="translate(-38 70.4129)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
+								<g class="sym">
+									<circle cx="0" cy="0" fill="yellow" r="10"/>
+									<text>Hello</text>
+								</g>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(19 1.24828)">
+								<path class="edge" d="M 0 0 V -1.24828 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">1</text>
+							</g>
+							<path class="edge" d="M 0 0 V -70.4129 H 38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+						</g>
+						<g class="a8 node n5 p0" transform="translate(38 59.5527)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">2</text>
+							</g>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(19 12.1084)">
+								<path class="edge" d="M 0 0 V -12.1084 H -19"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">3</text>
+							</g>
+							<path class="edge" d="M 0 0 V -59.5527 H -38"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -36,6 +36,7 @@ import xml.etree
 import msprime
 import numpy as np
 import pytest
+import svgwrite
 import xmlunittest
 
 import tests.test_wright_fisher as wf
@@ -2160,6 +2161,23 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         assert svg_no_css.count('class="site ') == ts.num_sites
         assert svg_no_css.count('class="mut ') == ts.num_mutations * 2
         self.verify_known_svg(svg, "ts.svg", overwrite_viz, width=200 * ts.num_trees)
+
+    def test_known_svg_ts_alt_symbols(self, overwrite_viz, draw_plotbox):
+        dwg = svgwrite.Drawing()
+
+        def pie(*, r, **kwargs):
+            ret = dwg.g(**kwargs)
+            ret.add(dwg.circle(r=r, center=(0, 0), fill="yellow"))
+            ret.add(dwg.text("Hello"))
+            return ret
+
+        ts = self.get_simple_ts()
+        svg = ts.draw_svg(
+            debug_box=draw_plotbox, node_attrs={0: {"element": pie, "r": 10}}
+        )
+        self.verify_known_svg(
+            svg, "ts_alt_symbols.svg", overwrite_viz, width=200 * ts.num_trees
+        )
 
     def test_known_svg_ts_no_axes(self, overwrite_viz, draw_plotbox):
         ts = self.get_simple_ts()


### PR DESCRIPTION
This is a draft that allows symbols in an SVG plot to be swapped for any SVG drawing commands. It's perhaps a bit hacky, but @awohns might be able too use it to do some funky stuff, so I'm draft PRing it here.

His idea was to swap the symbols for pie charts showing the distribution of populations under a node, which thus allows us to plot trees with huge numbers of tips using summary pie charts at the tips. He can take this further for examples.