### PR TITLE
Consistently use space to separate SVG transforms

### DIFF
--- a/python/tests/data/svg/internal_sample_ts.svg
+++ b/python/tests/data/svg/internal_sample_ts.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(77.3623 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(780.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(890.091 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/tree_both_axes.svg
+++ b/python/tests/data/svg/tree_both_axes.svg
@@ -6,52 +6,52 @@
 	<g class="tree t4">
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(118.4,200)">
+				<g transform="translate(118.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="180" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(180 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,70.7)">
+				<g transform="translate(0 70.7)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="131.4" y2="10"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 26.8)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">6.57</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 129.578)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 131.4)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 113.726)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/tree_muts_all_edge.svg
+++ b/python/tests/data/svg/tree_muts_all_edge.svg
@@ -9,20 +9,20 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(150,400)">
+				<g transform="translate(150 400)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="280" y1="363.2" y2="363.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 363.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(244.096 363.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/tree_x_axis.svg
+++ b/python/tests/data/svg/tree_x_axis.svg
@@ -6,20 +6,20 @@
 	<g class="tree t1">
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(200,200)">
+				<g transform="translate(200 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">pos on genome</text>
 				</g>
 				<line x1="20" x2="380" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(380 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/tree_y_axis_rank.svg
+++ b/python/tests/data/svg/tree_y_axis_rank.svg
@@ -6,7 +6,7 @@
 	<g class="tree t1">
 		<g class="axes">
 			<g class="y-axis">
-				<g transform="translate(0,89.1)">
+				<g transform="translate(0 89.1)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (relative steps)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="168.2" y2="10"/>
@@ -14,28 +14,28 @@
 					<g class="tick" transform="translate(56.8 49.55)">
 						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">5.31</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 128.65)">
 						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 168.2)">
 						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 89.1)">
 						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(77.3623 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(780.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(890.091 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_multiroot.svg
+++ b/python/tests/data/svg/ts_multiroot.svg
@@ -16,62 +16,62 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(800,200)">
+				<g transform="translate(800 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="1580" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(215 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(410 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">2</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(605 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">3</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(800 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">4</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(995 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">5</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(1190 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">6</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(1385 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">7</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(1580 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">8</text>
 						</g>
 					</g>
@@ -114,7 +114,7 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,74.1)">
+				<g transform="translate(0 74.1)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (WF gens)</text>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_mut_highlight.svg
+++ b/python/tests/data/svg/ts_mut_highlight.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(77.3623 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(780.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(890.091 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_mut_times.svg
+++ b/python/tests/data/svg/ts_mut_times.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(77.3623 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(780.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(890.091 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_mut_times_logscale.svg
+++ b/python/tests/data/svg/ts_mut_times_logscale.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(77.3623 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(780.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(890.091 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_mutations_no_edges.svg
+++ b/python/tests/data/svg/ts_mutations_no_edges.svg
@@ -9,20 +9,20 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(100,200)">
+				<g transform="translate(100 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="180" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(180 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_mutations_timed_no_edges.svg
+++ b/python/tests/data/svg/ts_mutations_timed_no_edges.svg
@@ -9,20 +9,20 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(100,200)">
+				<g transform="translate(100 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="180" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(180 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_plain.svg
+++ b/python/tests/data/svg/ts_plain.svg
@@ -6,44 +6,44 @@
 	<g class="tree-sequence">
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(212 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(404 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(596 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(788 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_plain_no_xlab.svg
+++ b/python/tests/data/svg/ts_plain_no_xlab.svg
@@ -10,37 +10,37 @@
 				<g class="ticks">
 					<g class="tick" transform="translate(20 180)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(212 180)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(404 180)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(596 180)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(788 180)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 180)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_plain_y.svg
+++ b/python/tests/data/svg/ts_plain_y.svg
@@ -6,51 +6,51 @@
 	<g class="tree-sequence">
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(518.4,200)">
+				<g transform="translate(518.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(241.44 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(426.08 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(610.72 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(795.36 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="-5" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,65.7)">
+				<g transform="translate(0 65.7)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
@@ -58,21 +58,21 @@
 					<g class="tick" transform="translate(56.8 121.4)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 66.8909)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">5</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 12.3817)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">10</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_rank.svg
+++ b/python/tests/data/svg/ts_rank.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(518.4,200)">
+				<g transform="translate(518.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(111.963 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(788.516 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.537 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(897.184 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
@@ -96,50 +96,50 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,65.7)">
+				<g transform="translate(0 65.7)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Node time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 121.4)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 105.486)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 89.5714)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 73.6571)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.75</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 57.7429)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">5.31</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 41.8286)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">6.57</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 25.9143)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">9.08</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_x_lim.svg
+++ b/python/tests/data/svg/ts_x_lim.svg
@@ -11,20 +11,20 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(300,200)">
+				<g transform="translate(300 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="20" x2="580" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(25.7731 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(509.15 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_xlabel.svg
+++ b/python/tests/data/svg/ts_xlabel.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(500,200)">
+				<g transform="translate(500 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">genomic position (bp)</text>
 				</g>
 				<line x1="20" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(77.3623 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(780.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(890.091 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.883 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_y_axis.svg
+++ b/python/tests/data/svg/ts_y_axis.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(518.4,200)">
+				<g transform="translate(518.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(111.963 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(788.516 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.537 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(897.184 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
@@ -96,50 +96,50 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,65.7)">
+				<g transform="translate(0 65.7)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (gens)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 121.4)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 120.152)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 109.292)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 102.321)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.75</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 63.504)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">5.31</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 49.7389)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">6.57</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 22.3778)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">9.08</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_y_axis_log.svg
+++ b/python/tests/data/svg/ts_y_axis_log.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(518.4,200)">
+				<g transform="translate(518.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(111.963 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(788.516 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.537 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(897.184 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
@@ -96,50 +96,50 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,65.7)">
+				<g transform="translate(0 65.7)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (log scale)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 121.4)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 116.755)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 89.39)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 78.0512)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.75</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 42.4584)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">5.31</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 34.6429)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">6.57</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 22.3778)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">9.08</text>
 						</g>
 					</g>

--- a/python/tests/data/svg/ts_y_axis_regular.svg
+++ b/python/tests/data/svg/ts_y_axis_regular.svg
@@ -13,44 +13,44 @@
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(518.4,200)">
+				<g transform="translate(518.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
 				<line x1="56.8" x2="980" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(111.963 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(788.516 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(893.537 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(897.184 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(980 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
-						<g transform="translate(0,6)">
+						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
@@ -96,7 +96,7 @@
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0,65.7)">
+				<g transform="translate(0 65.7)">
 					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
@@ -104,70 +104,70 @@
 					<g class="tick" transform="translate(56.8 121.4)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">0</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 110.498)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 99.5963)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">2</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 88.6945)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">3</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 77.7927)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">4</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 66.8909)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">5</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 55.989)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">6</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 45.0872)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">7</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 34.1854)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">8</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 23.2835)">
 						<line class="grid" x1="0" x2="923.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6,0)">
+						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">9</text>
 						</g>
 					</g>

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -573,7 +573,7 @@ class SvgPlot:
         the text tag occur around the (0,0) point of the containing group
         """
         dwg = self.drawing
-        group_attributes = {"transform": f"translate({rnd(pos[0])},{rnd(pos[1])})"}
+        group_attributes = {"transform": f"translate({rnd(pos[0])} {rnd(pos[1])})"}
         if group_class is not None:
             group_attributes["class_"] = group_class
         grp = add_to.add(dwg.g(**group_attributes))


### PR DESCRIPTION
May fix #1625

