### PR TITLE
Fix pickling of TreeSequence subclasses

### DIFF
--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3423,7 +3423,7 @@ class TreeSequence:
         return self.dump_tables()
 
     def __setstate__(self, tc):
-        self.__init__(tc.tree_sequence().ll_tree_sequence)
+        TreeSequence.__init__(self, tc.tree_sequence().ll_tree_sequence)
 
     def __eq__(self, other):
         return self.tables == other.tables


### PR DESCRIPTION
Fixes #1555

@petrelharp pyslim should probably add a pickle-unpickle test?

We could add sub-classing tests to tskit, but as it's not a recommended path I think the onus is on libraries doing so to test?