### PR TITLE
Add basic _repr_svg_ method on a tree seq

### DIFF
--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -1417,6 +1417,16 @@ class TestDrawTextExamples(TestTreeDraw):
                 t.draw_text(max_tree_height=bad_max_tree_height)
 
 
+class TestReprSvg(TestTreeDraw):
+    """
+    Tests the IPython _repr_svg_ shortcut
+    """
+
+    def test_repr_svg(self):
+        ts = self.get_simple_ts()
+        assert ts._repr_svg_() == ts.draw_svg()
+
+
 class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
     """
     Tests the SVG tree drawing.

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3765,6 +3765,21 @@ class TreeSequence:
         """
         return util.tree_sequence_html(self)
 
+    def _repr_svg_(self):
+        """
+        Called by jupyter notebooks to render a TreeSequence in standard SVG form, for
+        example when calling ``IPython.display.display_svg(ts)``. As parameters cannot
+        be passed to this function, the underlying :meth:`.draw_svg` method should be
+        used for more complex graphical needs.
+
+        .. note::
+            The SVG representation of large tree sequences can be enormous, and may
+            hang or crash the web browser in which the jupyter notebook is running.
+            For this reason, the default display of a tree sequence in a jupyter
+            notebook is the tabular form provided by the :meth:`._repr_html_` method .
+        """
+        return self.draw_svg()
+
     # num_samples was originally called sample_size, and so we must keep sample_size
     # around as a deprecated alias.
     @property


### PR DESCRIPTION
Partially addresses https://github.com/tskit-dev/tskit/issues/1268. Shame there's no way (I can find) of passing params to e.g. `IPython.display.display_svg`.