### PR TITLE
Change printfs to cast to long-long.

### DIFF
--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -672,7 +672,7 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
                     /* printf("u = %d v= %d s = %d bl = %f \n", u, v,
                      * tree.num_samples[v], */
                     /*         branch_length); */
-                    s += branch_length * tree.num_samples[v];
+                    s += branch_length * (double) tree.num_samples[v];
                     stack_top++;
                     stack[stack_top] = v;
                 }

--- a/c/tskit/convert.c
+++ b/c/tskit/convert.c
@@ -98,7 +98,7 @@ tsk_newick_converter_run(
                 }
                 /* We do this for ms-compatability. This should be a configurable option
                  * via the flags attribute */
-                label = v + 1;
+                label = (int) v + 1;
                 r = snprintf(buffer + s, buffer_size - s, "%d", label);
                 if (r < 0) {
                     ret = TSK_ERR_IO;

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -541,11 +541,11 @@ void
 tsk_blkalloc_print_state(tsk_blkalloc_t *self, FILE *out)
 {
     fprintf(out, "Block allocator%p::\n", (void *) self);
-    fprintf(out, "\ttop = %d\n", (int) self->top);
-    fprintf(out, "\tchunk_size = %d\n", (int) self->chunk_size);
-    fprintf(out, "\tnum_chunks = %d\n", (int) self->num_chunks);
-    fprintf(out, "\ttotal_allocated = %d\n", (int) self->total_allocated);
-    fprintf(out, "\ttotal_size = %d\n", (int) self->total_size);
+    fprintf(out, "\ttop = %lld\n", (long long) self->top);
+    fprintf(out, "\tchunk_size = %lld\n", (long long) self->chunk_size);
+    fprintf(out, "\tnum_chunks = %lld\n", (long long) self->num_chunks);
+    fprintf(out, "\ttotal_allocated = %lld\n", (long long) self->total_allocated);
+    fprintf(out, "\ttotal_size = %lld\n", (long long) self->total_size);
 }
 
 int TSK_WARN_UNUSED

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -46,8 +46,8 @@ tsk_vargen_print_state(const tsk_vargen_t *self, FILE *out)
     fprintf(out, "num_alleles = %lld\n", (long long) self->variant.num_alleles);
     for (j = 0; j < self->variant.num_alleles; j++) {
         fprintf(out, "\tlen = %lld, '%.*s'\n",
-            (long long) self->variant.allele_lengths[j], self->variant.allele_lengths[j],
-            self->variant.alleles[j]);
+            (long long) self->variant.allele_lengths[j],
+            (int) self->variant.allele_lengths[j], self->variant.alleles[j]);
     }
     fprintf(out, "num_samples = %lld\n", (long long) self->num_samples);
     for (j = 0; j < tsk_treeseq_get_num_nodes(self->tree_sequence); j++) {

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -40,17 +40,19 @@ tsk_vargen_print_state(const tsk_vargen_t *self, FILE *out)
     tsk_size_t j;
 
     fprintf(out, "tsk_vargen state\n");
-    fprintf(out, "tree_index = %d\n", self->tree.index);
-    fprintf(out, "tree_site_index = %d\n", (int) self->tree_site_index);
-    fprintf(out, "user_alleles = %d\n", self->user_alleles);
-    fprintf(out, "num_alleles = %d\n", self->variant.num_alleles);
+    fprintf(out, "tree_index = %lld\n", (long long) self->tree.index);
+    fprintf(out, "tree_site_index = %lld\n", (long long) self->tree_site_index);
+    fprintf(out, "user_alleles = %lld\n", (long long) self->user_alleles);
+    fprintf(out, "num_alleles = %lld\n", (long long) self->variant.num_alleles);
     for (j = 0; j < self->variant.num_alleles; j++) {
-        fprintf(out, "\tlen = %d, '%.*s'\n", self->variant.allele_lengths[j],
-            self->variant.allele_lengths[j], self->variant.alleles[j]);
+        fprintf(out, "\tlen = %lld, '%.*s'\n",
+            (long long) self->variant.allele_lengths[j], self->variant.allele_lengths[j],
+            self->variant.alleles[j]);
     }
-    fprintf(out, "num_samples = %d\n", (int) self->num_samples);
+    fprintf(out, "num_samples = %lld\n", (long long) self->num_samples);
     for (j = 0; j < tsk_treeseq_get_num_nodes(self->tree_sequence); j++) {
-        fprintf(out, "\t%d -> %d\n", (int) j, (int) self->sample_index_map[j]);
+        fprintf(out, "\t%lld -> %lld\n", (long long) j,
+            (long long) self->sample_index_map[j]);
     }
 }
 

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -224,7 +224,7 @@ static int
 tsk_ls_hmm_reset(tsk_ls_hmm_t *self)
 {
     int ret = 0;
-    double n = self->num_samples;
+    double n = (double) self->num_samples;
     tsk_size_t j;
     tsk_id_t u;
     const tsk_id_t *samples;
@@ -1022,7 +1022,7 @@ tsk_ls_hmm_compute_normalisation_factor_forward(tsk_ls_hmm_t *self)
     /* Compute the normalising constant used to avoid underflow */
     normalisation_factor = 0;
     for (j = 0; j < num_transitions; j++) {
-        normalisation_factor += N[j] * T[j].value;
+        normalisation_factor += (double) N[j] * T[j].value;
     }
     return normalisation_factor;
 }
@@ -1033,7 +1033,7 @@ tsk_ls_hmm_next_probability_forward(tsk_ls_hmm_t *self, tsk_id_t site_id, double
 {
     const double rho = self->recombination_rate[site_id];
     const double mu = self->mutation_rate[site_id];
-    const double n = self->num_samples;
+    const double n = (double) self->num_samples;
     const double num_alleles = self->num_alleles[site_id];
     double p_t, p_e;
 
@@ -1107,7 +1107,7 @@ tsk_ls_hmm_next_probability_viterbi(tsk_ls_hmm_t *self, tsk_id_t site, double p_
     const double rho = self->recombination_rate[site];
     const double mu = self->mutation_rate[site];
     const double num_alleles = self->num_alleles[site];
-    const double n = self->num_samples;
+    const double n = (double) self->num_samples;
     double p_recomb, p_no_recomb, p_t, p_e;
     bool recombination_required = false;
 

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -85,32 +85,32 @@ tsk_ls_hmm_print_state(tsk_ls_hmm_t *self, FILE *out)
     tsk_size_t j, l;
 
     fprintf(out, "tree_sequence   = %p\n", (void *) self->tree_sequence);
-    fprintf(out, "num_sites       = %d\n", self->num_sites);
-    fprintf(out, "num_samples     = %d\n", self->num_samples);
-    fprintf(out, "num_values      = %d\n", (int) self->num_values);
-    fprintf(out, "max_values      = %d\n", (int) self->max_values);
-    fprintf(out, "num_optimal_value_set_words = %d\n",
-        (int) self->num_optimal_value_set_words);
+    fprintf(out, "num_sites       = %lld\n", (long long) self->num_sites);
+    fprintf(out, "num_samples     = %lld\n", (long long) self->num_samples);
+    fprintf(out, "num_values      = %lld\n", (long long) self->num_values);
+    fprintf(out, "max_values      = %lld\n", (long long) self->max_values);
+    fprintf(out, "num_optimal_value_set_words = %lld\n",
+        (long long) self->num_optimal_value_set_words);
 
     fprintf(out, "sites::\n");
     for (l = 0; l < self->num_sites; l++) {
-        fprintf(out, "%d\t%d\t[", l, self->num_alleles[l]);
+        fprintf(out, "%lld\t%lld\t[", (long long) l, (long long) self->num_alleles[l]);
         for (j = 0; j < self->num_alleles[l]; j++) {
             fprintf(out, "%s,", self->alleles[l][j]);
         }
         fprintf(out, "]\n");
     }
-    fprintf(out, "transitions::%d\n", (int) self->num_transitions);
+    fprintf(out, "transitions::%lld\n", (long long) self->num_transitions);
     for (j = 0; j < self->num_transitions; j++) {
-        fprintf(out, "tree_node=%d\tvalue=%.14f\tvalue_index=%d\n",
-            self->transitions[j].tree_node, self->transitions[j].value,
-            self->transitions[j].value_index);
+        fprintf(out, "tree_node=%lld\tvalue=%.14f\tvalue_index=%lld\n",
+            (long long) self->transitions[j].tree_node, self->transitions[j].value,
+            (long long) self->transitions[j].value_index);
     }
     if (self->num_transitions > 0) {
-        fprintf(out, "tree::%d\n", (int) self->num_nodes);
+        fprintf(out, "tree::%lld\n", (long long) self->num_nodes);
         for (j = 0; j < self->num_nodes; j++) {
-            fprintf(out, "%d\tparent=%d\ttransition=%d\n", j, self->parent[j],
-                self->transition_index[j]);
+            fprintf(out, "%lld\tparent=%lld\ttransition=%lld\n", (long long) j,
+                (long long) self->parent[j], (long long) self->transition_index[j]);
         }
     }
     tsk_ls_hmm_check_state(self);
@@ -1223,13 +1223,14 @@ tsk_compressed_matrix_print_state(tsk_compressed_matrix_t *self, FILE *out)
     tsk_size_t l, j;
 
     fprintf(out, "Compressed matrix for %p\n", (void *) self->tree_sequence);
-    fprintf(out, "num_sites = %d\n", self->num_sites);
-    fprintf(out, "num_samples = %d\n", self->num_samples);
+    fprintf(out, "num_sites = %lld\n", (long long) self->num_sites);
+    fprintf(out, "num_samples = %lld\n", (long long) self->num_samples);
     for (l = 0; l < self->num_sites; l++) {
-        fprintf(out, "%d\ts=%f\tv=%d [", l, self->normalisation_factor[l],
-            self->num_transitions[l]);
+        fprintf(out, "%lld\ts=%f\tv=%lld [", (long long) l,
+            self->normalisation_factor[l], (long long) self->num_transitions[l]);
         for (j = 0; j < self->num_transitions[l]; j++) {
-            fprintf(out, "(%d, %f)", self->nodes[l][j], self->values[l][j]);
+            fprintf(
+                out, "(%lld, %f)", (long long) self->nodes[l][j], self->values[l][j]);
             if (j < self->num_transitions[l] - 1) {
                 fprintf(out, ",");
             } else {
@@ -1427,15 +1428,15 @@ tsk_viterbi_matrix_print_state(tsk_viterbi_matrix_t *self, FILE *out)
     tsk_id_t l, j;
 
     fprintf(out, "viterbi_matrix\n");
-    fprintf(out, "num_recomb_records = %d\n", (int) self->num_recomb_records);
-    fprintf(out, "max_recomb_records = %d\n", (int) self->max_recomb_records);
+    fprintf(out, "num_recomb_records = %lld\n", (long long) self->num_recomb_records);
+    fprintf(out, "max_recomb_records = %lld\n", (long long) self->max_recomb_records);
 
     j = 1;
     for (l = 0; l < (tsk_id_t) self->matrix.num_sites; l++) {
-        fprintf(out, "%d\t[", l);
+        fprintf(out, "%lld\t[", (long long) l);
         while (j < (tsk_id_t) self->num_recomb_records
                && self->recombination_required[j].site == l) {
-            fprintf(out, "(%d, %d) ", self->recombination_required[j].node,
+            fprintf(out, "(%lld, %d) ", (long long) self->recombination_required[j].node,
                 self->recombination_required[j].required);
             j++;
         }

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -51,10 +51,10 @@ void
 tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out)
 {
     fprintf(out, "tree_sequence = %p\n", (const void *) self->tree_sequence);
-    fprintf(out, "outer tree index = %d\n", (int) self->outer_tree->index);
+    fprintf(out, "outer tree index = %lld\n", (long long) self->outer_tree->index);
     fprintf(out, "outer tree interval = (%f, %f)\n", self->outer_tree->left,
         self->outer_tree->right);
-    fprintf(out, "inner tree index = %d\n", (int) self->inner_tree->index);
+    fprintf(out, "inner tree index = %lld\n", (long long) self->inner_tree->index);
     fprintf(out, "inner tree interval = (%f, %f)\n", self->inner_tree->left,
         self->inner_tree->right);
     tsk_ld_calc_check_state(self);

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -701,11 +701,12 @@ tsk_individual_table_print_state(const tsk_individual_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "tsk_individual_tbl: %p:\n", (const void *) self);
-    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows          = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "metadata_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here because we want to output
      * the offset columns. */
@@ -715,8 +716,8 @@ tsk_individual_table_print_state(const tsk_individual_table_t *self, FILE *out)
     fprintf(out, "parents_offset\tparents\n");
     fprintf(out, "metadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t", (int) j, self->flags[j]);
-        fprintf(out, "%d\t", self->location_offset[j]);
+        fprintf(out, "%lld\t%lld\t", (long long) j, (long long) self->flags[j]);
+        fprintf(out, "%lld\t", (long long) self->location_offset[j]);
         for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
             fprintf(out, "%f", self->location[k]);
             if (k + 1 < self->location_offset[j + 1]) {
@@ -724,15 +725,15 @@ tsk_individual_table_print_state(const tsk_individual_table_t *self, FILE *out)
             }
         }
         fprintf(out, "\t");
-        fprintf(out, "%d\t", self->parents_offset[j]);
+        fprintf(out, "%lld\t", (long long) self->parents_offset[j]);
         for (k = self->parents_offset[j]; k < self->parents_offset[j + 1]; k++) {
-            fprintf(out, "%d", self->parents[k]);
+            fprintf(out, "%lld", (long long) self->parents[k]);
             if (k + 1 < self->parents_offset[j + 1]) {
                 fprintf(out, ",");
             }
         }
         fprintf(out, "\t");
-        fprintf(out, "%d\t", self->metadata_offset[j]);
+        fprintf(out, "%lld\t", (long long) self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }
@@ -802,7 +803,7 @@ tsk_individual_table_dump_text(const tsk_individual_table_t *self, FILE *out)
     }
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%d\t", (int) j, (int) self->flags[j]);
+        err = fprintf(out, "%lld\t%lld\t", (long long) j, (long long) self->flags[j]);
         if (err < 0) {
             goto out;
         }
@@ -819,7 +820,7 @@ tsk_individual_table_dump_text(const tsk_individual_table_t *self, FILE *out)
             }
         }
         for (k = self->parents_offset[j]; k < self->parents_offset[j + 1]; k++) {
-            err = fprintf(out, "%d", self->parents[k]);
+            err = fprintf(out, "%lld", (long long) self->parents[k]);
             if (err < 0) {
                 goto out;
             }
@@ -1302,11 +1303,12 @@ tsk_node_table_print_state(const tsk_node_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "tsk_node_tbl: %p:\n", (const void *) self);
-    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows          = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "metadata_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here for simplicity because we want to output
      * the flags column directly. */
@@ -1314,8 +1316,9 @@ tsk_node_table_print_state(const tsk_node_table_t *self, FILE *out)
         out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "id\tflags\ttime\tpopulation\tindividual\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%f\t%d\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
-            (int) self->population[j], self->individual[j], self->metadata_offset[j]);
+        fprintf(out, "%lld\t%lld\t%f\t%lld\t%lld\t%lld\t", (long long) j,
+            (long long) self->flags[j], self->time[j], (long long) self->population[j],
+            (long long) self->individual[j], (long long) self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }
@@ -1352,10 +1355,10 @@ tsk_node_table_dump_text(const tsk_node_table_t *self, FILE *out)
     }
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%d\t%f\t%d\t%d\t%.*s\n", (int) j,
-            (int) (self->flags[j] & TSK_NODE_IS_SAMPLE), self->time[j],
-            self->population[j], self->individual[j], metadata_len,
-            self->metadata + self->metadata_offset[j]);
+        err = fprintf(out, "%lld\t%lld\t%f\t%lld\t%lld\t%.*s\n", (long long) j,
+            (long long) (self->flags[j] & TSK_NODE_IS_SAMPLE), self->time[j],
+            (long long) self->population[j], (long long) self->individual[j],
+            metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }
@@ -1884,11 +1887,12 @@ tsk_edge_table_print_state(const tsk_edge_table_t *self, FILE *out)
     fprintf(out, TABLE_SEP);
     fprintf(out, "edge_table: %p:\n", (const void *) self);
     fprintf(out, "options         = 0x%X\n", self->options);
-    fprintf(out, "num_rows        = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows        = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "metadata_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_edge_table_dump_text(self, out);
     tsk_bug_assert(ret == 0);
@@ -1921,8 +1925,9 @@ tsk_edge_table_dump_text(const tsk_edge_table_t *self, FILE *out)
     }
     for (j = 0; j < (tsk_id_t) self->num_rows; j++) {
         tsk_edge_table_get_row_unsafe(self, j, &row);
-        err = fprintf(out, "%d\t%.3f\t%.3f\t%d\t%d\t%.*s\n", j, row.left, row.right,
-            row.parent, row.child, row.metadata_length, row.metadata);
+        err = fprintf(out, "%lld\t%.3f\t%.3f\t%lld\t%lld\t%.*s\n", (long long) j,
+            row.left, row.right, (long long) row.parent, (long long) row.child,
+            row.metadata_length, row.metadata);
         if (err < 0) {
             goto out;
         }
@@ -2520,14 +2525,16 @@ tsk_site_table_print_state(const tsk_site_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "site_table: %p:\n", (const void *) self);
-    fprintf(out, "num_rows = %d\t(max= %d\tincrement = %d)\n", (int) self->num_rows,
-        (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "ancestral_state_length = %d\t(max= %d\tincrement = %d)\n",
-        (int) self->ancestral_state_length, (int) self->max_ancestral_state_length,
-        (int) self->max_ancestral_state_length_increment);
-    fprintf(out, "metadata_length = %d(\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows = %lld\t(max= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "ancestral_state_length = %lld\t(max= %lld\tincrement = %lld)\n",
+        (long long) self->ancestral_state_length,
+        (long long) self->max_ancestral_state_length,
+        (long long) self->max_ancestral_state_length_increment);
+    fprintf(out, "metadata_length = %lld(\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_site_table_dump_text(self, out);
     tsk_bug_assert(ret == 0);
@@ -2600,7 +2607,7 @@ tsk_site_table_dump_text(const tsk_site_table_t *self, FILE *out)
         ancestral_state_len
             = self->ancestral_state_offset[j + 1] - self->ancestral_state_offset[j];
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%f\t%.*s\t%.*s\n", (int) j, self->position[j],
+        err = fprintf(out, "%lld\t%f\t%.*s\t%.*s\n", (long long) j, self->position[j],
             ancestral_state_len, self->ancestral_state + self->ancestral_state_offset[j],
             metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
@@ -3143,14 +3150,16 @@ tsk_mutation_table_print_state(const tsk_mutation_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "mutation_table: %p:\n", (const void *) self);
-    fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n", (int) self->num_rows,
-        (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "derived_state_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->derived_state_length, (int) self->max_derived_state_length,
-        (int) self->max_derived_state_length_increment);
-    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "derived_state_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->derived_state_length,
+        (long long) self->max_derived_state_length,
+        (long long) self->max_derived_state_length_increment);
+    fprintf(out, "metadata_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_mutation_table_dump_text(self, out);
     tsk_bug_assert(ret == 0);
@@ -3221,8 +3230,9 @@ tsk_mutation_table_dump_text(const tsk_mutation_table_t *self, FILE *out)
         derived_state_len
             = self->derived_state_offset[j + 1] - self->derived_state_offset[j];
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%d\t%d\t%d\t%f\t%.*s\t%.*s\n", (int) j, self->site[j],
-            self->node[j], self->parent[j], self->time[j], derived_state_len,
+        err = fprintf(out, "%lld\t%lld\t%lld\t%lld\t%f\t%.*s\t%.*s\n", (long long) j,
+            (long long) self->site[j], (long long) self->node[j],
+            (long long) self->parent[j], self->time[j], derived_state_len,
             self->derived_state + self->derived_state_offset[j], metadata_len,
             self->metadata + self->metadata_offset[j]);
         if (err < 0) {
@@ -3658,11 +3668,12 @@ tsk_migration_table_print_state(const tsk_migration_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "migration_table: %p:\n", (const void *) self);
-    fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n", (int) self->num_rows,
-        (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "metadata_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     ret = tsk_migration_table_dump_text(self, out);
     tsk_bug_assert(ret == 0);
@@ -3726,9 +3737,10 @@ tsk_migration_table_dump_text(const tsk_migration_table_t *self, FILE *out)
     }
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%.3f\t%.3f\t%d\t%d\t%d\t%f\t%.*s\n", self->left[j],
-            self->right[j], self->node[j], self->source[j], self->dest[j], self->time[j],
-            metadata_len, self->metadata + self->metadata_offset[j]);
+        err = fprintf(out, "%.3f\t%.3f\t%lld\t%lld\t%lld\t%f\t%.*s\n", self->left[j],
+            self->right[j], (long long) self->node[j], (long long) self->source[j],
+            (long long) self->dest[j], self->time[j], metadata_len,
+            self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }
@@ -4130,17 +4142,19 @@ tsk_population_table_print_state(const tsk_population_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "population_table: %p:\n", (const void *) self);
-    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "metadata_length  = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->metadata_length, (int) self->max_metadata_length,
-        (int) self->max_metadata_length_increment);
+    fprintf(out, "num_rows          = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "metadata_length  = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->metadata_length, (long long) self->max_metadata_length,
+        (long long) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     write_metadata_schema_header(
         out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "index\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t", (int) j, self->metadata_offset[j]);
+        fprintf(
+            out, "%lld\t%lld\t", (long long) j, (long long) self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }
@@ -4652,22 +4666,24 @@ tsk_provenance_table_print_state(const tsk_provenance_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "provenance_table: %p:\n", (const void *) self);
-    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
-    fprintf(out, "timestamp_length  = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->timestamp_length, (int) self->max_timestamp_length,
-        (int) self->max_timestamp_length_increment);
-    fprintf(out, "record_length = %d\tmax= %d\tincrement = %d)\n",
-        (int) self->record_length, (int) self->max_record_length,
-        (int) self->max_record_length_increment);
+    fprintf(out, "num_rows          = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->num_rows, (long long) self->max_rows,
+        (long long) self->max_rows_increment);
+    fprintf(out, "timestamp_length  = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->timestamp_length, (long long) self->max_timestamp_length,
+        (long long) self->max_timestamp_length_increment);
+    fprintf(out, "record_length = %lld\tmax= %lld\tincrement = %lld)\n",
+        (long long) self->record_length, (long long) self->max_record_length,
+        (long long) self->max_record_length_increment);
     fprintf(out, TABLE_SEP);
     fprintf(out, "index\ttimestamp_offset\ttimestamp\trecord_offset\tprovenance\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t", (int) j, self->timestamp_offset[j]);
+        fprintf(
+            out, "%lld\t%lld\t", (long long) j, (long long) self->timestamp_offset[j]);
         for (k = self->timestamp_offset[j]; k < self->timestamp_offset[j + 1]; k++) {
             fprintf(out, "%c", self->timestamp[k]);
         }
-        fprintf(out, "\t%d\t", self->record_offset[j]);
+        fprintf(out, "\t%lld\t", (long long) self->record_offset[j]);
         for (k = self->record_offset[j]; k < self->record_offset[j + 1]; k++) {
             fprintf(out, "%c", self->record[k]);
         }
@@ -6764,14 +6780,14 @@ tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out)
     fprintf(out, "--ibd-finder stats--\n");
     fprintf(out, "===\nEdge table\n==\n");
     for (j = 0; j < self->tables->edges.num_rows; j++) {
-        fprintf(out, "L:%f, R:%f, P:%d, C:%d\n", self->tables->edges.left[j],
-            self->tables->edges.right[j], self->tables->edges.parent[j],
-            self->tables->edges.child[j]);
+        fprintf(out, "L:%f, R:%f, P:%lld, C:%lld\n", self->tables->edges.left[j],
+            self->tables->edges.right[j], (long long) self->tables->edges.parent[j],
+            (long long) self->tables->edges.child[j]);
     }
     fprintf(out, "===\nNode table\n==\n");
     for (j = 0; j < self->tables->nodes.num_rows; j++) {
-        fprintf(out, "ID:%f, Time:%f, Flag:%d\n", (double) j,
-            self->tables->nodes.time[j], self->tables->nodes.flags[j]);
+        fprintf(out, "ID:%f, Time:%f, Flag:%lld\n", (double) j,
+            self->tables->nodes.time[j], (long long) self->tables->nodes.flags[j]);
     }
     fprintf(out, "==\nSample pairs\n==\n");
     for (j = 0; j < 2 * self->num_pairs; j++) {
@@ -6782,9 +6798,9 @@ tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out)
     }
     fprintf(out, "===\nAncestral map\n==\n");
     for (j = 0; j < self->tables->nodes.num_rows; j++) {
-        fprintf(out, "Node %d: ", (int) j);
+        fprintf(out, "Node %lld: ", (long long) j);
         for (u = self->ancestor_map_head[j]; u != NULL; u = u->next) {
-            fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+            fprintf(out, "(%f,%f->%lld)", u->left, u->right, (long long) u->node);
         }
         fprintf(out, "\n");
     }
@@ -6793,7 +6809,7 @@ tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out)
         fprintf(out, "Pair (%i, %i)\n", (int) self->pairs[2 * j],
             (int) self->pairs[2 * j + 1]);
         for (u = self->ibd_segments_head[j]; u != NULL; u = u->next) {
-            fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+            fprintf(out, "(%f,%f->%lld)", u->left, u->right, (long long) u->node);
         }
         fprintf(out, "\n");
     }
@@ -6982,7 +6998,7 @@ print_segment_chain(tsk_segment_t *head, FILE *out)
     tsk_segment_t *u;
 
     for (u = head; u != NULL; u = u->next) {
-        fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+        fprintf(out, "(%f,%f->%lld)", u->left, u->right, (long long) u->node);
     }
 }
 
@@ -7018,26 +7034,27 @@ simplifier_print_state(simplifier_t *self, FILE *out)
     tsk_blkalloc_print_state(&self->interval_list_heap, out);
     fprintf(out, "===\nancestors\n==\n");
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
-        fprintf(out, "%d:\t", (int) j);
+        fprintf(out, "%lld:\t", (long long) j);
         print_segment_chain(self->ancestor_map_head[j], out);
         fprintf(out, "\n");
     }
     fprintf(out, "===\nnode_id map (input->output)\n==\n");
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
         if (self->node_id_map[j] != TSK_NULL) {
-            fprintf(out, "%d->%d\n", (int) j, self->node_id_map[j]);
+            fprintf(
+                out, "%lld->%lld\n", (long long) j, (long long) self->node_id_map[j]);
         }
     }
     fprintf(out, "===\nsegment queue\n==\n");
     for (j = 0; j < self->segment_queue_size; j++) {
         u = &self->segment_queue[j];
-        fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+        fprintf(out, "(%f,%f->%lld)", u->left, u->right, (long long) u->node);
         fprintf(out, "\n");
     }
     fprintf(out, "===\nbuffered children\n==\n");
     for (j = 0; j < self->num_buffered_children; j++) {
         child = self->buffered_children[j];
-        fprintf(out, "%d -> ", (int) j);
+        fprintf(out, "%lld -> ", (long long) j);
         for (int_list = self->child_edge_map_head[child]; int_list != NULL;
              int_list = int_list->next) {
             fprintf(out, "(%f, %f), ", int_list->left, int_list->right);
@@ -7046,15 +7063,16 @@ simplifier_print_state(simplifier_t *self, FILE *out)
     }
     fprintf(out, "===\nmutation node map\n==\n");
     for (j = 0; j < self->input_tables.mutations.num_rows; j++) {
-        fprintf(out, "%d\t-> %d\n", (int) j, self->mutation_node_map[j]);
+        fprintf(out, "%lld\t-> %lld\n", (long long) j,
+            (long long) self->mutation_node_map[j]);
     }
     fprintf(out, "===\nnode mutation id list map\n==\n");
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
         if (self->node_mutation_list_map_head[j] != NULL) {
-            fprintf(out, "%d\t-> [", (int) j);
+            fprintf(out, "%lld\t-> [", (long long) j);
             for (list_node = self->node_mutation_list_map_head[j]; list_node != NULL;
                  list_node = list_node->next) {
-                fprintf(out, "%d,", list_node->mutation);
+                fprintf(out, "%lld,", (long long) list_node->mutation);
             }
             fprintf(out, "]\n");
         }
@@ -7062,7 +7080,7 @@ simplifier_print_state(simplifier_t *self, FILE *out)
     if (!!(self->options & TSK_REDUCE_TO_SITE_TOPOLOGY)) {
         fprintf(out, "===\nposition_lookup\n==\n");
         for (j = 0; j < self->input_tables.sites.num_rows + 2; j++) {
-            fprintf(out, "%d\t-> %f\n", (int) j, self->position_lookup[j]);
+            fprintf(out, "%lld\t-> %f\n", (long long) j, self->position_lookup[j]);
         }
     }
     simplifier_check_state(self);

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -213,7 +213,7 @@ write_metadata_schema_header(
     const char *fmt = "#metadata_schema#\n"
                       "%.*s\n"
                       "#end#metadata_schema\n";
-    return fprintf(out, fmt, metadata_schema_length, metadata_schema);
+    return fprintf(out, fmt, (int) metadata_schema_length, metadata_schema);
 }
 
 /*************************
@@ -831,8 +831,8 @@ tsk_individual_table_dump_text(const tsk_individual_table_t *self, FILE *out)
                 }
             }
         }
-        err = fprintf(
-            out, "\t%.*s\n", metadata_len, self->metadata + self->metadata_offset[j]);
+        err = fprintf(out, "\t%.*s\n", (int) metadata_len,
+            self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }
@@ -1358,7 +1358,7 @@ tsk_node_table_dump_text(const tsk_node_table_t *self, FILE *out)
         err = fprintf(out, "%lld\t%lld\t%f\t%lld\t%lld\t%.*s\n", (long long) j,
             (long long) (self->flags[j] & TSK_NODE_IS_SAMPLE), self->time[j],
             (long long) self->population[j], (long long) self->individual[j],
-            metadata_len, self->metadata + self->metadata_offset[j]);
+            (int) metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }
@@ -1927,7 +1927,7 @@ tsk_edge_table_dump_text(const tsk_edge_table_t *self, FILE *out)
         tsk_edge_table_get_row_unsafe(self, j, &row);
         err = fprintf(out, "%lld\t%.3f\t%.3f\t%lld\t%lld\t%.*s\n", (long long) j,
             row.left, row.right, (long long) row.parent, (long long) row.child,
-            row.metadata_length, row.metadata);
+            (int) row.metadata_length, row.metadata);
         if (err < 0) {
             goto out;
         }
@@ -2609,7 +2609,7 @@ tsk_site_table_dump_text(const tsk_site_table_t *self, FILE *out)
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
         err = fprintf(out, "%lld\t%f\t%.*s\t%.*s\n", (long long) j, self->position[j],
             ancestral_state_len, self->ancestral_state + self->ancestral_state_offset[j],
-            metadata_len, self->metadata + self->metadata_offset[j]);
+            (int) metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }
@@ -3232,8 +3232,8 @@ tsk_mutation_table_dump_text(const tsk_mutation_table_t *self, FILE *out)
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
         err = fprintf(out, "%lld\t%lld\t%lld\t%lld\t%f\t%.*s\t%.*s\n", (long long) j,
             (long long) self->site[j], (long long) self->node[j],
-            (long long) self->parent[j], self->time[j], derived_state_len,
-            self->derived_state + self->derived_state_offset[j], metadata_len,
+            (long long) self->parent[j], self->time[j], (int) derived_state_len,
+            self->derived_state + self->derived_state_offset[j], (int) metadata_len,
             self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
@@ -3739,7 +3739,7 @@ tsk_migration_table_dump_text(const tsk_migration_table_t *self, FILE *out)
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
         err = fprintf(out, "%.3f\t%.3f\t%lld\t%lld\t%lld\t%f\t%.*s\n", self->left[j],
             self->right[j], (long long) self->node[j], (long long) self->source[j],
-            (long long) self->dest[j], self->time[j], metadata_len,
+            (long long) self->dest[j], self->time[j], (int) metadata_len,
             self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
@@ -4216,8 +4216,8 @@ tsk_population_table_dump_text(const tsk_population_table_t *self, FILE *out)
     }
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(
-            out, "%.*s\n", metadata_len, self->metadata + self->metadata_offset[j]);
+        err = fprintf(out, "%.*s\n", (int) metadata_len,
+            self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }
@@ -4736,8 +4736,8 @@ tsk_provenance_table_dump_text(const tsk_provenance_table_t *self, FILE *out)
     for (j = 0; j < self->num_rows; j++) {
         record_len = self->record_offset[j + 1] - self->record_offset[j];
         timestamp_len = self->timestamp_offset[j + 1] - self->timestamp_offset[j];
-        err = fprintf(out, "%.*s\t%.*s\n", record_len,
-            self->record + self->record_offset[j], timestamp_len,
+        err = fprintf(out, "%.*s\t%.*s\n", (int) record_len,
+            self->record + self->record_offset[j], (int) timestamp_len,
             self->timestamp + self->timestamp_offset[j]);
         if (err < 0) {
             goto out;
@@ -8770,7 +8770,7 @@ tsk_table_collection_print_state(const tsk_table_collection_t *self, FILE *out)
     write_metadata_schema_header(
         out, self->metadata_schema, self->metadata_schema_length);
     fprintf(out, "#metadata#\n");
-    fprintf(out, "%.*s\n", self->metadata_length, self->metadata);
+    fprintf(out, "%.*s\n", (int) self->metadata_length, self->metadata);
     fprintf(out, "#end#metadata\n");
     tsk_individual_table_print_state(&self->individuals, out);
     tsk_node_table_print_state(&self->nodes, out);

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -2608,8 +2608,9 @@ tsk_site_table_dump_text(const tsk_site_table_t *self, FILE *out)
             = self->ancestral_state_offset[j + 1] - self->ancestral_state_offset[j];
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
         err = fprintf(out, "%lld\t%f\t%.*s\t%.*s\n", (long long) j, self->position[j],
-            ancestral_state_len, self->ancestral_state + self->ancestral_state_offset[j],
-            (int) metadata_len, self->metadata + self->metadata_offset[j]);
+            (int) ancestral_state_len,
+            self->ancestral_state + self->ancestral_state_offset[j], (int) metadata_len,
+            self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
         }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1914,7 +1914,7 @@ fold(tsk_size_t *restrict coordinate, const tsk_size_t *restrict dims,
 
     for (k = 0; k < num_dims; k++) {
         tsk_bug_assert(coordinate[k] < dims[k]);
-        n += dims[k] - 1;
+        n += (double) dims[k] - 1;
         s += (int) coordinate[k];
     }
     n /= 2;
@@ -2015,9 +2015,9 @@ tsk_treeseq_site_allele_frequency_spectrum(const tsk_treeseq_t *self,
     memset(parent, 0xff, num_nodes * sizeof(*parent));
 
     for (j = 0; j < num_sample_sets; j++) {
-        total_counts[j] = sample_set_sizes[j];
+        total_counts[j] = (double) sample_set_sizes[j];
     }
-    total_counts[num_sample_sets] = self->num_samples;
+    total_counts[num_sample_sets] = (double) self->num_samples;
 
     /* Iterate over the trees */
     tj = 0;
@@ -2670,7 +2670,7 @@ Y1_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result
     size_t i;
 
     for (i = 0; i < result_dim; i++) {
-        ni = args.sample_set_sizes[i];
+        ni = (double) args.sample_set_sizes[i];
         denom = ni * (ni - 1) * (ni - 2);
         numer = x[i] * (ni - x[i]) * (ni - x[i] - 1);
         result[i] = numer / denom;
@@ -2728,8 +2728,8 @@ divergence_summary_func(size_t TSK_UNUSED(state_dim), const double *state,
     for (k = 0; k < result_dim; k++) {
         i = args.set_indexes[2 * k];
         j = args.set_indexes[2 * k + 1];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
         denom = ni * (nj - (i == j));
         result[k] = x[i] * (nj - x[j]) / denom;
     }
@@ -2768,15 +2768,15 @@ genetic_relatedness_summary_func(size_t state_dim, const double *state,
 
     for (k = 0; k < state_dim; k++) {
         sumx += x[k];
-        sumn += args.sample_set_sizes[k];
+        sumn += (double) args.sample_set_sizes[k];
     }
 
     meanx = sumx / sumn;
     for (k = 0; k < result_dim; k++) {
         i = args.set_indexes[2 * k];
         j = args.set_indexes[2 * k + 1];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
         result[k] = (x[i] - ni * meanx) * (x[j] - nj * meanx) / 2;
     }
     return 0;
@@ -2813,8 +2813,8 @@ Y2_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result
     for (k = 0; k < result_dim; k++) {
         i = args.set_indexes[2 * k];
         j = args.set_indexes[2 * k + 1];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
         denom = ni * nj * (nj - 1);
         result[k] = x[i] * (nj - x[j]) * (nj - x[j] - 1) / denom;
     }
@@ -2852,8 +2852,8 @@ f2_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result
     for (k = 0; k < result_dim; k++) {
         i = args.set_indexes[2 * k];
         j = args.set_indexes[2 * k + 1];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
         denom = ni * (ni - 1) * nj * (nj - 1);
         numer = x[i] * (x[i] - 1) * (nj - x[j]) * (nj - x[j] - 1)
                 - x[i] * (ni - x[i]) * (nj - x[j]) * x[j];
@@ -2898,9 +2898,9 @@ Y3_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result
         i = args.set_indexes[3 * tuple_index];
         j = args.set_indexes[3 * tuple_index + 1];
         k = args.set_indexes[3 * tuple_index + 2];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
-        nk = args.sample_set_sizes[k];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
+        nk = (double) args.sample_set_sizes[k];
         denom = ni * nj * nk;
         numer = x[i] * (nj - x[j]) * (nk - x[k]);
         result[tuple_index] = numer / denom;
@@ -2940,9 +2940,9 @@ f3_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result
         i = args.set_indexes[3 * tuple_index];
         j = args.set_indexes[3 * tuple_index + 1];
         k = args.set_indexes[3 * tuple_index + 2];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
-        nk = args.sample_set_sizes[k];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
+        nk = (double) args.sample_set_sizes[k];
         denom = ni * (ni - 1) * nj * nk;
         numer = x[i] * (x[i] - 1) * (nj - x[j]) * (nk - x[k])
                 - x[i] * (ni - x[i]) * (nj - x[j]) * x[k];
@@ -2988,10 +2988,10 @@ f4_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result
         j = args.set_indexes[4 * tuple_index + 1];
         k = args.set_indexes[4 * tuple_index + 2];
         l = args.set_indexes[4 * tuple_index + 3];
-        ni = args.sample_set_sizes[i];
-        nj = args.sample_set_sizes[j];
-        nk = args.sample_set_sizes[k];
-        nl = args.sample_set_sizes[l];
+        ni = (double) args.sample_set_sizes[i];
+        nj = (double) args.sample_set_sizes[j];
+        nk = (double) args.sample_set_sizes[k];
+        nl = (double) args.sample_set_sizes[l];
         denom = ni * nj * nk * nl;
         numer = x[i] * x[k] * (nj - x[j]) * (nl - x[l])
                 - x[i] * x[l] * (nj - x[j]) * (nk - x[k]);
@@ -4753,8 +4753,8 @@ norm_kc_vectors(kc_vectors *self, kc_vectors *other, double lambda)
 
     distance_sum = 0;
     for (i = 0; i < self->n + self->N; i++) {
-        vT1 = (self->m[i] * (1 - lambda)) + (lambda * self->M[i]);
-        vT2 = (other->m[i] * (1 - lambda)) + (lambda * other->M[i]);
+        vT1 = ((double) self->m[i] * (1 - lambda)) + (lambda * self->M[i]);
+        vT2 = ((double) other->m[i] * (1 - lambda)) + (lambda * other->M[i]);
         distance_sum += (vT1 - vT2) * (vT1 - vT2);
     }
 

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -64,27 +64,28 @@ tsk_treeseq_print_state(const tsk_treeseq_t *self, FILE *out)
     tsk_site_t site;
 
     fprintf(out, "tree_sequence state\n");
-    fprintf(out, "num_trees = %d\n", (int) self->num_trees);
-    fprintf(out, "samples = (%d)\n", (int) self->num_samples);
+    fprintf(out, "num_trees = %lld\n", (long long) self->num_trees);
+    fprintf(out, "samples = (%lld)\n", (long long) self->num_samples);
     for (j = 0; j < self->num_samples; j++) {
-        fprintf(out, "\t%d\n", (int) self->samples[j]);
+        fprintf(out, "\t%lld\n", (long long) self->samples[j]);
     }
     tsk_table_collection_print_state(self->tables, out);
     fprintf(out, "tree_sites = \n");
     for (j = 0; j < self->num_trees; j++) {
-        fprintf(out, "tree %d\t%d sites\n", (int) j, self->tree_sites_length[j]);
+        fprintf(out, "tree %lld\t%lld sites\n", (long long) j,
+            (long long) self->tree_sites_length[j]);
         for (k = 0; k < self->tree_sites_length[j]; k++) {
             site = self->tree_sites[j][k];
-            fprintf(
-                out, "\tsite %d pos = %f ancestral state = ", site.id, site.position);
+            fprintf(out, "\tsite %lld pos = %f ancestral state = ", (long long) site.id,
+                site.position);
             for (l = 0; l < site.ancestral_state_length; l++) {
                 fprintf(out, "%c", site.ancestral_state[l]);
             }
-            fprintf(out, " %d mutations\n", site.mutations_length);
+            fprintf(out, " %lld mutations\n", (long long) site.mutations_length);
             for (l = 0; l < site.mutations_length; l++) {
-                fprintf(out,
-                    "\t\tmutation %d node = %d derived_state = ", site.mutations[l].id,
-                    site.mutations[l].node);
+                fprintf(out, "\t\tmutation %lld node = %lld derived_state = ",
+                    (long long) site.mutations[l].id,
+                    (long long) site.mutations[l].node);
                 for (m = 0; m < site.mutations[l].derived_state_length; m++) {
                     fprintf(out, "%c", site.mutations[l].derived_state[m]);
                 }
@@ -3797,11 +3798,11 @@ tsk_tree_print_state(const tsk_tree_t *self, FILE *out)
 
     fprintf(out, "Tree state:\n");
     fprintf(out, "options = %d\n", self->options);
-    fprintf(out, "root_threshold = %d\n", self->root_threshold);
+    fprintf(out, "root_threshold = %lld\n", (long long) self->root_threshold);
     fprintf(out, "left = %f\n", self->left);
     fprintf(out, "right = %f\n", self->right);
-    fprintf(out, "left_root = %d\n", (int) self->left_root);
-    fprintf(out, "index = %d\n", (int) self->index);
+    fprintf(out, "left_root = %lld\n", (long long) self->left_root);
+    fprintf(out, "index = %lld\n", (long long) self->index);
     fprintf(out, "node\tparent\tlchild\trchild\tlsib\trsib");
     if (self->options & TSK_SAMPLE_LISTS) {
         fprintf(out, "\thead\ttail");
@@ -3809,22 +3810,24 @@ tsk_tree_print_state(const tsk_tree_t *self, FILE *out)
     fprintf(out, "\n");
 
     for (j = 0; j < self->num_nodes; j++) {
-        fprintf(out, "%d\t%d\t%d\t%d\t%d\t%d", (int) j, self->parent[j],
-            self->left_child[j], self->right_child[j], self->left_sib[j],
-            self->right_sib[j]);
+        fprintf(out, "%lld\t%lld\t%lld\t%lld\t%lld\t%lld", (long long) j,
+            (long long) self->parent[j], (long long) self->left_child[j],
+            (long long) self->right_child[j], (long long) self->left_sib[j],
+            (long long) self->right_sib[j]);
         if (self->options & TSK_SAMPLE_LISTS) {
-            fprintf(out, "\t%d\t%d\t", self->left_sample[j], self->right_sample[j]);
+            fprintf(out, "\t%lld\t%lld\t", (long long) self->left_sample[j],
+                (long long) self->right_sample[j]);
         }
         if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
-            fprintf(out, "\t%d\t%d\t%d", (int) self->num_samples[j],
-                (int) self->num_tracked_samples[j], self->marked[j]);
+            fprintf(out, "\t%lld\t%lld\t%lld", (long long) self->num_samples[j],
+                (long long) self->num_tracked_samples[j], (long long) self->marked[j]);
         }
         fprintf(out, "\n");
     }
     fprintf(out, "sites = \n");
     for (j = 0; j < self->sites_length; j++) {
         site = self->sites[j];
-        fprintf(out, "\t%d\t%f\n", site.id, site.position);
+        fprintf(out, "\t%lld\t%f\n", (long long) site.id, site.position);
     }
     tsk_tree_check_state(self);
 }
@@ -4482,11 +4485,11 @@ void
 tsk_diff_iter_print_state(const tsk_diff_iter_t *self, FILE *out)
 {
     fprintf(out, "tree_diff_iterator state\n");
-    fprintf(out, "num_edges = %d\n", (int) self->num_edges);
-    fprintf(out, "insertion_index = %d\n", (int) self->insertion_index);
-    fprintf(out, "removal_index = %d\n", (int) self->removal_index);
+    fprintf(out, "num_edges = %lld\n", (long long) self->num_edges);
+    fprintf(out, "insertion_index = %lld\n", (long long) self->insertion_index);
+    fprintf(out, "removal_index = %lld\n", (long long) self->removal_index);
     fprintf(out, "tree_left = %f\n", self->tree_left);
-    fprintf(out, "tree_index = %d\n", (int) self->tree_index);
+    fprintf(out, "tree_index = %lld\n", (long long) self->tree_index);
 }
 
 int TSK_WARN_UNUSED


### PR DESCRIPTION
A step towards 64 bit tables (#343), getting rid of some of the compiler warning noise.

I think this is harmless, because we were already casting to (int) in most places already, which was technically wrong. Casting up to long long won't do any harm. I've also added in a couple of other no controversy changes here, as I was looking at it.