### PR TITLE
pin working sphinx version

### DIFF
--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -23,7 +23,7 @@ pytest-cov
 pytest-xdist
 python_jsonschema_objects
 PyVCF
-sphinx
+sphinx<=3.3.1
 sphinx-argparse
 sphinx-issues
 sphinx_rtd_theme


### PR DESCRIPTION
Recent versions of Sphinx are incompatible with the version of autodocsumm that we're using (0.1.13).

Using the latest version of Sphinx when running `make` in the `docs` directory results in this error:
```
Running Sphinx v4.0.2

Extension error:
Could not import extension autodocsumm (exception: cannot import name 'force_decode' from 'sphinx.util' (/Users/awohns/miniconda3/envs/tskit-dev/lib/python3.9/site-packages/sphinx/util/__init__.py))
make: *** [all] Error 2
```

The CI pins Sphinx to version 3.3.1, we need to do the same in `python/requirements/development.txt` in order to build the docs. @benjeffery suggested setting `sphinx<4.0.0` but it seems some of the version 3 releases also don't play well with autodocsumm.