### PR TITLE
IBD result struct

### DIFF
--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -626,26 +626,17 @@ typedef struct _tsk_segment_t {
 } tsk_segment_t;
 
 typedef struct {
-    tsk_id_t *pairs;
+    const tsk_id_t *pairs;
     tsk_size_t num_pairs;
     tsk_size_t num_nodes;
     tsk_size_t num_unique_nodes_in_pair;
     int64_t *pair_map;
-    double sequence_length;
-    tsk_table_collection_t *tables;
+    tsk_id_t *paired_nodes_index;
     tsk_segment_t **ibd_segments_head;
     tsk_segment_t **ibd_segments_tail;
+    tsk_size_t total_segments;
     tsk_blkalloc_t segment_heap;
-    bool *is_sample;
-    tsk_id_t *paired_nodes_index;
-    double min_length;
-    double max_time;
-    tsk_segment_t **ancestor_map_head;
-    tsk_segment_t **ancestor_map_tail;
-    tsk_segment_t *segment_queue;
-    tsk_size_t segment_queue_size;
-    tsk_size_t max_segment_queue_size;
-} tsk_ibd_finder_t;
+} tsk_ibd_result_t;
 
 /****************************************************************************/
 /* Common function options */
@@ -3404,6 +3395,12 @@ tsk_id_t tsk_table_collection_check_integrity(
 
 /* Undocumented methods */
 
+/* TODO be systematic about where "result" should be in the params
+ * list, different here and in link_ancestors. */
+int tsk_table_collection_find_ibd(const tsk_table_collection_t *self,
+    tsk_ibd_result_t *result, const tsk_id_t *samples, tsk_size_t num_samples,
+    double min_length, double max_time, tsk_flags_t options);
+
 int tsk_table_collection_link_ancestors(tsk_table_collection_t *self, tsk_id_t *samples,
     tsk_size_t num_samples, tsk_id_t *ancestors, tsk_size_t num_ancestors,
     tsk_flags_t options, tsk_edge_table_t *result);
@@ -3494,15 +3491,12 @@ int tsk_squash_edges(
     tsk_edge_t *edges, tsk_size_t num_edges, tsk_size_t *num_output_edges);
 
 /* IBD finder API. This is experimental and the interface may change. */
-int tsk_ibd_finder_init(tsk_ibd_finder_t *ibd_finder, tsk_table_collection_t *tables,
-    tsk_id_t *pairs, tsk_size_t num_pairs);
-int tsk_ibd_finder_set_min_length(tsk_ibd_finder_t *self, double min_length);
-int tsk_ibd_finder_set_max_time(tsk_ibd_finder_t *self, double max_time);
-int tsk_ibd_finder_free(tsk_ibd_finder_t *self);
-int tsk_ibd_finder_run(tsk_ibd_finder_t *ibd_finder);
-int tsk_ibd_finder_get_ibd_segments(tsk_ibd_finder_t *ibd_finder, tsk_id_t pair_index,
-    tsk_segment_t **ret_ibd_segments_head);
-void tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out);
+
+tsk_size_t tsk_ibd_result_get_total_segments(const tsk_ibd_result_t *self);
+void tsk_ibd_result_print_state(tsk_ibd_result_t *self, FILE *out);
+int tsk_ibd_result_free(tsk_ibd_result_t *self);
+int tsk_ibd_result_get(const tsk_ibd_result_t *self, tsk_id_t sample_a,
+    tsk_id_t sample_b, tsk_segment_t **ret_head);
 
 #ifdef __cplusplus
 }

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -204,7 +204,7 @@ def convert_ibd_output_to_seglists(ibd_out):
     Converts the Python mock-up output back into lists of segments.
     This is needed to use the ibd_is_equal function.
     """
-
+    out = {}
     for key in ibd_out.keys():
         seg_list = []
         num_segs = len(ibd_out[key]["left"])
@@ -216,9 +216,8 @@ def convert_ibd_output_to_seglists(ibd_out):
                     node=ibd_out[key]["node"][s],
                 )
             )
-        ibd_out[key] = seg_list
-
-    return ibd_out
+        out[key] = seg_list
+    return out
 
 
 def ibd_is_equal(dict1, dict2):
@@ -873,3 +872,21 @@ class TestIbdRandomExamples:
             tables.sort()
             ts = tables.tree_sequence()
             verify_equal_ibd(ts)
+
+
+class TestIbdResult:
+    """
+    Test the IbdResult class interface.
+    """
+
+    def test_dict_interface(self):
+        ts = msprime.sim_ancestry(5, random_seed=2)
+        pairs = list(itertools.combinations(ts.samples(), 2))
+        result = ts.find_ibd(pairs)
+        assert len(result) == len(pairs)
+        for pair in pairs:
+            assert pair in result
+            assert result[pair] is not None
+        for k, v in result.items():
+            assert k in pairs
+            assert isinstance(v, dict)


### PR DESCRIPTION
This is stacked on #1618 so will be very noisy until that's merged

This is some initial work on refactoring the IBD code as we discussed @gtsambos. The idea is that we encapsulate all the IBD segment result information in this ``tsk_ibd_result_t`` struct, which we make available to the caller. All the details about how we store the segments for a pair of samples are hidden away, which gives us flexibility to do various things in the future.

Still some work to be done to really make use of this, though.
