### PR TITLE
Implement split_edges

### DIFF
--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5525,6 +5525,19 @@ class TreeSequence:
         )
         return tables.tree_sequence()
 
+    def split_edges(self, mode="leaf"):
+        """
+        Returns a tree sequence where edges are split by various rules.
+
+        This
+
+        :param str mode: The criteria by which edges should be split. Must be
+            ``leaf``, ``node``, or ``tree``. If ``leaf``, edges are split  when they
+            have different leaves in different trees. If ``node``, edges
+            are split when they have different nodes in different trees. If ``tree``,
+            edges which straddle tree breakpoints are split.
+        """
+
     def draw_svg(
         self,
         path=None,


### PR DESCRIPTION
Implements a naive, python version of `ts.split_edges` as described in #1345 with a few tests.

I've made it a draft PR for now. If the approach and output look reasonable I'll work up the C version. 

My implementation uses `edge_diffs` to bifurcate edges either by `leaf`, `node` or `tree`. In `mode=leaf`, edges are bifurcated when they different descendant leaves in different trees. In `mode=node`, edges are bifurcated when they have different descendant nodes in different trees. When `mode=tree`, edges that exist in multiple trees are bifurcated to create a "JBOT" (just a bunch of trees). 

I originally had `mode=sample` instead of `mode=leaf`, but that mean keeping track of the samples beneath each edge as we go along if there were internal samples or non-sample leaves. This seemed less elegant and algorithmically problematic than using `edge_diffs`... but perhaps not. Perhaps there's a better way to implement this?

It's also worth mentioning that we might want an `edge` (or `brick`) mode which analogously splits edges based on the edges beneath it, but I haven't implemented that here.

# PR Checklist:

- [ ] Functionality matches what we want
- [ ] C version of function
- [ ] Tests that fully cover new functionality.
- [ ] Documentation of `split_edges()`
- [ ] Update changelog
