### PR TITLE
time_units in the C API

### DIFF
--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -109,6 +109,8 @@ __tsk_nan_f(void)
 }
 #define TSK_UNKNOWN_TIME __tsk_nan_f()
 
+#define TSK_DEFAULT_TIME_UNITS "unknown"
+
 /**
 @brief Tskit Object IDs.
 
@@ -197,7 +199,7 @@ to the API or ABI are introduced, i.e., internal refactors of bugfixes.
 #define TSK_FILE_FORMAT_NAME          "tskit.trees"
 #define TSK_FILE_FORMAT_NAME_LENGTH   11
 #define TSK_FILE_FORMAT_VERSION_MAJOR 12
-#define TSK_FILE_FORMAT_VERSION_MINOR 5
+#define TSK_FILE_FORMAT_VERSION_MINOR 6
 
 /**
 @defgroup GENERAL_ERROR_GROUP General errors.

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -545,6 +545,9 @@ typedef struct {
     /** @brief The sequence length defining the tree sequence's coordinate space */
     double sequence_length;
     char *file_uuid;
+    /** @brief The units of the time dimension */
+    char *time_units;
+    tsk_size_t time_units_length;
     /** @brief The tree-sequence metadata */
     char *metadata;
     tsk_size_t metadata_length;
@@ -3570,6 +3573,19 @@ will be added to self).
 int tsk_table_collection_union(tsk_table_collection_t *self,
     const tsk_table_collection_t *other, const tsk_id_t *other_node_mapping,
     tsk_flags_t options);
+
+/**
+@brief Set the time_units
+@rst
+Copies the time_units string to this table collection, replacing any existing.
+@endrst
+@param self A pointer to a tsk_table_collection_t object.
+@param time_units A pointer to a char array
+@param time_units_length The size of the time units string in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_set_time_units(
+    tsk_table_collection_t *self, const char *time_units, tsk_size_t time_units_length);
 
 /**
 @brief Set the metadata

--- a/python/tests/test_file_format.py
+++ b/python/tests/test_file_format.py
@@ -43,7 +43,7 @@ import tskit.exceptions as exceptions
 
 
 CURRENT_FILE_MAJOR = 12
-CURRENT_FILE_MINOR = 5
+CURRENT_FILE_MINOR = 6
 
 test_data_dir = os.path.join(os.path.dirname(__file__), "data")
 
@@ -579,6 +579,7 @@ class TestDumpFormat(TestFileFormat):
             "sites/metadata_offset",
             "sites/metadata_schema",
             "sites/position",
+            "time_units",
             "uuid",
         ]
         ts.dump(self.temp_file)
@@ -899,6 +900,7 @@ class TestFileFormatErrors(TestFileFormat):
             # We skip these keys as they are optional
             if "metadata_schema" not in key and key not in [
                 "metadata",
+                "time_units",
                 "mutations/time",
             ]:
                 data = dict(all_data)

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -3326,7 +3326,7 @@ class TestTableCollection:
             array.nbytes * 2 if "_offset" in name else array.nbytes
             for name, array in store.items()
             # nbytes is the size of asdict, so exclude file format items
-            if name not in ["format/version", "format/name", "uuid"]
+            if name not in ["format/version", "format/name", "uuid", "time_units"]
         )
         assert nbytes == tables.nbytes
 


### PR DESCRIPTION
A start on #1644 

For now it is set to the default on `clear` and is non-optional for `equals` but we may want to rethink that.