### PR TITLE
Fix logic bug in find ibd.

### DIFF
--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -853,6 +853,16 @@ class TestIbdResult:
         assert result.min_length == min_length
         self.verify_segments(ts, result)
 
+    @pytest.mark.parametrize("min_length", [100, 101, 100000])
+    def test_min_length_longer_than_seq_length(self, min_length):
+        ts = msprime.sim_ancestry(
+            100, recombination_rate=0.1, sequence_length=100, random_seed=2
+        )
+        result = ts.ibd_segments(min_length=min_length)
+        assert result.min_length == min_length
+        assert result.num_segments == 0
+        self.verify_segments(ts, result)
+
     def test_recombination_discrete(self):
         ts = msprime.sim_ancestry(
             10, sequence_length=100, recombination_rate=0.1, random_seed=2


### PR DESCRIPTION
Closes #1739

I think this was a straightforward logic bug in how we were handling min_length. We were only checking if the segment queue needed expanding if the span was greater than min_length, but always adding to it. So basically any time we had a min_length set for a largish example we were going to hit this.

I can confirm the Python tests were provoking the issue. I tried reproducing in C, but it was too awkward and didn't seem worth the effort.

I refactored things a little while I was in there.