### PR TITLE
Unknown time doc

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -54,31 +54,6 @@ about particular nodes in the tree.
     :members:
     :autosummary:
 
-+++++++++
-Constants
-+++++++++
-
-.. autodata:: NULL
-    :annotation: = -1
-
-.. autodata:: NODE_IS_SAMPLE
-    :annotation: = 1
-
-.. autodata:: MISSING_DATA
-    :annotation: = -1
-
-.. autodata:: FORWARD
-    :annotation: = 1
-
-.. autodata:: REVERSE
-    :annotation: = -1
-
-.. autodata:: ALLELES_ACGT
-
-.. autodata:: UNKNOWN_TIME
-    :annotation:
-
-
 ++++++++++++++++++++++++
 Simple container classes
 ++++++++++++++++++++++++
@@ -495,6 +470,36 @@ Table functions
 .. autofunction:: pack_bytes
 
 .. autofunction:: unpack_bytes
+
+
+.. _sec_constants_api:
+
+*********
+Constants
+*********
+
+The following constants are used throughout the ``tskit`` API.
+
+.. autodata:: NULL
+    :annotation: = -1
+
+.. autodata:: NODE_IS_SAMPLE
+    :annotation: = 1
+
+.. autodata:: MISSING_DATA
+    :annotation: = -1
+
+.. autodata:: FORWARD
+    :annotation: = 1
+
+.. autodata:: REVERSE
+    :annotation: = -1
+
+.. autodata:: ALLELES_ACGT
+
+.. autodata:: UNKNOWN_TIME
+    :annotation:
+
 
 .. _sec_metadata_api:
 

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -75,6 +75,9 @@ Constants
 
 .. autodata:: ALLELES_ACGT
 
+.. autodata:: UNKNOWN_TIME
+    :annotation:
+
 
 ++++++++++++++++++++++++
 Simple container classes
@@ -557,3 +560,13 @@ information is planned for future versions.
 
 .. autoexception:: ProvenanceValidationError
 
+
+.. _sec_utility_api:
+
+*****************
+Utility functions
+*****************
+
+Some top-level utility functions.
+
+.. autofunction:: is_unknown_time

--- a/python/tskit/__init__.py
+++ b/python/tskit/__init__.py
@@ -46,7 +46,8 @@ ALLELES_01 = ("0", "1")
 #: the genotype integers 0, 1, 2, and 3, respectively.
 ALLELES_ACGT = ("A", "C", "G", "T")
 
-#: Special NAN value used to indicate unknown mutation times
+#: Special NAN value used to indicate unknown mutation times. Since this is a
+#: NAN value, you cannot use `==` to test for it. Use :func:`is_unknown_time` instead.
 UNKNOWN_TIME = _tskit.UNKNOWN_TIME
 
 #: Options for printing to strings and HTML, modify with tskit.set_print_options.

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -58,13 +58,14 @@ def canonical_json(obj):
 
 def is_unknown_time(time):
     """
-    As the default unknown mutation time is NAN equality always fails. This
-    method compares the bitfield such that unknown times can be detected.
-    Either single floats can be passed or lists/arrays.
+    As the default unknown mutation time (:const:`UNKNOWN_TIME`) is a specific NAN value,
+    equality always fails. This method compares the bitfield such that unknown times can
+    be detected. Either single floats can be passed or lists/arrays.
 
-    :param float or array-like time: Value or array to check.
+    :param time: Value or array to check.
+    :type time: Union[float, array-like]
     :return: A single boolean or array of booleans the same shape as ``time``.
-    :rtype: bool or np.array(dtype=bool)
+    :rtype: Union[bool, numpy.ndarray[bool]]
     """
     return np.asarray(time, dtype=np.float64).view(np.uint64) == np.float64(
         UNKNOWN_TIME


### PR DESCRIPTION
## Description

This creates a new documentation section for utility functions (there's only 1 documented there at the moment)

The second commit moves the "Constants" section of the API docs to a top-level section, rather than nesting it within "Trees and tree sequences", which I think is much more logical, as the constants are used in e.g. the tables API too.

Fixes #1504

