### PR TITLE
Added an extra min_length threshold check in find_ibd.

### DIFF
--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -7415,17 +7415,19 @@ tsk_ibd_finder_enqueue_segment(
     void *p;
 
     tsk_bug_assert(left < right);
-    /* Make sure we always have room for one more segment in the queue so we
-     * can put a tail sentinel on it */
-    if (self->segment_queue_size == self->max_segment_queue_size - 1) {
-        self->max_segment_queue_size *= 2;
-        p = tsk_realloc(self->segment_queue,
-            self->max_segment_queue_size * sizeof(*self->segment_queue));
-        if (p == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
-            goto out;
+    if (right - left > self->min_length) {
+        /* Make sure we always have room for one more segment in the queue so we
+         * can put a tail sentinel on it */
+        if (self->segment_queue_size == self->max_segment_queue_size - 1) {
+            self->max_segment_queue_size *= 2;
+            p = tsk_realloc(self->segment_queue,
+                self->max_segment_queue_size * sizeof(*self->segment_queue));
+            if (p == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            self->segment_queue = p;
         }
-        self->segment_queue = p;
     }
     seg = self->segment_queue + self->segment_queue_size;
     seg->left = left;

--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -266,7 +266,7 @@ class IbdFinder:
                             max(seg.left, s.left),
                             min(seg.right, s.right),
                         )
-                        if intvl[1] - intvl[0] > 0:
+                        if intvl[1] - intvl[0] > self.min_length:
                             list_to_add.add(Segment(intvl[0], intvl[1], s.node))
                         s = s.next
 


### PR DESCRIPTION
As per a private comment to @jeromekelleher , this small alteration doesn't change any of the output (all the tests still pass), but it should greatly reduce the internal memory needs of `find_ibd` when a minimum length is specified. (Basically, this stops lots of tiny segments from being appended to the master lists of ancestral segments)

I think we originally were considering various more flexible definitions of IBD where this condition is not wanted, but we've now settled on a definition of IBD that requires the IBD segments to maintain distinct genealogical paths along their length, so this condition is no longer needed I think.

Unless there are any objections, I'll change the relevant part of the C codebase too

@petrelharp @dvukcevic
