### PR TITLE
Use jukes cantor instead of msprime for failing test

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -860,7 +860,7 @@ class MutatedTopologyExamplesMixin:
         )
         tables.sort()
         ts = tables.tree_sequence().simplify()
-        ts = msprime.mutate(ts, rate=0.01, random_seed=42)
+        ts = tsutil.jukes_cantor(ts, 10, 0.01, seed=1)
         assert ts.num_sites > 0
         self.verify(ts)
 


### PR DESCRIPTION
Getting this error on Ci since msprime 1.0.0:
```
FAILED tests/test_tree_stats.py::TestSiteTajimasD::test_wright_fisher_simplified
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=1e-06
E           
E           x and y nan location mismatch:
E            x: array([[nan, nan, nan, nan]])
E            y: array([[ nan,  nan,  nan, -inf]])

../../.local/lib/python3.7/site-packages/numpy/testing/_private/utils.py:746: AssertionError
```

Hopefully using the tskit jukes cantor fixes this.