### PR TITLE
Improve string and html output

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,24 +4,27 @@
 
 **Breaking changes**
 
-- `Mutation.position` and `Mutation.index` which were deprecated in 0.2.2 (Sep '19) have
+- ``Mutation.position`` and ``Mutation.index`` which were deprecated in 0.2.2 (Sep '19) have
   been removed.
 
 **Features**
 
-- Add `Table.append` method for adding rows from classes such as `SiteTableRow` and
-  `Site` (:user:`benjeffery`, :issue:`1111`, :pr:`1254`).
+- Add ``Table.append`` method for adding rows from classes such as ``SiteTableRow`` and
+  ``Site`` (:user:`benjeffery`, :issue:`1111`, :pr:`1254`).
 
 - SVG visualization of a single tree allows all mutations on an edge to be plotted
   via the ``all_edge_mutations`` param (:user:`hyanwong`,:issue:`1253`, :pr:`1258`).
 
-- Entity classes such as `Mutation`, `Node` are now python dataclasses
+- Entity classes such as ``Mutation``, ``Node`` are now python dataclasses
   (:user:`benjeffery`, :pr:`1261`).
 
 - Metadata decoding for table row access is now lazy (:user:`benjeffery`, :pr:`1261`).
 
 - Add html notebook representation for ``Tree`` and change ``Tree.__str__`` from dict
   representation to info table. (:user:`benjeffery`, :issue:`1269`, :pr:`1304`).
+
+- Improve display of tables when ``print``ed, limiting lines set via
+  ``tskit.set_print_options`` (:user:`benjeffery`,:issue:`1270`, :pr:`1300`).
 
 **Fixes**
 

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -540,7 +540,15 @@ class CommonTestsMixin:
             table = self.table_class()
             table.set_columns(**input_data)
             s = str(table)
-            assert len(s.splitlines()) == num_rows + 1
+            assert len(s.splitlines()) == num_rows + 4
+        input_data = self.make_input_data(41)
+        table = self.table_class()
+        table.set_columns(**input_data)
+        assert "1 rows skipped" in str(table)
+        tskit.set_print_options(max_lines=None)
+        assert "1 rows skipped" not in str(table)
+        tskit.set_print_options(max_lines=40)
+        tskit.MAX_LINES = 40
 
     def test_repr_html(self):
         for num_rows in [0, 10, 40, 50]:
@@ -555,8 +563,8 @@ class CommonTestsMixin:
             if num_rows == 50:
                 assert len(html.splitlines()) == num_rows + 11
                 assert (
-                    html.split("</tr>")[21]
-                    == "\n<tr><td><em>... skipped 10 rows ...</em></td>"
+                    html.split("</tr>")[21] == "\n<tr><td><em>10 rows skipped "
+                    "(tskit.set_print_options)</em></td>"
                 )
             else:
                 assert len(html.splitlines()) == num_rows + 20

--- a/python/tskit/__init__.py
+++ b/python/tskit/__init__.py
@@ -47,10 +47,10 @@ ALLELES_01 = ("0", "1")
 ALLELES_ACGT = ("A", "C", "G", "T")
 
 #: Special NAN value used to indicate unknown mutation times
-"""
-Say what
-"""
 UNKNOWN_TIME = _tskit.UNKNOWN_TIME
+
+#: Options for printing to strings and HTML, modify with tskit.set_print_options.
+_print_options = {"max_lines": 40}
 
 from tskit.provenance import __version__  # NOQA
 from tskit.provenance import validate_provenance  # NOQA


### PR DESCRIPTION

Fixes #1270 by making `__str__` for tables output unicode tables. 

Introduces `tskit.MAX_LINES` which controls the number of lines to truncate the table to, in this way a user can see the whole of a table by setting it to `None`

Also displays decoded metadata instead of base64 encoding it, which also applies to HTML output. Metadata is truncated, to try to keep tables ~80 chars width. This is not controllable. 

OLD:
![Screenshot from 2021-04-07 23-56-32](https://user-images.githubusercontent.com/8552/113947073-c4424a00-9801-11eb-82f3-3bd5636175f5.png)

NEW:
![Screenshot from 2021-04-07 23-51-31](https://user-images.githubusercontent.com/8552/113947103-d2906600-9801-11eb-8f5a-1cd0739fbaa8.png)
