### PR TITLE
Add ts.copy

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1637,6 +1637,21 @@ class TestTreeSequence(HighLevelTestCase):
                         assert edge.right >= tree.interval.right
             assert np.all(edge_visited)
 
+    def test_copy(self, ts_fixture):
+        # No modifier results in a pure copy
+        assert ts_fixture.copy() == ts_fixture
+        # No-op modifier results in a pure copy
+        assert ts_fixture.copy(modifier=lambda tables: tables) == ts_fixture
+        # Changing a table works
+        diff_ts = ts_fixture.copy(
+            modifier=lambda tables: tables.provenances.add_row(record="TEST")
+        )
+        assert diff_ts != ts_fixture
+        assert diff_ts.equals(ts_fixture, ignore_provenance=True)
+        # modifier is keyword only
+        with pytest.raises(TypeError):
+            ts_fixture.copy(lambda tables: tables)
+
 
 class TestTreeSequenceMethodSignatures:
     ts = msprime.simulate(10, random_seed=1234)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7149,6 +7149,20 @@ class TreeSequence:
 
         yield from combinatorics.treeseq_count_topologies(self, sample_sets)
 
+    def copy(self, *, modifier=None):
+        """
+        Returns a copy of this tree sequence, optionally applying the "modifier" function
+        to the underlying tables of the copy.
+
+        :param modifier: A function which is called with the tables of this
+            tree sequence as a single argument. [optional, keyword-only]
+        :rtype: a new (:class:`tskit.TreeSequence`)
+        """
+        tables = self.dump_tables()
+        if modifier is not None:
+            modifier(tables)
+        return tables.tree_sequence()
+
     ############################################
     #
     # Deprecated APIs. These are either already unsupported, or will be unsupported in a


### PR DESCRIPTION
This seems to be a very common pattern:

```python
    tables = ts.dump_tables()
    #do something with tables e.g.
    tables.provenances.add_row(record=record)
    ts = tables.tree_sequence()
```
This PR adds `TreeSequence.copy` which takes an optional `modifier` argument. With this the above becomes:
```python
ts = ts.copy(modifier=lambda tables: tables.provenances.add_row(record=record))
```

Having the words "copy" and "modify" in the resulting code clarify what is going on to the reader. To me this is clearer, but I'd like to hear some opinions as lambdas(or a locally defined function) aren't generally the most popular thing in python.
