### PR TITLE
Use integer format for text trees if positions are integers

### DIFF
--- a/python/tests/data/svg/ts_plain_y.svg
+++ b/python/tests/data/svg/ts_plain_y.svg
@@ -56,21 +56,21 @@
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+						<text text-anchor="end">0</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 66.8909)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.00</text>
+						<text text-anchor="end">5</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 12.3817)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">10.00</text>
+						<text text-anchor="end">10</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_y_axis_regular.svg
+++ b/python/tests/data/svg/ts_y_axis_regular.svg
@@ -102,70 +102,70 @@
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+						<text text-anchor="end">0</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 110.498)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.00</text>
+						<text text-anchor="end">1</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 99.5963)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">2.00</text>
+						<text text-anchor="end">2</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 88.6945)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">3.00</text>
+						<text text-anchor="end">3</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 77.7927)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">4.00</text>
+						<text text-anchor="end">4</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 66.8909)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.00</text>
+						<text text-anchor="end">5</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 55.989)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.00</text>
+						<text text-anchor="end">6</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 45.0872)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">7.00</text>
+						<text text-anchor="end">7</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 34.1854)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">8.00</text>
+						<text text-anchor="end">8</text>
 					</g>
 				</g>
 				<g class="tick" transform="translate(56.8 23.2835)">
 					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 					<line x1="0" x2="-5" y1="0" y2="0"/>
 					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">9.00</text>
+						<text text-anchor="end">9</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -833,7 +833,7 @@ class TestDrawTextExamples(TestTreeDraw):
             "0.27┊ ┃ ┃  4  ┊\n"
             "    ┊ ┃ ┃ ┏┻┓ ┊\n"
             "0.00┊ 1 2 0 3 ┊\n"
-            "  0.00      1.00\n"
+            "    0         1\n"
         )
         self.verify_text_rendering(ts.draw_text(order="tree"), tree)
 
@@ -883,7 +883,7 @@ class TestDrawTextExamples(TestTreeDraw):
             "0.27┊ ┃ ┃  4      ┊\n"
             "    ┊ ┃ ┃ ┏┻┓     ┊\n"
             "0.00┊ 1 2 0 3     ┊\n"
-            "  0.00          1.00\n"
+            "    0             1\n"
         )
         drawn = ts.draw_text(node_labels=labels, order="tree")
         self.verify_text_rendering(drawn, tree)

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -1490,17 +1490,17 @@ class TextTreeSequence:
         self.ts = ts
 
         time_label_format = "{:.2f}" if time_label_format is None else time_label_format
-        position_label_format = (
-            "{:.2f}" if position_label_format is None else position_label_format
-        )
+        tick_labels = ts.breakpoints(as_array=True)
+        if position_label_format is None:
+            integer_ticks = np.all(np.round(tick_labels) == tick_labels)
+            label_precision = 0 if integer_ticks else 2
+            position_label_format = f"{{:.{label_precision}f}}"
 
         time = ts.tables.nodes.time
         time_scale_labels = [
             time_label_format.format(time[u]) for u in range(ts.num_nodes)
         ]
-        position_scale_labels = [
-            position_label_format.format(x) for x in ts.breakpoints()
-        ]
+        position_scale_labels = [position_label_format.format(x) for x in tick_labels]
         trees = [
             VerticalTextTree(
                 tree,


### PR DESCRIPTION
As we do for the SVG format. This is useful now that msprime.sim_ancestry defaults to integer breakpoints.

I'm not sure if we need additional tests, as I've adjusted some cases in the existing tests which have 0,1 breakpoints. I also feel it's probably too trivial to stick in the changelog?
