### PR TITLE
Cache decoded schemas, to speed up replicates

### DIFF
--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -26,6 +26,7 @@ import abc
 import builtins
 import collections
 import copy
+import functools
 import json
 import pprint
 import struct
@@ -679,6 +680,8 @@ class MetadataSchema:
         pass  # pragma: no cover
 
 
+# Often many replicate tree sequences are processed with identical schemas, so cache them
+@functools.lru_cache(maxsize=128)
 def parse_metadata_schema(encoded_schema: str) -> MetadataSchema:
     """
     Create a schema object from its string encoding. The exact class returned is


### PR DESCRIPTION
Fixes #1945

`MetadataSchema` classes are immutable so this is an easy win.