### PR TITLE
Add time units to the SVG Y axis label, if known

### DIFF
--- a/python/tests/data/svg/ts_multiroot.svg
+++ b/python/tests/data/svg/ts_multiroot.svg
@@ -5,65 +5,65 @@
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
-			<path d="M20,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M215,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M410,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M605,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M800,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M995,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M1190,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M1385,0 l195,0 l0,138.2 l0,25 l0,5 l-195,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M56.8,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M247.2,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M437.6,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M628,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M818.4,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M1008.8,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M1199.2,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M1389.6,0 l190.4,0 l0,138.2 l0,25 l0,5 l-190.4,0 l0,-5 l0,-25 l0,-138.2z"/>
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g transform="translate(800 200)">
+				<g transform="translate(818.4 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
-				<line x1="20" x2="1580" y1="163.2" y2="163.2"/>
+				<line x1="56.8" x2="1580" y1="163.2" y2="163.2"/>
 				<g class="ticks">
-					<g class="tick" transform="translate(20 163.2)">
+					<g class="tick" transform="translate(56.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">0</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(215 163.2)">
+					<g class="tick" transform="translate(247.2 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">1</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(410 163.2)">
+					<g class="tick" transform="translate(437.6 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">2</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(605 163.2)">
+					<g class="tick" transform="translate(628 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">3</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(800 163.2)">
+					<g class="tick" transform="translate(818.4 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">4</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(995 163.2)">
+					<g class="tick" transform="translate(1008.8 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">5</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(1190 163.2)">
+					<g class="tick" transform="translate(1199.2 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">6</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(1385 163.2)">
+					<g class="tick" transform="translate(1389.6 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">7</text>
@@ -76,60 +76,134 @@
 						</g>
 					</g>
 				</g>
-				<g class="site s0" transform="translate(103.433 163.2)">
+				<g class="site s0" transform="translate(114.916 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
-					<g class="mut m0">
-						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
-					</g>
 				</g>
-				<g class="site s1" transform="translate(554.167 163.2)">
+				<g class="site s1" transform="translate(136.56 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m1">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
 					</g>
+					<g class="mut m0">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
 				</g>
-				<g class="site s2" transform="translate(581.7 163.2)">
+				<g class="site s2" transform="translate(189.603 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+				</g>
+				<g class="site s3" transform="translate(220.849 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m2">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
 					</g>
 				</g>
-				<g class="site s3" transform="translate(680.046 163.2)">
+				<g class="site s4" transform="translate(299.998 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m3">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
 					</g>
 				</g>
-				<g class="site s4" transform="translate(688.415 163.2)">
+				<g class="site s5" transform="translate(562.804 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m4">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
 					</g>
 				</g>
-				<g class="site s5" transform="translate(1097.78 163.2)">
+				<g class="site s6" transform="translate(677.111 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+				</g>
+				<g class="site s7" transform="translate(873.543 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m6">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
 					<g class="mut m5">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+				</g>
+				<g class="site s8" transform="translate(1354.7 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m8">
+						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+					<g class="mut m7">
+						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
+					</g>
+				</g>
+				<g class="site s9" transform="translate(1429.51 163.2)">
+					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
+					<g class="mut m9">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
 					</g>
 				</g>
 			</g>
 			<g class="y-axis">
-				<g transform="translate(0 74.1)">
-					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (WF gens)</text>
+				<g transform="translate(0 65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (generations)</text>
+				</g>
+				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
+				<g class="ticks">
+					<g class="tick" transform="translate(56.8 121.4)">
+						<line class="grid" x1="0" x2="1523.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">0</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 102.48)">
+						<line class="grid" x1="0" x2="1523.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">1</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 83.56)">
+						<line class="grid" x1="0" x2="1523.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">2</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 64.64)">
+						<line class="grid" x1="0" x2="1523.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">3</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 45.72)">
+						<line class="grid" x1="0" x2="1523.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">4</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 26.8)">
+						<line class="grid" x1="0" x2="1523.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">5</text>
+						</g>
+					</g>
 				</g>
 			</g>
 		</g>
 		<g class="plotbox trees">
-			<g class="tree t0" transform="translate(20 0)">
+			<g class="tree t0" transform="translate(56.8 0)">
 				<g class="plotbox">
-					<g class="i10 leaf node n0 p0 root sample" transform="translate(32.9167 121.4)">
+					<g class="i10 leaf node n0 p0 root sample" transform="translate(32.5333 121.4)">
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="c2 i1 node n15 p0 root" transform="translate(103.958 26.8)">
-						<g class="a15 c3 i9 m0 node n6 p0 s0" transform="translate(32.2917 75.68)">
-							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
+					<g class="c2 i1 node n15 p0 root" transform="translate(101.467 26.8)">
+						<g class="a15 c3 i9 m0 m2 node n6 p0 s1 s3" transform="translate(31.3333 75.68)">
+							<g class="a6 i12 leaf m1 node n2 p0 s1 sample" transform="translate(-25.0667 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
+								<g class="mut m1 s1 unknown_time" transform="translate(0 -9.46)">
+									<line x1="0" x2="0" y1="0" y2="9.46"/>
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab lft" transform="translate(-5 0)">1</text>
+								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
@@ -138,32 +212,37 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">4</text>
 							</g>
-							<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.8333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H -25.8333"/>
+							<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.0667 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<path class="edge" d="M 0 0 V -75.68 H -32.2917"/>
-							<g class="mut m0 s0 unknown_time" transform="translate(0 -37.84)">
-								<line x1="0" x2="0" y1="0" y2="37.84"/>
+							<path class="edge" d="M 0 0 V -75.68 H -31.3333"/>
+							<g class="mut m0 s1 unknown_time" transform="translate(0 -50.4533)">
+								<line x1="0" x2="0" y1="0" y2="50.4533"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
 								<text class="lab rgt" transform="translate(5 0)">0</text>
+							</g>
+							<g class="mut m2 s3 unknown_time" transform="translate(0 -25.2267)">
+								<line x1="0" x2="0" y1="0" y2="25.2267"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
 						</g>
-						<g class="a15 c2 i6 node n11 p0" transform="translate(-32.2917 56.76)">
-							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.9167 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H 12.9167"/>
+						<g class="a15 c2 i6 node n11 p0" transform="translate(-31.3333 56.76)">
+							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.5333 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H 12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<g class="a11 i13 leaf node n3 p0 sample" transform="translate(12.9167 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H -12.9167"/>
+							<g class="a11 i13 leaf node n3 p0 sample" transform="translate(12.5333 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H -12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -56.76 H 32.2917"/>
+							<path class="edge" d="M 0 0 V -56.76 H 31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">11</text>
 						</g>
@@ -172,11 +251,11 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t1" transform="translate(215 0)">
+			<g class="tree t1" transform="translate(247.2 0)">
 				<g class="plotbox">
-					<g class="c3 i9 node n6 p0 root" transform="translate(58.75 102.48)">
-						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
+					<g class="c3 i9 node n6 p0 root" transform="translate(57.6 102.48)">
+						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">2</text>
 						</g>
@@ -185,32 +264,37 @@
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">4</text>
 						</g>
-						<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.8333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -25.8333"/>
+						<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="c2 i3 node n12 p0 root" transform="translate(129.792 64.64)">
-						<g class="a12 i10 leaf node n0 p0 sample" transform="translate(-19.375 56.76)">
-							<path class="edge" d="M 0 0 V -56.76 H 19.375"/>
+					<g class="c2 i3 node n12 p0 root" transform="translate(126.533 64.64)">
+						<g class="a12 i10 leaf m3 node n0 p0 s4 sample" transform="translate(-18.8 56.76)">
+							<path class="edge" d="M 0 0 V -56.76 H 18.8"/>
+							<g class="mut m3 s4 unknown_time" transform="translate(0 -28.38)">
+								<line x1="0" x2="0" y1="0" y2="28.38"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">3</text>
+							</g>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a12 c2 i6 node n11 p0" transform="translate(19.375 18.92)">
-							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.9167 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H 12.9167"/>
+						<g class="a12 c2 i6 node n11 p0" transform="translate(18.8 18.92)">
+							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.5333 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H 12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<g class="a11 i13 leaf node n3 p0 sample" transform="translate(12.9167 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H -12.9167"/>
+							<g class="a11 i13 leaf node n3 p0 sample" transform="translate(12.5333 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H -12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -18.92 H -19.375"/>
+							<path class="edge" d="M 0 0 V -18.92 H -18.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
 						</g>
@@ -219,16 +303,16 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t2" transform="translate(410 0)">
+			<g class="tree t2" transform="translate(437.6 0)">
 				<g class="plotbox">
-					<g class="i10 leaf node n0 p0 root sample" transform="translate(32.9167 121.4)">
+					<g class="i10 leaf node n0 p0 root sample" transform="translate(32.5333 121.4)">
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="c2 i0 node n14 p0 root" transform="translate(103.958 26.8)">
-						<g class="a14 c3 i9 m2 node n6 p0 s2" transform="translate(32.2917 75.68)">
-							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
+					<g class="c2 i0 node n14 p0 root" transform="translate(101.467 26.8)">
+						<g class="a14 c3 i9 node n6 p0" transform="translate(31.3333 75.68)">
+							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
@@ -237,37 +321,32 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">4</text>
 							</g>
-							<g class="a6 i15 leaf m1 node n5 p0 s1 sample" transform="translate(25.8333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H -25.8333"/>
-								<g class="mut m1 s1 unknown_time" transform="translate(0 -9.46)">
+							<g class="a6 i15 leaf m4 node n5 p0 s5 sample" transform="translate(25.0667 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
+								<g class="mut m4 s5 unknown_time" transform="translate(0 -9.46)">
 									<line x1="0" x2="0" y1="0" y2="9.46"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-									<text class="lab rgt" transform="translate(5 0)">1</text>
+									<text class="lab rgt" transform="translate(5 0)">4</text>
 								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<path class="edge" d="M 0 0 V -75.68 H -32.2917"/>
-							<g class="mut m2 s2 unknown_time" transform="translate(0 -37.84)">
-								<line x1="0" x2="0" y1="0" y2="37.84"/>
-								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-								<text class="lab rgt" transform="translate(5 0)">2</text>
-							</g>
+							<path class="edge" d="M 0 0 V -75.68 H -31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
 						</g>
-						<g class="a14 c2 i6 node n11 p0" transform="translate(-32.2917 56.76)">
-							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.9167 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H 12.9167"/>
+						<g class="a14 c2 i6 node n11 p0" transform="translate(-31.3333 56.76)">
+							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.5333 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H 12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<g class="a11 i13 leaf node n3 p0 sample" transform="translate(12.9167 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H -12.9167"/>
+							<g class="a11 i13 leaf node n3 p0 sample" transform="translate(12.5333 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H -12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -56.76 H 32.2917"/>
+							<path class="edge" d="M 0 0 V -56.76 H 31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">11</text>
 						</g>
@@ -276,55 +355,45 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t3" transform="translate(605 0)">
+			<g class="tree t3" transform="translate(628 0)">
 				<g class="plotbox">
-					<g class="i10 leaf node n0 p0 root sample" transform="translate(32.9167 121.4)">
+					<g class="i10 leaf node n0 p0 root sample" transform="translate(32.5333 121.4)">
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="c2 i0 node n14 p0 root" transform="translate(103.958 26.8)">
-						<g class="a14 c3 i9 node n6 p0" transform="translate(32.2917 75.68)">
-							<g class="a6 i12 leaf m4 node n2 p0 s4 sample" transform="translate(-25.8333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
-								<g class="mut m4 s4 unknown_time" transform="translate(0 -9.46)">
-									<line x1="0" x2="0" y1="0" y2="9.46"/>
-									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-									<text class="lab lft" transform="translate(-5 0)">4</text>
-								</g>
+					<g class="c2 i0 node n14 p0 root" transform="translate(101.467 26.8)">
+						<g class="a14 c3 i9 node n6 p0" transform="translate(31.3333 75.68)">
+							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<g class="a6 i14 leaf m3 node n4 p0 s3 sample" transform="translate(0.0 18.92)">
+							<g class="a6 i14 leaf node n4 p0 sample" transform="translate(0.0 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 0.0"/>
-								<g class="mut m3 s3 unknown_time" transform="translate(0 -9.46)">
-									<line x1="0" x2="0" y1="0" y2="9.46"/>
-									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-									<text class="lab rgt" transform="translate(5 0)">3</text>
-								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">4</text>
 							</g>
-							<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.8333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H -25.8333"/>
+							<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.0667 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<path class="edge" d="M 0 0 V -75.68 H -32.2917"/>
+							<path class="edge" d="M 0 0 V -75.68 H -31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
 						</g>
-						<g class="a14 c2 i8 node n7 p0" transform="translate(-32.2917 75.68)">
-							<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.9167 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
+						<g class="a14 c2 i8 node n7 p0" transform="translate(-31.3333 75.68)">
+							<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.9167 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+							<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.5333 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge" d="M 0 0 V -75.68 H 32.2917"/>
+							<path class="edge" d="M 0 0 V -75.68 H 31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">7</text>
 						</g>
@@ -333,50 +402,60 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t4" transform="translate(800 0)">
+			<g class="tree t4" transform="translate(818.4 0)">
 				<g class="plotbox">
-					<g class="c2 i8 node n7 p0 root" transform="translate(45.8333 102.48)">
-						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
+					<g class="c2 i8 node n7 p0 root" transform="translate(45.0667 102.48)">
+						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">1</text>
 						</g>
-						<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+						<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">3</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
-					<g class="c2 i2 node n13 p0 root" transform="translate(113.646 45.72)">
-						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-29.0625 75.68)">
-							<path class="edge" d="M 0 0 V -75.68 H 29.0625"/>
+					<g class="c2 i2 node n13 p0 root" transform="translate(110.867 45.72)">
+						<g class="a13 i10 leaf m5 node n0 p0 s7 sample" transform="translate(-28.2 75.68)">
+							<path class="edge" d="M 0 0 V -75.68 H 28.2"/>
+							<g class="mut m5 s7 unknown_time" transform="translate(0 -37.84)">
+								<line x1="0" x2="0" y1="0" y2="37.84"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">5</text>
+							</g>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a13 c2 i5 node n10 p0" transform="translate(29.0625 37.84)">
-							<g class="a10 i15 leaf node n5 p0 sample" transform="translate(19.375 37.84)">
-								<path class="edge" d="M 0 0 V -37.84 H -19.375"/>
+						<g class="a13 c2 i5 node n10 p0" transform="translate(28.2 37.84)">
+							<g class="a10 i15 leaf m6 node n5 p0 s7 sample" transform="translate(18.8 37.84)">
+								<path class="edge" d="M 0 0 V -37.84 H -18.8"/>
+								<g class="mut m6 s7 unknown_time" transform="translate(0 -18.92)">
+									<line x1="0" x2="0" y1="0" y2="18.92"/>
+									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+									<text class="lab rgt" transform="translate(5 0)">6</text>
+								</g>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<g class="a10 c2 i9 node n6 p0" transform="translate(-19.375 18.92)">
-								<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.9167 18.92)">
-									<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
+							<g class="a10 c2 i9 node n6 p0" transform="translate(-18.8 18.92)">
+								<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.5333 18.92)">
+									<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">2</text>
 								</g>
-								<g class="a6 i14 leaf node n4 p0 sample" transform="translate(12.9167 18.92)">
-									<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+								<g class="a6 i14 leaf node n4 p0 sample" transform="translate(12.5333 18.92)">
+									<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 									<text class="lab" transform="translate(0 11)">4</text>
 								</g>
-								<path class="edge" d="M 0 0 V -18.92 H 19.375"/>
+								<path class="edge" d="M 0 0 V -18.92 H 18.8"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
 								<text class="lab lft" transform="translate(-3 -7.0)">6</text>
 							</g>
-							<path class="edge" d="M 0 0 V -37.84 H -29.0625"/>
+							<path class="edge" d="M 0 0 V -37.84 H -28.2"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7.0)">10</text>
 						</g>
@@ -385,49 +464,44 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t5" transform="translate(995 0)">
+			<g class="tree t5" transform="translate(1008.8 0)">
 				<g class="plotbox">
-					<g class="c2 i9 node n6 p0 root" transform="translate(45.8333 102.48)">
-						<g class="a6 i12 leaf m5 node n2 p0 s5 sample" transform="translate(-12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
-							<g class="mut m5 s5 unknown_time" transform="translate(0 -9.46)">
-								<line x1="0" x2="0" y1="0" y2="9.46"/>
-								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-								<text class="lab lft" transform="translate(-5 0)">5</text>
-							</g>
+					<g class="c2 i9 node n6 p0 root" transform="translate(45.0667 102.48)">
+						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">2</text>
 						</g>
-						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">4</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="c2 i8 node n7 p0 root" transform="translate(97.5 102.48)">
-						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
+					<g class="c2 i8 node n7 p0 root" transform="translate(95.2 102.48)">
+						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">1</text>
 						</g>
-						<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+						<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">3</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
-					<g class="c2 i2 node n13 p0 root" transform="translate(149.167 45.72)">
-						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-12.9167 75.68)">
-							<path class="edge" d="M 0 0 V -75.68 H 12.9167"/>
+					<g class="c2 i2 node n13 p0 root" transform="translate(145.333 45.72)">
+						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-12.5333 75.68)">
+							<path class="edge" d="M 0 0 V -75.68 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a13 i15 leaf node n5 p0 sample" transform="translate(12.9167 75.68)">
-							<path class="edge" d="M 0 0 V -75.68 H -12.9167"/>
+						<g class="a13 i15 leaf node n5 p0 sample" transform="translate(12.5333 75.68)">
+							<path class="edge" d="M 0 0 V -75.68 H -12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">5</text>
 						</g>
@@ -436,16 +510,21 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t6" transform="translate(1190 0)">
+			<g class="tree t6" transform="translate(1199.2 0)">
 				<g class="plotbox">
-					<g class="c3 i9 node n6 p0 root" transform="translate(58.75 102.48)">
-						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
+					<g class="c3 i9 node n6 p0 root" transform="translate(57.6 102.48)">
+						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">2</text>
 						</g>
-						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(25.8333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -25.8333"/>
+						<g class="a6 i14 leaf m7 node n4 p0 s8 sample" transform="translate(25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
+							<g class="mut m7 s8 unknown_time" transform="translate(0 -9.46)">
+								<line x1="0" x2="0" y1="0" y2="9.46"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab rgt" transform="translate(5 0)">7</text>
+							</g>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">4</text>
 						</g>
@@ -457,18 +536,23 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="i11 leaf node n1 p0 root sample" transform="translate(110.417 121.4)">
+					<g class="i11 leaf node n1 p0 root sample" transform="translate(107.733 121.4)">
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">1</text>
 					</g>
-					<g class="c2 i7 node n8 p0 root" transform="translate(149.167 102.48)">
-						<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
+					<g class="c2 i7 node n8 p0 root" transform="translate(145.333 102.48)">
+						<g class="a8 i10 leaf m8 node n0 p0 s8 sample" transform="translate(-12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
+							<g class="mut m8 s8 unknown_time" transform="translate(0 -9.46)">
+								<line x1="0" x2="0" y1="0" y2="9.46"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">8</text>
+							</g>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">0</text>
 						</g>
-						<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.9167 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+						<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">5</text>
 						</g>
@@ -477,16 +561,21 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t7" transform="translate(1385 0)">
+			<g class="tree t7" transform="translate(1389.6 0)">
 				<g class="plotbox">
-					<g class="c3 i9 node n6 p0 root" transform="translate(58.75 102.48)">
-						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.8333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 25.8333"/>
+					<g class="c3 i9 node n6 p0 root" transform="translate(57.6 102.48)">
+						<g class="a6 i12 leaf m9 node n2 p0 s9 sample" transform="translate(-25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
+							<g class="mut m9 s9 unknown_time" transform="translate(0 -9.46)">
+								<line x1="0" x2="0" y1="0" y2="9.46"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">9</text>
+							</g>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">2</text>
 						</g>
-						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(25.8333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -25.8333"/>
+						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">4</text>
 						</g>
@@ -498,24 +587,24 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="c2 i4 node n9 p0 root" transform="translate(142.708 83.56)">
-						<g class="a9 i11 leaf node n1 p0 sample" transform="translate(19.375 37.84)">
-							<path class="edge" d="M 0 0 V -37.84 H -19.375"/>
+					<g class="c2 i4 node n9 p0 root" transform="translate(139.067 83.56)">
+						<g class="a9 i11 leaf node n1 p0 sample" transform="translate(18.8 37.84)">
+							<path class="edge" d="M 0 0 V -37.84 H -18.8"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">1</text>
 						</g>
-						<g class="a9 c2 i7 node n8 p0" transform="translate(-19.375 18.92)">
-							<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.9167 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H 12.9167"/>
+						<g class="a9 c2 i7 node n8 p0" transform="translate(-18.8 18.92)">
+							<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.5333 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.9167 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H -12.9167"/>
+							<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.5333 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<path class="edge" d="M 0 0 V -18.92 H 19.375"/>
+							<path class="edge" d="M 0 0 V -18.92 H 18.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7.0)">8</text>
 						</g>

--- a/python/tests/data/svg/ts_y_axis.svg
+++ b/python/tests/data/svg/ts_y_axis.svg
@@ -97,7 +97,7 @@
 			</g>
 			<g class="y-axis">
 				<g transform="translate(0 65.7)">
-					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (gens)</text>
+					<text class="lab" text-anchor="middle" transform="translate(11) rotate(-90)">Time (generations)</text>
 				</g>
 				<line x1="56.8" x2="56.8" y1="121.4" y2="10"/>
 				<g class="ticks">

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -126,7 +126,8 @@ class Simplifier:
         self.input_sites = list(ts.sites())
         self.A_head = [None for _ in range(ts.num_nodes)]
         self.A_tail = [None for _ in range(ts.num_nodes)]
-        self.tables = tskit.TableCollection(sequence_length=ts.sequence_length)
+        self.tables = self.ts.tables.copy()
+        self.tables.clear()
         self.edge_buffer = {}
         self.node_id_map = np.zeros(ts.num_nodes, dtype=np.int32) - 1
         self.mutation_node_map = [-1 for _ in range(self.num_mutations)]

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -2454,10 +2454,12 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         )
 
     def test_known_svg_ts_y_axis(self, overwrite_viz, draw_plotbox):
-        ts = self.get_simple_ts()
-        y_label = "Time (gens)"
-        svg = ts.draw_svg(y_axis=True, y_label=y_label, debug_box=draw_plotbox)
-        assert y_label in svg
+        tables = self.get_simple_ts().dump_tables()
+        # set units
+        tables.time_units = "generations"
+        ts = tables.tree_sequence()
+        svg = ts.draw_svg(y_axis=True, debug_box=draw_plotbox)
+        assert "Time (generations)" in svg
         self.verify_known_svg(
             svg, "ts_y_axis.svg", overwrite_viz, width=200 * ts.num_trees
         )
@@ -2546,15 +2548,16 @@ class TestDrawSvg(TestTreeDraw, xmlunittest.XmlTestMixin):
         )
         tables.sort()
         ts = tables.tree_sequence().simplify()
-        tables = msprime.mutate(ts, rate=0.1, random_seed=123).dump_tables()
+        tables = tsutil.jukes_cantor(ts, 10, mu=0.1, seed=123).dump_tables()
         # Set unknown times, so we are msprime 0.7.4 and 1.0.0 compatible
         tables.mutations.time = np.full(tables.mutations.num_rows, tskit.UNKNOWN_TIME)
         svg = tables.tree_sequence().draw_svg(
-            y_label="Time (WF gens)", y_gridlines=True, debug_box=draw_plotbox
+            y_axis=True, y_gridlines=True, debug_box=draw_plotbox
         )
         self.verify_known_svg(
             svg, "ts_multiroot.svg", overwrite_viz, width=200 * ts.num_trees
         )
+        assert "Time (generations)" in svg
 
     def test_known_svg_ts_xlim(self, overwrite_viz, draw_plotbox, caplog):
         ts = self.get_simple_ts()

--- a/python/tests/test_wright_fisher.py
+++ b/python/tests/test_wright_fisher.py
@@ -199,6 +199,7 @@ class WrightFisherSimulator:
         flattened = [n for pop in pops for n in pop]
         flags[flattened] = tskit.NODE_IS_SAMPLE
         tables.nodes.flags = flags
+        tables.time_units = "generations"
         return tables
 
 
@@ -249,6 +250,7 @@ class TestSimulation:
             seed=self.random_seed,
             record_migrations=True,
         )
+        assert tables.time_units == "generations"
         assert tables.nodes.num_rows == 5 * 4 * (1 + 1)
         assert tables.edges.num_rows > 0
         assert tables.migrations.num_rows == 5 * 4

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -551,6 +551,8 @@ class SvgPlot:
                 y_label = "Node time"
             else:
                 y_label = "Time"
+            if ts.time_units != "unknown":
+                y_label += f" ({ts.time_units})"
         self.x_label = x_label
         self.y_label = y_label
         self.offsets = Offsets() if offsets is None else offsets


### PR DESCRIPTION
Now that we have time_units, I think we should add them, if known, to the default y-axis label when doing `draw_svg`. Here I make the built-in WF simulator quote units in generations, which the modified drawing code then shows by default in braces:

<img width="459" alt="Screenshot 2021-10-08 at 14 54 32" src="https://user-images.githubusercontent.com/4699014/136569361-d8b71c75-124e-4ca3-a322-8ca776b55a48.png">

This is likely to lead to less confusion between e.g. years vs generations when plotting inferred tree sequences 