### PR TITLE
Prevent extending from self

### DIFF
--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -645,6 +645,10 @@ test_node_table(void)
     ret = tsk_node_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    /* Can't extend from self */
+    ret = tsk_node_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
+
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_node_table_equals(&table, &table2, 0));
     ret = tsk_node_table_extend(&table, &table2, table2.num_rows, NULL, 0);
@@ -1026,6 +1030,10 @@ test_edge_table_with_options(tsk_flags_t options)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_edge_table_init(&table2, options);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /* Can't extend from self */
+    ret = tsk_edge_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
 
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_edge_table_equals(&table, &table2, 0));
@@ -1593,6 +1601,10 @@ test_site_table(void)
     ret = tsk_site_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    /* Can't extend from self */
+    ret = tsk_site_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
+
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_site_table_equals(&table, &table2, 0));
     ret = tsk_site_table_extend(&table, &table2, table2.num_rows, NULL, 0);
@@ -1991,6 +2003,10 @@ test_mutation_table(void)
     ret = tsk_mutation_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    /* Can't extend from self */
+    ret = tsk_mutation_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
+
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_mutation_table_equals(&table, &table2, 0));
     ret = tsk_mutation_table_extend(&table, &table2, table2.num_rows, NULL, 0);
@@ -2358,6 +2374,10 @@ test_migration_table(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_migration_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /* Can't extend from self */
+    ret = tsk_migration_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
 
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_migration_table_equals(&table, &table2, 0));
@@ -2803,6 +2823,10 @@ test_individual_table(void)
     ret = tsk_individual_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    /* Can't extend from self */
+    ret = tsk_individual_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
+
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_individual_table_equals(&table, &table2, 0));
     ret = tsk_individual_table_extend(&table, &table2, table2.num_rows, NULL, 0);
@@ -3048,6 +3072,10 @@ test_population_table(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_population_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /* Can't extend from self */
+    ret = tsk_population_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
 
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_population_table_equals(&table, &table2, 0));
@@ -3330,6 +3358,10 @@ test_provenance_table(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_provenance_table_init(&table2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /* Can't extend from self */
+    ret = tsk_provenance_table_extend(&table, &table, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_CANNOT_EXTEND_FROM_SELF);
 
     /* Two empty tables */
     CU_ASSERT_TRUE(tsk_provenance_table_equals(&table, &table2, 0));

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -357,6 +357,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED:
             ret = "Only binary mutations are supported for this operation";
             break;
+        case TSK_ERR_CANNOT_EXTEND_FROM_SELF:
+            ret = "Tables can only be extended using rows from a different table";
+            break;
 
         /* Stats errors */
         case TSK_ERR_BAD_NUM_WINDOWS:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -274,6 +274,7 @@ not found in the file.
 #define TSK_ERR_SORT_OFFSET_NOT_SUPPORTED                           -803
 #define TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -804
 #define TSK_ERR_MIGRATIONS_NOT_SUPPORTED                            -805
+#define TSK_ERR_CANNOT_EXTEND_FROM_SELF                             -806
 
 /* Stats errors */
 #define TSK_ERR_BAD_NUM_WINDOWS                                     -900

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -652,6 +652,11 @@ tsk_individual_table_extend(tsk_individual_table_t *self,
     tsk_size_t j;
     tsk_individual_t individual;
 
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
+
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_individual_table_expand_main_columns(self, num_rows);
     if (ret != 0) {
@@ -1250,6 +1255,11 @@ tsk_node_table_extend(tsk_node_table_t *self, const tsk_node_table_t *other,
     tsk_size_t j;
     tsk_node_t node;
 
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
+
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_node_table_expand_main_columns(self, num_rows);
     if (ret != 0) {
@@ -1792,6 +1802,11 @@ tsk_edge_table_extend(tsk_edge_table_t *self, const tsk_edge_table_t *other,
     int ret = 0;
     tsk_size_t j;
     tsk_edge_t edge;
+
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
 
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_edge_table_expand_main_columns(self, num_rows);
@@ -2459,6 +2474,11 @@ tsk_site_table_extend(tsk_site_table_t *self, const tsk_site_table_t *other,
     tsk_size_t j;
     tsk_site_t site;
 
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
+
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_site_table_expand_main_columns(self, num_rows);
     if (ret != 0) {
@@ -3073,6 +3093,11 @@ tsk_mutation_table_extend(tsk_mutation_table_t *self, const tsk_mutation_table_t
     tsk_size_t j;
     tsk_mutation_t mutation;
 
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
+
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_mutation_table_expand_main_columns(self, num_rows);
     if (ret != 0) {
@@ -3583,6 +3608,11 @@ tsk_migration_table_extend(tsk_migration_table_t *self,
     tsk_size_t j;
     tsk_migration_t migration;
 
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
+
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_migration_table_expand_main_columns(self, num_rows);
     if (ret != 0) {
@@ -4056,6 +4086,11 @@ tsk_population_table_extend(tsk_population_table_t *self,
     int ret = 0;
     tsk_size_t j;
     tsk_population_t population;
+
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
 
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_population_table_expand_main_columns(self, num_rows);
@@ -4572,6 +4607,11 @@ tsk_provenance_table_extend(tsk_provenance_table_t *self,
     int ret = 0;
     tsk_size_t j;
     tsk_provenance_t provenance;
+
+    if (self == other) {
+        ret = TSK_ERR_CANNOT_EXTEND_FROM_SELF;
+        goto out;
+    }
 
     /* We know how much to expand the non-ragged columns, so do it ahead of time */
     ret = tsk_provenance_table_expand_main_columns(self, num_rows);


### PR DESCRIPTION
When extending, it was possible to extend using rows from `self` however this is unsafe as `add_row` can re-allocate any ragged arrays, making the data form `get_row` invalid. Seems simplest to prevent doing this operation as I can't see much use for it.