### PR TITLE
Remove _tskit module mocking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,26 +12,10 @@
 import os
 import subprocess
 import sys
-from unittest.mock import MagicMock
 
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.docfields import TypedField
-
-# It's easier not to try to build the low-level module for the
-# documentation build on readthedocs, so we mock the module. Follows
-# the recommended pattern at
-# http://docs.readthedocs.org/en/latest/faq.html
-
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-MOCK_MODULES = ["_tskit"]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 
 sys.path.insert(0, os.path.abspath("../python"))

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -481,24 +481,18 @@ Constants
 The following constants are used throughout the ``tskit`` API.
 
 .. autodata:: NULL
-    :annotation: = -1
 
 .. autodata:: NODE_IS_SAMPLE
-    :annotation: = 1
 
 .. autodata:: MISSING_DATA
-    :annotation: = -1
 
 .. autodata:: FORWARD
-    :annotation: = 1
 
 .. autodata:: REVERSE
-    :annotation: = -1
 
 .. autodata:: ALLELES_ACGT
 
 .. autodata:: UNKNOWN_TIME
-    :annotation:
 
 
 .. _sec_metadata_api:


### PR DESCRIPTION
AFAICS we don't need to do this "mocking" think any more - I can compile the docs without it, and I seem to remember someone saying that this way of doing things was deprecated now.

If we remove this, it fixes https://github.com/tskit-dev/tskit/pull/1559#issuecomment-876374053