### PR TITLE
Add ancestral_state to map_mutations

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -2936,6 +2936,23 @@ test_simplest_map_mutations(void)
     CU_ASSERT_EQUAL_FATAL(transitions[0].state, 1);
     free(transitions);
 
+    /* Assign the ancestral_state */
+    genotypes[0] = 1;
+    genotypes[1] = 1;
+    ancestral_state = 0;
+    ret = tsk_tree_map_mutations(&t, genotypes, NULL, TSK_MM_FIXED_ANCESTRAL_STATE,
+        &ancestral_state, &num_transitions, &transitions);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ancestral_state, 0);
+    CU_ASSERT_EQUAL_FATAL(num_transitions, 2);
+    CU_ASSERT_EQUAL_FATAL(transitions[0].node, 0);
+    CU_ASSERT_EQUAL_FATAL(transitions[0].parent, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(transitions[0].state, 1);
+    CU_ASSERT_EQUAL_FATAL(transitions[1].node, 1);
+    CU_ASSERT_EQUAL_FATAL(transitions[1].parent, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(transitions[1].state, 1);
+    free(transitions);
+
     tsk_tree_free(&t);
     tsk_treeseq_free(&ts);
 }
@@ -4387,6 +4404,24 @@ test_single_tree_map_mutations(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(num_transitions, 3);
     free(transitions);
+
+    ancestral_state = 5;
+    ret = tsk_tree_map_mutations(&t, genotypes, NULL, TSK_MM_FIXED_ANCESTRAL_STATE,
+        &ancestral_state, &num_transitions, &transitions);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(num_transitions, 4);
+    CU_ASSERT_EQUAL_FATAL(ancestral_state, 5);
+    free(transitions);
+
+    ancestral_state = -1;
+    ret = tsk_tree_map_mutations(&t, genotypes, NULL, TSK_MM_FIXED_ANCESTRAL_STATE,
+        &ancestral_state, &num_transitions, &transitions);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_ANCESTRAL_STATE);
+
+    ancestral_state = 64;
+    ret = tsk_tree_map_mutations(&t, genotypes, NULL, TSK_MM_FIXED_ANCESTRAL_STATE,
+        &ancestral_state, &num_transitions, &transitions);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_ANCESTRAL_STATE);
 
     genotypes[0] = 64;
     ret = tsk_tree_map_mutations(

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -403,6 +403,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_BAD_GENOTYPE:
             ret = "Bad genotype value provided";
             break;
+        case TSK_ERR_BAD_ANCESTRAL_STATE:
+            ret = "Bad ancestral state specified";
+            break;
 
         /* Genotype decoding errors */
         case TSK_ERR_TOO_MANY_ALLELES:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -297,6 +297,7 @@ An unsupported type was provided for a column in the file.
 /* Mutation mapping errors */
 #define TSK_ERR_GENOTYPES_ALL_MISSING                              -1000
 #define TSK_ERR_BAD_GENOTYPE                                       -1001
+#define TSK_ERR_BAD_ANCESTRAL_STATE                                -1002
 
 /* Genotype decoding errors */
 #define TSK_ERR_MUST_IMPUTE_NON_SAMPLES                            -1100

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -54,6 +54,9 @@ extern "C" {
 #define TSK_STAT_POLARISED          (1 << 10)
 #define TSK_STAT_SPAN_NORMALISE     (1 << 11)
 
+/* Options for map_mutations */
+#define TSK_MM_FIXED_ANCESTRAL_STATE (1 << 0)
+
 #define TSK_DIR_FORWARD 1
 #define TSK_DIR_REVERSE -1
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -6,6 +6,9 @@
 
 **Features**
 
+- ``map_mutations`` now allows the ancestral state to be specified
+  (:user:`hyanwong`, :user:`jeromekelleher`, :issue:`1542`, :pr:`1550`)
+
 **Fixes**
 
 --------------------


### PR DESCRIPTION
Starts to address #1542. Currently this is a draft version of a change to the python-only Hartigan `map_mutations` code. I *think* this is right, but it could do with checking and also we should add a few round-trip tests with ancestral state specified (I'm not sure how comprehensive to make this, e.g. whether to patch it in to the round trip tests higher up).

The doesn't code up the C version, but I guess that should be easy. It also doesn't add the ancestral state function to the fitch map_mutations code, but we don't use that except for testing anyway.

I guess it's OK that the algorithm is allowed to put a mutation above the root, so that the ancestral state for the whole tree switches immediately?

