### PR TITLE
64 bit test branch

### DIFF
--- a/c/examples/error_handling.c
+++ b/c/examples/error_handling.c
@@ -19,9 +19,9 @@ main(int argc, char **argv)
         fprintf(stderr, "%s", tsk_strerror(ret));
         exit(EXIT_FAILURE);
     }
-    printf("Loaded tree sequence with %d nodes and %d edges from %s\n",
-        tsk_treeseq_get_num_nodes(&ts),
-        tsk_treeseq_get_num_edges(&ts),
+    printf("Loaded tree sequence with %lld nodes and %lld edges from %s\n",
+        (long long)tsk_treeseq_get_num_nodes(&ts),
+        (long long)tsk_treeseq_get_num_edges(&ts),
         argv[1]);
     tsk_treeseq_free(&ts);
 

--- a/c/examples/haploid_wright_fisher.c
+++ b/c/examples/haploid_wright_fisher.c
@@ -58,19 +58,19 @@ simulate(
             children[j] = child;
         }
         if (t % simplify_interval == 0) {
-            printf("Simplify at generation %d: (%d nodes %d edges)",
-                t,
-                tables->nodes.num_rows,
-                tables->edges.num_rows);
+            printf("Simplify at generation %lld: (%lld nodes %lld edges)",
+                (long long)t,
+                (long long)tables->nodes.num_rows,
+                (long long)tables->edges.num_rows);
             /* Note: Edges must be sorted for simplify to work, and we use a brute force
              * approach of sorting each time here for simplicity. This is inefficient. */
             ret = tsk_table_collection_sort(tables, NULL, 0);
             check_tsk_error(ret);
             ret = tsk_table_collection_simplify(tables, children, N, 0, NULL);
             check_tsk_error(ret);
-            printf(" -> (%d nodes %d edges)\n",
-                tables->nodes.num_rows,
-                tables->edges.num_rows);
+            printf(" -> (%lld nodes %lld edges)\n",
+                (long long)tables->nodes.num_rows,
+                (long long)tables->edges.num_rows);
             for (j = 0; j < N; j++) {
                 children[j] = j;
             }

--- a/c/examples/streaming.c
+++ b/c/examples/streaming.c
@@ -24,8 +24,8 @@ main(int argc, char **argv)
             break;
         }
         check_tsk_error(ret);
-        fprintf(stderr, "Tree sequence %d had %d mutations\n", j,
-            (int) tables.mutations.num_rows);
+        fprintf(stderr, "Tree sequence %d had %lld mutations\n", j,
+            (long long) tables.mutations.num_rows);
         ret = tsk_mutation_table_truncate(&tables.mutations, 0);
         check_tsk_error(ret);
         ret = tsk_table_collection_dumpf(&tables, stdout, 0);

--- a/c/examples/tree_iteration.c
+++ b/c/examples/tree_iteration.c
@@ -26,17 +26,17 @@ main(int argc, char **argv)
 
     printf("Iterate forwards\n");
     for (iter = tsk_tree_first(&tree); iter == 1; iter = tsk_tree_next(&tree)) {
-        printf("\ttree %d has %d roots\n",
-            tsk_tree_get_index(&tree),
-            tsk_tree_get_num_roots(&tree));
+        printf("\ttree %lld has %lld roots\n",
+            (long long)tsk_tree_get_index(&tree),
+            (long long)tsk_tree_get_num_roots(&tree));
     }
     check_tsk_error(iter);
 
     printf("Iterate backwards\n");
     for (iter = tsk_tree_last(&tree); iter == 1; iter = tsk_tree_prev(&tree)) {
-        printf("\ttree %d has %d roots\n",
-            tsk_tree_get_index(&tree),
-            tsk_tree_get_num_roots(&tree));
+        printf("\ttree %lld has %lld roots\n",
+            (long long)tsk_tree_get_index(&tree),
+            (long long)tsk_tree_get_num_roots(&tree));
     }
     check_tsk_error(iter);
 

--- a/c/examples/tree_traversal.c
+++ b/c/examples/tree_traversal.c
@@ -18,7 +18,7 @@ _traverse(tsk_tree_t *tree, tsk_id_t u, int depth)
     for (j = 0; j < depth; j++) {
         printf("    ");
     }
-    printf("Visit recursive %d\n", u);
+    printf("Visit recursive %lld\n", (long long)u);
     for (v = tree->left_child[u]; v != TSK_NULL; v = tree->right_sib[v]) {
         _traverse(tree, v, depth + 1);
     }
@@ -51,7 +51,7 @@ traverse_stack(tsk_tree_t *tree)
         while (stack_top >= 0) {
             u = stack[stack_top];
             stack_top--;
-            printf("Visit stack %d\n", u);
+            printf("Visit stack %lld\n", (long long)u);
             /* Put nodes on the stack right-to-left, so we visit in left-to-right */
             for (v = tree->right_child[u]; v != TSK_NULL; v = tree->left_sib[v]) {
                 stack_top++;
@@ -73,7 +73,7 @@ traverse_upwards(tsk_tree_t *tree)
     for (j = 0; j < num_samples; j++) {
         u = samples[j];
         while (u != TSK_NULL) {
-            printf("Visit upwards: %d\n", u);
+            printf("Visit upwards: %lld\n", (long long)u);
             u = tree->parent[u];
         }
     }

--- a/c/tests/test_file_format.c
+++ b/c/tests/test_file_format.c
@@ -368,7 +368,7 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     ret = kastore_open(&store, _tmp_file_name, "r", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = kastore_gets_uint32(&store, offset_col, &offset_array, &offset_len);
+    ret = kastore_gets_uint64(&store, offset_col, &offset_array, &offset_len);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     offset_copy = malloc(offset_len * sizeof(*offset_array));
     CU_ASSERT_FATAL(offset_copy != NULL);

--- a/c/tests/test_file_format.c
+++ b/c/tests/test_file_format.c
@@ -361,7 +361,7 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     tsk_table_collection_t tables;
     tsk_size_t *offset_array, *offset_copy;
     size_t offset_len;
-    uint32_t data_len;
+    tsk_size_t data_len;
 
     ret = tsk_treeseq_dump(ts, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -381,7 +381,8 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, offset_copy, offset_len, KAS_UINT32, 0);
+    ret = kastore_puts(
+        &store, offset_col, offset_copy, offset_len, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -394,7 +395,8 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, offset_copy, offset_len, KAS_UINT32, 0);
+    ret = kastore_puts(
+        &store, offset_col, offset_copy, offset_len, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -406,7 +408,8 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, offset_copy, offset_len, KAS_UINT32, 0);
+    ret = kastore_puts(
+        &store, offset_col, offset_copy, offset_len, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -417,7 +420,7 @@ verify_bad_offset_columns(tsk_treeseq_t *ts, const char *offset_col)
     copy_store_drop_columns(ts, 1, &offset_col, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, offset_col, NULL, 0, KAS_UINT32, 0);
+    ret = kastore_puts(&store, offset_col, NULL, 0, TSK_SIZE_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -515,9 +518,9 @@ test_malformed_indexes(void)
     copy_store_drop_columns(ts, 2, cols, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[0], NULL, 0, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[0], NULL, 0, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[1], NULL, 0, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[1], NULL, 0, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -530,9 +533,9 @@ test_malformed_indexes(void)
     copy_store_drop_columns(ts, 2, cols, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[0], good_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[0], good_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[1], bad_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[1], bad_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -543,9 +546,9 @@ test_malformed_indexes(void)
     copy_store_drop_columns(ts, 2, cols, _tmp_file_name);
     ret = kastore_open(&store, _tmp_file_name, "a", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[0], bad_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[0], bad_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = kastore_puts(&store, cols[1], good_index, num_edges, KAS_INT32, 0);
+    ret = kastore_puts(&store, cols[1], good_index, num_edges, TSK_ID_STORAGE_TYPE, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -839,19 +842,19 @@ test_load_node_table_errors(void)
     double L = 1;
     double time = 0;
     double flags = 0;
-    int32_t population = 0;
-    int32_t individual = 0;
+    tsk_id_t population = 0;
+    tsk_id_t individual = 0;
     int8_t metadata = 0;
-    uint32_t metadata_offset[] = { 0, 1 };
-    uint32_t version[2]
+    tsk_size_t metadata_offset[] = { 0, 1 };
+    tsk_size_t version[2]
         = { TSK_FILE_FORMAT_VERSION_MAJOR, TSK_FILE_FORMAT_VERSION_MINOR };
     write_table_col_t write_cols[] = {
         { "nodes/time", (void *) &time, 1, KAS_FLOAT64 },
-        { "nodes/flags", (void *) &flags, 1, KAS_UINT32 },
-        { "nodes/population", (void *) &population, 1, KAS_INT32 },
-        { "nodes/individual", (void *) &individual, 1, KAS_INT32 },
+        { "nodes/flags", (void *) &flags, 1, TSK_FLAG_STORAGE_TYPE },
+        { "nodes/population", (void *) &population, 1, TSK_ID_STORAGE_TYPE },
+        { "nodes/individual", (void *) &individual, 1, TSK_ID_STORAGE_TYPE },
         { "nodes/metadata", (void *) &metadata, 1, KAS_UINT8 },
-        { "nodes/metadata_offset", (void *) metadata_offset, 2, KAS_UINT32 },
+        { "nodes/metadata_offset", (void *) metadata_offset, 2, TSK_SIZE_STORAGE_TYPE },
         { "format/name", (void *) format_name, sizeof(format_name), KAS_INT8 },
         { "format/version", (void *) version, 2, KAS_UINT32 },
         { "uuid", (void *) uuid, uuid_size, KAS_INT8 },

--- a/c/tests/test_minimal_cpp.cpp
+++ b/c/tests/test_minimal_cpp.cpp
@@ -168,7 +168,9 @@ test_edge_sorting()
     assert(tables.edges.num_rows == (tsk_size_t) n - 1);
 
     /* Make sure the edges are unsorted */
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_EDGE_ORDERING);
+    /* Not calling TSK_CHECK_TREES so casting is safe */
+    ret = (tsk_id_t) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_EDGE_ORDERING);
     assert(ret == TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME);
 
     /* Sort the tables */
@@ -183,7 +185,8 @@ test_edge_sorting()
     tsk_table_sorter_free(&sorter);
 
     /* Make sure the edges are now sorted */
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_EDGE_ORDERING);
+    ret = (tsk_id_t) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_EDGE_ORDERING);
     assert(ret == 0);
 
     tsk_table_collection_free(&tables);

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -5025,12 +5025,15 @@ test_sort_tables_individuals(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1.0;
     parse_individuals(individuals, &tables.individuals);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDIVIDUAL_ORDERING);
+    /* Not calling with TSK_CHECK_TREES so casting is safe */
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_INDIVIDUAL_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSORTED_INDIVIDUALS);
 
     ret = tsk_table_collection_sort(&tables, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDIVIDUAL_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_INDIVIDUAL_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Check that the sort is stable */
@@ -5219,7 +5222,7 @@ test_dump_load_unsorted_with_options(tsk_flags_t tc_options)
     CU_ASSERT_EQUAL_FATAL(ret_id, 3);
 
     /* Verify that it's unsorted */
-    ret = tsk_table_collection_check_integrity(&t1, TSK_CHECK_EDGE_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(&t1, TSK_CHECK_EDGE_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME);
 
     ret = tsk_table_collection_dump(&t1, _tmp_file_name, 0);
@@ -5314,7 +5317,7 @@ test_dump_fail_no_file(void)
     CU_ASSERT_EQUAL_FATAL(ret_id, 3);
 
     /* Verify that it's unsorted */
-    ret = tsk_table_collection_check_integrity(&t1, TSK_CHECK_EDGE_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(&t1, TSK_CHECK_EDGE_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME);
 
     /* Make sure the file doesn't exist beforehand. */
@@ -5510,7 +5513,8 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_node_table_add_row(
         &tables.nodes, TSK_NODE_IS_SAMPLE, INFINITY, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, ret_id);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    /* Not calling with TSK_CHECK_TREES so casting is safe */
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_NONFINITE);
 
     ret = tsk_node_table_clear(&tables.nodes);
@@ -5518,9 +5522,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_node_table_add_row(
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, ret_id);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_NO_CHECK_POPULATION_REFS);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_NO_CHECK_POPULATION_REFS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
 
     ret = tsk_node_table_clear(&tables.nodes);
@@ -5528,7 +5533,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_node_table_add_row(
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, ret_id);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
 
     ret = tsk_node_table_clear(&tables.nodes);
@@ -5539,69 +5544,69 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_node_table_add_row(
         &tables.nodes, TSK_NODE_IS_SAMPLE, 1.0, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* edges */
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, TSK_NULL, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NULL_PARENT);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 2, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 1, TSK_NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NULL_CHILD);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, 1.0, 1, 2, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, INFINITY, 1, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_GENOME_COORDS_NONFINITE);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, -1.0, 1.0, 1, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_LEFT_LESS_ZERO);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, 1.1, 1, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_RIGHT_GREATER_SEQ_LENGTH);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.5, 0.1, 1, 0, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_EDGE_INTERVAL);
 
     ret = tsk_edge_table_clear(&tables.edges);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_edge_table_add_row(&tables.edges, 0.0, 0.5, 0, 1, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NODE_TIME_ORDERING);
 
     ret = tsk_edge_table_clear(&tables.edges);
@@ -5610,21 +5615,21 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     /* sites */
     ret_id = tsk_site_table_add_row(&tables.sites, INFINITY, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SITE_POSITION);
 
     ret = tsk_site_table_clear(&tables.sites);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_site_table_add_row(&tables.sites, -0.5, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SITE_POSITION);
 
     ret = tsk_site_table_clear(&tables.sites);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_site_table_add_row(&tables.sites, 1.5, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SITE_POSITION);
 
     ret = tsk_site_table_clear(&tables.sites);
@@ -5633,9 +5638,9 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     CU_ASSERT_FATAL(ret_id >= 0);
     ret_id = tsk_site_table_add_row(&tables.sites, 0.5, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_SITE_DUPLICATES);
+    ret = (int) tsk_table_collection_check_integrity(&tables, TSK_CHECK_SITE_DUPLICATES);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SITE_POSITION);
 
     ret = tsk_site_table_clear(&tables.sites);
@@ -5644,9 +5649,9 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     CU_ASSERT_FATAL(ret_id >= 0);
     ret_id = tsk_site_table_add_row(&tables.sites, 0.4, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_SITE_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(&tables, TSK_CHECK_SITE_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSORTED_SITES);
 
     ret = tsk_site_table_clear(&tables.sites);
@@ -5660,7 +5665,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 2, 0, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SITE_OUT_OF_BOUNDS);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5668,7 +5673,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 2, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     /* A mixture of known and unknown times on a site fails */
@@ -5680,7 +5685,8 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN);
 
     /* But on different sites, passes */
@@ -5692,21 +5698,23 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 1, 0, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_mutation_table_add_row(&tables.mutations, 0, 1, 2, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_OUT_OF_BOUNDS);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_mutation_table_add_row(&tables.mutations, 0, 1, 0, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_PARENT_EQUAL);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5716,11 +5724,12 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 1, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_PARENT_AFTER_CHILD);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5731,11 +5740,12 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 1, 1, 0, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_PARENT_DIFFERENT_SITE);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5746,9 +5756,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 1, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSORTED_MUTATIONS);
 
     /* Unknown times pass */
@@ -5760,9 +5771,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Correctly ordered times pass */
@@ -5777,9 +5789,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Incorrectly ordered times fail */
@@ -5791,9 +5804,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, 1, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSORTED_MUTATIONS);
 
     /* Putting incorrectly ordered times on diff sites passes */
@@ -5811,9 +5825,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 1, 0, TSK_NULL, 1, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5821,7 +5836,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, NAN, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_NONFINITE);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5829,7 +5844,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 0, 0, TSK_NULL, INFINITY, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_NONFINITE);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5837,9 +5852,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_mutation_table_add_row(
         &tables.mutations, 1, 1, TSK_NULL, 0, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_TIME_YOUNGER_THAN_NODE);
 
     ret = tsk_mutation_table_clear(&tables.mutations);
@@ -5849,9 +5865,10 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     CU_ASSERT_FATAL(ret_id >= 0);
     ret_id = tsk_mutation_table_add_row(&tables.mutations, 1, 1, 0, 2, NULL, 0, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_MUTATION_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_MUTATION_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_MUTATION);
 
     /* migrations */
@@ -5865,7 +5882,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.0, 0.5, 2, 0, 1, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5873,7 +5890,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.0, 0.5, 1, 2, 1, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5881,7 +5898,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.0, 0.5, 1, 0, 2, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5889,7 +5906,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.0, 0.5, 1, 0, 1, INFINITY, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_NONFINITE);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5897,7 +5914,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.0, INFINITY, 1, 0, 1, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_GENOME_COORDS_NONFINITE);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5905,7 +5922,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, -0.3, 0.5, 1, 0, 1, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_LEFT_LESS_ZERO);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5913,7 +5930,7 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.0, 1.5, 1, 0, 1, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_RIGHT_GREATER_SEQ_LENGTH);
 
     ret = tsk_migration_table_clear(&tables.migrations);
@@ -5921,27 +5938,28 @@ test_table_collection_check_integrity_with_options(tsk_flags_t tc_options)
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.6, 0.5, 1, 0, 1, 1.5, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_EDGE_INTERVAL);
     ret = tsk_migration_table_clear(&tables.migrations);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     parse_individuals(individuals, &tables.individuals);
     CU_ASSERT_EQUAL_FATAL(tables.individuals.num_rows, 3);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDIVIDUAL_ORDERING);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_CHECK_INDIVIDUAL_ORDERING);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSORTED_INDIVIDUALS);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Check that an individual can't be its own parent */
     tables.individuals.parents[0] = 0;
     tables.individuals.parents[1] = 1;
     tables.individuals.parents[2] = 2;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INDIVIDUAL_SELF_PARENT);
 
     tables.individuals.parents[0] = -2;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
 
     tsk_table_collection_free(&tables);
@@ -5952,6 +5970,7 @@ test_table_collection_check_integrity_no_populations(void)
 {
     int ret;
     tsk_id_t ret_id;
+    tsk_id_t ret_num_trees;
     tsk_treeseq_t ts;
     tsk_table_collection_t tables;
 
@@ -5963,32 +5982,35 @@ test_table_collection_check_integrity_no_populations(void)
     /* Add in some bad population references and check that we can use
      * TSK_NO_CHECK_POPULATION_REFS with TSK_CHECK_TREES */
     tables.nodes.population[0] = 10;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    /* Not calling with TSK_CHECK_TREES so casting is safe */
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_NO_CHECK_POPULATION_REFS);
+    ret_num_trees = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
+    CU_ASSERT_EQUAL_FATAL(ret_num_trees, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_NO_CHECK_POPULATION_REFS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(
+    ret_num_trees = tsk_table_collection_check_integrity(
         &tables, TSK_CHECK_TREES | TSK_NO_CHECK_POPULATION_REFS);
     /* CHECK_TREES returns the number of trees */
-    CU_ASSERT_EQUAL_FATAL(ret, 3);
+    CU_ASSERT_EQUAL_FATAL(ret_num_trees, 3);
     tables.nodes.population[0] = TSK_NULL;
 
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret_id = tsk_migration_table_add_row(
         &tables.migrations, 0.4, 0.5, 1, 0, 1, 1.5, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret_id, 0);
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_NO_CHECK_POPULATION_REFS);
+    ret_num_trees = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
+    CU_ASSERT_EQUAL_FATAL(ret_num_trees, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
+    ret = (int) tsk_table_collection_check_integrity(
+        &tables, TSK_NO_CHECK_POPULATION_REFS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(
+    ret_num_trees = tsk_table_collection_check_integrity(
         &tables, TSK_CHECK_TREES | TSK_NO_CHECK_POPULATION_REFS);
-    CU_ASSERT_EQUAL_FATAL(ret, 3);
+    CU_ASSERT_EQUAL_FATAL(ret_num_trees, 3);
 
     tsk_table_collection_free(&tables);
     tsk_treeseq_free(&ts);
@@ -6139,7 +6161,7 @@ test_table_collection_subset_with_options(tsk_flags_t options)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_subset(&tables_copy, nodes, 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables_copy, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables_copy, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FATAL(tsk_node_table_equals(&tables.nodes, &tables_copy.nodes, 0));
     CU_ASSERT_EQUAL_FATAL(tables_copy.individuals.num_rows, 2);
@@ -6158,7 +6180,7 @@ test_table_collection_subset_with_options(tsk_flags_t options)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_subset(&tables_copy, nodes, 4, TSK_KEEP_UNREFERENCED);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables_copy, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables_copy, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FATAL(tsk_table_collection_equals(&tables, &tables_copy, 0));
 

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -410,14 +410,14 @@ test_node_table(void)
     tsk_id_t ret_id;
     tsk_node_table_t table, table2;
     tsk_node_t node, node2;
-    uint32_t num_rows = 100;
+    tsk_size_t num_rows = 100;
     tsk_id_t j;
-    uint32_t *flags;
+    tsk_flags_t *flags;
     tsk_id_t *population;
     double *time;
     tsk_id_t *individual;
     char *metadata;
-    uint32_t *metadata_offset;
+    tsk_size_t *metadata_offset;
     const char *test_metadata = "test";
     tsk_size_t test_metadata_length = 4;
     char metadata_copy[test_metadata_length + 1];
@@ -491,18 +491,18 @@ test_node_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     num_rows *= 2;
-    flags = malloc(num_rows * sizeof(uint32_t));
+    flags = malloc(num_rows * sizeof(tsk_flags_t));
     CU_ASSERT_FATAL(flags != NULL);
-    memset(flags, 1, num_rows * sizeof(uint32_t));
-    population = malloc(num_rows * sizeof(uint32_t));
+    memset(flags, 1, num_rows * sizeof(tsk_flags_t));
+    population = malloc(num_rows * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(population != NULL);
-    memset(population, 2, num_rows * sizeof(uint32_t));
+    memset(population, 2, num_rows * sizeof(tsk_size_t));
     time = malloc(num_rows * sizeof(double));
     CU_ASSERT_FATAL(time != NULL);
     memset(time, 0, num_rows * sizeof(double));
-    individual = malloc(num_rows * sizeof(uint32_t));
+    individual = malloc(num_rows * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(individual != NULL);
-    memset(individual, 3, num_rows * sizeof(uint32_t));
+    memset(individual, 3, num_rows * sizeof(tsk_size_t));
     metadata = malloc(num_rows * sizeof(char));
     memset(metadata, 'a', num_rows * sizeof(char));
     CU_ASSERT_FATAL(metadata != NULL);
@@ -514,12 +514,12 @@ test_node_table(void)
     ret = tsk_node_table_set_columns(&table, num_rows, flags, time, population,
         individual, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
@@ -534,19 +534,21 @@ test_node_table(void)
     ret = tsk_node_table_append_columns(&table, num_rows, flags, time, population,
         individual, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.flags + num_rows, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population + num_rows, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population + num_rows, population, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time + num_rows, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual + num_rows, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual + num_rows, individual, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.metadata + num_rows, metadata, num_rows * sizeof(char)), 0);
@@ -559,12 +561,12 @@ test_node_table(void)
     /* Truncate back to the original number of rows. */
     ret = tsk_node_table_truncate(&table, num_rows);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
@@ -579,20 +581,21 @@ test_node_table(void)
      * should be set to the empty string. If individual is NULL it should be set to -1.
      */
     num_rows = 10;
-    memset(population, 0xff, num_rows * sizeof(uint32_t));
-    memset(individual, 0xff, num_rows * sizeof(uint32_t));
+    memset(population, 0xff, num_rows * sizeof(tsk_size_t));
+    memset(individual, 0xff, num_rows * sizeof(tsk_size_t));
     ret = tsk_node_table_set_columns(
         &table, num_rows, flags, time, NULL, NULL, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.population, population, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.individual, individual, num_rows * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.metadata_offset, metadata_offset, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.metadata_offset, metadata_offset, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, num_rows);
 
@@ -616,7 +619,7 @@ test_node_table(void)
     ret = tsk_node_table_set_columns(
         &table, num_rows, flags, time, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
@@ -626,16 +629,16 @@ test_node_table(void)
     ret = tsk_node_table_append_columns(
         &table, num_rows, flags, time, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.flags + num_rows, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time + num_rows, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                         (num_rows + 1) * sizeof(tsk_size_t)),
         0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset + num_rows, metadata_offset,
-                        num_rows * sizeof(uint32_t)),
+                        num_rows * sizeof(tsk_size_t)),
         0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
@@ -763,7 +766,7 @@ test_edge_table_with_options(tsk_flags_t options)
     tsk_id_t *parent, *child;
     double *left, *right;
     char *metadata;
-    uint32_t *metadata_offset;
+    tsk_size_t *metadata_offset;
     const char *test_metadata = "test";
     tsk_size_t test_metadata_length = 4;
     char metadata_copy[test_metadata_length + 1];
@@ -1021,7 +1024,7 @@ test_edge_table_with_options(tsk_flags_t options)
                             (num_rows + 1) * sizeof(tsk_size_t)),
             0);
         CU_ASSERT_EQUAL(memcmp(table.metadata_offset + num_rows, metadata_offset,
-                            num_rows * sizeof(uint32_t)),
+                            num_rows * sizeof(tsk_size_t)),
             0);
     }
     CU_ASSERT_EQUAL(table.metadata_length, 0);
@@ -1489,11 +1492,11 @@ test_site_table(void)
     CU_ASSERT_FATAL(position != NULL);
     ancestral_state = malloc(num_rows * sizeof(char));
     CU_ASSERT_FATAL(ancestral_state != NULL);
-    ancestral_state_offset = malloc((num_rows + 1) * sizeof(uint32_t));
+    ancestral_state_offset = malloc((num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(ancestral_state_offset != NULL);
     metadata = malloc(num_rows * sizeof(char));
     CU_ASSERT_FATAL(metadata != NULL);
-    metadata_offset = malloc((num_rows + 1) * sizeof(uint32_t));
+    metadata_offset = malloc((num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(metadata_offset != NULL);
 
     for (j = 0; j < num_rows; j++) {
@@ -1591,13 +1594,13 @@ test_site_table(void)
         &table, num_rows, position, ancestral_state, ancestral_state_offset, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    memset(metadata_offset, 0, (num_rows + 1) * sizeof(uint32_t));
+    memset(metadata_offset, 0, (num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_EQUAL(memcmp(table.position, position, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.ancestral_state, ancestral_state, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.ancestral_state_length, num_rows);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
-                        (num_rows + 1) * sizeof(uint32_t)),
+                        (num_rows + 1) * sizeof(tsk_size_t)),
         0);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
@@ -2147,7 +2150,7 @@ test_migration_table(void)
     double *left, *right, *time;
     tsk_migration_t migration, migration2;
     char *metadata;
-    uint32_t *metadata_offset;
+    tsk_size_t *metadata_offset;
     const char *test_metadata = "test";
     tsk_size_t test_metadata_length = 4;
     char metadata_copy[test_metadata_length + 1];
@@ -2502,7 +2505,7 @@ test_individual_table(void)
     tsk_size_t num_rows = 100;
     tsk_id_t j;
     tsk_size_t k;
-    uint32_t *flags;
+    tsk_flags_t *flags;
     double *location;
     tsk_id_t *parents;
     char *metadata;
@@ -2561,7 +2564,7 @@ test_individual_table(void)
         ret = tsk_individual_table_get_row(&table, (tsk_id_t) j, &individual);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_EQUAL(individual.id, j);
-        CU_ASSERT_EQUAL(individual.flags, (uint32_t) j);
+        CU_ASSERT_EQUAL(individual.flags, (tsk_flags_t) j);
         CU_ASSERT_EQUAL(individual.location_length, spatial_dimension);
         CU_ASSERT_NSTRING_EQUAL(
             individual.location, test_location, spatial_dimension * sizeof(double));
@@ -2602,7 +2605,7 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 0);
 
     num_rows *= 2;
-    flags = malloc(num_rows * sizeof(uint32_t));
+    flags = malloc(num_rows * sizeof(tsk_flags_t));
     CU_ASSERT_FATAL(flags != NULL);
     for (k = 0; k < num_rows; k++) {
         flags[k] = k + num_rows;
@@ -2640,7 +2643,7 @@ test_individual_table(void)
     ret = tsk_individual_table_set_columns(&table, num_rows, flags, location,
         location_offset, parents, parents_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.location, location, spatial_dimension * num_rows * sizeof(double)),
         0);
@@ -2666,9 +2669,9 @@ test_individual_table(void)
     ret = tsk_individual_table_append_columns(&table, num_rows, flags, location,
         location_offset, parents, parents_offset, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.flags + num_rows, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.metadata + num_rows, metadata, num_rows * sizeof(char)), 0);
@@ -2694,7 +2697,7 @@ test_individual_table(void)
     /* Truncate back to num_rows */
     ret = tsk_individual_table_truncate(&table, num_rows);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.location, location, spatial_dimension * num_rows * sizeof(double)),
         0);
@@ -2760,7 +2763,8 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(
         memcmp(table.location_offset, zeros, (num_rows + 1) * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.location_offset + num_rows, zeros, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.location_offset + num_rows, zeros, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.location_length, 0);
     tsk_individual_table_print_state(&table, _devnull);
@@ -2782,7 +2786,8 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(
         memcmp(table.parents_offset, zeros, (num_rows + 1) * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.parents_offset + num_rows, zeros, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.parents_offset + num_rows, zeros, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.parents_length, 0);
     tsk_individual_table_print_state(&table, _devnull);
@@ -2794,7 +2799,7 @@ test_individual_table(void)
     ret = tsk_individual_table_set_columns(&table, num_rows, flags, location,
         location_offset, parents, parents_offset, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(tsk_flags_t)), 0);
     CU_ASSERT_EQUAL(
         memcmp(table.location, location, spatial_dimension * num_rows * sizeof(double)),
         0);
@@ -2821,7 +2826,8 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(
         memcmp(table.metadata_offset, zeros, (num_rows + 1) * sizeof(tsk_size_t)), 0);
     CU_ASSERT_EQUAL(
-        memcmp(table.metadata_offset + num_rows, zeros, num_rows * sizeof(uint32_t)), 0);
+        memcmp(table.metadata_offset + num_rows, zeros, num_rows * sizeof(tsk_size_t)),
+        0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
     tsk_individual_table_print_state(&table, _devnull);
@@ -3198,12 +3204,12 @@ test_provenance_table(void)
     tsk_size_t num_rows = 100;
     tsk_size_t j;
     char *timestamp;
-    uint32_t *timestamp_offset;
+    tsk_size_t *timestamp_offset;
     const char *test_timestamp = "2017-12-06T20:40:25+00:00";
     tsk_size_t test_timestamp_length = (tsk_size_t) strlen(test_timestamp);
     char timestamp_copy[test_timestamp_length + 1];
     char *record;
-    uint32_t *record_offset;
+    tsk_size_t *record_offset;
     const char *test_record = "{\"json\"=1234}";
     tsk_size_t test_record_length = (tsk_size_t) strlen(test_record);
     char record_copy[test_record_length + 1];
@@ -5373,7 +5379,7 @@ test_table_overflow(void)
     int ret;
     tsk_id_t ret_id;
     tsk_table_collection_t tables;
-    tsk_size_t max_rows = ((tsk_size_t) INT32_MAX) + 1;
+    tsk_size_t max_rows = ((tsk_size_t) TSK_MAX_ID) + 1;
 
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5429,7 +5435,7 @@ test_column_overflow(void)
     int ret;
     tsk_id_t ret_id;
     tsk_table_collection_t tables;
-    tsk_size_t too_big = ((tsk_size_t) UINT32_MAX);
+    tsk_size_t too_big = TSK_MAX_SIZE;
     double zero = 0;
     char zeros[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
     tsk_id_t id_zeros[] = { 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -126,7 +126,7 @@ insert_edge_metadata(tsk_table_collection_t *tables)
     for (j = 0; j < (tsk_id_t) tables->edges.num_rows; j++) {
         ret = tsk_edge_table_get_row(&tables->edges, j, &edge);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        snprintf(metadata, sizeof(metadata), "md_%d\n", j);
+        snprintf(metadata, sizeof(metadata), "md_%lld\n", (long long) j);
         ret_id = tsk_edge_table_add_row(&edges, edge.left, edge.right, edge.parent,
             edge.child, metadata, (tsk_size_t) strlen(metadata));
         CU_ASSERT_FATAL(ret_id >= 0);
@@ -434,8 +434,8 @@ test_node_table(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     for (j = 0; j < (tsk_id_t) num_rows; j++) {
-        ret_id = tsk_node_table_add_row(
-            &table, (tsk_flags_t) j, j, j, j, test_metadata, test_metadata_length);
+        ret_id = tsk_node_table_add_row(&table, (tsk_flags_t) j, (double) j, j, j,
+            test_metadata, test_metadata_length);
         CU_ASSERT_EQUAL_FATAL(ret_id, j);
         CU_ASSERT_EQUAL(table.flags[j], (tsk_flags_t) j);
         CU_ASSERT_EQUAL(table.time[j], j);
@@ -1775,7 +1775,7 @@ test_mutation_table(void)
     len = 0;
     for (j = 0; j < (tsk_id_t) num_rows; j++) {
         k = TSK_MIN((tsk_size_t) j + 1, max_len);
-        ret_id = tsk_mutation_table_add_row(&table, j, j, j, j, c, k, c, k);
+        ret_id = tsk_mutation_table_add_row(&table, j, j, j, (double) j, c, k, c, k);
         CU_ASSERT_EQUAL_FATAL(ret_id, j);
         CU_ASSERT_EQUAL(table.site[j], j);
         CU_ASSERT_EQUAL(table.node[j], j);
@@ -1830,7 +1830,7 @@ test_mutation_table(void)
         node[j] = j;
         site[j] = j + 1;
         parent[j] = j + 2;
-        time[j] = j + 3;
+        time[j] = (double) (j + 3);
         derived_state[j] = 'Y';
         derived_state_offset[j] = (tsk_size_t) j;
         metadata[j] = 'M';
@@ -2004,7 +2004,7 @@ test_mutation_table(void)
     /* Test extend method */
     for (j = 0; j < (tsk_id_t) num_rows; j++) {
         parent[j] = j + 2;
-        time[j] = j + 3;
+        time[j] = (double) (j + 3);
         metadata[j] = (char) ('A' + j);
         metadata_offset[j] = (tsk_size_t) j;
     }
@@ -2166,8 +2166,8 @@ test_migration_table(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     for (j = 0; j < (tsk_id_t) num_rows; j++) {
-        ret_id = tsk_migration_table_add_row(
-            &table, j, j, j, j, j, j, test_metadata, test_metadata_length);
+        ret_id = tsk_migration_table_add_row(&table, (double) j, (double) j, j, j, j,
+            (double) j, test_metadata, test_metadata_length);
         CU_ASSERT_EQUAL_FATAL(ret_id, j);
         CU_ASSERT_EQUAL(table.left[j], j);
         CU_ASSERT_EQUAL(table.right[j], j);
@@ -2608,12 +2608,12 @@ test_individual_table(void)
     flags = malloc(num_rows * sizeof(tsk_flags_t));
     CU_ASSERT_FATAL(flags != NULL);
     for (k = 0; k < num_rows; k++) {
-        flags[k] = k + num_rows;
+        flags[k] = (tsk_flags_t)(k + num_rows);
     }
     location = malloc(spatial_dimension * num_rows * sizeof(double));
     CU_ASSERT_FATAL(location != NULL);
     for (k = 0; k < spatial_dimension * num_rows; k++) {
-        location[k] = k + (num_rows * 2);
+        location[k] = (double) (k + (num_rows * 2));
     }
     location_offset = malloc((num_rows + 1) * sizeof(tsk_size_t));
     CU_ASSERT_FATAL(location_offset != NULL);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -2285,6 +2285,7 @@ test_simplest_bad_indexes(void)
     tsk_id_t bad_indexes[] = { -1, 3, 4, 1000 };
     size_t j;
     tsk_id_t ret_id;
+    tsk_id_t ret_num_trees;
     int ret;
 
     ret = tsk_table_collection_init(&tables, 0);
@@ -2299,32 +2300,32 @@ test_simplest_bad_indexes(void)
     CU_ASSERT_EQUAL_FATAL(ret_id, 0);
 
     /* Make sure we have a good set of records */
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDEXES);
+    ret = (int) tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TABLES_NOT_INDEXED);
     ret = tsk_table_collection_build_index(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
+    ret_num_trees = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
     /* TSK_CHECK_TREES returns the number of trees */
-    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    CU_ASSERT_EQUAL_FATAL(ret_num_trees, 1);
 
     for (j = 0; j < sizeof(bad_indexes) / sizeof(*bad_indexes); j++) {
         tables.indexes.edge_insertion_order[0] = bad_indexes[j];
-        ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
-        CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EDGE_OUT_OF_BOUNDS);
+        ret_num_trees = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
+        CU_ASSERT_EQUAL_FATAL(ret_num_trees, TSK_ERR_EDGE_OUT_OF_BOUNDS);
         tables.indexes.edge_insertion_order[0] = 0;
 
         tables.indexes.edge_removal_order[0] = bad_indexes[j];
-        ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
-        CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EDGE_OUT_OF_BOUNDS);
+        ret_num_trees = tsk_table_collection_check_integrity(&tables, TSK_CHECK_TREES);
+        CU_ASSERT_EQUAL_FATAL(ret_num_trees, TSK_ERR_EDGE_OUT_OF_BOUNDS);
         tables.indexes.edge_removal_order[0] = 0;
     }
 
     ret = tsk_table_collection_drop_index(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDEXES);
+    ret = (int) tsk_table_collection_check_integrity(&tables, TSK_CHECK_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TABLES_NOT_INDEXED);
 
     tsk_table_collection_free(&tables);
@@ -2354,91 +2355,91 @@ test_simplest_bad_migrations(void)
     CU_ASSERT_EQUAL_FATAL(ret_id, 0);
 
     /* We only need basic intregity checks for migrations */
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Bad node reference */
     tables.migrations.node[0] = -1;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     tables.migrations.node[0] = 0;
 
     /* Bad node reference */
     tables.migrations.node[0] = 1;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     tables.migrations.node[0] = 0;
 
     /* Bad population reference */
     tables.migrations.source[0] = -1;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
     tables.migrations.source[0] = 0;
 
     /* Bad population reference */
     tables.migrations.source[0] = 2;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
     tables.migrations.source[0] = 0;
 
     /* Bad population reference */
     tables.migrations.dest[0] = -1;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
     tables.migrations.dest[0] = 1;
 
     /* Bad population reference */
     tables.migrations.dest[0] = 2;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_POPULATION_OUT_OF_BOUNDS);
     tables.migrations.dest[0] = 1;
 
     /* Bad time values */
     tables.migrations.time[0] = NAN;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_TIME_NONFINITE);
     tables.migrations.time[0] = 1.0;
 
     tables.migrations.time[0] = INFINITY;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_TIME_NONFINITE);
     tables.migrations.time[0] = 1.0;
 
     /* Bad left coordinate */
     tables.migrations.left[0] = -1;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_LEFT_LESS_ZERO);
     tables.migrations.left[0] = 0;
 
     tables.migrations.left[0] = NAN;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_GENOME_COORDS_NONFINITE);
     tables.migrations.left[0] = 0;
 
     tables.migrations.left[0] = -INFINITY;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_GENOME_COORDS_NONFINITE);
     tables.migrations.left[0] = 0;
 
     /* Bad right coordinate */
     tables.migrations.right[0] = 2;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_RIGHT_GREATER_SEQ_LENGTH);
     tables.migrations.right[0] = 1;
 
     tables.migrations.right[0] = NAN;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_GENOME_COORDS_NONFINITE);
     tables.migrations.right[0] = 1;
 
     tables.migrations.right[0] = INFINITY;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_GENOME_COORDS_NONFINITE);
     tables.migrations.right[0] = 1;
 
     /* Bad interval coordinate */
     tables.migrations.right[0] = 0;
-    ret = tsk_table_collection_check_integrity(&tables, 0);
+    ret = (int) tsk_table_collection_check_integrity(&tables, 0);
     CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_EDGE_INTERVAL);
     tables.migrations.right[0] = 1;
 

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -33,8 +33,8 @@
 static void
 tsk_ld_calc_check_state(const tsk_ld_calc_t *self)
 {
-    uint32_t u;
-    uint32_t num_nodes = (uint32_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
+    tsk_size_t u;
+    tsk_size_t num_nodes = tsk_treeseq_get_num_nodes(self->tree_sequence);
     tsk_tree_t *tA = self->outer_tree;
     tsk_tree_t *tB = self->inner_tree;
 

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -53,6 +53,8 @@ missing data.
 @endrst
 */
 typedef int32_t tsk_id_t;
+#define TSK_MAX_ID INT32_MAX
+#define TSK_ID_STORAGE_TYPE KAS_INT32
 
 /**
 @brief Tskit sizes.
@@ -62,6 +64,8 @@ Sizes in tskit are defined by the ``tsk_size_t`` type.
 @endrst
 */
 typedef uint32_t tsk_size_t;
+#define TSK_MAX_SIZE (tsk_size_t) UINT32_MAX
+#define TSK_SIZE_STORAGE_TYPE KAS_UINT32
 
 /**
 @brief Container for bitwise flags.
@@ -72,6 +76,7 @@ specify options to API functions.
 @endrst
 */
 typedef uint32_t tsk_flags_t;
+#define TSK_FLAG_STORAGE_TYPE KAS_UINT32
 
 /****************************************************************************/
 /* Definitions for the basic objects */

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -52,9 +52,9 @@ when manipulating these ID values. The reserved value ``TSK_NULL`` (-1) defines
 missing data.
 @endrst
 */
-typedef int32_t tsk_id_t;
-#define TSK_MAX_ID INT32_MAX
-#define TSK_ID_STORAGE_TYPE KAS_INT32
+typedef int64_t tsk_id_t;
+#define TSK_MAX_ID INT64_MAX
+#define TSK_ID_STORAGE_TYPE KAS_INT64
 
 /**
 @brief Tskit sizes.
@@ -63,9 +63,9 @@ typedef int32_t tsk_id_t;
 Sizes in tskit are defined by the ``tsk_size_t`` type.
 @endrst
 */
-typedef uint32_t tsk_size_t;
-#define TSK_MAX_SIZE (tsk_size_t) UINT32_MAX
-#define TSK_SIZE_STORAGE_TYPE KAS_UINT32
+typedef uint64_t tsk_size_t;
+#define TSK_MAX_SIZE (tsk_size_t) UINT64_MAX
+#define TSK_SIZE_STORAGE_TYPE KAS_UINT64
 
 /**
 @brief Container for bitwise flags.

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -296,7 +296,7 @@ tsk_treeseq_init_nodes(tsk_treeseq_t *self)
 {
     size_t j, k;
     size_t num_nodes = self->tables->nodes.num_rows;
-    const uint32_t *restrict node_flags = self->tables->nodes.flags;
+    const tsk_flags_t *restrict node_flags = self->tables->nodes.flags;
     int ret = 0;
 
     /* Determine the sample size */


### PR DESCRIPTION
Not for merging.

Stacked on #1516, #1517 and #1518.

@bhaller this branch passes all the C tests and has 64bit wide ids and sizes. Will be interesting to see SLiM performance with this code!

To change from 32-64 only the following changes are needed: 

It is also possible to keep 32bit ids but have 64bit sizes, which would fix the metadata issue, but avoid table bloat.