### PR TITLE
Add RankTree.leaves()

### DIFF
--- a/python/tests/test_combinatorics.py
+++ b/python/tests/test_combinatorics.py
@@ -481,6 +481,31 @@ class TestRankTree:
         six_leaf_sym = RankTree(children=[three_leaf_asym, three_leaf_asym])
         assert six_leaf_sym.is_symmetrical()
 
+    @pytest.mark.parametrize("n", range(7))
+    def test_leaves(self, n):
+        for tree in RankTree.all_unlabelled_trees(n):
+            first_labelled_tree = RankTree.unrank(n, (tree.shape_rank(), 0))
+            assert list(first_labelled_tree.leaves()) == list(range(n))
+
+    @pytest.mark.parametrize("n", range(5))
+    def test_no_leaves(self, n):
+        for tree in RankTree.all_unlabelled_trees(n):
+            assert list(tree.leaves()) == [None] * n
+
+    @pytest.mark.parametrize("n", range(6))
+    def test_newick_order(self, n):
+        del_digits = {ord(c): "" for c in "1234567890"}
+        del_other = {ord(c): "" for c in "(,);"}
+        for unlabelled_tree in RankTree.all_unlabelled_trees(n):
+            first_labelled_tree = RankTree.unrank(n, (unlabelled_tree.shape_rank(), 0))
+            newick_braces = first_labelled_tree.newick().translate(del_digits)
+            for tree in RankTree.all_labellings(unlabelled_tree):
+                nwk = tree.newick()
+                assert nwk.translate(del_digits) == newick_braces
+                assert nwk.translate(del_other) == "".join(
+                    str(x) for x in tree.leaves()
+                )
+
 
 class TestPartialTopologyCounter:
     def test_add_sibling_topologies_simple(self):

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -1024,6 +1024,13 @@ class RankTree:
                         yield [labeled_first] + labeled_rest
 
     def newick(self):
+        """
+        Return a newick string for this RankTree. For a given tree shape, the order of
+        each child grouping in the string (the "orientation" of the topology) will
+        always be identical. In other words, the grouping braces will stay in an
+        identical order and only the labels will change with each unique labelling
+        (the labels will be listed in the same order as returned by ``.leaves()``)
+        """
         if self.is_leaf():
             return str(self.label) if self.labelled() else ""
         return "(" + ",".join(c.newick() for c in self.children) + ")"
@@ -1043,6 +1050,20 @@ class RankTree:
 
     def leaf_partition(self):
         return [c.num_leaves for c in self.children]
+
+    def leaves(self):
+        """
+        Return a iterator over all the labels in the RankTree, in standard left-right
+        traversal order of the canonical orientation of the topology.
+
+        .. note::
+            The default (0th) labelling, produces ``n`` labels in numerical order, from
+            ``0`` to ``n-1`` so that ``unrank(n, (shape_rank, 0)).leaves()`` is
+            equivalent to ``range(n)`` for any ``n`` and valid associated ``shape_rank``.
+        """
+        if self.is_leaf():
+            return (self.label,)
+        return (label for c in self.children for label in c.leaves())
 
     def group_children_by_num_leaves(self):
         def same_num_leaves(c1, c2):


### PR DESCRIPTION
## Description

Adds an iterator over the leaf labels of a RankTree. After discussion with @daniel-goldstein we simply called this `.leaves()` in analogy with the iterator `Tree.leaves()`. This also internally documents some properties of the order returned by both `.leaves()` and `.newick()`, and tests they are true up to topologies of size 5 or 7.

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
