### PR TITLE
Convert most size_t values to tsk_size_t.

### DIFF
--- a/c/tests/test_genotypes.c
+++ b/c/tests/test_genotypes.c
@@ -880,8 +880,8 @@ test_single_tree_silent_mutations_i16(void)
     tsk_flags_t options[] = { 0, TSK_16_BIT_GENOTYPES };
     tsk_id_t all_samples[] = { 0, 1, 2, 3 };
     tsk_id_t *samples[] = { NULL, all_samples };
-    size_t num_samples = 4;
-    size_t s, f;
+    tsk_size_t num_samples = 4;
+    tsk_size_t s, f;
     int ret;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL,

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -219,8 +219,8 @@ verify_genealogical_nearest_neighbours(tsk_treeseq_t *ts)
     int ret;
     const tsk_id_t *samples;
     const tsk_id_t *sample_sets[2];
-    size_t sample_set_size[2];
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t sample_set_size[2];
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *A = malloc(2 * num_samples * sizeof(double));
     CU_ASSERT_FATAL(A != NULL);
 
@@ -258,8 +258,8 @@ verify_mean_descendants(tsk_treeseq_t *ts)
     int ret;
     tsk_id_t *samples;
     const tsk_id_t *sample_sets[2];
-    size_t sample_set_size[2];
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t sample_set_size[2];
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *C = malloc(2 * tsk_treeseq_get_num_nodes(ts) * sizeof(double));
     CU_ASSERT_FATAL(C != NULL);
 
@@ -295,8 +295,8 @@ typedef struct {
 } general_stat_error_params_t;
 
 static int
-general_stat_error(
-    size_t TSK_UNUSED(K), const double *TSK_UNUSED(X), size_t M, double *Y, void *params)
+general_stat_error(tsk_size_t TSK_UNUSED(K), const double *TSK_UNUSED(X), tsk_size_t M,
+    double *Y, void *params)
 {
     int ret = 0;
     CU_ASSERT_FATAL(M == 1);
@@ -313,7 +313,7 @@ static void
 verify_window_errors(tsk_treeseq_t *ts, tsk_flags_t mode)
 {
     int ret;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *W = calloc(num_samples, sizeof(double));
     /* node mode requires this much space at least */
     double *sigma = calloc(tsk_treeseq_get_num_nodes(ts), sizeof(double));
@@ -355,7 +355,7 @@ static void
 verify_summary_func_errors(tsk_treeseq_t *ts, tsk_flags_t mode)
 {
     int ret;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *W = calloc(num_samples, sizeof(double));
     /* We need this much space for NODE mode */
     double *sigma = calloc(tsk_treeseq_get_num_nodes(ts), sizeof(double));
@@ -428,7 +428,7 @@ verify_one_way_weighted_func_errors(tsk_treeseq_t *ts, one_way_weighted_method *
     tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *weights = malloc(num_samples * sizeof(double));
     double result;
-    size_t j;
+    tsk_size_t j;
 
     for (j = 0; j < num_samples; j++) {
         weights[j] = 1.0;
@@ -451,7 +451,7 @@ verify_one_way_weighted_covariate_func_errors(
     double *weights = malloc(num_samples * sizeof(double));
     double *covariates = NULL;
     double result;
-    size_t j;
+    tsk_size_t j;
 
     for (j = 0; j < num_samples; j++) {
         weights[j] = 1.0;
@@ -615,9 +615,9 @@ verify_four_way_stat_func_errors(tsk_treeseq_t *ts, general_sample_stat_method *
 
 static int
 general_stat_identity(
-    size_t K, const double *restrict X, size_t M, double *Y, void *params)
+    tsk_size_t K, const double *restrict X, tsk_size_t M, double *Y, void *params)
 {
-    size_t k;
+    tsk_size_t k;
     CU_ASSERT_FATAL(M == K);
     CU_ASSERT_FATAL(params == NULL);
 
@@ -633,7 +633,7 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
     CU_ASSERT_FATAL(ts != NULL);
 
     int ret;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *W = malloc(num_samples * sizeof(double));
     tsk_id_t *stack = malloc(tsk_treeseq_get_num_nodes(ts) * sizeof(*stack));
     tsk_id_t root, u, v;
@@ -641,7 +641,7 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
     double s, branch_length;
     double *sigma = malloc(tsk_treeseq_get_num_trees(ts) * sizeof(*sigma));
     tsk_tree_t tree;
-    size_t j;
+    tsk_size_t j;
     CU_ASSERT_FATAL(W != NULL);
     CU_ASSERT_FATAL(stack != NULL);
 
@@ -688,9 +688,10 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
 }
 
 static int
-general_stat_sum(size_t K, const double *restrict X, size_t M, double *Y, void *params)
+general_stat_sum(
+    tsk_size_t K, const double *restrict X, tsk_size_t M, double *Y, void *params)
 {
-    size_t k, m;
+    tsk_size_t k, m;
     double s = 0;
     CU_ASSERT_FATAL(params == NULL);
 
@@ -705,14 +706,15 @@ general_stat_sum(size_t K, const double *restrict X, size_t M, double *Y, void *
 }
 
 static void
-verify_general_stat_dims(tsk_treeseq_t *ts, size_t K, size_t M, tsk_flags_t options)
+verify_general_stat_dims(
+    tsk_treeseq_t *ts, tsk_size_t K, tsk_size_t M, tsk_flags_t options)
 {
     int ret;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *W = malloc(K * num_samples * sizeof(double));
     /* We need this much space for NODE mode; no harm for other modes. */
     double *sigma = calloc(tsk_treeseq_get_num_nodes(ts) * M, sizeof(double));
-    size_t j, k;
+    tsk_size_t j, k;
     CU_ASSERT_FATAL(W != NULL);
 
     for (j = 0; j < num_samples; j++) {
@@ -729,18 +731,19 @@ verify_general_stat_dims(tsk_treeseq_t *ts, size_t K, size_t M, tsk_flags_t opti
 }
 
 static void
-verify_general_stat_windows(tsk_treeseq_t *ts, size_t num_windows, tsk_flags_t options)
+verify_general_stat_windows(
+    tsk_treeseq_t *ts, tsk_size_t num_windows, tsk_flags_t options)
 {
     int ret;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *W = malloc(num_samples * sizeof(double));
-    size_t M = 5;
+    tsk_size_t M = 5;
     /* We need this much space for NODE mode; no harm for other modes. */
     double *sigma
         = calloc(M * tsk_treeseq_get_num_nodes(ts) * num_windows, sizeof(double));
     double *windows = malloc((num_windows + 1) * sizeof(*windows));
     double L = tsk_treeseq_get_sequence_length(ts);
-    size_t j;
+    tsk_size_t j;
     CU_ASSERT_FATAL(W != NULL);
     CU_ASSERT_FATAL(sigma != NULL);
     CU_ASSERT_FATAL(windows != NULL);
@@ -766,12 +769,12 @@ static void
 verify_default_general_stat(tsk_treeseq_t *ts)
 {
     int ret;
-    size_t K = 2;
-    size_t M = 1;
-    size_t num_samples = tsk_treeseq_get_num_samples(ts);
+    tsk_size_t K = 2;
+    tsk_size_t M = 1;
+    tsk_size_t num_samples = tsk_treeseq_get_num_samples(ts);
     double *W = malloc(K * num_samples * sizeof(double));
     double sigma1, sigma2;
-    size_t j, k;
+    tsk_size_t j, k;
     CU_ASSERT_FATAL(W != NULL);
 
     for (j = 0; j < num_samples; j++) {
@@ -1121,7 +1124,7 @@ test_paper_ex_trait_covariance(void)
     tsk_treeseq_t ts;
     double result;
     double *weights;
-    size_t j;
+    tsk_size_t j;
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -692,7 +692,7 @@ static void
 verify_sample_counts(tsk_treeseq_t *ts, size_t num_tests, sample_count_test_t *tests)
 {
     int ret;
-    size_t j, num_samples, n, k;
+    tsk_size_t j, num_samples, n, k;
     tsk_id_t stop, sample_index;
     tsk_tree_t tree;
     const tsk_id_t *samples;
@@ -820,7 +820,7 @@ verify_sample_sets_for_tree(tsk_tree_t *tree)
 {
     int ret, stack_top, j;
     tsk_id_t u, v;
-    size_t tmp, n, num_nodes, num_samples;
+    tsk_size_t tmp, n, num_nodes, num_samples;
     tsk_id_t *stack, *samples;
     const tsk_treeseq_t *ts = tree->tree_sequence;
     tsk_id_t *sample_index_map = ts->sample_index_map;
@@ -3604,8 +3604,8 @@ test_single_tree_iter(void)
     tsk_treeseq_t ts;
     tsk_tree_t tree;
     tsk_id_t u, v, w;
-    size_t num_samples;
-    uint32_t num_nodes = 7;
+    tsk_size_t num_samples;
+    tsk_size_t num_nodes = 7;
 
     tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
@@ -3666,9 +3666,9 @@ test_single_nonbinary_tree_iter(void)
     tsk_treeseq_t ts;
     tsk_tree_t tree;
     tsk_id_t u, v, w;
-    size_t num_samples;
-    size_t num_nodes = 10;
-    size_t total_samples = 7;
+    tsk_size_t num_samples;
+    tsk_size_t num_nodes = 10;
+    tsk_size_t total_samples = 7;
 
     tsk_treeseq_from_text(&ts, 1, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     ret = tsk_tree_init(&tree, &ts, 0);
@@ -3755,8 +3755,8 @@ test_single_tree_general_samples_iter(void)
     tsk_treeseq_t ts;
     tsk_tree_t tree;
     tsk_id_t u, v, w;
-    size_t num_samples;
-    uint32_t num_nodes = 7;
+    tsk_size_t num_samples;
+    tsk_size_t num_nodes = 7;
 
     tsk_treeseq_from_text(&ts, 6, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
     samples = tsk_treeseq_get_samples(&ts);
@@ -5575,8 +5575,8 @@ test_genealogical_nearest_neighbours_errors(void)
     const tsk_id_t *reference_sets[2];
     tsk_id_t reference_set_0[4], reference_set_1[4];
     tsk_id_t focal[] = { 0, 1, 2, 3 };
-    size_t reference_set_size[2];
-    size_t num_focal = 4;
+    tsk_size_t reference_set_size[2];
+    tsk_size_t num_focal = 4;
     double *A = malloc(2 * num_focal * sizeof(double));
     CU_ASSERT_FATAL(A != NULL);
 

--- a/c/tskit/convert.c
+++ b/c/tskit/convert.c
@@ -42,7 +42,7 @@
  * pointless. */
 
 typedef struct {
-    size_t precision;
+    unsigned int precision;
     tsk_flags_t options;
     char *newick;
     tsk_id_t *traversal_stack;
@@ -145,7 +145,7 @@ out:
 
 static int
 tsk_newick_converter_init(tsk_newick_converter_t *self, const tsk_tree_t *tree,
-    size_t precision, tsk_flags_t options)
+    unsigned int precision, tsk_flags_t options)
 {
     int ret = 0;
 
@@ -171,7 +171,7 @@ tsk_newick_converter_free(tsk_newick_converter_t *self)
 }
 
 int
-tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
+tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, unsigned int precision,
     tsk_flags_t options, size_t buffer_size, char *buffer)
 {
     int ret = 0;

--- a/c/tskit/convert.h
+++ b/c/tskit/convert.h
@@ -32,7 +32,7 @@ extern "C" {
 
 #include <tskit/trees.h>
 
-int tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
+int tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, unsigned int precision,
     tsk_flags_t options, size_t buffer_size, char *buffer);
 
 #ifdef __cplusplus

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -648,8 +648,8 @@ tsk_blkalloc_free(tsk_blkalloc_t *self)
 
 /* Mirrors the semantics of numpy's searchsorted function. Uses binary
  * search to find the index of the closest value in the array. */
-size_t
-tsk_search_sorted(const double *restrict array, size_t size, double value)
+tsk_size_t
+tsk_search_sorted(const double *restrict array, tsk_size_t size, double value)
 {
     int64_t upper = (int64_t) size;
     int64_t lower = 0;
@@ -669,7 +669,7 @@ tsk_search_sorted(const double *restrict array, size_t size, double value)
         }
     }
     offset = (int64_t)(array[lower] < value);
-    return (size_t)(lower + offset);
+    return (tsk_size_t)(lower + offset);
 }
 
 /* Rounds the specified double to the closest multiple of 10**-num_digits. If

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -109,6 +109,66 @@ __tsk_nan_f(void)
 }
 #define TSK_UNKNOWN_TIME __tsk_nan_f()
 
+/**
+@brief Tskit Object IDs.
+
+@rst
+All objects in tskit are referred to by integer IDs corresponding to the
+row they occupy in the relevant table. The ``tsk_id_t`` type should be used
+when manipulating these ID values. The reserved value ``TSK_NULL`` (-1) defines
+missing data.
+@endrst
+*/
+#ifdef _TSK_BIG_TABLES
+/* Allow tables to have more than 2^31 rows. This is an EXPERIMENTAL feature
+ * and is not supported in any way. This typedef is only included for
+ * future-proofing purposes, so that we can be sure that we don't make any
+ * design decisions that are incompatible with big tables by building the
+ * library in 64 bit mode in CI. See the discussion here for more background:
+
+ * https://github.com/tskit-dev/tskit/issues/343
+ *
+ * If you need big tables, please open an issue on GitHub to discuss, or comment
+ * on the thread above.
+ */
+typedef int64_t tsk_id_t;
+#define TSK_MAX_ID INT64_MAX
+#define TSK_ID_STORAGE_TYPE KAS_INT64
+#else
+typedef int32_t tsk_id_t;
+#define TSK_MAX_ID INT32_MAX
+#define TSK_ID_STORAGE_TYPE KAS_INT32
+#endif
+
+/**
+@brief Tskit sizes.
+
+@rst
+The ``tsk_size_t`` type is an unsigned integer used for any size or count value.
+@endrst
+*/
+#ifdef _TSK_BIG_TABLES
+/* TODO get rid of this typdef once we move to 64 bit sizes */
+typedef uint64_t tsk_size_t;
+#define TSK_MAX_SIZE UINT64_MAX
+#define TSK_SIZE_STORAGE_TYPE KAS_UINT64
+#else
+typedef uint32_t tsk_size_t;
+#define TSK_MAX_SIZE UINT32_MAX
+#define TSK_SIZE_STORAGE_TYPE KAS_UINT32
+#endif
+
+/**
+@brief Container for bitwise flags.
+
+@rst
+Bitwise flags are used in tskit as a column type and also as a way to
+specify options to API functions.
+@endrst
+*/
+typedef uint32_t tsk_flags_t;
+#define TSK_FLAGS_STORAGE_TYPE KAS_UINT32
+
 // clang-format off
 /**
 @defgroup API_VERSION_GROUP API version macros.
@@ -409,7 +469,7 @@ extern int tsk_blkalloc_init(tsk_blkalloc_t *self, size_t chunk_size);
 extern void *tsk_blkalloc_get(tsk_blkalloc_t *self, size_t size);
 extern void tsk_blkalloc_free(tsk_blkalloc_t *self);
 
-size_t tsk_search_sorted(const double *array, size_t size, double value);
+tsk_size_t tsk_search_sorted(const double *array, tsk_size_t size, double value);
 double tsk_round(double x, unsigned int ndigits);
 
 bool tsk_is_unknown_time(double val);

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -106,12 +106,12 @@ out:
 
 static int
 vargen_init_samples_and_index_map(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
-    const tsk_id_t *samples, size_t num_samples, size_t num_samples_alloc,
+    const tsk_id_t *samples, tsk_size_t num_samples, size_t num_samples_alloc,
     tsk_flags_t options)
 {
     int ret = 0;
     const tsk_flags_t *flags = tree_sequence->tables->nodes.flags;
-    size_t j, num_nodes;
+    tsk_size_t j, num_nodes;
     bool impute_missing = !!(options & TSK_ISOLATED_NOT_MISSING);
     tsk_id_t u;
 
@@ -149,12 +149,12 @@ out:
 
 int
 tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
-    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    const tsk_id_t *samples, tsk_size_t num_samples, const char **alleles,
     tsk_flags_t options)
 {
     int ret = TSK_ERR_NO_MEMORY;
     tsk_flags_t tree_options;
-    size_t num_samples_alloc, max_alleles_limit;
+    tsk_size_t num_samples_alloc, max_alleles_limit;
     tsk_size_t max_alleles;
 
     tsk_bug_assert(tree_sequence != NULL);

--- a/c/tskit/genotypes.h
+++ b/c/tskit/genotypes.h
@@ -49,14 +49,14 @@ typedef struct {
 } tsk_variant_t;
 
 typedef struct {
-    size_t num_samples;
-    size_t num_sites;
+    tsk_size_t num_samples;
+    tsk_size_t num_sites;
     const tsk_treeseq_t *tree_sequence;
     const tsk_id_t *samples;          /* samples being used */
     const tsk_id_t *sample_index_map; /* reverse index map being used */
     bool user_alleles;
     char *user_alleles_mem;
-    size_t tree_site_index;
+    tsk_size_t tree_site_index;
     int finished;
     tsk_id_t *traversal_stack;
     tsk_tree_t tree;
@@ -68,7 +68,7 @@ typedef struct {
 } tsk_vargen_t;
 
 int tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
-    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    const tsk_id_t *samples, tsk_size_t num_samples, const char **alleles,
     tsk_flags_t options);
 int tsk_vargen_next(tsk_vargen_t *self, tsk_variant_t **variant);
 int tsk_vargen_free(tsk_vargen_t *self);

--- a/c/tskit/haplotype_matching.c
+++ b/c/tskit/haplotype_matching.c
@@ -268,7 +268,7 @@ tsk_ls_hmm_remove_dead_roots(tsk_ls_hmm_t *self)
     const tsk_id_t left_root = self->tree.left_root;
     const tsk_id_t *restrict parent = self->parent;
     tsk_id_t root, u;
-    size_t j;
+    tsk_size_t j;
     const tsk_id_t root_marker = -2;
 
     for (root = left_root; root != TSK_NULL; root = right_sib[root]) {
@@ -364,7 +364,7 @@ out:
 
 static int
 tsk_ls_hmm_get_allele_index(tsk_ls_hmm_t *self, tsk_id_t site, const char *allele_state,
-    const size_t allele_length)
+    const tsk_size_t allele_length)
 {
     int ret = TSK_ERR_ALLELE_NOT_FOUND;
     const char **alleles = self->alleles[site];
@@ -469,7 +469,7 @@ tsk_ls_hmm_discretise_values(tsk_ls_hmm_t *self)
     int ret = 0;
     tsk_value_transition_t *T = self->transitions;
     double *values = self->values;
-    size_t j, k, num_values;
+    tsk_size_t j, k, num_values;
 
     num_values = 0;
     for (j = 0; j < self->num_transitions; j++) {
@@ -539,7 +539,7 @@ bit_is_set(uint64_t value, uint8_t bit)
 }
 
 static inline tsk_id_t
-get_smallest_element(const uint64_t *restrict A, size_t u, size_t num_words)
+get_smallest_element(const uint64_t *restrict A, tsk_size_t u, tsk_size_t num_words)
 {
     size_t base = (size_t) u * num_words;
     const uint64_t *restrict a = A + base;
@@ -738,9 +738,9 @@ tsk_ls_hmm_build_optimal_value_sets(tsk_ls_hmm_t *self)
     const tsk_value_transition_t *restrict T = self->transitions;
     const tsk_id_t *restrict T_index = self->transition_index;
     tsk_argsort_t *restrict order = self->transition_time_order;
-    const size_t num_optimal_value_set_words = self->num_optimal_value_set_words;
+    const tsk_size_t num_optimal_value_set_words = self->num_optimal_value_set_words;
     uint64_t *restrict A = self->optimal_value_sets;
-    size_t j;
+    tsk_size_t j;
     tsk_id_t u, v, state, parent_state;
 
     /* argsort the transitions by node time so we can visit them in the
@@ -798,11 +798,11 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
     tsk_value_transition_t *restrict T_old = self->transitions_copy;
     tsk_transition_stack_t *stack = self->transition_stack;
     uint64_t *restrict A = self->optimal_value_sets;
-    const size_t num_optimal_value_set_words = self->num_optimal_value_set_words;
+    const tsk_size_t num_optimal_value_set_words = self->num_optimal_value_set_words;
     tsk_transition_stack_t s, child_s;
     tsk_id_t root, u, v;
     int stack_top = 0;
-    size_t j, old_num_transitions;
+    tsk_size_t j, old_num_transitions;
 
     memcpy(T_old, T, self->num_transitions * sizeof(*T));
     old_num_transitions = self->num_transitions;
@@ -812,7 +812,7 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
         stack[0].tree_node = root;
         stack[0].old_state = T_old[T_index[root]].value_index;
         stack[0].new_state
-            = get_smallest_element(A, (size_t) root, num_optimal_value_set_words);
+            = get_smallest_element(A, (tsk_size_t) root, num_optimal_value_set_words);
         stack[0].transition_parent = 0;
         stack_top = 0;
 
@@ -831,11 +831,11 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
                 if (T_index[v] != TSK_NULL) {
                     child_s.old_state = T_old[T_index[v]].value_index;
                 }
-                if (!all_zero(A, (size_t) v, num_optimal_value_set_words)) {
-                    if (!element_in(
-                            A, (size_t) v, s.new_state, num_optimal_value_set_words)) {
+                if (!all_zero(A, (tsk_size_t) v, num_optimal_value_set_words)) {
+                    if (!element_in(A, (tsk_size_t) v, s.new_state,
+                            num_optimal_value_set_words)) {
                         child_s.new_state = get_smallest_element(
-                            A, (size_t) v, num_optimal_value_set_words);
+                            A, (tsk_size_t) v, num_optimal_value_set_words);
                         child_s.transition_parent = (tsk_id_t) self->num_transitions;
                         /* Add a new transition */
                         tsk_bug_assert(self->num_transitions < self->max_transitions);
@@ -865,9 +865,9 @@ tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
         u = T_old[j].tree_node;
         if (u != TSK_NULL) {
             T_index[u] = TSK_NULL;
-            while (
-                u != TSK_NULL && !all_zero(A, (size_t) u, num_optimal_value_set_words)) {
-                memset(A + ((size_t) u) * num_optimal_value_set_words, 0,
+            while (u != TSK_NULL
+                   && !all_zero(A, (tsk_size_t) u, num_optimal_value_set_words)) {
+                memset(A + ((tsk_size_t) u) * num_optimal_value_set_words, 0,
                     num_optimal_value_set_words * sizeof(uint64_t));
                 u = parent[u];
             }
@@ -1164,10 +1164,10 @@ out:
 
 int
 tsk_compressed_matrix_init(tsk_compressed_matrix_t *self, tsk_treeseq_t *tree_sequence,
-    size_t block_size, tsk_flags_t options)
+    tsk_size_t block_size, tsk_flags_t options)
 {
     int ret = 0;
-    size_t num_sites;
+    tsk_size_t num_sites;
 
     memset(self, 0, sizeof(*self));
     self->tree_sequence = tree_sequence;
@@ -1336,7 +1336,7 @@ tsk_compressed_matrix_decode(tsk_compressed_matrix_t *self, double *values)
         }
         for (j = 0; j < num_tree_sites; j++) {
             site_id = sites[j].id;
-            site_array = values + ((size_t) site_id) * self->num_samples;
+            site_array = values + ((tsk_size_t) site_id) * self->num_samples;
             if (self->num_transitions[site_id] == 0) {
                 memset(site_array, 0, self->num_samples * sizeof(site_array));
             } else {
@@ -1379,7 +1379,7 @@ out:
 
 int
 tsk_viterbi_matrix_init(tsk_viterbi_matrix_t *self, tsk_treeseq_t *tree_sequence,
-    size_t block_size, tsk_flags_t options)
+    tsk_size_t block_size, tsk_flags_t options)
 {
     int ret = 0;
 

--- a/c/tskit/haplotype_matching.h
+++ b/c/tskit/haplotype_matching.h
@@ -42,7 +42,7 @@ typedef struct {
 } tsk_value_transition_t;
 
 typedef struct {
-    size_t index;
+    tsk_size_t index;
     double value;
 } tsk_argsort_t;
 
@@ -81,8 +81,8 @@ typedef struct {
 typedef struct {
     tsk_compressed_matrix_t matrix;
     tsk_recomb_required_record *recombination_required;
-    size_t num_recomb_records;
-    size_t max_recomb_records;
+    tsk_size_t num_recomb_records;
+    tsk_size_t max_recomb_records;
 } tsk_viterbi_matrix_t;
 
 typedef struct _tsk_ls_hmm_t {
@@ -109,14 +109,14 @@ typedef struct _tsk_ls_hmm_t {
     tsk_id_t *transition_index;
     /* Buffer used to argsort the transitions by node time */
     tsk_argsort_t *transition_time_order;
-    size_t num_transitions;
-    size_t max_transitions;
+    tsk_size_t num_transitions;
+    tsk_size_t max_transitions;
     /* The distinct values in the transitions */
     double *values;
-    size_t num_values;
-    size_t max_values;
+    tsk_size_t num_values;
+    tsk_size_t max_values;
     /* Number of machine words per node optimal value set. */
-    size_t num_optimal_value_set_words;
+    tsk_size_t num_optimal_value_set_words;
     uint64_t *optimal_value_sets;
     /* The parent transition; used during compression */
     tsk_id_t *transition_parent;
@@ -144,7 +144,7 @@ int tsk_ls_hmm_run(tsk_ls_hmm_t *self, int8_t *haplotype,
     double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *), void *output);
 
 int tsk_compressed_matrix_init(tsk_compressed_matrix_t *self,
-    tsk_treeseq_t *tree_sequence, size_t block_size, tsk_flags_t options);
+    tsk_treeseq_t *tree_sequence, tsk_size_t block_size, tsk_flags_t options);
 int tsk_compressed_matrix_free(tsk_compressed_matrix_t *self);
 int tsk_compressed_matrix_clear(tsk_compressed_matrix_t *self);
 void tsk_compressed_matrix_print_state(tsk_compressed_matrix_t *self, FILE *out);
@@ -154,7 +154,7 @@ int tsk_compressed_matrix_store_site(tsk_compressed_matrix_t *self, tsk_id_t sit
 int tsk_compressed_matrix_decode(tsk_compressed_matrix_t *self, double *values);
 
 int tsk_viterbi_matrix_init(tsk_viterbi_matrix_t *self, tsk_treeseq_t *tree_sequence,
-    size_t block_size, tsk_flags_t options);
+    tsk_size_t block_size, tsk_flags_t options);
 int tsk_viterbi_matrix_free(tsk_viterbi_matrix_t *self);
 int tsk_viterbi_matrix_clear(tsk_viterbi_matrix_t *self);
 void tsk_viterbi_matrix_print_state(tsk_viterbi_matrix_t *self, FILE *out);

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -453,10 +453,10 @@ out:
 /* Checks that the specified list of offsets is well-formed. */
 static int
 check_offsets(
-    size_t num_rows, const tsk_size_t *offsets, tsk_size_t length, bool check_length)
+    tsk_size_t num_rows, const tsk_size_t *offsets, tsk_size_t length, bool check_length)
 {
     int ret = TSK_ERR_BAD_OFFSET;
-    size_t j;
+    tsk_size_t j;
 
     if (offsets[0] != 0) {
         goto out;
@@ -475,7 +475,7 @@ out:
 }
 
 static int
-expand_column(void **column, size_t new_max_rows, size_t element_size)
+expand_column(void **column, tsk_size_t new_max_rows, size_t element_size)
 {
     int ret = 0;
     void *tmp;
@@ -1721,7 +1721,7 @@ tsk_node_table_free(tsk_node_table_t *self)
 void
 tsk_node_table_print_state(const tsk_node_table_t *self, FILE *out)
 {
-    size_t j, k;
+    tsk_size_t j, k;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "tsk_node_tbl: %p:\n", (const void *) self);
@@ -1762,7 +1762,7 @@ int
 tsk_node_table_dump_text(const tsk_node_table_t *self, FILE *out)
 {
     int ret = TSK_ERR_IO;
-    size_t j;
+    tsk_size_t j;
     tsk_size_t metadata_len;
     int err;
 
@@ -1933,7 +1933,7 @@ tsk_edge_table_has_metadata(const tsk_edge_table_t *self)
 }
 
 static int
-tsk_edge_table_expand_main_columns(tsk_edge_table_t *self, size_t additional_rows)
+tsk_edge_table_expand_main_columns(tsk_edge_table_t *self, tsk_size_t additional_rows)
 {
     int ret = 0;
     tsk_size_t increment
@@ -3131,7 +3131,7 @@ tsk_site_table_set_metadata_schema(tsk_site_table_t *self, const char *metadata_
 int
 tsk_site_table_dump_text(const tsk_site_table_t *self, FILE *out)
 {
-    size_t j;
+    tsk_size_t j;
     int ret = TSK_ERR_IO;
     int err;
     tsk_size_t ancestral_state_len, metadata_len;
@@ -3239,7 +3239,7 @@ out:
 
 static int
 tsk_mutation_table_expand_main_columns(
-    tsk_mutation_table_t *self, size_t additional_rows)
+    tsk_mutation_table_t *self, tsk_size_t additional_rows)
 {
     int ret = 0;
     tsk_size_t increment
@@ -3926,7 +3926,7 @@ out:
 
 static int
 tsk_migration_table_expand_main_columns(
-    tsk_migration_table_t *self, size_t additional_rows)
+    tsk_migration_table_t *self, tsk_size_t additional_rows)
 {
     int ret = 0;
     tsk_size_t increment
@@ -4379,7 +4379,7 @@ tsk_migration_table_set_metadata_schema(tsk_migration_table_t *self,
 int
 tsk_migration_table_dump_text(const tsk_migration_table_t *self, FILE *out)
 {
-    size_t j;
+    tsk_size_t j;
     int ret = TSK_ERR_IO;
     tsk_size_t metadata_len;
     int err;
@@ -6426,19 +6426,19 @@ typedef struct {
     /* The input segments. This buffer is sorted by the algorithm and we also
      * assume that there is space for an extra element at the end */
     tsk_segment_t *segments;
-    size_t num_segments;
-    size_t index;
-    size_t num_overlapping;
+    tsk_size_t num_segments;
+    tsk_size_t index;
+    tsk_size_t num_overlapping;
     double left;
     double right;
     /* Output buffer */
-    size_t max_overlapping;
+    tsk_size_t max_overlapping;
     tsk_segment_t **overlapping;
 } segment_overlapper_t;
 
 typedef struct {
     tsk_id_t *samples;
-    size_t num_samples;
+    tsk_size_t num_samples;
     tsk_flags_t options;
     tsk_table_collection_t *tables;
     /* Keep a copy of the input tables */
@@ -6450,8 +6450,8 @@ typedef struct {
     bool *is_sample;
     /* Segments for a particular parent that are processed together */
     tsk_segment_t *segment_queue;
-    size_t segment_queue_size;
-    size_t max_segment_queue_size;
+    tsk_size_t segment_queue_size;
+    tsk_size_t max_segment_queue_size;
     segment_overlapper_t segment_overlapper;
     tsk_blkalloc_t segment_heap;
     /* Buffer for output edges. For each child we keep a linked list of
@@ -6460,7 +6460,7 @@ typedef struct {
     interval_list_t **child_edge_map_head;
     interval_list_t **child_edge_map_tail;
     tsk_id_t *buffered_children;
-    size_t num_buffered_children;
+    tsk_size_t num_buffered_children;
     /* For each mutation, map its output node. */
     tsk_id_t *mutation_node_map;
     /* Map of input mutation IDs to output mutation IDs. */
@@ -6516,7 +6516,7 @@ segment_overlapper_free(segment_overlapper_t *self)
  */
 static int TSK_WARN_UNUSED
 segment_overlapper_start(
-    segment_overlapper_t *self, tsk_segment_t *segments, size_t num_segments)
+    segment_overlapper_t *self, tsk_segment_t *segments, tsk_size_t num_segments)
 {
     int ret = 0;
     tsk_segment_t *sentinel;
@@ -6551,11 +6551,11 @@ out:
 
 static int TSK_WARN_UNUSED
 segment_overlapper_next(segment_overlapper_t *self, double *left, double *right,
-    tsk_segment_t ***overlapping, size_t *num_overlapping)
+    tsk_segment_t ***overlapping, tsk_size_t *num_overlapping)
 {
     int ret = 0;
-    size_t j, k;
-    size_t n = self->num_segments;
+    tsk_size_t j, k;
+    tsk_size_t n = self->num_segments;
     tsk_segment_t *S = self->segments;
 
     if (self->index < n) {
@@ -6629,9 +6629,9 @@ cmp_node_id(const void *a, const void *b)
  */
 typedef struct {
     tsk_id_t *samples;
-    size_t num_samples;
+    tsk_size_t num_samples;
     tsk_id_t *ancestors;
-    size_t num_ancestors;
+    tsk_size_t num_ancestors;
     tsk_table_collection_t *tables;
     tsk_edge_table_t *result;
     tsk_segment_t **ancestor_map_head;
@@ -6639,15 +6639,15 @@ typedef struct {
     bool *is_sample;
     bool *is_ancestor;
     tsk_segment_t *segment_queue;
-    size_t segment_queue_size;
-    size_t max_segment_queue_size;
+    tsk_size_t segment_queue_size;
+    tsk_size_t max_segment_queue_size;
     segment_overlapper_t segment_overlapper;
     tsk_blkalloc_t segment_heap;
     tsk_blkalloc_t interval_list_heap;
     interval_list_t **child_edge_map_head;
     interval_list_t **child_edge_map_tail;
     tsk_id_t *buffered_children;
-    size_t num_buffered_children;
+    tsk_size_t num_buffered_children;
     double sequence_length;
 } ancestor_mapper_t;
 
@@ -6687,14 +6687,14 @@ out:
 
 static int
 ancestor_mapper_flush_edges(
-    ancestor_mapper_t *self, tsk_id_t parent, size_t *ret_num_edges)
+    ancestor_mapper_t *self, tsk_id_t parent, tsk_size_t *ret_num_edges)
 {
     int ret = 0;
     tsk_id_t ret_id;
-    size_t j;
+    tsk_size_t j;
     tsk_id_t child;
     interval_list_t *x;
-    size_t num_edges = 0;
+    tsk_size_t num_edges = 0;
 
     qsort(self->buffered_children, self->num_buffered_children, sizeof(tsk_id_t),
         cmp_node_id);
@@ -6793,7 +6793,7 @@ static int
 ancestor_mapper_init_samples(ancestor_mapper_t *self, tsk_id_t *samples)
 {
     int ret = 0;
-    size_t j;
+    tsk_size_t j;
 
     /* Go through the samples to check for errors. */
     for (j = 0; j < self->num_samples; j++) {
@@ -6820,7 +6820,7 @@ static int
 ancestor_mapper_init_ancestors(ancestor_mapper_t *self, tsk_id_t *ancestors)
 {
     int ret = 0;
-    size_t j;
+    tsk_size_t j;
 
     /* Go through the samples to check for errors. */
     for (j = 0; j < self->num_ancestors; j++) {
@@ -6839,8 +6839,8 @@ out:
 }
 
 static int
-ancestor_mapper_init(ancestor_mapper_t *self, tsk_id_t *samples, size_t num_samples,
-    tsk_id_t *ancestors, size_t num_ancestors, tsk_table_collection_t *tables,
+ancestor_mapper_init(ancestor_mapper_t *self, tsk_id_t *samples, tsk_size_t num_samples,
+    tsk_id_t *ancestors, tsk_size_t num_ancestors, tsk_table_collection_t *tables,
     tsk_edge_table_t *result)
 {
     int ret = 0;
@@ -6963,7 +6963,7 @@ ancestor_mapper_merge_ancestors(ancestor_mapper_t *self, tsk_id_t input_id)
 {
     int ret = 0;
     tsk_segment_t **X, *x;
-    size_t j, num_overlapping, num_flushed_edges;
+    tsk_size_t j, num_overlapping, num_flushed_edges;
     double left, right, prev_right;
     bool is_sample = self->is_sample[input_id];
     bool is_ancestor = self->is_ancestor[input_id];
@@ -7037,10 +7037,10 @@ out:
 
 static int TSK_WARN_UNUSED
 ancestor_mapper_process_parent_edges(
-    ancestor_mapper_t *self, tsk_id_t parent, size_t start, size_t end)
+    ancestor_mapper_t *self, tsk_id_t parent, tsk_size_t start, tsk_size_t end)
 {
     int ret = 0;
-    size_t j;
+    tsk_size_t j;
     tsk_segment_t *x;
     const tsk_edge_table_t *input_edges = &self->tables->edges;
     tsk_id_t child;
@@ -7078,10 +7078,10 @@ static int TSK_WARN_UNUSED
 ancestor_mapper_run(ancestor_mapper_t *self)
 {
     int ret = 0;
-    size_t j, start;
+    tsk_size_t j, start;
     tsk_id_t parent, current_parent;
     const tsk_edge_table_t *input_edges = &self->tables->edges;
-    size_t num_edges = input_edges->num_rows;
+    tsk_size_t num_edges = input_edges->num_rows;
 
     if (num_edges > 0) {
         start = 0;
@@ -7195,7 +7195,7 @@ static int
 tsk_ibd_finder_init_samples(tsk_ibd_finder_t *self)
 {
     int ret = 0;
-    size_t j;
+    tsk_size_t j;
     tsk_id_t u;
 
     /* Go through the sample pairs to define samples. */
@@ -7225,7 +7225,7 @@ static int
 tsk_ibd_finder_index_samples(tsk_ibd_finder_t *self)
 {
     int ret = 0;
-    size_t i;
+    tsk_size_t i;
     tsk_id_t idx;
 
     self->paired_nodes_index
@@ -7267,7 +7267,7 @@ static int
 tsk_ibd_finder_build_pair_map(tsk_ibd_finder_t *self)
 {
     int ret = 0;
-    size_t i;
+    tsk_size_t i, index;
     tsk_id_t sample0, sample1;
     tsk_id_t row, col;
     size_t matrix_size = self->num_unique_nodes_in_pair * self->num_unique_nodes_in_pair;
@@ -7294,14 +7294,12 @@ tsk_ibd_finder_build_pair_map(tsk_ibd_finder_t *self)
         tsk_bug_assert(row >= 0);
         tsk_bug_assert(col >= 0);
 
-        if (self->pair_map[(size_t) row * self->num_unique_nodes_in_pair + (size_t) col]
-            != -1) {
+        index = ((tsk_size_t) row) * self->num_unique_nodes_in_pair + (tsk_size_t) col;
+        if (self->pair_map[index] != -1) {
             ret = TSK_ERR_DUPLICATE_SAMPLE_PAIRS;
             goto out;
         }
-
-        self->pair_map[(size_t) row * self->num_unique_nodes_in_pair + (size_t) col]
-            = (int64_t) i;
+        self->pair_map[index] = (int64_t) i;
     }
 
 out:
@@ -7432,7 +7430,7 @@ tsk_ibd_finder_find_sample_pair_index2(
 {
     int ret = -1;
     tsk_id_t s0, s1;
-    size_t row, col;
+    tsk_size_t row, col;
 
     s0 = self->paired_nodes_index[sample0];
     s1 = self->paired_nodes_index[sample1];
@@ -7441,8 +7439,8 @@ tsk_ibd_finder_find_sample_pair_index2(
         goto out;
     }
 
-    row = TSK_MIN((size_t) s0, (size_t) s1);
-    col = TSK_MAX((size_t) s0, (size_t) s1);
+    row = TSK_MIN((tsk_size_t) s0, (tsk_size_t) s1);
+    col = TSK_MAX((tsk_size_t) s0, (tsk_size_t) s1);
 
     ret = (int) self->pair_map[row * self->num_unique_nodes_in_pair + col];
 out:
@@ -7540,7 +7538,7 @@ out:
 void
 tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out)
 {
-    size_t j;
+    tsk_size_t j;
     tsk_segment_t *u = NULL;
 
     fprintf(out, "--ibd-finder stats--\n");
@@ -7586,10 +7584,10 @@ tsk_ibd_finder_run(tsk_ibd_finder_t *self)
 {
     const tsk_edge_table_t *input_edges = &self->tables->edges;
     int ret = 0;
-    size_t j;
+    tsk_size_t j;
     tsk_id_t u;
     tsk_id_t current_parent = -1;
-    size_t num_edges = input_edges->num_rows;
+    tsk_size_t num_edges = input_edges->num_rows;
     tsk_segment_t *seg;
     tsk_segment_t *s;
     double intvl_l, intvl_r, current_time;
@@ -7681,7 +7679,7 @@ tsk_ibd_finder_free(tsk_ibd_finder_t *self)
 static void
 simplifier_check_state(simplifier_t *self)
 {
-    size_t j, k;
+    tsk_size_t j, k;
     tsk_segment_t *u;
     mutation_id_list_t *list_node;
     tsk_id_t site;
@@ -7689,7 +7687,7 @@ simplifier_check_state(simplifier_t *self)
     tsk_id_t child;
     double position, last_position;
     bool found;
-    size_t num_intervals;
+    tsk_size_t num_intervals;
 
     for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
         tsk_bug_assert((self->ancestor_map_head[j] == NULL)
@@ -7771,7 +7769,7 @@ print_segment_chain(tsk_segment_t *head, FILE *out)
 static void
 simplifier_print_state(simplifier_t *self, FILE *out)
 {
-    size_t j;
+    tsk_size_t j;
     tsk_segment_t *u;
     mutation_id_list_t *list_node;
     interval_list_t *int_list;
@@ -7913,14 +7911,14 @@ simplifier_rewind_node(simplifier_t *self, tsk_id_t input_id, tsk_id_t output_id
 }
 
 static int
-simplifier_flush_edges(simplifier_t *self, tsk_id_t parent, size_t *ret_num_edges)
+simplifier_flush_edges(simplifier_t *self, tsk_id_t parent, tsk_size_t *ret_num_edges)
 {
     int ret = 0;
     tsk_id_t ret_id;
-    size_t j;
+    tsk_size_t j;
     tsk_id_t child;
     interval_list_t *x;
-    size_t num_edges = 0;
+    tsk_size_t num_edges = 0;
 
     qsort(self->buffered_children, self->num_buffered_children, sizeof(tsk_id_t),
         cmp_node_id);
@@ -7976,8 +7974,8 @@ static bool
 simplifier_map_reduced_coordinates(simplifier_t *self, double *left, double *right)
 {
     double *X = self->position_lookup;
-    size_t N = self->input_tables.sites.num_rows + 2;
-    size_t left_index, right_index;
+    tsk_size_t N = self->input_tables.sites.num_rows + 2;
+    tsk_size_t left_index, right_index;
     bool skip = false;
 
     left_index = tsk_search_sorted(X, N, *left);
@@ -8047,7 +8045,7 @@ simplifier_init_sites(simplifier_t *self)
     int ret = 0;
     tsk_id_t node;
     mutation_id_list_t *list_node;
-    size_t j;
+    tsk_size_t j;
 
     self->mutation_id_map
         = calloc(self->input_tables.mutations.num_rows, sizeof(tsk_id_t));
@@ -8146,7 +8144,7 @@ simplifier_init_samples(simplifier_t *self, const tsk_id_t *samples)
 {
     int ret = 0;
     tsk_id_t node_id;
-    size_t j;
+    tsk_size_t j;
 
     /* Go through the samples to check for errors. */
     for (j = 0; j < self->num_samples; j++) {
@@ -8176,7 +8174,7 @@ out:
 }
 
 static int
-simplifier_init(simplifier_t *self, const tsk_id_t *samples, size_t num_samples,
+simplifier_init(simplifier_t *self, const tsk_id_t *samples, tsk_size_t num_samples,
     tsk_table_collection_t *tables, tsk_flags_t options)
 {
     int ret = 0;
@@ -8331,7 +8329,7 @@ simplifier_merge_ancestors(simplifier_t *self, tsk_id_t input_id)
 {
     int ret = 0;
     tsk_segment_t **X, *x;
-    size_t j, num_overlapping, num_flushed_edges;
+    tsk_size_t j, num_overlapping, num_flushed_edges;
     double left, right, prev_right;
     tsk_id_t ancestry_node;
     tsk_id_t output_id = self->node_id_map[input_id];
@@ -8507,10 +8505,10 @@ out:
 
 static int TSK_WARN_UNUSED
 simplifier_process_parent_edges(
-    simplifier_t *self, tsk_id_t parent, size_t start, size_t end)
+    simplifier_t *self, tsk_id_t parent, tsk_size_t start, tsk_size_t end)
 {
     int ret = 0;
-    size_t j;
+    tsk_size_t j;
     const tsk_edge_table_t *input_edges = &self->input_tables.edges;
     tsk_id_t child;
     double left, right;
@@ -8584,8 +8582,9 @@ simplifier_output_sites(simplifier_t *self)
             for (input_mutation = site_start; input_mutation < site_end;
                  input_mutation++) {
                 if (self->mutation_id_map[input_mutation] != TSK_NULL) {
-                    tsk_bug_assert(self->tables->mutations.num_rows
-                                   == (size_t) self->mutation_id_map[input_mutation]);
+                    tsk_bug_assert(
+                        self->tables->mutations.num_rows
+                        == (tsk_size_t) self->mutation_id_map[input_mutation]);
                     mapped_node = self->mutation_node_map[input_mutation];
                     tsk_bug_assert(mapped_node != TSK_NULL);
                     mapped_parent = self->input_tables.mutations.parent[input_mutation];
@@ -8782,7 +8781,7 @@ simplifier_insert_input_roots(simplifier_t *self)
     int ret = 0;
     tsk_id_t input_id, output_id;
     tsk_segment_t *x;
-    size_t num_flushed_edges;
+    tsk_size_t num_flushed_edges;
     double youngest_root_time = DBL_MAX;
     const double *node_time = self->tables->nodes.time;
 
@@ -8827,10 +8826,10 @@ static int TSK_WARN_UNUSED
 simplifier_run(simplifier_t *self, tsk_id_t *node_map)
 {
     int ret = 0;
-    size_t j, start;
+    tsk_size_t j, start;
     tsk_id_t parent, current_parent;
     const tsk_edge_table_t *input_edges = &self->input_tables.edges;
-    size_t num_edges = input_edges->num_rows;
+    tsk_size_t num_edges = input_edges->num_rows;
 
     if (num_edges > 0) {
         start = 0;
@@ -9358,13 +9357,13 @@ static tsk_id_t TSK_WARN_UNUSED
 tsk_table_collection_check_tree_integrity(const tsk_table_collection_t *self)
 {
     tsk_id_t ret = 0;
-    size_t j, k;
+    tsk_size_t j, k;
     tsk_id_t u, site, mutation;
     double tree_left, tree_right;
     const double sequence_length = self->sequence_length;
     const tsk_id_t num_sites = (tsk_id_t) self->sites.num_rows;
     const tsk_id_t num_mutations = (tsk_id_t) self->mutations.num_rows;
-    const size_t num_edges = self->edges.num_rows;
+    const tsk_size_t num_edges = self->edges.num_rows;
     const double *restrict site_position = self->sites.position;
     const tsk_id_t *restrict mutation_site = self->mutations.site;
     const tsk_id_t *restrict mutation_node = self->mutations.node;
@@ -9727,7 +9726,7 @@ tsk_table_collection_build_index(
 {
     int ret = TSK_ERR_GENERIC;
     tsk_id_t ret_id;
-    size_t j;
+    tsk_size_t j;
     double *time = self->nodes.time;
     index_sort_t *sort_buff = NULL;
     tsk_id_t parent;
@@ -9940,7 +9939,7 @@ tsk_table_collection_read_format_data(tsk_table_collection_t *self, kastore_t *s
     }
     if (ret == 1) {
         ret = kastore_gets_int8(
-            store, "metadata", (int8_t **) &metadata, (size_t *) &metadata_length);
+            store, "metadata", (int8_t **) &metadata, &metadata_length);
         if (ret != 0) {
             ret = tsk_set_kas_error(ret);
             goto out;
@@ -10341,7 +10340,7 @@ tsk_table_collection_simplify(tsk_table_collection_t *self, const tsk_id_t *samp
         samples = local_samples;
     }
 
-    ret = simplifier_init(&simplifier, samples, (size_t) num_samples, self, options);
+    ret = simplifier_init(&simplifier, samples, num_samples, self, options);
     if (ret != 0) {
         goto out;
     }
@@ -10375,8 +10374,8 @@ tsk_table_collection_link_ancestors(tsk_table_collection_t *self, tsk_id_t *samp
         goto out;
     }
 
-    ret = ancestor_mapper_init(&ancestor_mapper, samples, (size_t) num_samples,
-        ancestors, (size_t) num_ancestors, self, result);
+    ret = ancestor_mapper_init(
+        &ancestor_mapper, samples, num_samples, ancestors, num_ancestors, self, result);
     if (ret != 0) {
         goto out;
     }
@@ -11462,7 +11461,7 @@ int TSK_WARN_UNUSED
 tsk_squash_edges(tsk_edge_t *edges, tsk_size_t num_edges, tsk_size_t *num_output_edges)
 {
     int ret = 0;
-    size_t j, k, l;
+    tsk_size_t j, k, l;
 
     if (num_edges < 2) {
         *num_output_edges = num_edges;

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -42,66 +42,6 @@ extern "C" {
 
 #include <tskit/core.h>
 
-/**
-@brief Tskit Object IDs.
-
-@rst
-All objects in tskit are referred to by integer IDs corresponding to the
-row they occupy in the relevant table. The ``tsk_id_t`` type should be used
-when manipulating these ID values. The reserved value ``TSK_NULL`` (-1) defines
-missing data.
-@endrst
-*/
-#ifdef _TSK_BIG_TABLES
-/* Allow tables to have more than 2^31 rows. This is an EXPERIMENTAL feature
- * and is not supported in any way. This typedef is only included for
- * future-proofing purposes, so that we can be sure that we don't make any
- * design decisions that are incompatible with big tables by building the
- * library in 64 bit mode in CI. See the discussion here for more background:
-
- * https://github.com/tskit-dev/tskit/issues/343
- *
- * If you need big tables, please open an issue on GitHub to discuss, or comment
- * on the thread above.
- */
-typedef int64_t tsk_id_t;
-#define TSK_MAX_ID INT64_MAX
-#define TSK_ID_STORAGE_TYPE KAS_INT64
-#else
-typedef int32_t tsk_id_t;
-#define TSK_MAX_ID INT32_MAX
-#define TSK_ID_STORAGE_TYPE KAS_INT32
-#endif
-
-/**
-@brief Tskit sizes.
-
-@rst
-Sizes in tskit are defined by the ``tsk_size_t`` type.
-@endrst
-*/
-#ifdef _TSK_BIG_TABLES
-/* TODO get rid of this typdef once we move to 64 bit sizes */
-typedef uint64_t tsk_size_t;
-#define TSK_MAX_SIZE UINT64_MAX
-#define TSK_SIZE_STORAGE_TYPE KAS_UINT64
-#else
-typedef uint32_t tsk_size_t;
-#define TSK_MAX_SIZE UINT32_MAX
-#define TSK_SIZE_STORAGE_TYPE KAS_UINT32
-#endif
-
-/**
-@brief Container for bitwise flags.
-
-@rst
-Bitwise flags are used in tskit as a column type and also as a way to
-specify options to API functions.
-@endrst
-*/
-typedef uint32_t tsk_flags_t;
-#define TSK_FLAGS_STORAGE_TYPE KAS_UINT32
-
 /****************************************************************************/
 /* Definitions for the basic objects */
 /****************************************************************************/
@@ -687,9 +627,9 @@ typedef struct _tsk_segment_t {
 
 typedef struct {
     tsk_id_t *pairs;
-    size_t num_pairs;
-    size_t num_nodes;
-    size_t num_unique_nodes_in_pair;
+    tsk_size_t num_pairs;
+    tsk_size_t num_nodes;
+    tsk_size_t num_unique_nodes_in_pair;
     int64_t *pair_map;
     double sequence_length;
     tsk_table_collection_t *tables;
@@ -703,8 +643,8 @@ typedef struct {
     tsk_segment_t **ancestor_map_head;
     tsk_segment_t **ancestor_map_tail;
     tsk_segment_t *segment_queue;
-    size_t segment_queue_size;
-    size_t max_segment_queue_size;
+    tsk_size_t segment_queue_size;
+    tsk_size_t max_segment_queue_size;
 } tsk_ibd_finder_t;
 
 /****************************************************************************/

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -168,6 +168,7 @@ typedef struct {
      * from a specific subset. By default sample counts are tracked and roots
      * maintained. If TSK_NO_SAMPLE_COUNTS is specified, then neither sample
      * counts or roots are available. */
+    /* TODO should these be tsk_size_t values? */
     tsk_id_t *num_samples;
     tsk_id_t *num_tracked_samples;
     /* TODO the only place this feature seems to be used is in the ld_calculator.
@@ -282,20 +283,18 @@ int tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *othe
     double lambda_, double *result);
 
 int tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
-    const tsk_id_t *focal, size_t num_focal, const tsk_id_t *const *reference_sets,
-    const size_t *reference_set_size, size_t num_reference_sets, tsk_flags_t options,
-    double *ret_array);
+    const tsk_id_t *focal, tsk_size_t num_focal, const tsk_id_t *const *reference_sets,
+    const tsk_size_t *reference_set_size, tsk_size_t num_reference_sets,
+    tsk_flags_t options, double *ret_array);
 int tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
-    const tsk_id_t *const *reference_sets, const size_t *reference_set_size,
-    size_t num_reference_sets, tsk_flags_t options, double *ret_array);
+    const tsk_id_t *const *reference_sets, const tsk_size_t *reference_set_size,
+    tsk_size_t num_reference_sets, tsk_flags_t options, double *ret_array);
 
-/* TODO change all these size_t's to tsk_size_t */
+typedef int general_stat_func_t(tsk_size_t state_dim, const double *state,
+    tsk_size_t result_dim, double *result, void *params);
 
-typedef int general_stat_func_t(size_t state_dim, const double *state, size_t result_dim,
-    double *result, void *params);
-
-int tsk_treeseq_general_stat(const tsk_treeseq_t *self, size_t K, const double *W,
-    size_t M, general_stat_func_t *f, void *f_params, size_t num_windows,
+int tsk_treeseq_general_stat(const tsk_treeseq_t *self, tsk_size_t K, const double *W,
+    tsk_size_t M, general_stat_func_t *f, void *f_params, tsk_size_t num_windows,
     const double *windows, double *sigma, tsk_flags_t options);
 
 /* One way weighted stats */
@@ -418,16 +417,17 @@ bool tsk_tree_is_sample(const tsk_tree_t *self, tsk_id_t u);
 
 int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options);
 int tsk_tree_set_tracked_samples(
-    tsk_tree_t *self, size_t num_tracked_samples, const tsk_id_t *tracked_samples);
+    tsk_tree_t *self, tsk_size_t num_tracked_samples, const tsk_id_t *tracked_samples);
 int tsk_tree_set_tracked_samples_from_sample_list(
     tsk_tree_t *self, tsk_tree_t *other, tsk_id_t node);
 
 int tsk_tree_get_parent(const tsk_tree_t *self, tsk_id_t u, tsk_id_t *parent);
 int tsk_tree_get_time(const tsk_tree_t *self, tsk_id_t u, double *t);
 int tsk_tree_get_mrca(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca);
-int tsk_tree_get_num_samples(const tsk_tree_t *self, tsk_id_t u, size_t *num_samples);
+int tsk_tree_get_num_samples(
+    const tsk_tree_t *self, tsk_id_t u, tsk_size_t *num_samples);
 int tsk_tree_get_num_tracked_samples(
-    const tsk_tree_t *self, tsk_id_t u, size_t *num_tracked_samples);
+    const tsk_tree_t *self, tsk_id_t u, tsk_size_t *num_tracked_samples);
 int tsk_tree_get_sites(
     const tsk_tree_t *self, const tsk_site_t **sites, tsk_size_t *sites_length);
 int tsk_tree_depth(const tsk_tree_t *self, tsk_id_t u, tsk_size_t *depth);

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -235,9 +235,9 @@ Then, continuing from above:
 
 3. Fetch the pull request, and store it as a local branch.
    For instance, to name the local branch ``my_pr_copy``::
-    
+
        $ git fetch upstream pull/854/head:my_pr_copy
-   
+
    You should probably call the branch something more descriptive,
    though. (Also note that you might need to put ``origin`` instead
    of ``upstream`` for the remote repository name: see ``git remote -v``
@@ -826,8 +826,10 @@ Type conventions
 ----------------
 
 - ``tsk_id_t`` is an ID for any entity in a table.
-- ``tsk_size_t`` refers to the size of a table or entity that can be stored in a table.
-- ``size_t`` is an OS size, e.g. the result of ``sizeof``.
+- ``tsk_size_t`` refers to any size or count values in tskit.
+- ``size_t`` is a standard C type and refers to the size of a memory block.
+  This should only be used when computing memory block sizes for functions
+  like ``malloc`` or passing the size of a memory buffer as a parameter.
 - Error indicators (the return type of most functions) are ``int``.
 - ``uint32_t`` etc should be avoided (any that exist are a leftover from older
   code that didn't use ``tsk_size_t`` etc.)
@@ -1096,7 +1098,7 @@ uninstalling and reinstalling the pre-commit hooks fixed the problem:
    > git commit -a -m 'wrote the docs'
    [main 79b81ff] fixed all the things
     1 file changed, 42 insertions(+)
-      
+
 
 ***********************
 Releasing a new version

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2020 Tskit Developers
+ * Copyright (c) 2019-2021 Tskit Developers
  * Copyright (c) 2015-2018 University of Oxford
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -237,12 +237,12 @@ handle_library_error(int err)
 }
 
 static PyObject *
-convert_node_id_list(tsk_id_t *children, size_t num_children)
+convert_node_id_list(tsk_id_t *children, tsk_size_t num_children)
 {
     PyObject *ret = NULL;
     PyObject *t;
     PyObject *py_int;
-    size_t j;
+    tsk_size_t j;
 
     t = PyTuple_New(num_children);
     if (t == NULL) {
@@ -287,12 +287,12 @@ out:
 }
 
 static PyObject *
-make_mutation_id_list(const tsk_mutation_t *mutations, size_t length)
+make_mutation_id_list(const tsk_mutation_t *mutations, tsk_size_t length)
 {
     PyObject *ret = NULL;
     PyObject *t;
     PyObject *item;
-    size_t j;
+    tsk_size_t j;
 
     t = PyTuple_New(length);
     if (t == NULL) {
@@ -498,7 +498,7 @@ make_alleles(tsk_variant_t *variant)
 {
     PyObject *ret = NULL;
     PyObject *item, *t;
-    size_t j;
+    tsk_size_t j;
 
     t = PyTuple_New(variant->num_alleles + variant->has_missing_data);
     if (t == NULL) {
@@ -526,7 +526,7 @@ out:
 }
 
 static PyObject *
-make_variant(tsk_variant_t *variant, size_t num_samples)
+make_variant(tsk_variant_t *variant, tsk_size_t num_samples)
 {
     PyObject *ret = NULL;
     npy_intp dims = num_samples;
@@ -547,12 +547,12 @@ out:
 }
 
 static PyObject *
-convert_sites(const tsk_site_t *sites, size_t num_sites)
+convert_sites(const tsk_site_t *sites, tsk_size_t num_sites)
 {
     PyObject *ret = NULL;
     PyObject *l = NULL;
     PyObject *py_site = NULL;
-    size_t j;
+    tsk_size_t j;
 
     l = PyList_New(num_sites);
     if (l == NULL) {
@@ -572,12 +572,12 @@ out:
 }
 
 static PyObject *
-convert_transitions(tsk_state_transition_t *transitions, size_t num_transitions)
+convert_transitions(tsk_state_transition_t *transitions, tsk_size_t num_transitions)
 {
     PyObject *ret = NULL;
     PyObject *l = NULL;
     PyObject *py_transition = NULL;
-    size_t j;
+    tsk_size_t j;
 
     l = PyList_New(num_transitions);
     if (l == NULL) {
@@ -604,7 +604,7 @@ convert_compressed_matrix_site(tsk_compressed_matrix_t *matrix, unsigned int sit
     PyObject *ret = NULL;
     PyObject *list = NULL;
     PyObject *item = NULL;
-    size_t j, num_values;
+    tsk_size_t j, num_values;
 
     if (site >= matrix->num_sites) {
         PyErr_SetString(PyExc_ValueError, "Site index out of bounds");
@@ -710,7 +710,8 @@ out:
 }
 
 static PyObject *
-table_get_column_array(size_t num_rows, void *data, int npy_type, size_t element_size)
+table_get_column_array(
+    tsk_size_t num_rows, void *data, int npy_type, size_t element_size)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
@@ -5269,7 +5270,7 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     PyArrayObject *samples_array = NULL;
     PyArrayObject *node_map_array = NULL;
     npy_intp *shape, dims;
-    size_t num_samples;
+    tsk_size_t num_samples;
     tsk_flags_t options = 0;
     int filter_sites = true;
     int filter_individuals = false;
@@ -5297,7 +5298,7 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
         goto out;
     }
     shape = PyArray_DIMS(samples_array);
-    num_samples = shape[0];
+    num_samples = (tsk_size_t) shape[0];
     if (filter_sites) {
         options |= TSK_FILTER_SITES;
     }
@@ -5350,7 +5351,7 @@ TableCollection_link_ancestors(TableCollection *self, PyObject *args, PyObject *
     PyArrayObject *samples_array = NULL;
     PyArrayObject *ancestors_array = NULL;
     npy_intp *shape;
-    size_t num_samples, num_ancestors;
+    tsk_size_t num_samples, num_ancestors;
     static char *kwlist[] = { "samples", "ancestors", NULL };
     EdgeTable *result = NULL;
     PyObject *result_args = NULL;
@@ -5368,7 +5369,7 @@ TableCollection_link_ancestors(TableCollection *self, PyObject *args, PyObject *
         goto out;
     }
     shape = PyArray_DIMS(samples_array);
-    num_samples = shape[0];
+    num_samples = (tsk_size_t) shape[0];
 
     ancestors_array = (PyArrayObject *) PyArray_FROMANY(
         ancestors, NPY_INT32, 1, 1, NPY_ARRAY_IN_ARRAY);
@@ -5376,7 +5377,7 @@ TableCollection_link_ancestors(TableCollection *self, PyObject *args, PyObject *
         goto out;
     }
     shape = PyArray_DIMS(ancestors_array);
-    num_ancestors = shape[0];
+    num_ancestors = (tsk_size_t) shape[0];
 
     result_args = PyTuple_New(0);
     if (result_args == NULL) {
@@ -5413,7 +5414,7 @@ TableCollection_subset(TableCollection *self, PyObject *args, PyObject *kwds)
     tsk_flags_t options = 0;
     int reorder_populations = true;
     int remove_unreferenced = true;
-    size_t num_nodes;
+    tsk_size_t num_nodes;
     static char *kwlist[]
         = { "nodes", "reorder_populations", "remove_unreferenced", NULL };
 
@@ -5430,7 +5431,7 @@ TableCollection_subset(TableCollection *self, PyObject *args, PyObject *kwds)
         goto out;
     }
     shape = PyArray_DIMS(nodes_array);
-    num_nodes = shape[0];
+    num_nodes = (tsk_size_t) shape[0];
     if (!reorder_populations) {
         options |= TSK_NO_CHANGE_POPULATIONS;
     }
@@ -6377,7 +6378,7 @@ TreeSequence_get_node(TreeSequence *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "record index out of bounds");
         goto out;
     }
-    err = tsk_treeseq_get_node(self->tree_sequence, (size_t) record_index, &record);
+    err = tsk_treeseq_get_node(self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6406,7 +6407,7 @@ TreeSequence_get_edge(TreeSequence *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "record index out of bounds");
         goto out;
     }
-    err = tsk_treeseq_get_edge(self->tree_sequence, (size_t) record_index, &record);
+    err = tsk_treeseq_get_edge(self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6435,7 +6436,8 @@ TreeSequence_get_migration(TreeSequence *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "record index out of bounds");
         goto out;
     }
-    err = tsk_treeseq_get_migration(self->tree_sequence, (size_t) record_index, &record);
+    err = tsk_treeseq_get_migration(
+        self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6509,7 +6511,7 @@ TreeSequence_get_table_metadata_schemas(TreeSequence *self)
     PyObject *ret = NULL;
     PyObject *value = NULL;
     PyObject *schema = NULL;
-    size_t j;
+    tsk_size_t j;
     tsk_table_collection_t *tables;
     struct schema_pair {
         const char *schema;
@@ -6570,7 +6572,8 @@ TreeSequence_get_mutation(TreeSequence *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "record index out of bounds");
         goto out;
     }
-    err = tsk_treeseq_get_mutation(self->tree_sequence, (size_t) record_index, &record);
+    err = tsk_treeseq_get_mutation(
+        self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6600,7 +6603,7 @@ TreeSequence_get_individual(TreeSequence *self, PyObject *args)
         goto out;
     }
     err = tsk_treeseq_get_individual(
-        self->tree_sequence, (size_t) record_index, &record);
+        self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6630,7 +6633,7 @@ TreeSequence_get_population(TreeSequence *self, PyObject *args)
         goto out;
     }
     err = tsk_treeseq_get_population(
-        self->tree_sequence, (size_t) record_index, &record);
+        self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6660,7 +6663,7 @@ TreeSequence_get_provenance(TreeSequence *self, PyObject *args)
         goto out;
     }
     err = tsk_treeseq_get_provenance(
-        self->tree_sequence, (size_t) record_index, &record);
+        self->tree_sequence, (tsk_id_t) record_index, &record);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6674,7 +6677,7 @@ static PyObject *
 TreeSequence_get_num_edges(TreeSequence *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_records;
+    tsk_size_t num_records;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6689,7 +6692,7 @@ static PyObject *
 TreeSequence_get_num_migrations(TreeSequence *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_records;
+    tsk_size_t num_records;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6704,7 +6707,7 @@ static PyObject *
 TreeSequence_get_num_individuals(TreeSequence *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_records;
+    tsk_size_t num_records;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6719,7 +6722,7 @@ static PyObject *
 TreeSequence_get_num_populations(TreeSequence *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_records;
+    tsk_size_t num_records;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6734,7 +6737,7 @@ static PyObject *
 TreeSequence_get_num_trees(TreeSequence *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_trees;
+    tsk_size_t num_trees;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6800,7 +6803,7 @@ static PyObject *
 TreeSequence_get_num_samples(TreeSequence *self)
 {
     PyObject *ret = NULL;
-    size_t num_samples;
+    tsk_size_t num_samples;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6815,7 +6818,7 @@ static PyObject *
 TreeSequence_get_num_nodes(TreeSequence *self)
 {
     PyObject *ret = NULL;
-    size_t num_nodes;
+    tsk_size_t num_nodes;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -6862,16 +6865,16 @@ TreeSequence_genealogical_nearest_neighbours(
     PyObject *ret = NULL;
     static char *kwlist[] = { "focal", "reference_sets", NULL };
     const tsk_id_t **reference_sets = NULL;
-    size_t *reference_set_size = NULL;
+    tsk_size_t *reference_set_size = NULL;
     PyObject *focal = NULL;
     PyObject *reference_sets_list = NULL;
     PyArrayObject *focal_array = NULL;
     PyArrayObject **reference_set_arrays = NULL;
     PyArrayObject *ret_array = NULL;
     npy_intp *shape, dims[2];
-    size_t num_focal = 0;
-    size_t num_reference_sets = 0;
-    size_t j;
+    tsk_size_t num_focal = 0;
+    tsk_size_t num_reference_sets = 0;
+    tsk_size_t j;
     int err;
 
     if (TreeSequence_check_state(self) != 0) {
@@ -6992,13 +6995,13 @@ TreeSequence_mean_descendants(TreeSequence *self, PyObject *args, PyObject *kwds
     PyObject *ret = NULL;
     static char *kwlist[] = { "reference_sets", NULL };
     const tsk_id_t **reference_sets = NULL;
-    size_t *reference_set_size = NULL;
+    tsk_size_t *reference_set_size = NULL;
     PyObject *reference_sets_list = NULL;
     PyArrayObject **reference_set_arrays = NULL;
     PyArrayObject *ret_array = NULL;
     npy_intp *shape, dims[2];
-    size_t num_reference_sets = 0;
-    size_t j;
+    tsk_size_t num_reference_sets = 0;
+    tsk_size_t j;
     int err;
 
     if (TreeSequence_check_state(self) != 0) {
@@ -7082,7 +7085,7 @@ out:
 /* Run the Python callable that takes X as parameter and must return a
  * 1D array of length M that we copy in to the Y array */
 static int
-general_stat_func(size_t K, const double *X, size_t M, double *Y, void *params)
+general_stat_func(tsk_size_t K, const double *X, tsk_size_t M, double *Y, void *params)
 {
     int ret = TSK_PYTHON_CALLBACK_ERROR;
     PyObject *callable = (PyObject *) params;
@@ -7815,7 +7818,7 @@ static PyObject *
 TreeSequence_get_num_mutations(TreeSequence *self)
 {
     PyObject *ret = NULL;
-    size_t num_mutations;
+    tsk_size_t num_mutations;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -7830,7 +7833,7 @@ static PyObject *
 TreeSequence_get_num_sites(TreeSequence *self)
 {
     PyObject *ret = NULL;
-    size_t num_sites;
+    tsk_size_t num_sites;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -7845,7 +7848,7 @@ static PyObject *
 TreeSequence_get_num_provenances(TreeSequence *self)
 {
     PyObject *ret = NULL;
-    size_t num_provenances;
+    tsk_size_t num_provenances;
 
     if (TreeSequence_check_state(self) != 0) {
         goto out;
@@ -7862,15 +7865,15 @@ TreeSequence_get_genotype_matrix(TreeSequence *self, PyObject *args, PyObject *k
     PyObject *ret = NULL;
     static char *kwlist[] = { "isolated_as_missing", "alleles", NULL };
     int err;
-    size_t num_sites;
-    size_t num_samples;
+    tsk_size_t num_sites;
+    tsk_size_t num_samples;
     npy_intp dims[2];
     PyObject *py_alleles = Py_None;
     PyArrayObject *genotype_matrix = NULL;
     tsk_vargen_t *vg = NULL;
     char *V;
     tsk_variant_t *variant;
-    size_t j;
+    tsk_size_t j;
     int isolated_as_missing = 1;
     const char **alleles = NULL;
     tsk_flags_t options = 0;
@@ -8196,7 +8199,7 @@ Tree_init(Tree *self, PyObject *args, PyObject *kwds)
     TreeSequence *tree_sequence = NULL;
     tsk_id_t *tracked_samples = NULL;
     unsigned int options = 0;
-    size_t j, num_tracked_samples, num_nodes;
+    tsk_size_t j, num_tracked_samples, num_nodes;
     PyObject *item;
 
     self->tree = NULL;
@@ -8643,7 +8646,7 @@ Tree_get_children(Tree *self, PyObject *args)
     PyObject *ret = NULL;
     int node;
     tsk_id_t u;
-    size_t j, num_children;
+    tsk_size_t j, num_children;
     tsk_id_t *children = NULL;
 
     if (Tree_get_node_argument(self, args, &node) != 0) {
@@ -8821,7 +8824,7 @@ static PyObject *
 Tree_get_num_samples(Tree *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_samples;
+    tsk_size_t num_samples;
     int err, node;
 
     if (Tree_get_node_argument(self, args, &node) != 0) {
@@ -8841,7 +8844,7 @@ static PyObject *
 Tree_get_num_tracked_samples(Tree *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    size_t num_tracked_samples;
+    tsk_size_t num_tracked_samples;
     int err, node;
 
     if (Tree_get_node_argument(self, args, &node) != 0) {
@@ -9609,7 +9612,7 @@ VariantGenerator_init(VariantGenerator *self, PyObject *args, PyObject *kwds)
     PyObject *py_alleles = Py_None;
     PyArrayObject *samples_array = NULL;
     tsk_id_t *samples = NULL;
-    size_t num_samples = 0;
+    tsk_size_t num_samples = 0;
     int isolated_as_missing = 1;
     const char **alleles = NULL;
     npy_intp *shape;
@@ -9637,7 +9640,7 @@ VariantGenerator_init(VariantGenerator *self, PyObject *args, PyObject *kwds)
             goto out;
         }
         shape = PyArray_DIMS(samples_array);
-        num_samples = (size_t) shape[0];
+        num_samples = (tsk_size_t) shape[0];
         samples = PyArray_DATA(samples_array);
     }
     if (py_alleles != Py_None) {
@@ -9782,7 +9785,7 @@ LdCalculator_get_r2(LdCalculator *self, PyObject *args)
         goto out;
     }
     Py_BEGIN_ALLOW_THREADS err
-        = tsk_ld_calc_get_r2(self->ld_calc, (size_t) a, (size_t) b, &r2);
+        = tsk_ld_calc_get_r2(self->ld_calc, (tsk_id_t) a, (tsk_id_t) b, &r2);
     Py_END_ALLOW_THREADS if (err != 0)
     {
         handle_library_error(err);
@@ -9972,7 +9975,7 @@ CompressedMatrix_get_normalisation_factor(CompressedMatrix *self, void *closure)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
-    size_t num_sites;
+    tsk_size_t num_sites;
     npy_intp dims;
 
     if (CompressedMatrix_check_state(self) != 0) {
@@ -9996,7 +9999,7 @@ CompressedMatrix_get_num_transitions(CompressedMatrix *self, void *closure)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
-    size_t num_sites;
+    tsk_size_t num_sites;
     npy_intp dims;
 
     if (CompressedMatrix_check_state(self) != 0) {
@@ -10207,7 +10210,7 @@ ViterbiMatrix_get_normalisation_factor(ViterbiMatrix *self, void *closure)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
-    size_t num_sites;
+    tsk_size_t num_sites;
     npy_intp dims;
 
     if (ViterbiMatrix_check_state(self) != 0) {
@@ -10231,7 +10234,7 @@ ViterbiMatrix_get_num_transitions(ViterbiMatrix *self, void *closure)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
-    size_t num_sites;
+    tsk_size_t num_sites;
     npy_intp dims;
 
     if (ViterbiMatrix_check_state(self) != 0) {


### PR DESCRIPTION
Clarify the conventions around using size_t vs tsk_size_t

Closes #1573

Removes (nearly) all size_t values from the public API, and clarifies how we should use them within the library. This is a good step towards 1.0 I think, and should clear up some of the mess on 32 bit machines when we have 64 bit tsk_size_t.
