### PR TITLE
Replace direct references to sizes

### DIFF
--- a/c/tests/test_file_format.c
+++ b/c/tests/test_file_format.c
@@ -361,7 +361,7 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     tsk_table_collection_t tables;
     tsk_size_t *offset_array, *offset_copy;
     size_t offset_len;
-    uint32_t data_len;
+    tsk_size_t data_len;
 
     ret = tsk_treeseq_dump(ts, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -381,7 +381,8 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, offset_copy, offset_len, KAS_UINT32, 0);
+    ret = kastore_puts(
+        &store, offset_col, offset_copy, offset_len, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -394,7 +395,8 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, offset_copy, offset_len, KAS_UINT32, 0);
+    ret = kastore_puts(
+        &store, offset_col, offset_copy, offset_len, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -406,7 +408,8 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, offset_copy, offset_len, KAS_UINT32, 0);
+    ret = kastore_puts(
+        &store, offset_col, offset_copy, offset_len, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -417,7 +420,7 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, NULL, 0, KAS_UINT32, 0);
+    ret = kastore_puts(&store, offset_col, NULL, 0, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -515,9 +518,9 @@ test_malformed_indexes(void)
     copy_store_drop_columns(ts, 2, cols, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[0], NULL, 0, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[0], NULL, 0, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[1], NULL, 0, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[1], NULL, 0, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -530,9 +533,9 @@ test_malformed_indexes(void)
     copy_store_drop_columns(ts, 2, cols, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[0], good_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[0], good_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[1], bad_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[1], bad_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -543,9 +546,9 @@ test_malformed_indexes(void)
     copy_store_drop_columns(ts, 2, cols, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[0], bad_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[0], bad_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[1], good_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[1], good_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -839,19 +842,19 @@ test_load_node_table_errors(void)
     double L = 1;
     double time = 0;
     double flags = 0;
-    int32_t population = 0;
-    int32_t individual = 0;
+    tsk_id_t population = 0;
+    tsk_id_t individual = 0;
     int8_t metadata = 0;
-    uint32_t metadata_offset[] = { 0, 1 };
-    uint32_t version[2]
+    tsk_size_t metadata_offset[] = { 0, 1 };
+    tsk_size_t version[2]
         = { TSK_FILE_FORMAT_VERSION_MAJOR, TSK_FILE_FORMAT_VERSION_MINOR };
     write_table_col_t write_cols[] = {
         { "nodes/time", (void *) &time, 1, KAS_FLOAT64 },
-        { "nodes/flags", (void *) &flags, 1, KAS_UINT32 },
-        { "nodes/population", (void *) &population, 1, KAS_INT32 },
-        { "nodes/individual", (void *) &individual, 1, KAS_INT32 },
+        { "nodes/flags", (void *) &flags, 1, TSK_FLAGS_STORAGE_TYPE },
+        { "nodes/population", (void *) &population, 1, TSK_ID_STORAGE_TYPE },
+        { "nodes/individual", (void *) &individual, 1, TSK_ID_STORAGE_TYPE },
         { "nodes/metadata", (void *) &metadata, 1, KAS_UINT8 },
-        { "nodes/metadata_offset", (void *) metadata_offset, 2, KAS_UINT32 },
+        { "nodes/metadata_offset", (void *) metadata_offset, 2, TSK_SIZE_STORAGE_TYPE },
         { "format/name", (void *) format_name, sizeof(format_name), KAS_INT8 },
         { "format/version", (void *) version, 2, KAS_UINT32 },
         { "uuid", (void *) uuid, uuid_size, KAS_INT8 },

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -410,14 +410,14 @@ test_node_table(void)
     tsk_id_t ret_id;
     tsk_node_table_t table, table2;
     tsk_node_t node, node2;
-    uint32_t num_rows = 100;
+    tsk_size_t num_rows = 100;
     tsk_id_t j;
-    uint32_t *flags;
+    tsk_flags_t *flags;
     tsk_id_t *population;
     double *time;
     tsk_id_t *individual;
     char *metadata;
-    uint32_t *metadata_offset;
+    tsk_size_t *metadata_offset;
     const char *test_metadata = "test";
     tsk_size_t test_metadata_length = 4;
     char metadata_copy[test_metadata_length + 1];
@@ -491,18 +491,18 @@ test_node_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     num_rows *= 2;
-    flags = malloc(num_rows * sizeof(uint32_t));
+    flags = malloc(num_rows * sizeof(tsk_flags_t));
     CU_ASSERT_FATAL(flags != NULL);
-    memset(flags, 1, num_rows * sizeof(uint32_t));
-    population = malloc(num_rows * sizeof(uint32_t));
+    memset(flags, 1, num_rows * sizeof(tsk_flags_t));
+    population = malloc(num_rows * sizeof(tsk_id_t));
     CU_ASSERT_FATAL(population != NULL);
-    memset(population, 2, num_rows * sizeof(uint32_t));
+    memset(population, 2, num_rows * sizeof(tsk_id_t));
     time = malloc(num_rows * sizeof(double));
     CU_ASSERT_FATAL(time != NULL);
     memset(time, 0, num_rows * sizeof(double));
-    individual = malloc(num_rows * sizeof(uint32_t));
+    individual = malloc(num_rows * sizeof(tsk_id_t));
     CU_ASSERT_FATAL(individual != NULL);
-    memset(individual, 3, num_rows * sizeof(uint32_t));
+    memset(individual, 3, num_rows * sizeof(tsk_id_t));
     metadata = malloc(num_rows * sizeof(char));
     memset(metadata, 'a', num_rows * sizeof(char));
     CU_ASSERT_FATAL(metadata != NULL);
@@ -514,12 +514,12 @@ test_node_table(void)
     ret = tsk_node_table_set_columns(&table, num_rows, flags, time, population,
         individual, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
@@ -534,19 +534,19 @@ test_node_table(void)
     ret = tsk_node_table_append_columns(&table, num_rows, flags, time, population,
         individual, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.flags + num_rows, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population + num_rows, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population + num_rows, population, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time + num_rows, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual + num_rows, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual + num_rows, individual, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.metadata + num_rows, metadata, num_rows * sizeof(char)), 0);
@@ -559,12 +559,12 @@ test_node_table(void)
     /* Truncate back to the original number of rows. */
     ret = tsk_node_table_truncate(&table, num_rows);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
@@ -579,20 +579,21 @@ test_node_table(void)
      * should be set to the empty string. If individual is NULL it should be set to -1.
      */
     num_rows = 10;
-    memset(population, 0xff, num_rows * sizeof(uint32_t));
-    memset(individual, 0xff, num_rows * sizeof(uint32_t));
+    memset(population, 0xff, num_rows * sizeof(tsk_id_t));
+    memset(individual, 0xff, num_rows * sizeof(tsk_id_t));
     ret = tsk_node_table_set_columns(
         &table, num_rows, flags, time, NULL, NULL, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.metadata_offset, metadata_offset, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.metadata_offset, metadata_offset, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, num_rows);
 
@@ -616,7 +617,7 @@ test_node_table(void)
     ret = tsk_node_table_set_columns(
         &table, num_rows, flags, time, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
@@ -626,16 +627,16 @@ test_node_table(void)
     ret = tsk_node_table_append_columns(
         &table, num_rows, flags, time, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.flags + num_rows, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time + num_rows, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
         0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset + num_rows, metadata_offset,
-                        num_rows * sizeof(uint32_t)),
+                        num_rows * sizeof(tsk_size_t)),
         0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
@@ -763,7 +764,7 @@ test_edge_table_with_options(tsk_flags_t options)
     tsk_id_t *parent, *child;
     double *left, *right;
     char *metadata;
-    uint32_t *metadata_offset;
+    tsk_size_t *metadata_offset;
     const char *test_metadata = "test";
     tsk_size_t test_metadata_length = 4;
     char metadata_copy[test_metadata_length + 1];
@@ -1021,7 +1022,7 @@ test_edge_table_with_options(tsk_flags_t options)
                             (num_rows + 1) * sizeof(tsk_size_t)),
             0);
         CU_ASSERT_EQUAL(memcmp(table.metadata_offset + num_rows, metadata_offset,
-                            num_rows * sizeof(uint32_t)),
+                            num_rows * sizeof(tsk_size_t)),
             0);
     }
     CU_ASSERT_EQUAL(table.metadata_length, 0);
@@ -1489,11 +1490,11 @@ test_site_table(void)
     CU_ASSERT_FATAL(position != NULL);
     ancestral_state = malloc(num_rows * sizeof(char));
     CU_ASSERT_FATAL(ancestral_state != NULL);
-    ancestral_state_offset = malloc((num_rows + 1) * sizeof(uint32_t));
+    ancestral_state_offset = malloc((num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(ancestral_state_offset != NULL);
     metadata = malloc(num_rows * sizeof(char));
     CU_ASSERT_FATAL(metadata != NULL);
-    metadata_offset = malloc((num_rows + 1) * sizeof(uint32_t));
+    metadata_offset = malloc((num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(metadata_offset != NULL);
 
     for (j = 0; j < num_rows; j++) {
@@ -1591,13 +1592,13 @@ test_site_table(void)
         &table, num_rows, position, ancestral_state, ancestral_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    memset(metadata_offset, 0, (num_rows + 1) * sizeof(uint32_t));
+    memset(metadata_offset, 0, (num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_EQUAL(memcmp(table.position, position, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.ancestral_state, ancestral_state, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.ancestral_state_length, num_rows);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
-                        (num_rows + 1) * sizeof(uint32_t)),
+                        (num_rows + 1) * sizeof(tsk_size_t)),
         0);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
@@ -2147,7 +2148,7 @@ test_migration_table(void)
     double *left, *right, *time;
     tsk_migration_t migration, migration2;
     char *metadata;
-    uint32_t *metadata_offset;
+    tsk_size_t *metadata_offset;
     const char *test_metadata = "test";
     tsk_size_t test_metadata_length = 4;
     char metadata_copy[test_metadata_length + 1];
@@ -2502,7 +2503,7 @@ test_individual_table(void)
     tsk_size_t num_rows = 100;
     tsk_id_t j;
     tsk_size_t k;
-    uint32_t *flags;
+    tsk_flags_t *flags;
     double *location;
     tsk_id_t *parents;
     char *metadata;
@@ -2561,7 +2562,7 @@ test_individual_table(void)
         ret = tsk_individual_table_get_row(&table, (tsk_id_t) j, &individual);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_EQUAL(individual.id, j);
-        CU_ASSERT_EQUAL(individual.flags, (uint32_t) j);
+        CU_ASSERT_EQUAL(individual.flags, (tsk_flags_t) j);
         CU_ASSERT_EQUAL(individual.location_length, spatial_dimension);
         CU_ASSERT_NSTRING_EQUAL(
             individual.location, test_location, spatial_dimension * sizeof(double));
@@ -2602,7 +2603,7 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     num_rows *= 2;
-    flags = malloc(num_rows * sizeof(uint32_t));
+    flags = malloc(num_rows * sizeof(tsk_flags_t));
     CU_ASSERT_FATAL(flags != NULL);
     for (k = 0; k < num_rows; k++) {
         flags[k] = k + num_rows;
@@ -2640,7 +2641,7 @@ test_individual_table(void)
     ret = tsk_individual_table_set_columns(&table, num_rows, flags, location,
         location_offset, parents, parents_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.location, location, spatial_dimension * num_rows * sizeof(double)),
         0);
@@ -2666,9 +2667,9 @@ test_individual_table(void)
     ret = tsk_individual_table_append_columns(&table, num_rows, flags, location,
         location_offset, parents, parents_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.flags + num_rows, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.metadata + num_rows, metadata, num_rows * sizeof(char)), 0);
@@ -2694,7 +2695,7 @@ test_individual_table(void)
     /* Truncate back to num_rows */
     ret = tsk_individual_table_truncate(&table, num_rows);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.location, location, spatial_dimension * num_rows * sizeof(double)),
         0);
@@ -2760,7 +2761,8 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(
         memcmp(table.location_offset, zeros, (num_rows + 1) * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.location_offset + num_rows, zeros, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.location_offset + num_rows, zeros, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.location_length, 0);
     tsk_individual_table_print_state(&table, _devnull);
@@ -2782,7 +2784,8 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(
         memcmp(table.parents_offset, zeros, (num_rows + 1) * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.parents_offset + num_rows, zeros, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.parents_offset + num_rows, zeros, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.parents_length, 0);
     tsk_individual_table_print_state(&table, _devnull);
@@ -2794,7 +2797,7 @@ test_individual_table(void)
     ret = tsk_individual_table_set_columns(&table, num_rows, flags, location,
         location_offset, parents, parents_offset, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.location, location, spatial_dimension * num_rows * sizeof(double)),
         0);
@@ -2821,7 +2824,8 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(
         memcmp(table.metadata_offset, zeros, (num_rows + 1) * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.metadata_offset + num_rows, zeros, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.metadata_offset + num_rows, zeros, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
     tsk_individual_table_print_state(&table, _devnull);
@@ -3198,12 +3202,12 @@ test_provenance_table(void)
     tsk_size_t num_rows = 100;
     tsk_size_t j;
     char *timestamp;
-    uint32_t *timestamp_offset;
+    tsk_size_t *timestamp_offset;
     const char *test_timestamp = "2017-12-06T20:40:25+00:00";
     tsk_size_t test_timestamp_length = (tsk_size_t) strlen(test_timestamp);
     char timestamp_copy[test_timestamp_length + 1];
     char *record;
-    uint32_t *record_offset;
+    tsk_size_t *record_offset;
     const char *test_record = "{\"json\"=1234}";
     tsk_size_t test_record_length = (tsk_size_t) strlen(test_record);
     char record_copy[test_record_length + 1];
@@ -5373,7 +5377,7 @@ test_table_overflow(void)
     int ret;
     tsk_id_t ret_id;
     tsk_table_collection_t tables;
-    tsk_size_t max_rows = ((tsk_size_t) INT32_MAX) + 1;
+    tsk_size_t max_rows = ((tsk_size_t) TSK_MAX_ID) + 1;
 
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5429,7 +5433,7 @@ test_column_overflow(void)
     int ret;
     tsk_id_t ret_id;
     tsk_table_collection_t tables;
-    tsk_size_t too_big = ((tsk_size_t) UINT32_MAX);
+    tsk_size_t too_big = TSK_MAX_SIZE;
     double zero = 0;
     char zeros[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
     tsk_id_t id_zeros[] = { 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -33,8 +33,8 @@
 static void
 tsk_ld_calc_check_state(const tsk_ld_calc_t *self)
 {
-    uint32_t u;
-    uint32_t num_nodes = (uint32_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
+    tsk_size_t u;
+    tsk_size_t num_nodes = tsk_treeseq_get_num_nodes(self->tree_sequence);
     tsk_tree_t *tA = self->outer_tree;
     tsk_tree_t *tB = self->inner_tree;
 

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -56,13 +56,13 @@ typedef struct {
 } write_table_col_t;
 
 /* Returns true if adding the specified number of rows would result in overflow.
- * Tables can support indexes from 0 to INT32_MAX, and therefore have at most
- * INT32_MAX + 1 rows */
+ * Tables can support indexes from 0 to TSK_MAX_ID, and therefore have at most
+ * TSK_MAX_ID + 1 rows */
 static bool
 check_table_overflow(tsk_size_t current_size, tsk_size_t additional_rows)
 {
     uint64_t new_size = (uint64_t) current_size + (uint64_t) additional_rows;
-    return new_size > ((uint64_t) INT32_MAX) + 1;
+    return new_size > ((uint64_t) TSK_MAX_ID) + 1;
 }
 
 /* Returns true if adding the specified number of elements would result in overflow
@@ -72,7 +72,7 @@ static bool
 check_offset_overflow(tsk_size_t current_size, tsk_size_t additional_elements)
 {
     uint64_t new_size = (uint64_t) current_size + (uint64_t) additional_elements;
-    return new_size > UINT32_MAX;
+    return new_size > TSK_MAX_SIZE;
 }
 
 static int
@@ -884,19 +884,20 @@ static int
 tsk_individual_table_dump(const tsk_individual_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
-        { "individuals/flags", (void *) self->flags, self->num_rows, KAS_UINT32 },
+        { "individuals/flags", (void *) self->flags, self->num_rows,
+            TSK_FLAGS_STORAGE_TYPE },
         { "individuals/location", (void *) self->location, self->location_length,
             KAS_FLOAT64 },
         { "individuals/location_offset", (void *) self->location_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "individuals/parents", (void *) self->parents, self->parents_length,
-            KAS_INT32 },
+            TSK_ID_STORAGE_TYPE },
         { "individuals/parents_offset", (void *) self->parents_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "individuals/metadata", (void *) self->metadata, self->metadata_length,
             KAS_UINT8 },
         { "individuals/metadata_offset", (void *) self->metadata_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "individuals/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
     };
@@ -919,19 +920,20 @@ tsk_individual_table_load(tsk_individual_table_t *self, kastore_t *store)
         metadata_schema_length;
 
     read_table_col_t read_cols[] = {
-        { "individuals/flags", (void **) &flags, &num_rows, 0, KAS_UINT32, 0 },
+        { "individuals/flags", (void **) &flags, &num_rows, 0, TSK_FLAGS_STORAGE_TYPE,
+            0 },
         { "individuals/location", (void **) &location, &location_length, 0, KAS_FLOAT64,
             0 },
         { "individuals/location_offset", (void **) &location_offset, &num_rows, 1,
-            KAS_UINT32, 0 },
-        { "individuals/parents", (void **) &parents, &parents_length, 0, KAS_INT32,
-            TSK_COL_OPTIONAL },
+            TSK_SIZE_STORAGE_TYPE, 0 },
+        { "individuals/parents", (void **) &parents, &parents_length, 0,
+            TSK_ID_STORAGE_TYPE, TSK_COL_OPTIONAL },
         { "individuals/parents_offset", (void **) &parents_offset, &num_rows, 1,
-            KAS_UINT32, TSK_COL_OPTIONAL },
+            TSK_SIZE_STORAGE_TYPE, TSK_COL_OPTIONAL },
         { "individuals/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
             0 },
         { "individuals/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
-            KAS_UINT32, 0 },
+            TSK_SIZE_STORAGE_TYPE, 0 },
         { "individuals/metadata_schema", (void **) &metadata_schema,
             &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -1435,12 +1437,14 @@ tsk_node_table_dump(const tsk_node_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
         { "nodes/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
-        { "nodes/flags", (void *) self->flags, self->num_rows, KAS_UINT32 },
-        { "nodes/population", (void *) self->population, self->num_rows, KAS_INT32 },
-        { "nodes/individual", (void *) self->individual, self->num_rows, KAS_INT32 },
+        { "nodes/flags", (void *) self->flags, self->num_rows, TSK_FLAGS_STORAGE_TYPE },
+        { "nodes/population", (void *) self->population, self->num_rows,
+            TSK_ID_STORAGE_TYPE },
+        { "nodes/individual", (void *) self->individual, self->num_rows,
+            TSK_ID_STORAGE_TYPE },
         { "nodes/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8 },
         { "nodes/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
-            KAS_UINT32 },
+            TSK_SIZE_STORAGE_TYPE },
         { "nodes/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
 
@@ -1463,12 +1467,14 @@ tsk_node_table_load(tsk_node_table_t *self, kastore_t *store)
 
     read_table_col_t read_cols[] = {
         { "nodes/time", (void **) &time, &num_rows, 0, KAS_FLOAT64, 0 },
-        { "nodes/flags", (void **) &flags, &num_rows, 0, KAS_UINT32, 0 },
-        { "nodes/population", (void **) &population, &num_rows, 0, KAS_INT32, 0 },
-        { "nodes/individual", (void **) &individual, &num_rows, 0, KAS_INT32, 0 },
-        { "nodes/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
-        { "nodes/metadata_offset", (void **) &metadata_offset, &num_rows, 1, KAS_UINT32,
+        { "nodes/flags", (void **) &flags, &num_rows, 0, TSK_FLAGS_STORAGE_TYPE, 0 },
+        { "nodes/population", (void **) &population, &num_rows, 0, TSK_ID_STORAGE_TYPE,
             0 },
+        { "nodes/individual", (void **) &individual, &num_rows, 0, TSK_ID_STORAGE_TYPE,
+            0 },
+        { "nodes/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
+        { "nodes/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            TSK_SIZE_STORAGE_TYPE, 0 },
         { "nodes/metadata_schema", (void **) &metadata_schema, &metadata_schema_length,
             0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -1991,15 +1997,15 @@ tsk_edge_table_dump(const tsk_edge_table_t *self, kastore_t *store)
     write_table_col_t write_cols[] = {
         { "edges/left", (void *) self->left, self->num_rows, KAS_FLOAT64 },
         { "edges/right", (void *) self->right, self->num_rows, KAS_FLOAT64 },
-        { "edges/parent", (void *) self->parent, self->num_rows, KAS_INT32 },
-        { "edges/child", (void *) self->child, self->num_rows, KAS_INT32 },
+        { "edges/parent", (void *) self->parent, self->num_rows, TSK_ID_STORAGE_TYPE },
+        { "edges/child", (void *) self->child, self->num_rows, TSK_ID_STORAGE_TYPE },
         { "edges/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
     };
     write_table_col_t write_cols_metadata[] = {
         { "edges/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8 },
         { "edges/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
-            KAS_UINT32 },
+            TSK_SIZE_STORAGE_TYPE },
     };
 
     ret = write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
@@ -2033,12 +2039,12 @@ tsk_edge_table_load(tsk_edge_table_t *self, kastore_t *store)
     read_table_col_t read_cols[] = {
         { "edges/left", (void **) &left, &num_rows, 0, KAS_FLOAT64, 0 },
         { "edges/right", (void **) &right, &num_rows, 0, KAS_FLOAT64, 0 },
-        { "edges/parent", (void **) &parent, &num_rows, 0, KAS_INT32, 0 },
-        { "edges/child", (void **) &child, &num_rows, 0, KAS_INT32, 0 },
+        { "edges/parent", (void **) &parent, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
+        { "edges/child", (void **) &child, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
         { "edges/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
             TSK_COL_OPTIONAL },
-        { "edges/metadata_offset", (void **) &metadata_offset, &num_rows, 1, KAS_UINT32,
-            TSK_COL_OPTIONAL },
+        { "edges/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            TSK_SIZE_STORAGE_TYPE, TSK_COL_OPTIONAL },
         { "edges/metadata_schema", (void **) &metadata_schema, &metadata_schema_length,
             0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -2636,10 +2642,10 @@ tsk_site_table_dump(const tsk_site_table_t *self, kastore_t *store)
         { "sites/ancestral_state", (void *) self->ancestral_state,
             self->ancestral_state_length, KAS_UINT8 },
         { "sites/ancestral_state_offset", (void *) self->ancestral_state_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "sites/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8 },
         { "sites/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
-            KAS_UINT32 },
+            TSK_SIZE_STORAGE_TYPE },
         { "sites/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
     };
@@ -2664,10 +2670,10 @@ tsk_site_table_load(tsk_site_table_t *self, kastore_t *store)
         { "sites/ancestral_state", (void **) &ancestral_state, &ancestral_state_length,
             0, KAS_UINT8, 0 },
         { "sites/ancestral_state_offset", (void **) &ancestral_state_offset, &num_rows,
-            1, KAS_UINT32, 0 },
+            1, TSK_SIZE_STORAGE_TYPE, 0 },
         { "sites/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
-        { "sites/metadata_offset", (void **) &metadata_offset, &num_rows, 1, KAS_UINT32,
-            0 },
+        { "sites/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            TSK_SIZE_STORAGE_TYPE, 0 },
         { "sites/metadata_schema", (void **) &metadata_schema, &metadata_schema_length,
             0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -3259,18 +3265,19 @@ static int
 tsk_mutation_table_dump(const tsk_mutation_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
-        { "mutations/site", (void *) self->site, self->num_rows, KAS_INT32 },
-        { "mutations/node", (void *) self->node, self->num_rows, KAS_INT32 },
-        { "mutations/parent", (void *) self->parent, self->num_rows, KAS_INT32 },
+        { "mutations/site", (void *) self->site, self->num_rows, TSK_ID_STORAGE_TYPE },
+        { "mutations/node", (void *) self->node, self->num_rows, TSK_ID_STORAGE_TYPE },
+        { "mutations/parent", (void *) self->parent, self->num_rows,
+            TSK_ID_STORAGE_TYPE },
         { "mutations/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
         { "mutations/derived_state", (void *) self->derived_state,
             self->derived_state_length, KAS_UINT8 },
         { "mutations/derived_state_offset", (void *) self->derived_state_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "mutations/metadata", (void *) self->metadata, self->metadata_length,
             KAS_UINT8 },
         { "mutations/metadata_offset", (void *) self->metadata_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "mutations/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
 
@@ -3294,18 +3301,18 @@ tsk_mutation_table_load(tsk_mutation_table_t *self, kastore_t *store)
     tsk_size_t num_rows, derived_state_length, metadata_length, metadata_schema_length;
 
     read_table_col_t read_cols[] = {
-        { "mutations/site", (void **) &site, &num_rows, 0, KAS_INT32, 0 },
-        { "mutations/node", (void **) &node, &num_rows, 0, KAS_INT32, 0 },
-        { "mutations/parent", (void **) &parent, &num_rows, 0, KAS_INT32, 0 },
+        { "mutations/site", (void **) &site, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
+        { "mutations/node", (void **) &node, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
+        { "mutations/parent", (void **) &parent, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
         { "mutations/time", (void **) &time, &num_rows, 0, KAS_FLOAT64,
             TSK_COL_OPTIONAL },
         { "mutations/derived_state", (void **) &derived_state, &derived_state_length, 0,
             KAS_UINT8, 0 },
         { "mutations/derived_state_offset", (void **) &derived_state_offset, &num_rows,
-            1, KAS_UINT32, 0 },
+            1, TSK_SIZE_STORAGE_TYPE, 0 },
         { "mutations/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
         { "mutations/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
-            KAS_UINT32, 0 },
+            TSK_SIZE_STORAGE_TYPE, 0 },
         { "mutations/metadata_schema", (void **) &metadata_schema,
             &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -3797,14 +3804,15 @@ tsk_migration_table_dump(const tsk_migration_table_t *self, kastore_t *store)
     write_table_col_t write_cols[] = {
         { "migrations/left", (void *) self->left, self->num_rows, KAS_FLOAT64 },
         { "migrations/right", (void *) self->right, self->num_rows, KAS_FLOAT64 },
-        { "migrations/node", (void *) self->node, self->num_rows, KAS_INT32 },
-        { "migrations/source", (void *) self->source, self->num_rows, KAS_INT32 },
-        { "migrations/dest", (void *) self->dest, self->num_rows, KAS_INT32 },
+        { "migrations/node", (void *) self->node, self->num_rows, TSK_ID_STORAGE_TYPE },
+        { "migrations/source", (void *) self->source, self->num_rows,
+            TSK_ID_STORAGE_TYPE },
+        { "migrations/dest", (void *) self->dest, self->num_rows, TSK_ID_STORAGE_TYPE },
         { "migrations/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
         { "migrations/metadata", (void *) self->metadata, self->metadata_length,
             KAS_UINT8 },
         { "migrations/metadata_offset", (void *) self->metadata_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "migrations/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
     };
@@ -3830,14 +3838,14 @@ tsk_migration_table_load(tsk_migration_table_t *self, kastore_t *store)
     read_table_col_t read_cols[] = {
         { "migrations/left", (void **) &left, &num_rows, 0, KAS_FLOAT64, 0 },
         { "migrations/right", (void **) &right, &num_rows, 0, KAS_FLOAT64, 0 },
-        { "migrations/node", (void **) &node, &num_rows, 0, KAS_INT32, 0 },
-        { "migrations/source", (void **) &source, &num_rows, 0, KAS_INT32, 0 },
-        { "migrations/dest", (void **) &dest, &num_rows, 0, KAS_INT32, 0 },
+        { "migrations/node", (void **) &node, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
+        { "migrations/source", (void **) &source, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
+        { "migrations/dest", (void **) &dest, &num_rows, 0, TSK_ID_STORAGE_TYPE, 0 },
         { "migrations/time", (void **) &time, &num_rows, 0, KAS_FLOAT64, 0 },
         { "migrations/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
             TSK_COL_OPTIONAL },
         { "migrations/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
-            KAS_UINT32, TSK_COL_OPTIONAL },
+            TSK_SIZE_STORAGE_TYPE, TSK_COL_OPTIONAL },
         { "migrations/metadata_schema", (void **) &metadata_schema,
             &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -4273,7 +4281,7 @@ tsk_population_table_dump(const tsk_population_table_t *self, kastore_t *store)
         { "populations/metadata", (void *) self->metadata, self->metadata_length,
             KAS_UINT8 },
         { "populations/metadata_offset", (void *) self->metadata_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "populations/metadata_schema", (void *) self->metadata_schema,
             self->metadata_schema_length, KAS_UINT8 },
     };
@@ -4294,7 +4302,7 @@ tsk_population_table_load(tsk_population_table_t *self, kastore_t *store)
         { "populations/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
             0 },
         { "populations/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
-            KAS_UINT32, 0 },
+            TSK_SIZE_STORAGE_TYPE, 0 },
         { "populations/metadata_schema", (void **) &metadata_schema,
             &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
     };
@@ -4795,10 +4803,10 @@ tsk_provenance_table_dump(const tsk_provenance_table_t *self, kastore_t *store)
         { "provenances/timestamp", (void *) self->timestamp, self->timestamp_length,
             KAS_UINT8 },
         { "provenances/timestamp_offset", (void *) self->timestamp_offset,
-            self->num_rows + 1, KAS_UINT32 },
+            self->num_rows + 1, TSK_SIZE_STORAGE_TYPE },
         { "provenances/record", (void *) self->record, self->record_length, KAS_UINT8 },
         { "provenances/record_offset", (void *) self->record_offset, self->num_rows + 1,
-            KAS_UINT32 },
+            TSK_SIZE_STORAGE_TYPE },
     };
     return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
 }
@@ -4817,10 +4825,10 @@ tsk_provenance_table_load(tsk_provenance_table_t *self, kastore_t *store)
         { "provenances/timestamp", (void **) &timestamp, &timestamp_length, 0, KAS_UINT8,
             0 },
         { "provenances/timestamp_offset", (void **) &timestamp_offset, &num_rows, 1,
-            KAS_UINT32, 0 },
+            TSK_SIZE_STORAGE_TYPE, 0 },
         { "provenances/record", (void **) &record, &record_length, 0, KAS_UINT8, 0 },
         { "provenances/record_offset", (void **) &record_offset, &num_rows, 1,
-            KAS_UINT32, 0 },
+            TSK_SIZE_STORAGE_TYPE, 0 },
     };
 
     ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
@@ -8693,7 +8701,7 @@ tsk_table_collection_check_tree_integrity(const tsk_table_collection_t *self)
         /* This is technically possible; if we have 2**31 edges each defining
          * a single tree, and there's a gap between each of these edges we
          * would overflow this counter. */
-        if (num_trees == INT32_MAX) {
+        if (num_trees == TSK_MAX_ID) {
             ret = TSK_ERR_TREE_OVERFLOW;
             goto out;
         }
@@ -9243,8 +9251,10 @@ tsk_table_collection_dump_indexes(const tsk_table_collection_t *self, kastore_t 
 {
     int ret = 0;
     write_table_col_t write_cols[] = {
-        { "indexes/edge_insertion_order", NULL, self->indexes.num_edges, KAS_INT32 },
-        { "indexes/edge_removal_order", NULL, self->indexes.num_edges, KAS_INT32 },
+        { "indexes/edge_insertion_order", NULL, self->indexes.num_edges,
+            TSK_ID_STORAGE_TYPE },
+        { "indexes/edge_removal_order", NULL, self->indexes.num_edges,
+            TSK_ID_STORAGE_TYPE },
     };
 
     if (tsk_table_collection_has_index(self, 0)) {
@@ -9266,9 +9276,9 @@ tsk_table_collection_load_indexes(tsk_table_collection_t *self, kastore_t *store
 
     read_table_col_t read_cols[] = {
         { "indexes/edge_insertion_order", (void **) &edge_insertion_order, &num_rows, 0,
-            KAS_INT32, TSK_COL_OPTIONAL },
+            TSK_ID_STORAGE_TYPE, TSK_COL_OPTIONAL },
         { "indexes/edge_removal_order", (void **) &edge_removal_order, &num_rows, 0,
-            KAS_INT32, TSK_COL_OPTIONAL },
+            TSK_ID_STORAGE_TYPE, TSK_COL_OPTIONAL },
     };
 
     ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -53,6 +53,8 @@ missing data.
 @endrst
 */
 typedef int32_t tsk_id_t;
+#define TSK_MAX_ID INT32_MAX
+#define TSK_ID_STORAGE_TYPE KAS_INT32
 
 /**
 @brief Tskit sizes.
@@ -62,6 +64,8 @@ Sizes in tskit are defined by the ``tsk_size_t`` type.
 @endrst
 */
 typedef uint32_t tsk_size_t;
+#define TSK_MAX_SIZE UINT32_MAX
+#define TSK_SIZE_STORAGE_TYPE KAS_UINT32
 
 /**
 @brief Container for bitwise flags.
@@ -72,6 +76,7 @@ specify options to API functions.
 @endrst
 */
 typedef uint32_t tsk_flags_t;
+#define TSK_FLAGS_STORAGE_TYPE KAS_UINT32
 
 /****************************************************************************/
 /* Definitions for the basic objects */

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -296,7 +296,7 @@ tsk_treeseq_init_nodes(tsk_treeseq_t *self)
 {
     size_t j, k;
     size_t num_nodes = self->tables->nodes.num_rows;
-    const uint32_t *restrict node_flags = self->tables->nodes.flags;
+    const tsk_flags_t *restrict node_flags = self->tables->nodes.flags;
     int ret = 0;
 
     /* Determine the sample size */


### PR DESCRIPTION
Almost all of these direct references to 32 should have been `tsk_X` anyway. 

I've also modified the overflow checkers to not need a wider type - please double check the logic here!

I've also `#defined` the kastore types - I know we'll have to do something more clever than just changing them but it still seemed a good thing to do.