### PR TITLE
Y lab rotation & tick label tweaks

### DIFF
--- a/python/tests/data/svg/internal_sample_ts.svg
+++ b/python/tests/data/svg/internal_sample_ts.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}#XYZ .leaf .sym {fill: magenta} #XYZ .sample > .sym {fill: cyan}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}#XYZ .leaf .sym {fill: magenta} #XYZ .sample > .sym {fill: cyan}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(77.3623 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(77.3623 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(780.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(780.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(890.091 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(890.091 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(68 163.2)">
@@ -97,8 +99,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 root s0" transform="translate(70.6667 22.3778)">
-						<g class="a9 node n4" transform="translate(-25.3333 97.7739)">
+					<g class="c2 m0 m1 node n9 root s0" transform="translate(70.6667 22.3778)">
+						<g class="a9 c2 node n4" transform="translate(-25.3333 97.7739)">
 							<g class="a4 leaf node n0" transform="translate(-12.6667 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 12.6667"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
@@ -113,7 +115,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 s0" transform="translate(25.3333 86.9138)">
+						<g class="a9 c2 m2 node n5 s0" transform="translate(25.3333 86.9138)">
 							<g class="a5 leaf node n2 sample" transform="translate(-12.6667 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 12.6667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -161,8 +163,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 root s2 sample" transform="translate(80.8 63.504)">
-						<g class="a7 m3 m4 node n4 s1" transform="translate(-30.4 56.6478)">
+					<g class="c2 m5 node n7 root s2 sample" transform="translate(80.8 63.504)">
+						<g class="a7 c2 m3 m4 node n4 s1" transform="translate(-30.4 56.6478)">
 							<g class="a4 leaf node n0" transform="translate(-15.2 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 15.2"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
@@ -187,7 +189,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5" transform="translate(30.4 45.7876)">
+						<g class="a7 c2 node n5" transform="translate(30.4 45.7876)">
 							<g class="a5 leaf node n2 sample" transform="translate(-15.2 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 15.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -225,8 +227,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 root" transform="translate(70.6667 102.321)">
-						<g class="a6 node n4" transform="translate(-25.3333 17.8305)">
+					<g class="c2 node n6 root" transform="translate(70.6667 102.321)">
+						<g class="a6 c2 node n4" transform="translate(-25.3333 17.8305)">
 							<g class="a4 leaf node n0" transform="translate(-12.6667 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 12.6667"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
@@ -241,7 +243,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5" transform="translate(25.3333 6.97033)">
+						<g class="a6 c2 node n5" transform="translate(25.3333 6.97033)">
 							<g class="a5 leaf node n2 sample" transform="translate(-12.6667 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 12.6667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -274,8 +276,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 root sample" transform="translate(80.8 63.504)">
-						<g class="a7 node n4" transform="translate(-30.4 56.6478)">
+					<g class="c2 node n7 root sample" transform="translate(80.8 63.504)">
+						<g class="a7 c2 node n4" transform="translate(-30.4 56.6478)">
 							<g class="a4 leaf node n0" transform="translate(-15.2 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 15.2"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
@@ -290,7 +292,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5" transform="translate(30.4 45.7876)">
+						<g class="a7 c2 node n5" transform="translate(30.4 45.7876)">
 							<g class="a5 leaf node n2 sample" transform="translate(-15.2 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 15.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -328,8 +330,8 @@
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">7</text>
 					</g>
-					<g class="node n8 root sample" transform="translate(111.2 49.7389)">
-						<g class="a8 node n4" transform="translate(-30.4 70.4129)">
+					<g class="c2 node n8 root sample" transform="translate(111.2 49.7389)">
+						<g class="a8 c2 node n4" transform="translate(-30.4 70.4129)">
 							<g class="a4 leaf node n0" transform="translate(-15.2 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 15.2"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
@@ -344,7 +346,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5" transform="translate(30.4 59.5527)">
+						<g class="a8 c2 node n5" transform="translate(30.4 59.5527)">
 							<g class="a5 leaf node n2 sample" transform="translate(-15.2 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 15.2"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree.svg
+++ b/python/tests/data/svg/tree.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" id="XYZ" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.edge {stroke: blue}]]></style>
 	</defs>
 	<g class="tree t4">
 		<g class="plotbox">
-			<g class="node n8 p0 root" transform="translate(100 26.8)">
-				<g class="a8 node n4 p0" transform="translate(-40 138.937)">
+			<g class="c2 node n8 p0 root" transform="translate(100 26.8)">
+				<g class="a8 c2 node n4 p0" transform="translate(-40 138.937)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-20 2.46307)">
 						<path class="edge" d="M 0 0 V -2.46307 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -21,7 +21,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a8 node n5 p0" transform="translate(40 117.508)">
+				<g class="a8 c2 node n5 p0" transform="translate(40 117.508)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 23.8921)">
 						<path class="edge" d="M 0 0 V -23.8921 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree_both_axes.svg
+++ b/python/tests/data/svg/tree_both_axes.svg
@@ -1,62 +1,66 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree t4">
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(118.4,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(118.4,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="180" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(56.8 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(180 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(180 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,70.7)">
-					<text text-anchor="middle">Time</text>
+				<g transform="translate(0,70.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="131.4" y2="10"/>
-				<g class="tick" transform="translate(56.8 26.8)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.57</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 26.8)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">6.57</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 129.578)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.11</text>
+					<g class="tick" transform="translate(56.8 129.578)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 131.4)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+					<g class="tick" transform="translate(56.8 131.4)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 113.726)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.11</text>
+					<g class="tick" transform="translate(56.8 113.726)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.11</text>
+						</g>
 					</g>
 				</g>
 			</g>
 		</g>
 		<g class="plotbox">
-			<g class="node n8 p0 root" transform="translate(118.4 26.8)">
-				<g class="a8 node n4 p0" transform="translate(-30.8 102.778)">
+			<g class="c2 node n8 p0 root" transform="translate(118.4 26.8)">
+				<g class="a8 c2 node n4 p0" transform="translate(-30.8 102.778)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-15.4 1.82204)">
 						<path class="edge" d="M 0 0 V -1.82204 H 15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -71,7 +75,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a8 node n5 p0" transform="translate(30.8 86.9259)">
+				<g class="a8 c2 node n5 p0" transform="translate(30.8 86.9259)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-15.4 17.6741)">
 						<path class="edge" d="M 0 0 V -17.6741 H 15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree_muts.svg
+++ b/python/tests/data/svg/tree_muts.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree t0">
 		<g class="plotbox">
-			<g class="m0 m1 node n9 p0 root s0" transform="translate(100 27.5778)">
-				<g class="a9 node n4 p0" transform="translate(-40 138.85)">
+			<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(100 27.5778)">
+				<g class="a9 c2 node n4 p0" transform="translate(-40 138.85)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-20 1.77269)">
 						<path class="edge" d="M 0 0 V -1.77269 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -21,7 +21,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a9 m2 node n5 p0 s0" transform="translate(40 123.427)">
+				<g class="a9 c2 m2 node n5 p0 s0" transform="translate(40 123.427)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 17.1953)">
 						<path class="edge" d="M 0 0 V -17.1953 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree_muts_all_edge.svg
+++ b/python/tests/data/svg/tree_muts_all_edge.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="400" version="1.1" width="300">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree t1">
 		<g class="background">
@@ -9,20 +9,22 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(150,400)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(150,400)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="280" y1="363.2" y2="363.2"/>
-				<g class="tick" transform="translate(20 363.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 363.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(244.096 363.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(244.096 363.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s1" transform="translate(20.0757 363.2)">
@@ -55,8 +57,8 @@
 			</g>
 		</g>
 		<g class="plotbox">
-			<g class="m5 node n7 p0 root s2" transform="translate(150 45.7111)">
-				<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-65 279.529)">
+			<g class="c2 m5 node n7 p0 root s2" transform="translate(150 45.7111)">
+				<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-65 279.529)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-32.5 6.15963)">
 						<path class="edge" d="M 0 0 V -6.15963 H 32.5"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -81,7 +83,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a7 node n5 p0" transform="translate(65 225.94)">
+				<g class="a7 c2 node n5 p0" transform="translate(65 225.94)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-32.5 59.7493)">
 						<path class="edge" d="M 0 0 V -59.7493 H 32.5"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree_timed_muts.svg
+++ b/python/tests/data/svg/tree_timed_muts.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree t0">
 		<g class="plotbox">
-			<g class="m0 m1 node n9 p0 root s0" transform="translate(100 72.4037)">
-				<g class="a9 node n4 p0" transform="translate(-40 94.5886)">
+			<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(100 72.4037)">
+				<g class="a9 c2 node n4 p0" transform="translate(-40 94.5886)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-20 1.20761)">
 						<path class="edge" d="M 0 0 V -1.20761 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -21,7 +21,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a9 m2 node n5 p0 s0" transform="translate(40 84.0823)">
+				<g class="a9 c2 m2 node n5 p0 s0" transform="translate(40 84.0823)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 11.714)">
 						<path class="edge" d="M 0 0 V -11.714 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree_x_axis.svg
+++ b/python/tests/data/svg/tree_x_axis.svg
@@ -1,25 +1,27 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="400">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree t1">
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(200,200)">
-					<text text-anchor="middle">pos on genome</text>
+				<g transform="translate(200,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">pos on genome</text>
 				</g>
 				<line x1="20" x2="380" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(380 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(380 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s1" transform="translate(20.1216 163.2)">
@@ -46,8 +48,8 @@
 			</g>
 		</g>
 		<g class="plotbox">
-			<g class="m5 node n7 p0 root s2" transform="translate(200 23.4889)">
-				<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-90 105.584)">
+			<g class="c2 m5 node n7 p0 root s2" transform="translate(200 23.4889)">
+				<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-90 105.584)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-45 2.32663)">
 						<path class="edge" d="M 0 0 V -2.32663 H 45"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -72,7 +74,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a7 node n5 p0" transform="translate(90 85.3425)">
+				<g class="a7 c2 node n5 p0" transform="translate(90 85.3425)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-45 22.5686)">
 						<path class="edge" d="M 0 0 V -22.5686 H 45"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/tree_y_axis_rank.svg
+++ b/python/tests/data/svg/tree_y_axis_rank.svg
@@ -1,48 +1,50 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.y-axis line.grid {stroke: #CCCCCC}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.y-axis line.grid {stroke: #CCCCCC}]]></style>
 	</defs>
 	<g class="tree t1">
 		<g class="axes">
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,89.1)">
-					<text text-anchor="middle">Time (relative steps)</text>
+				<g transform="translate(0,89.1)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (relative steps)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="168.2" y2="10"/>
-				<g class="tick" transform="translate(56.8 49.55)">
-					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.31</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 49.55)">
+						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">5.31</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 128.65)">
-					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.11</text>
+					<g class="tick" transform="translate(56.8 128.65)">
+						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 168.2)">
-					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+					<g class="tick" transform="translate(56.8 168.2)">
+						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 89.1)">
-					<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.11</text>
+					<g class="tick" transform="translate(56.8 89.1)">
+						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.11</text>
+						</g>
 					</g>
 				</g>
 			</g>
 		</g>
 		<g class="plotbox">
-			<g class="m5 node n7 p0 root s2" transform="translate(118.4 49.55)">
-				<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-30.8 79.1)">
+			<g class="c2 m5 node n7 p0 root s2" transform="translate(118.4 49.55)">
+				<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-30.8 79.1)">
 					<g class="a4 leaf node n0 p0 sample" transform="translate(-15.4 39.55)">
 						<path class="edge" d="M 0 0 V -39.55 H 15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -67,7 +69,7 @@
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 				</g>
-				<g class="a7 node n5 p0" transform="translate(30.8 39.55)">
+				<g class="a7 c2 node n5 p0" transform="translate(30.8 39.55)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-15.4 79.1)">
 						<path class="edge" d="M 0 0 V -79.1 H 15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(77.3623 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(77.3623 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(780.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(780.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(890.091 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(890.091 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(68 163.2)">
@@ -97,8 +99,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-38 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -113,7 +115,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -151,8 +153,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -177,7 +179,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -210,8 +212,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-38 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(96 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -226,7 +228,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -249,8 +251,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-38 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(96 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -265,7 +267,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -293,8 +295,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-38 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(96 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -309,7 +311,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_multiroot.svg
+++ b/python/tests/data/svg/ts_multiroot.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1600">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -16,62 +16,64 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(800,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(800,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="1580" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(215 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1</text>
+					<g class="tick" transform="translate(215 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(410 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>2</text>
+					<g class="tick" transform="translate(410 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">2</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(605 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>3</text>
+					<g class="tick" transform="translate(605 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">3</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(800 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>4</text>
+					<g class="tick" transform="translate(800 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">4</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(995 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>5</text>
+					<g class="tick" transform="translate(995 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">5</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(1190 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>6</text>
+					<g class="tick" transform="translate(1190 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">6</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(1385 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>7</text>
+					<g class="tick" transform="translate(1385 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">7</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(1580 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>8</text>
+					<g class="tick" transform="translate(1580 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">8</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(103.433 163.2)">
@@ -112,8 +114,8 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,74.1)">
-					<text text-anchor="middle">Time (WF gens)</text>
+				<g transform="translate(0,74.1)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (WF gens)</text>
 				</g>
 			</g>
 		</g>
@@ -124,8 +126,8 @@
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="i1 node n15 p0 root" transform="translate(103.958 26.8)">
-						<g class="a15 i9 m0 node n6 p0 s0" transform="translate(32.2917 75.68)">
+					<g class="c2 i1 node n15 p0 root" transform="translate(103.958 26.8)">
+						<g class="a15 c3 i9 m0 node n6 p0 s0" transform="translate(32.2917 75.68)">
 							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -150,7 +152,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
 						</g>
-						<g class="a15 i6 node n11 p0" transform="translate(-32.2917 56.76)">
+						<g class="a15 c2 i6 node n11 p0" transform="translate(-32.2917 56.76)">
 							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.9167 37.84)">
 								<path class="edge" d="M 0 0 V -37.84 H 12.9167"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -172,7 +174,7 @@
 			</g>
 			<g class="tree t1" transform="translate(215 0)">
 				<g class="plotbox">
-					<g class="i9 node n6 p0 root" transform="translate(58.75 102.48)">
+					<g class="c3 i9 node n6 p0 root" transform="translate(58.75 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -191,13 +193,13 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="i3 node n12 p0 root" transform="translate(129.792 64.64)">
+					<g class="c2 i3 node n12 p0 root" transform="translate(129.792 64.64)">
 						<g class="a12 i10 leaf node n0 p0 sample" transform="translate(-19.375 56.76)">
 							<path class="edge" d="M 0 0 V -56.76 H 19.375"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a12 i6 node n11 p0" transform="translate(19.375 18.92)">
+						<g class="a12 c2 i6 node n11 p0" transform="translate(19.375 18.92)">
 							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.9167 37.84)">
 								<path class="edge" d="M 0 0 V -37.84 H 12.9167"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -223,8 +225,8 @@
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="i0 node n14 p0 root" transform="translate(103.958 26.8)">
-						<g class="a14 i9 m2 node n6 p0 s2" transform="translate(32.2917 75.68)">
+					<g class="c2 i0 node n14 p0 root" transform="translate(103.958 26.8)">
+						<g class="a14 c3 i9 m2 node n6 p0 s2" transform="translate(32.2917 75.68)">
 							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -254,7 +256,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
 						</g>
-						<g class="a14 i6 node n11 p0" transform="translate(-32.2917 56.76)">
+						<g class="a14 c2 i6 node n11 p0" transform="translate(-32.2917 56.76)">
 							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.9167 37.84)">
 								<path class="edge" d="M 0 0 V -37.84 H 12.9167"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -280,8 +282,8 @@
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="i0 node n14 p0 root" transform="translate(103.958 26.8)">
-						<g class="a14 i9 node n6 p0" transform="translate(32.2917 75.68)">
+					<g class="c2 i0 node n14 p0 root" transform="translate(103.958 26.8)">
+						<g class="a14 c3 i9 node n6 p0" transform="translate(32.2917 75.68)">
 							<g class="a6 i12 leaf m4 node n2 p0 s4 sample" transform="translate(-25.8333 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
 								<g class="mut m4 s4 unknown_time" transform="translate(0 -9.46)">
@@ -311,7 +313,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
 						</g>
-						<g class="a14 i8 node n7 p0" transform="translate(-32.2917 75.68)">
+						<g class="a14 c2 i8 node n7 p0" transform="translate(-32.2917 75.68)">
 							<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.9167 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -333,7 +335,7 @@
 			</g>
 			<g class="tree t4" transform="translate(800 0)">
 				<g class="plotbox">
-					<g class="i8 node n7 p0 root" transform="translate(45.8333 102.48)">
+					<g class="c2 i8 node n7 p0 root" transform="translate(45.8333 102.48)">
 						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.9167 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -347,19 +349,19 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
-					<g class="i2 node n13 p0 root" transform="translate(113.646 45.72)">
+					<g class="c2 i2 node n13 p0 root" transform="translate(113.646 45.72)">
 						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-29.0625 75.68)">
 							<path class="edge" d="M 0 0 V -75.68 H 29.0625"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a13 i5 node n10 p0" transform="translate(29.0625 37.84)">
+						<g class="a13 c2 i5 node n10 p0" transform="translate(29.0625 37.84)">
 							<g class="a10 i15 leaf node n5 p0 sample" transform="translate(19.375 37.84)">
 								<path class="edge" d="M 0 0 V -37.84 H -19.375"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<g class="a10 i9 node n6 p0" transform="translate(-19.375 18.92)">
+							<g class="a10 c2 i9 node n6 p0" transform="translate(-19.375 18.92)">
 								<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.9167 18.92)">
 									<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -385,7 +387,7 @@
 			</g>
 			<g class="tree t5" transform="translate(995 0)">
 				<g class="plotbox">
-					<g class="i9 node n6 p0 root" transform="translate(45.8333 102.48)">
+					<g class="c2 i9 node n6 p0 root" transform="translate(45.8333 102.48)">
 						<g class="a6 i12 leaf m5 node n2 p0 s5 sample" transform="translate(-12.9167 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 							<g class="mut m5 s5 unknown_time" transform="translate(0 -9.46)">
@@ -404,7 +406,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="i8 node n7 p0 root" transform="translate(97.5 102.48)">
+					<g class="c2 i8 node n7 p0 root" transform="translate(97.5 102.48)">
 						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.9167 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -418,7 +420,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
-					<g class="i2 node n13 p0 root" transform="translate(149.167 45.72)">
+					<g class="c2 i2 node n13 p0 root" transform="translate(149.167 45.72)">
 						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-12.9167 75.68)">
 							<path class="edge" d="M 0 0 V -75.68 H 12.9167"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -436,7 +438,7 @@
 			</g>
 			<g class="tree t6" transform="translate(1190 0)">
 				<g class="plotbox">
-					<g class="i9 node n6 p0 root" transform="translate(58.75 102.48)">
+					<g class="c3 i9 node n6 p0 root" transform="translate(58.75 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -459,7 +461,7 @@
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">1</text>
 					</g>
-					<g class="i7 node n8 p0 root" transform="translate(149.167 102.48)">
+					<g class="c2 i7 node n8 p0 root" transform="translate(149.167 102.48)">
 						<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.9167 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -477,7 +479,7 @@
 			</g>
 			<g class="tree t7" transform="translate(1385 0)">
 				<g class="plotbox">
-					<g class="i9 node n6 p0 root" transform="translate(58.75 102.48)">
+					<g class="c3 i9 node n6 p0 root" transform="translate(58.75 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -496,13 +498,13 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="i4 node n9 p0 root" transform="translate(142.708 83.56)">
+					<g class="c2 i4 node n9 p0 root" transform="translate(142.708 83.56)">
 						<g class="a9 i11 leaf node n1 p0 sample" transform="translate(19.375 37.84)">
 							<path class="edge" d="M 0 0 V -37.84 H -19.375"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">1</text>
 						</g>
-						<g class="a9 i7 node n8 p0" transform="translate(-19.375 18.92)">
+						<g class="a9 c2 i7 node n8 p0" transform="translate(-19.375 18.92)">
 							<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.9167 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_mut_highlight.svg
+++ b/python/tests/data/svg/ts_mut_highlight.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.edge {stroke: grey}.mut .sym{stroke:pink} .mut text{fill:pink}.mut.m2 .sym,.m2>line, .m2>.node .edge{stroke:red} .mut.m2 text{fill:red}.mut.m3 .sym,.m3>line, .m3>.node .edge{stroke:cyan} .mut.m3 text{fill:cyan}.mut.m4 .sym,.m4>line, .m4>.node .edge{stroke:blue} .mut.m4 text{fill:blue}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.edge {stroke: grey}.mut .sym{stroke:pink} .mut text{fill:pink}.mut.m2 .sym,.m2>line, .m2>.node .edge{stroke:red} .mut.m2 text{fill:red}.mut.m3 .sym,.m3>line, .m3>.node .edge{stroke:cyan} .mut.m3 text{fill:cyan}.mut.m4 .sym,.m4>line, .m4>.node .edge{stroke:blue} .mut.m4 text{fill:blue}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(77.3623 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(77.3623 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(780.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(780.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(890.091 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(890.091 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(68 163.2)">
@@ -97,8 +99,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-38 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -113,7 +115,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -151,8 +153,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -177,7 +179,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -210,8 +212,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-38 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(96 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -226,7 +228,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -249,8 +251,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-38 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(96 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -265,7 +267,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -293,8 +295,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-38 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(96 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -309,7 +311,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_mut_times.svg
+++ b/python/tests/data/svg/ts_mut_times.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(77.3623 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(77.3623 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(780.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(780.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(890.091 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(890.091 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(68 163.2)">
@@ -97,8 +99,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 53.943)">
-						<g class="a9 node n4 p0" transform="translate(-38 66.6067)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 53.943)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 66.6067)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
 								<path class="edge" d="M 0 0 V -0.850364 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -113,7 +115,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 59.2084)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 59.2084)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
 								<path class="edge" d="M 0 0 V -8.24865 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -151,8 +153,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 81.9594)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 38.5902)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 81.9594)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 38.5902)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
 								<path class="edge" d="M 0 0 V -0.850364 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -177,7 +179,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 31.1919)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
 								<path class="edge" d="M 0 0 V -8.24865 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -210,8 +212,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 108.403)">
-						<g class="a6 node n4 p0" transform="translate(-38 12.1467)">
+					<g class="c2 node n6 p0 root" transform="translate(96 108.403)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 12.1467)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
 								<path class="edge" d="M 0 0 V -0.850364 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -226,7 +228,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 4.74841)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 4.74841)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
 								<path class="edge" d="M 0 0 V -8.24865 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -249,8 +251,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 81.9594)">
-						<g class="a7 node n4 p0" transform="translate(-38 38.5902)">
+					<g class="c2 node n7 p0 root" transform="translate(96 81.9594)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 38.5902)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
 								<path class="edge" d="M 0 0 V -0.850364 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -265,7 +267,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 31.1919)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
 								<path class="edge" d="M 0 0 V -8.24865 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -293,8 +295,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 72.5822)">
-						<g class="a8 node n4 p0" transform="translate(-38 47.9674)">
+					<g class="c2 node n8 p0 root" transform="translate(96 72.5822)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 47.9674)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
 								<path class="edge" d="M 0 0 V -0.850364 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -309,7 +311,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 40.5692)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 40.5692)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
 								<path class="edge" d="M 0 0 V -8.24865 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_mut_times_logscale.svg
+++ b/python/tests/data/svg/ts_mut_times_logscale.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(77.3623 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(77.3623 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(780.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(780.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(890.091 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(890.091 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(68 163.2)">
@@ -97,8 +99,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 29.9844)">
-						<g class="a9 node n4 p0" transform="translate(-38 87.1271)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 29.9844)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 87.1271)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 4.28849)">
 								<path class="edge" d="M 0 0 V -4.28849 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -113,7 +115,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 61.8645)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 61.8645)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
 								<path class="edge" d="M 0 0 V -29.5511 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -151,8 +153,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 48.5225)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 68.589)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 48.5225)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 68.589)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 4.28849)">
 								<path class="edge" d="M 0 0 V -4.28849 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -177,7 +179,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 43.3264)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 43.3264)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
 								<path class="edge" d="M 0 0 V -29.5511 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -210,8 +212,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 81.3812)">
-						<g class="a6 node n4 p0" transform="translate(-38 35.7303)">
+					<g class="c2 node n6 p0 root" transform="translate(96 81.3812)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 35.7303)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 4.28849)">
 								<path class="edge" d="M 0 0 V -4.28849 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -226,7 +228,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 10.4677)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 10.4677)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
 								<path class="edge" d="M 0 0 V -29.5511 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -249,8 +251,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 48.5225)">
-						<g class="a7 node n4 p0" transform="translate(-38 68.589)">
+					<g class="c2 node n7 p0 root" transform="translate(96 48.5225)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 68.589)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 4.28849)">
 								<path class="edge" d="M 0 0 V -4.28849 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -265,7 +267,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 43.3264)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 43.3264)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
 								<path class="edge" d="M 0 0 V -29.5511 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -293,8 +295,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 41.3074)">
-						<g class="a8 node n4 p0" transform="translate(-38 75.8041)">
+					<g class="c2 node n8 p0 root" transform="translate(96 41.3074)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 75.8041)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 4.28849)">
 								<path class="edge" d="M 0 0 V -4.28849 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -309,7 +311,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 50.5416)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 50.5416)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
 								<path class="edge" d="M 0 0 V -29.5511 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_mutations_no_edges.svg
+++ b/python/tests/data/svg/ts_mutations_no_edges.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -9,20 +9,22 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(100,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(100,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="180" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(180 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1</text>
+					<g class="tick" transform="translate(180 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(32.7433 163.2)">

--- a/python/tests/data/svg/ts_mutations_timed_no_edges.svg
+++ b/python/tests/data/svg/ts_mutations_timed_no_edges.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -9,20 +9,22 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(100,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(100,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="180" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(180 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1</text>
+					<g class="tick" transform="translate(180 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(32.7433 163.2)">

--- a/python/tests/data/svg/ts_no_axes.svg
+++ b/python/tests/data/svg/ts_no_axes.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 26.4667)">
-						<g class="a9 node n4 p0" transform="translate(-38 130.073)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 26.4667)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 130.073)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.66063)">
 								<path class="edge" d="M 0 0 V -1.66063 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -23,7 +23,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 115.625)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 115.625)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
 								<path class="edge" d="M 0 0 V -16.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -61,8 +61,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 81.1785)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 75.3608)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 81.1785)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 75.3608)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.66063)">
 								<path class="edge" d="M 0 0 V -1.66063 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -87,7 +87,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 60.9131)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 60.9131)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
 								<path class="edge" d="M 0 0 V -16.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -120,8 +120,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 132.819)">
-						<g class="a6 node n4 p0" transform="translate(-38 23.7206)">
+					<g class="c2 node n6 p0 root" transform="translate(96 132.819)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 23.7206)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.66063)">
 								<path class="edge" d="M 0 0 V -1.66063 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -136,7 +136,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 9.27292)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 9.27292)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
 								<path class="edge" d="M 0 0 V -16.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -159,8 +159,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 81.1785)">
-						<g class="a7 node n4 p0" transform="translate(-38 75.3608)">
+					<g class="c2 node n7 p0 root" transform="translate(96 81.1785)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 75.3608)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.66063)">
 								<path class="edge" d="M 0 0 V -1.66063 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -175,7 +175,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 60.9131)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 60.9131)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
 								<path class="edge" d="M 0 0 V -16.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -203,8 +203,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 62.8662)">
-						<g class="a8 node n4 p0" transform="translate(-38 93.6731)">
+					<g class="c2 node n8 p0 root" transform="translate(96 62.8662)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 93.6731)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.66063)">
 								<path class="edge" d="M 0 0 V -1.66063 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -219,7 +219,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 79.2254)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 79.2254)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
 								<path class="edge" d="M 0 0 V -16.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_plain.svg
+++ b/python/tests/data/svg/ts_plain.svg
@@ -1,49 +1,51 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(212 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(212 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(404 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(404 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(596 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(596 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(788 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(788 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -51,8 +53,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-38 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -67,7 +69,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -105,8 +107,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -131,7 +133,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -164,8 +166,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-38 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(96 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -180,7 +182,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -203,8 +205,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-38 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(96 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -219,7 +221,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -247,8 +249,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-38 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(96 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -263,7 +265,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_plain_no_xlab.svg
+++ b/python/tests/data/svg/ts_plain_no_xlab.svg
@@ -1,46 +1,48 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="axes">
 			<g class="x-axis">
 				<line x1="20" x2="980" y1="180" y2="180"/>
-				<g class="tick" transform="translate(20 180)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 180)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(212 180)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(212 180)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(404 180)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(404 180)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(596 180)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(596 180)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(788 180)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(788 180)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 180)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 180)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -48,8 +50,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 24.2444)">
-						<g class="a9 node n4 p0" transform="translate(-38 112.519)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 24.2444)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 112.519)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.43653)">
 								<path class="edge" d="M 0 0 V -1.43653 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -64,7 +66,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 100.021)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 100.021)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
 								<path class="edge" d="M 0 0 V -13.9345 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -102,8 +104,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 71.5728)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 65.1907)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 71.5728)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 65.1907)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.43653)">
 								<path class="edge" d="M 0 0 V -1.43653 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -128,7 +130,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 52.6927)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 52.6927)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
 								<path class="edge" d="M 0 0 V -13.9345 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -161,8 +163,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 116.244)">
-						<g class="a6 node n4 p0" transform="translate(-38 20.5195)">
+					<g class="c2 node n6 p0 root" transform="translate(96 116.244)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 20.5195)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.43653)">
 								<path class="edge" d="M 0 0 V -1.43653 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -177,7 +179,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 8.02152)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 8.02152)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
 								<path class="edge" d="M 0 0 V -13.9345 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -200,8 +202,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 71.5728)">
-						<g class="a7 node n4 p0" transform="translate(-38 65.1907)">
+					<g class="c2 node n7 p0 root" transform="translate(96 71.5728)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 65.1907)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.43653)">
 								<path class="edge" d="M 0 0 V -1.43653 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -216,7 +218,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 52.6927)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 52.6927)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
 								<path class="edge" d="M 0 0 V -13.9345 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -244,8 +246,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 55.7318)">
-						<g class="a8 node n4 p0" transform="translate(-38 81.0317)">
+					<g class="c2 node n8 p0 root" transform="translate(96 55.7318)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 81.0317)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.43653)">
 								<path class="edge" d="M 0 0 V -1.43653 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -260,7 +262,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 68.5337)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 68.5337)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
 								<path class="edge" d="M 0 0 V -13.9345 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_plain_y.svg
+++ b/python/tests/data/svg/ts_plain_y.svg
@@ -1,76 +1,80 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.y-axis line.grid {stroke: #CCCCCC}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.y-axis line.grid {stroke: #CCCCCC}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(518.4,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(518.4,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(56.8 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(241.44 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(241.44 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(426.08 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(426.08 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(610.72 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(610.72 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(795.36 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(795.36 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="-5" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="-5" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,65.7)">
-					<text text-anchor="middle">Time</text>
+				<g transform="translate(0,65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
-				<g class="tick" transform="translate(56.8 121.4)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 121.4)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 66.8909)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5</text>
+					<g class="tick" transform="translate(56.8 66.8909)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">5</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 12.3817)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">10</text>
+					<g class="tick" transform="translate(56.8 12.3817)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">10</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -78,8 +82,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(56.8 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-36.16 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.16 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -94,7 +98,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -132,8 +136,8 @@
 			</g>
 			<g class="tree t1" transform="translate(241.44 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(92.32 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-36.16 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(92.32 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.16 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -158,7 +162,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -191,8 +195,8 @@
 			</g>
 			<g class="tree t2" transform="translate(426.08 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(92.32 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-36.16 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(92.32 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.16 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -207,7 +211,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(36.16 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(36.16 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -230,8 +234,8 @@
 			</g>
 			<g class="tree t3" transform="translate(610.72 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(92.32 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-36.16 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(92.32 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-36.16 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -246,7 +250,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -274,8 +278,8 @@
 			</g>
 			<g class="tree t4" transform="translate(795.36 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(92.32 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-36.16 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(92.32 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-36.16 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -290,7 +294,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(36.16 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(36.16 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_rank.svg
+++ b/python/tests/data/svg/ts_rank.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(518.4,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(518.4,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(56.8 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(111.963 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(111.963 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(788.516 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(788.516 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.537 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.537 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(897.184 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(897.184 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(102.96 163.2)">
@@ -94,50 +96,52 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,65.7)">
-					<text text-anchor="middle">Node time</text>
+				<g transform="translate(0,65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Node time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
-				<g class="tick" transform="translate(56.8 121.4)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 121.4)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 105.486)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.11</text>
+					<g class="tick" transform="translate(56.8 105.486)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 89.5714)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.11</text>
+					<g class="tick" transform="translate(56.8 89.5714)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 73.6571)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.75</text>
+					<g class="tick" transform="translate(56.8 73.6571)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.75</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 57.7429)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.31</text>
+					<g class="tick" transform="translate(56.8 57.7429)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">5.31</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 41.8286)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.57</text>
+					<g class="tick" transform="translate(56.8 41.8286)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">6.57</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 25.9143)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">9.08</text>
+					<g class="tick" transform="translate(56.8 25.9143)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">9.08</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -145,8 +149,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(56.8 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(92.32 25.9143)">
-						<g class="a9 node n4 p0" transform="translate(-36.16 79.5714)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(92.32 25.9143)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.16 79.5714)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 15.9143)">
 								<path class="edge" d="M 0 0 V -15.9143 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -161,7 +165,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(36.16 63.6571)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 63.6571)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
 								<path class="edge" d="M 0 0 V -31.8286 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -199,8 +203,8 @@
 			</g>
 			<g class="tree t1" transform="translate(241.44 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(92.32 57.7429)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-36.16 47.7429)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(92.32 57.7429)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.16 47.7429)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 15.9143)">
 								<path class="edge" d="M 0 0 V -15.9143 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -225,7 +229,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 31.8286)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 31.8286)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
 								<path class="edge" d="M 0 0 V -31.8286 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -258,8 +262,8 @@
 			</g>
 			<g class="tree t2" transform="translate(426.08 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(92.32 73.6571)">
-						<g class="a6 node n4 p0" transform="translate(-36.16 31.8286)">
+					<g class="c2 node n6 p0 root" transform="translate(92.32 73.6571)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.16 31.8286)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 15.9143)">
 								<path class="edge" d="M 0 0 V -15.9143 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -274,7 +278,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(36.16 15.9143)">
+						<g class="a6 c2 node n5 p0" transform="translate(36.16 15.9143)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
 								<path class="edge" d="M 0 0 V -31.8286 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -297,8 +301,8 @@
 			</g>
 			<g class="tree t3" transform="translate(610.72 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(92.32 57.7429)">
-						<g class="a7 node n4 p0" transform="translate(-36.16 47.7429)">
+					<g class="c2 node n7 p0 root" transform="translate(92.32 57.7429)">
+						<g class="a7 c2 node n4 p0" transform="translate(-36.16 47.7429)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 15.9143)">
 								<path class="edge" d="M 0 0 V -15.9143 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -313,7 +317,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 31.8286)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 31.8286)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
 								<path class="edge" d="M 0 0 V -31.8286 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -341,8 +345,8 @@
 			</g>
 			<g class="tree t4" transform="translate(795.36 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(92.32 41.8286)">
-						<g class="a8 node n4 p0" transform="translate(-36.16 63.6571)">
+					<g class="c2 node n8 p0 root" transform="translate(92.32 41.8286)">
+						<g class="a8 c2 node n4 p0" transform="translate(-36.16 63.6571)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 15.9143)">
 								<path class="edge" d="M 0 0 V -15.9143 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -357,7 +361,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(36.16 47.7429)">
+						<g class="a8 c2 node n5 p0" transform="translate(36.16 47.7429)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
 								<path class="edge" d="M 0 0 V -31.8286 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_x_lim.svg
+++ b/python/tests/data/svg/ts_x_lim.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="600">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -11,20 +11,22 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(300,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(300,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="580" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(25.7731 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(25.7731 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(509.15 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(509.15 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s1" transform="translate(25.9364 163.2)">
@@ -53,8 +55,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="node n9 p0 root" transform="translate(93.3333 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-36.6667 97.7739)">
+					<g class="c2 node n9 p0 root" transform="translate(93.3333 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.6667 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.3333 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.3333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -69,7 +71,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 node n5 p0" transform="translate(36.6667 86.9138)">
+						<g class="a9 c2 node n5 p0" transform="translate(36.6667 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.3333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -92,8 +94,8 @@
 			</g>
 			<g class="tree t1" transform="translate(206.667 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(93.3333 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-36.6667 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(93.3333 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.6667 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.3333 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.3333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -118,7 +120,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.6667 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.6667 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.3333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -151,8 +153,8 @@
 			</g>
 			<g class="tree t2" transform="translate(393.333 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(93.3333 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-36.6667 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(93.3333 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.6667 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.3333 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.3333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -167,7 +169,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(36.6667 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(36.6667 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.3333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_xlabel.svg
+++ b/python/tests/data/svg/ts_xlabel.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(500,200)">
-					<text text-anchor="middle">genomic position (bp)</text>
+				<g transform="translate(500,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">genomic position (bp)</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(20 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(20 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(77.3623 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(77.3623 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(780.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(780.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(890.091 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(890.091 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.883 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.883 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(68 163.2)">
@@ -97,8 +99,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-38 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-38 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -113,7 +115,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(38 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -151,8 +153,8 @@
 			</g>
 			<g class="tree t1" transform="translate(212 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(96 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -177,7 +179,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -210,8 +212,8 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(96 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-38 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(96 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-38 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -226,7 +228,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(38 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -249,8 +251,8 @@
 			</g>
 			<g class="tree t3" transform="translate(596 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(96 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-38 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(96 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-38 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -265,7 +267,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(38 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -293,8 +295,8 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(96 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-38 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(96 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-38 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -309,7 +311,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(38 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 19"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_y_axis.svg
+++ b/python/tests/data/svg/ts_y_axis.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(518.4,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(518.4,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(56.8 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(111.963 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(111.963 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(788.516 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(788.516 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.537 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.537 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(897.184 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(897.184 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(102.96 163.2)">
@@ -94,50 +96,52 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,65.7)">
-					<text text-anchor="middle">Time (gens)</text>
+				<g transform="translate(0,65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (gens)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
-				<g class="tick" transform="translate(56.8 121.4)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 121.4)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 120.152)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.11</text>
+					<g class="tick" transform="translate(56.8 120.152)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 109.292)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.11</text>
+					<g class="tick" transform="translate(56.8 109.292)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 102.321)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.75</text>
+					<g class="tick" transform="translate(56.8 102.321)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.75</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 63.504)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.31</text>
+					<g class="tick" transform="translate(56.8 63.504)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">5.31</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 49.7389)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.57</text>
+					<g class="tick" transform="translate(56.8 49.7389)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">6.57</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 22.3778)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">9.08</text>
+					<g class="tick" transform="translate(56.8 22.3778)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">9.08</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -145,8 +149,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(56.8 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-36.16 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.16 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -161,7 +165,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -199,8 +203,8 @@
 			</g>
 			<g class="tree t1" transform="translate(241.44 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(92.32 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-36.16 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(92.32 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.16 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -225,7 +229,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -258,8 +262,8 @@
 			</g>
 			<g class="tree t2" transform="translate(426.08 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(92.32 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-36.16 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(92.32 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.16 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -274,7 +278,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(36.16 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(36.16 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -297,8 +301,8 @@
 			</g>
 			<g class="tree t3" transform="translate(610.72 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(92.32 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-36.16 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(92.32 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-36.16 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -313,7 +317,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -341,8 +345,8 @@
 			</g>
 			<g class="tree t4" transform="translate(795.36 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(92.32 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-36.16 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(92.32 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-36.16 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -357,7 +361,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(36.16 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(36.16 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_y_axis_log.svg
+++ b/python/tests/data/svg/ts_y_axis_log.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(518.4,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(518.4,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(56.8 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(111.963 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(111.963 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(788.516 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(788.516 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.537 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.537 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(897.184 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(897.184 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(102.96 163.2)">
@@ -94,50 +96,52 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,65.7)">
-					<text text-anchor="middle">Time (log scale)</text>
+				<g transform="translate(0,65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (log scale)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
-				<g class="tick" transform="translate(56.8 121.4)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 121.4)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 116.755)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0.11</text>
+					<g class="tick" transform="translate(56.8 116.755)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 89.39)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.11</text>
+					<g class="tick" transform="translate(56.8 89.39)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.11</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 78.0512)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1.75</text>
+					<g class="tick" transform="translate(56.8 78.0512)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1.75</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 42.4584)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5.31</text>
+					<g class="tick" transform="translate(56.8 42.4584)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">5.31</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 34.6429)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6.57</text>
+					<g class="tick" transform="translate(56.8 34.6429)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">6.57</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 22.3778)">
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">9.08</text>
+					<g class="tick" transform="translate(56.8 22.3778)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">9.08</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -145,8 +149,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(56.8 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-36.16 94.3769)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.16 94.3769)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 4.64534)">
 								<path class="edge" d="M 0 0 V -4.64534 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -161,7 +165,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(36.16 67.0122)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 67.0122)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
 								<path class="edge" d="M 0 0 V -32.01 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -199,8 +203,8 @@
 			</g>
 			<g class="tree t1" transform="translate(241.44 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(92.32 42.4584)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-36.16 74.2963)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(92.32 42.4584)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.16 74.2963)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 4.64534)">
 								<path class="edge" d="M 0 0 V -4.64534 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -225,7 +229,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 46.9316)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 46.9316)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
 								<path class="edge" d="M 0 0 V -32.01 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -258,8 +262,8 @@
 			</g>
 			<g class="tree t2" transform="translate(426.08 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(92.32 78.0512)">
-						<g class="a6 node n4 p0" transform="translate(-36.16 38.7034)">
+					<g class="c2 node n6 p0 root" transform="translate(92.32 78.0512)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.16 38.7034)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 4.64534)">
 								<path class="edge" d="M 0 0 V -4.64534 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -274,7 +278,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(36.16 11.3388)">
+						<g class="a6 c2 node n5 p0" transform="translate(36.16 11.3388)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
 								<path class="edge" d="M 0 0 V -32.01 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -297,8 +301,8 @@
 			</g>
 			<g class="tree t3" transform="translate(610.72 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(92.32 42.4584)">
-						<g class="a7 node n4 p0" transform="translate(-36.16 74.2963)">
+					<g class="c2 node n7 p0 root" transform="translate(92.32 42.4584)">
+						<g class="a7 c2 node n4 p0" transform="translate(-36.16 74.2963)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 4.64534)">
 								<path class="edge" d="M 0 0 V -4.64534 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -313,7 +317,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 46.9316)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 46.9316)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
 								<path class="edge" d="M 0 0 V -32.01 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -341,8 +345,8 @@
 			</g>
 			<g class="tree t4" transform="translate(795.36 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(92.32 34.6429)">
-						<g class="a8 node n4 p0" transform="translate(-36.16 82.1118)">
+					<g class="c2 node n8 p0 root" transform="translate(92.32 34.6429)">
+						<g class="a8 c2 node n4 p0" transform="translate(-36.16 82.1118)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 4.64534)">
 								<path class="edge" d="M 0 0 V -4.64534 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -357,7 +361,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(36.16 54.7471)">
+						<g class="a8 c2 node n5 p0" transform="translate(36.16 54.7471)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
 								<path class="edge" d="M 0 0 V -32.01 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/data/svg/ts_y_axis_regular.svg
+++ b/python/tests/data/svg/ts_y_axis_regular.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="1000">
 	<defs>
-		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity:0}.background path:nth-child(odd) {fill-opacity:.1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold}.axes, .tree {font-size: 14px; text-anchor:middle}.y-axis line.grid {stroke: #FAFAFA}.y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}.x-axis .tick g {transform: translateY(0.9em)}.x-axis > .lab text {transform: translateY(-0.8em)}.axes line, .edge {stroke:black; fill:none}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
@@ -13,44 +13,46 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="lab" transform="translate(518.4,200)">
-					<text text-anchor="middle">Genome position</text>
+				<g transform="translate(518.4,200)">
+					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
-				<g class="tick" transform="translate(56.8 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.00</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.00</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(111.963 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.06</text>
+					<g class="tick" transform="translate(111.963 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.06</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(788.516 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.79</text>
+					<g class="tick" transform="translate(788.516 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.79</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(893.537 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(893.537 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(897.184 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>0.91</text>
+					<g class="tick" transform="translate(897.184 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">0.91</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(980 163.2)">
-					<line x1="0" x2="0" y1="0" y2="5"/>
-					<g class="lab" transform="translate(0,5)">
-						<text>1.00</text>
+					<g class="tick" transform="translate(980 163.2)">
+						<line x1="0" x2="0" y1="0" y2="5"/>
+						<g transform="translate(0,6)">
+							<text class="lab">1.00</text>
+						</g>
 					</g>
 				</g>
 				<g class="site s0" transform="translate(102.96 163.2)">
@@ -94,78 +96,80 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g class="lab" transform="translate(0,65.7)">
-					<text text-anchor="middle">Time</text>
+				<g transform="translate(0,65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
-				<g class="tick" transform="translate(56.8 121.4)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">0</text>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 121.4)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">0</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 110.498)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">1</text>
+					<g class="tick" transform="translate(56.8 110.498)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">1</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 99.5963)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">2</text>
+					<g class="tick" transform="translate(56.8 99.5963)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">2</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 88.6945)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">3</text>
+					<g class="tick" transform="translate(56.8 88.6945)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">3</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 77.7927)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">4</text>
+					<g class="tick" transform="translate(56.8 77.7927)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">4</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 66.8909)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">5</text>
+					<g class="tick" transform="translate(56.8 66.8909)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">5</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 55.989)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">6</text>
+					<g class="tick" transform="translate(56.8 55.989)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">6</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 45.0872)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">7</text>
+					<g class="tick" transform="translate(56.8 45.0872)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">7</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 34.1854)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">8</text>
+					<g class="tick" transform="translate(56.8 34.1854)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">8</text>
+						</g>
 					</g>
-				</g>
-				<g class="tick" transform="translate(56.8 23.2835)">
-					<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
-					<line x1="0" x2="-5" y1="0" y2="0"/>
-					<g class="lab" transform="translate(-5,0)">
-						<text text-anchor="end">9</text>
+					<g class="tick" transform="translate(56.8 23.2835)">
+						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6,0)">
+							<text class="lab" text-anchor="end">9</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -173,8 +177,8 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(56.8 0)">
 				<g class="plotbox">
-					<g class="m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
-						<g class="a9 node n4 p0" transform="translate(-36.16 97.7739)">
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(92.32 22.3778)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.16 97.7739)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -189,7 +193,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a9 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -227,8 +231,8 @@
 			</g>
 			<g class="tree t1" transform="translate(241.44 0)">
 				<g class="plotbox">
-					<g class="m5 node n7 p0 root s2" transform="translate(92.32 63.504)">
-						<g class="a7 m3 m4 node n4 p0 s1" transform="translate(-36.16 56.6478)">
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(92.32 63.504)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.16 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -253,7 +257,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -286,8 +290,8 @@
 			</g>
 			<g class="tree t2" transform="translate(426.08 0)">
 				<g class="plotbox">
-					<g class="node n6 p0 root" transform="translate(92.32 102.321)">
-						<g class="a6 node n4 p0" transform="translate(-36.16 17.8305)">
+					<g class="c2 node n6 p0 root" transform="translate(92.32 102.321)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.16 17.8305)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -302,7 +306,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a6 node n5 p0" transform="translate(36.16 6.97033)">
+						<g class="a6 c2 node n5 p0" transform="translate(36.16 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -325,8 +329,8 @@
 			</g>
 			<g class="tree t3" transform="translate(610.72 0)">
 				<g class="plotbox">
-					<g class="node n7 p0 root" transform="translate(92.32 63.504)">
-						<g class="a7 node n4 p0" transform="translate(-36.16 56.6478)">
+					<g class="c2 node n7 p0 root" transform="translate(92.32 63.504)">
+						<g class="a7 c2 node n4 p0" transform="translate(-36.16 56.6478)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -341,7 +345,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a7 node n5 p0" transform="translate(36.16 45.7876)">
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -369,8 +373,8 @@
 			</g>
 			<g class="tree t4" transform="translate(795.36 0)">
 				<g class="plotbox">
-					<g class="node n8 p0 root" transform="translate(92.32 49.7389)">
-						<g class="a8 node n4 p0" transform="translate(-36.16 70.4129)">
+					<g class="c2 node n8 p0 root" transform="translate(92.32 49.7389)">
+						<g class="a8 c2 node n4 p0" transform="translate(-36.16 70.4129)">
 							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -385,7 +389,7 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
 						</g>
-						<g class="a8 node n5 p0" transform="translate(36.16 59.5527)">
+						<g class="a8 c2 node n5 p0" transform="translate(36.16 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
 								<path class="edge" d="M 0 0 V -12.1084 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -2008,7 +2008,10 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
             assert svg_no_css.count("axes") == 1
             assert svg_no_css.count("x-axis") == 0
             assert svg_no_css.count("y-axis") == 1
-            assert svg_no_css.count("tick") == len({tree.time(u) for u in tree.nodes()})
+            assert svg_no_css.count("ticks") == 1
+            assert svg_no_css.count('class="tick"') == len(
+                {tree.time(u) for u in tree.nodes()}
+            )
 
     def test_y_axis_noticks(self):
         tree = msprime.simulate(4, random_seed=2).first()
@@ -2085,13 +2088,13 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         degree_2_ts = ts.keep_intervals([[0.2, 0.8]])
         svg = degree_2_ts.draw_svg(y_axis=False)
         assert svg.count('class="tick"') == 3
-        assert svg.count("<text>0.2") == 1
-        assert svg.count("<text>0.8") == 1
+        assert svg.count('<text class="lab">0.2') == 1
+        assert svg.count('<text class="lab">0.8') == 1
         degree_1_ts = ts.keep_intervals([[0.05, 0.15]])
         svg = degree_1_ts.draw_svg(y_axis=False)
         assert svg.count('class="tick"') == 2
-        assert svg.count("<text>0.05") == 1
-        assert svg.count("<text>0.15") == 1
+        assert svg.count('<text class="lab">0.05') == 1
+        assert svg.count('<text class="lab">0.15') == 1
 
     def test_bad_xlim(self):
         ts = msprime.simulate(10, random_seed=2)

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -460,16 +460,13 @@ class SvgPlot:
     """ The base class for plotting either a tree or a tree sequence as an SVG file"""
 
     standard_style = (
-        ".background path {fill: #808080; fill-opacity:0}"
-        ".background path:nth-child(odd) {fill-opacity:.1}"
+        ".background path {fill: #808080; fill-opacity: 0}"
+        ".background path:nth-child(odd) {fill-opacity: .1}"
         ".axes {font-size: 14px}"
         ".x-axis .tick .lab {font-weight: bold}"
-        ".axes, .tree {font-size: 14px; text-anchor:middle}"
-        ".y-axis line.grid {stroke: #FAFAFA}"
-        ".y-axis > .lab text {transform: translateX(0.8em) rotate(-90deg)}"
-        ".x-axis .tick g {transform: translateY(0.9em)}"
-        ".x-axis > .lab text {transform: translateY(-0.8em)}"
-        ".axes line, .edge {stroke:black; fill:none}"
+        ".axes, .tree {font-size: 14px; text-anchor: middle}"
+        ".axes line, .edge {stroke: black; fill: none}"
+        ".y-axis .grid {stroke: #FAFAFA}"
         ".node > .sym {fill: black; stroke: none}"
         ".site > .sym {stroke: black}"
         ".mut text {fill: red; font-style: italic}"
@@ -610,6 +607,7 @@ class SvgPlot:
                 x_axis,
                 pos=((self.plotbox.left + self.plotbox.right) / 2, self.plotbox.max_y),
                 group_class="lab",
+                transform="translate(0 -11)",
                 text_anchor="middle",
             )
         if self.x_axis:
@@ -635,7 +633,11 @@ class SvgPlot:
                         dwg.line((0, rnd(upper_length)), (0, rnd(tick_length_lower)))
                     )
                     self.add_text_in_group(
-                        lab, tick, pos=(0, tick_length_lower), group_class="lab"
+                        lab,
+                        tick,
+                        group_class="lab",
+                        pos=(0, tick_length_lower),  # pos + transform allows sensible
+                        transform="translate(0 8)",  # rotation via css transforms
                     )
             if site_muts is not None:
                 # Add sites as vertical lines with overlaid mutations as upper chevrons
@@ -695,6 +697,7 @@ class SvgPlot:
                 pos=(0, (upper + lower) / 2),
                 group_class="lab",
                 text_anchor="middle",
+                transform="translate(11) rotate(-90)",
             )
         if self.y_axis:
             y_axis.add(dwg.line((x, rnd(lower)), (x, rnd(upper))))


### PR DESCRIPTION
## Description

This fixes a minor "bug" so that viewing a default SVG in Inkscape will properly rotate the Y axis label

It also tidies up the grouping of tick marks so they are more consistent with the other labels, and can be rotated via css without annoying pixel tweaking. Apologies about all the updated SVG files @benjeffery - now that some of these examples are in the viz tutorial, we might be able to offload the visual checking to that, I suppose.

