### PR TITLE
Ibd avl tree

### DIFF
--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -818,7 +818,7 @@ tsk_avl_tree_int_free(tsk_avl_tree_int_t *TSK_UNUSED(self))
 }
 
 tsk_avl_node_int_t *
-tsk_avl_tree_int_search(tsk_avl_tree_int_t *self, int64_t key)
+tsk_avl_tree_int_search(const tsk_avl_tree_int_t *self, int64_t key)
 {
     tsk_avl_node_int_t *P = self->head.rlink;
 

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -482,7 +482,7 @@ typedef struct {
 int tsk_avl_tree_int_init(tsk_avl_tree_int_t *self);
 int tsk_avl_tree_int_free(tsk_avl_tree_int_t *self);
 void tsk_avl_tree_int_print_state(tsk_avl_tree_int_t *self, FILE *out);
-tsk_avl_node_int_t *tsk_avl_tree_int_search(tsk_avl_tree_int_t *self, int64_t key);
+tsk_avl_node_int_t *tsk_avl_tree_int_search(const tsk_avl_tree_int_t *self, int64_t key);
 int tsk_avl_tree_int_insert(tsk_avl_tree_int_t *self, tsk_avl_node_int_t *node);
 
 tsk_size_t tsk_search_sorted(const double *array, tsk_size_t size, double value);

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -626,16 +626,10 @@ typedef struct _tsk_segment_t {
 } tsk_segment_t;
 
 typedef struct {
-    const tsk_id_t *pairs;
-    tsk_size_t num_pairs;
     tsk_size_t num_nodes;
-    tsk_size_t num_unique_nodes_in_pair;
-    int64_t *pair_map;
-    tsk_id_t *paired_nodes_index;
-    tsk_segment_t **ibd_segments_head;
-    tsk_segment_t **ibd_segments_tail;
+    tsk_avl_tree_int_t pair_map;
     tsk_size_t total_segments;
-    tsk_blkalloc_t segment_heap;
+    tsk_blkalloc_t heap;
 } tsk_ibd_result_t;
 
 /****************************************************************************/

--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -129,10 +129,11 @@ class IbdResult:
     set of sample pairs.
     """
 
-    def __init__(self, pairs):
+    def __init__(self, pairs, num_nodes):
         # TODO not sure we should to this, but let's keep compatibility with
         # the C output for now.
         self.segments = {pair: [] for pair in pairs}
+        self.num_nodes = num_nodes
 
     def add_segment(self, a, b, seg):
         key = (a, b) if a < b else (b, a)
@@ -169,7 +170,7 @@ class IbdFinder:
         self.ts = ts
         self.sample_pairs = sample_pairs
         self.check_sample_pairs()
-        self.result = IbdResult(sample_pairs)
+        self.result = IbdResult(sample_pairs, ts.num_nodes)
         self.samples = list({i for pair in self.sample_pairs for i in pair})
 
         self.sample_id_map = np.zeros(ts.num_nodes, dtype=int) - 1


### PR DESCRIPTION
This converts the IBD result object to use an AVL tree internally for storage instead of a lookup matrix. We're not changing the semantics of the object yet so that we can store segments for arbitrary sample pairs, this is just the minimal changes required to change the backend. 

I'll follow up with more PRs for how we can change the semantics later, probably good to get this squared away first so that we can keep the diffs smaller.

Stacked on #1655 and #1637 