### PR TITLE
Use Hartigan parsimony for the standard test

### DIFF
--- a/python/tests/test_parsimony.py
+++ b/python/tests/test_parsimony.py
@@ -743,6 +743,8 @@ class TestParsimonyMissingData(TestParsimonyBase):
         alleles = ["0", "1"]
         with pytest.raises(ValueError):
             fitch_map_mutations(tree, genotypes, alleles)
+        with pytest.raises(ValueError):
+            hartigan_map_mutations(tree, genotypes, alleles)
         with pytest.raises(tskit.LibraryError):
             tree.map_mutations(genotypes, alleles)
 


### PR DESCRIPTION
Just spotted this @jeromekelleher - I think in all the "normal" parsimony tests we should be testing the Hartigan algorithm, rather than the fitch one, no?