### PR TITLE
Added a TreeSequence wrapper for find_ibd.

### DIFF
--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -330,6 +330,14 @@ class TestIbdSingleBinaryTree:
         with pytest.raises(ValueError):
             ibd.IbdFinder(self.ts, sample_pairs=[(0, 1), (1, 0)])
 
+    # A simple test of the Python wrapper.
+    def test_ts(self):
+        pairs = [(0, 1), (0, 2), (1, 2)]
+        ibd_tab = self.ts.tables.find_ibd(samples=pairs)
+        ibd_ts = self.ts.find_ibd(samples=pairs)
+        for p in pairs:
+            assert ibd_tab[p] == ibd_ts[p]
+
 
 class TestIbdTwoSamplesTwoTrees:
 

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -375,6 +375,20 @@ class TestTableCollection(LowLevelTestCase):
             assert list(value["right"]) == [1]
             assert len(value["node"]) == 1
 
+    def test_ibd_output_treeseq(self):
+        ts = msprime.simulate(10, random_seed=1)
+        segs = ts.find_ibd([(0, 1), (2, 3)])
+        assert isinstance(segs, dict)
+        assert len(segs) > 0
+        for key, value in segs.items():
+            assert isinstance(key, tuple)
+            assert len(key) == 2
+            assert isinstance(value, dict)
+            assert len(value) == 3
+            assert list(value["left"]) == [0]
+            assert list(value["right"]) == [1]
+            assert len(value["node"]) == 1
+
     def test_ibd_output_recomb(self):
         ts = msprime.simulate(10, recombination_rate=1, random_seed=1)
         assert ts.num_trees > 1

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3452,43 +3452,17 @@ class TableCollection:
 
     def find_ibd(self, samples, max_time=None, min_length=None):
         """
-        Returns a dictionary containing all IBD (identical-by-descent) segments for the
-        supplied list of sample pairs.
+        Equivalent to the :meth:`TreeSequence.find_ibd` method; please see its
+        documentation for more details, and use this method only if you specifically need
+        to work with a :class:`TableCollection` object.
 
-        A pair of nodes ``(u, v)`` has an IBD segment with a left and right coordinate
-        ``[left, right)`` and ancestral node ``a`` iff the most recent common ancestor
-        of the segment ``[left, right)`` in nodes ``u`` and ``v`` is ``a``, and the
-        segment has been inherited along the same genealogical path (ie. it has not
-        been broken by recombination). The segments returned are the longest possible
-        ones.
-
-        Note that this definition is purely genealogical -- allelic states
-        *are not* considered here. If used without time or length thresholds, the
-        segments returned for a given pair will partition the span of the contig
-        represented by the tree sequence.
-
-        Each item in the outputted dictionary object contains the IBD segments for a
-        particular sample pair. Suppose the output is
-
-        .. code-block:: python
-
-            {
-                (0, 1): {
-                    "left": array([0.0]),
-                    "right": array([1.0]),
-                    "node": array([4]),
-                },
-                (0, 2): {
-                    "left": array([0.5, 0.0]),
-                    "right": array([1.0, 0.5]),
-                    "node": array([3, 5]),
-                },
-            }
-
-        This indicates that samples 0 and 1 share a single IBD segment on the interval
-        `[0.0, 1.0)` inherited from the ancestor with node ID 4. Samples 0 and 2 share
-        one IBD segment on the interval `[0.5, 1.0)` inherited from node 3, and another
-        segment on the interval `[0.0, 0.5)` inherited from node 5.
+        This method has the same input data requirements as
+        :meth:`TableCollection.simplify`. In particular, the table collection must be
+        sorted in the canonical order. To find out if this is needed, see
+        :meth:`TableCollection.sort`. If the edge table contains any edges with identical
+        parents and children over adjacent genomic intervals, any IBD intervals
+        underneath the edges will also be split across the breakpoint(s). To prevent this
+        behaviour in this situation, use :meth:`EdgeTable.squash` beforehand.
 
         :param list samples: A list of pairs of integers, with each pair specified as
             a tuple. In each pair, the integers correspond to the node IDs of a pair of
@@ -3505,6 +3479,7 @@ class TableCollection:
             numpy.ndarray objects, each of the same length, with datatypes np.float64,
             np.float64 and np.int32 respectively.
         :rtype: dict
+
         """
         max_time = sys.float_info.max if max_time is None else max_time
         min_length = 0 if min_length is None else min_length

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7160,6 +7160,66 @@ class TreeSequence:
 
         yield from combinatorics.treeseq_count_topologies(self, sample_sets)
 
+    def find_ibd(self, samples, max_time=None, min_length=None):
+        """
+        Returns a dictionary containing all IBD (identical-by-descent) segments for the
+        supplied list of sample pairs.
+
+        A pair of nodes ``(u, v)`` has an IBD segment with a left and right coordinate
+        ``[left, right)`` and ancestral node ``a`` iff the most recent common ancestor
+        of the segment ``[left, right)`` in nodes ``u`` and ``v`` is ``a``, and the
+        segment has been inherited along the same genealogical path (ie. it has not
+        been broken by recombination). The segments returned are the longest possible
+        ones.
+
+        Note that this definition is purely genealogical -- allelic states
+        *are not* considered here. If used without time or length thresholds, the
+        segments returned for a given pair will partition the span of the contig
+        represented by the tree sequence.
+
+        Each item in the outputted dictionary object contains the IBD segments for a
+        particular sample pair. Suppose the output is
+
+        .. code-block:: python
+
+            {
+                (0, 1): {
+                    "left": array([0.0]),
+                    "right": array([1.0]),
+                    "node": array([4]),
+                },
+                (0, 2): {
+                    "left": array([0.5, 0.0]),
+                    "right": array([1.0, 0.5]),
+                    "node": array([3, 5]),
+                },
+            }
+
+        This indicates that samples 0 and 1 share a single IBD segment on the interval
+        `[0.0, 1.0)` inherited from the ancestor with node ID 4. Samples 0 and 2 share
+        one IBD segment on the interval `[0.5, 1.0)` inherited from node 3, and another
+        segment on the interval `[0.0, 0.5)` inherited from node 5.
+
+        :param list samples: A list of pairs of integers, with each pair specified as
+            a tuple. In each pair, the integers correspond to the node IDs of a pair of
+            chromosomes whose IBD segments will be returned by this method.
+        :param float max_time: Only segments inherited from common
+            ancestors whose node times are more recent than the specified time
+            will be returned. Specifying a maximum time is strongly recommended when
+            working with large tree sequences.
+        :param float min_length: Only segments longer than the specified length
+            will be returned.
+        :return: A dictionary object indexed by the specified pairs in ``samples``.
+            The value of each item is itself a dictionary indexed by the following keys:
+            ``left``, ``right`` and ``node``. The values held by these three keys are
+            numpy.ndarray objects, each of the same length, with datatypes np.float64,
+            np.float64 and np.int32 respectively.
+        :rtype: dict
+        """
+        return tables.TableCollection.find_ibd(
+            self.tables, samples, max_time, min_length
+        )
+
     ############################################
     #
     # Deprecated APIs. These are either already unsupported, or will be unsupported in a


### PR DESCRIPTION
Closes #1617.

I only made very basic tests as the find_ibd method on tables has already been tested thoroughly.