### PR TITLE
Rearrange checks

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -6,6 +6,8 @@
 
 - The ``tables`` argument to ``tsk_treeseq_init`` is no longer ``const``, to allow for future no-copy tree sequence creation.
   (:user:`benjeffery`, :issue:`1718`, :pr:`1719`)
+- Additional consistency checks for mutation tables are now run by ``tsk_table_collection_check_integrity``
+  even when ``TSK_CHECK_MUTATION_ORDERING`` is not passed in. (:user:`petrelharp`, :issue:`1713`, :pr:`1722`)
 
 - ``num_tracked_samples`` and ``num_samples`` in ``tsk_tree_t`` are now typed as ``tsk_size_t``
   (:user:`benjeffery`, :issue:`1723`, :pr:`1727`)
@@ -18,6 +20,7 @@
   ``tsk_edge_table_set_max_rows_increment(tables->edges, 1024)``, which results in adding
   space for 1024 additional rows each time we run out of space in the edge table.
   (:user:`benjeffery`, :issue:`5`, :pr:`1683`)
+- ``tsk_table_collection_check_integrity`` now has a ``TSK_CHECK_MIGRATION_ORDERING`` flag. (:user:`petrelharp`, :pr:`1722`)
 
 - The default behaviour for ragged column growth is now to double the current size of the column,
   up to a threshold. To keep the previous behaviour, use (e.g.)

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -3550,11 +3550,11 @@ test_single_tree_bad_mutations(void)
     tables.mutations.parent[0] = TSK_NULL;
 
     /* parent_id > mutation id */
-    tables.mutations.parent[2] = 3;
+    tables.mutations.parent[3] = 4;
     ret = tsk_treeseq_init(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, TSK_ERR_MUTATION_PARENT_AFTER_CHILD);
     tsk_treeseq_free(&ts);
-    tables.mutations.parent[2] = TSK_NULL;
+    tables.mutations.parent[3] = TSK_NULL;
 
     /* time < node time */
     tables.mutations.time[2] = 0;

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -308,6 +308,11 @@ tsk_strerror_internal(int err)
                   "values for any single site.";
             break;
 
+        /* Migration errors */
+        case TSK_ERR_UNSORTED_MIGRATIONS:
+            ret = "Migrations must be sorted by time.";
+            break;
+
         /* Sample errors */
         case TSK_ERR_DUPLICATE_SAMPLE:
             ret = "Duplicate sample value";

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -313,6 +313,9 @@ An unsupported type was provided for a column in the file.
 #define TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_NODE                -508
 #define TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN            -509
 
+/* Migration errors */
+#define TSK_ERR_UNSORTED_MIGRATIONS                                 -550
+
 /* Sample errors */
 #define TSK_ERR_DUPLICATE_SAMPLE                                    -600
 #define TSK_ERR_BAD_SAMPLES                                         -601

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -170,7 +170,8 @@ read_table_ragged_cols(kastore_t *store, tsk_size_t *num_rows,
     read_table_ragged_col_t *cols, tsk_flags_t TSK_UNUSED(flags))
 {
     int ret = 0;
-    size_t data_len, offset_len;
+    size_t data_len = 0; // initial value unused, just to keep the compiler happy.
+    size_t offset_len;
     int type;
     read_table_ragged_col_t *col;
     char offset_col_name[TSK_MAX_COL_NAME_LEN];

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -681,12 +681,13 @@ typedef struct {
 #define TSK_CHECK_SITE_ORDERING (1 << 1)
 #define TSK_CHECK_SITE_DUPLICATES (1 << 2)
 #define TSK_CHECK_MUTATION_ORDERING (1 << 3)
-#define TSK_CHECK_INDEXES (1 << 4)
-#define TSK_CHECK_TREES (1 << 5)
-#define TSK_CHECK_INDIVIDUAL_ORDERING (1 << 6)
+#define TSK_CHECK_INDIVIDUAL_ORDERING (1 << 4)
+#define TSK_CHECK_MIGRATION_ORDERING (1 << 5)
+#define TSK_CHECK_INDEXES (1 << 6)
+#define TSK_CHECK_TREES (1 << 7)
 
 /* Leave room for more positive check flags */
-#define TSK_NO_CHECK_POPULATION_REFS (1 << 10)
+#define TSK_NO_CHECK_POPULATION_REFS (1 << 12)
 
 /* Flags for load tables */
 #define TSK_BUILD_INDEXES (1 << 0)
@@ -3655,9 +3656,12 @@ int tsk_table_collection_set_indexes(tsk_table_collection_t *self,
 
 Checks the integrity of this table collection. The default checks (i.e., with
 options = 0) guarantee the integrity of memory and entity references within the
-table collection. All spatial values (along the genome) are checked
+table collection. All positions along the genome are checked
 to see if they are finite values and within the required bounds. Time values
 are checked to see if they are finite or marked as unknown.
+Consistency of the direction of inheritance is also checked: whether
+parents are more recent than children, mutations are not more recent
+than their nodes or their mutation parents, etcetera.
 
 To check if a set of tables fulfills the :ref:`requirements
 <sec_valid_tree_sequence_requirements>` needed for a valid tree sequence, use
@@ -3686,6 +3690,8 @@ TSK_CHECK_MUTATION_ORDERING
     constraints.
 TSK_CHECK_INDIVIDUAL_ORDERING
     Check individual parents are before children, where specified.
+TSK_CHECK_MIGRATION_ORDERING
+    Check migrations are ordered by time.
 TSK_CHECK_INDEXES
     Check that the table indexes exist, and contain valid edge
     references.


### PR DESCRIPTION
This will close #1713. Since we already have all the `TSK_CHECK_X_ORDERING` flags we needed (except X=MIGRATIONS), I just went through to make sure that the things checked under CHECK_ORDERING were all ordering-related. They were, except for mutations. So, I've moved a bunch of consistency checks out of `TSK_CHECK_MUTATION_ORDERING`, i.e., checks that weren't previously done by default that now are: This turned up a few nonsensical tables in the tests. But we should make sure it's actually what we want to do? These checks are:
- mutation time younger than node
- mixed known/unknown times at a site
- site of parent mutation agrees with site

Other notes:
- I don't think we need a `TSK_CHECK_ORDERING` flag, since you get that from `TSK_CHECK_TREES`, and I don't think anyone's going to want to check ordering without checking the other optional properties.
- Hm, *however*, `TSK_CHECK_TREES` also implies running `tsk_table_collection_check_tree_integrity`, which is more expensive (it builds trees; everything else is a single pass through the tables). So, maybe we do want a generic `CHECK_ORDERING`?
- There was no previous check for migration ordering; I've implemented it (although we don't have a `sort` for it yet...)
- I've also made the printing out of tables a tad nicer (it was hard for me to find the table I wanted)
