### PR TITLE
Don't sort individuals by default

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -16,7 +16,14 @@
 
 - FIXME breaking changes for tree API and virtual root
 
+- Individuals are no longer guaranteed or required to be topologically sorted in a tree sequence. 
+  ``tsk_table_collection_sort`` no longer sorts individuals.
+  (:user:`benjeffery`, :issue:`1774`, :pr:`1789`)
+
 **Features**
+
+- Add ``tsk_table_collection_individual_topological_sort`` to sort the individuals as this is no longer done by the
+  default sort. (:user:`benjeffery`, :issue:`1774`, :pr:`1789`)
 
 - The default behaviour for table size growth is now to double the current size of the table,
   up to a threshold. To keep the previous behaviour, use (e.g.)

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -2077,10 +2077,10 @@ test_simplest_bad_individuals(void)
     tsk_treeseq_free(&ts);
     tables.individuals.parents[0] = TSK_NULL;
 
-    /* Unsorted individuals */
+    /* Unsorted individuals are OK*/
     tables.individuals.parents[0] = 1;
     ret = tsk_treeseq_init(&ts, &tables, load_flags);
-    CU_ASSERT_EQUAL(ret, TSK_ERR_UNSORTED_INDIVIDUALS);
+    CU_ASSERT_EQUAL(ret, 0);
     tsk_treeseq_free(&ts);
     tables.individuals.parents[0] = TSK_NULL;
 

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -3672,16 +3672,32 @@ TSK_NO_CHECK_INTEGRITY
 
 @endrst
 
-@param self A pointer to a tsk_individual_table_t object.
+@param self A pointer to a tsk_table_collection_t object.
 @param start The position to begin sorting in each table; all rows less than this
     position must fulfill the tree sequence sortedness requirements. If this is
     NULL, sort all rows.
-@param options Sort options. Currently unused; should be
-    set to zero to ensure compatibility with later versions of tskit.
+@param options Sort options.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_table_collection_sort(
     tsk_table_collection_t *self, const tsk_bookmark_t *start, tsk_flags_t options);
+
+/**
+@brief Sorts the individual table in this collection.
+
+@rst
+Sorts the individual table in place, so that parents come before children,
+and the parent column is remapped as required. Node references to individuals
+are also updated.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param options Sort options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_individual_topological_sort(
+    tsk_table_collection_t *self, tsk_flags_t options);
 
 /**
 @brief Puts the tables into canonical form.

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -566,13 +566,8 @@ Individual requirements
 -----------------------
 
 Individuals are a basic type in a tree sequence and are not defined with
-respect to any other tables. Individuals can have a reference to their parent
-individuals, if present these references must be valid or null (-1).
-
-Individuals must be sorted such that parents are before children.
-Sorting a set of tables using :meth:`TableCollection.sort` will ensure that
-this requirement is fulfilled.
-
+respect to any other tables. Individuals can have a reference to any number of
+their parent individuals, if present these references must be valid or null (-1).
 
 .. _sec_node_requirements:
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -27,8 +27,14 @@
   are multiple roots. Previously orders were defined locally for each root, but
   are now globally across all roots. (:user:`jeromekelleher`, :pr:`1704`).
 
+- Individuals are no longer guaranteed or required to be topologically sorted in a tree sequence.
+  ``TableCollection.sort`` no longer sorts individuals.
+  (:user:`benjeffery`, :issue:`1774`, :pr:`1789`)
 
 **Features**
+
+- Add ``TableCollection.sort_individuals`` to sort the individuals as this is no longer done by the
+  default sort. (:user:`benjeffery`, :issue:`1774`, :pr:`1789`)
 
 - Add ``__setitem__`` to all tables allowing single rows to be updated. For example
   ``tables.nodes[0] = tables.nodes[0].replace(flags=tskit.NODE_IS_SAMPLE)``

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6633,6 +6633,26 @@ out:
 }
 
 static PyObject *
+TableCollection_sort_individuals(TableCollection *self, PyObject *args, PyObject *kwds)
+{
+    int err;
+    PyObject *ret = NULL;
+
+    if (TableCollection_check_state(self) != 0) {
+        goto out;
+    }
+
+    err = tsk_table_collection_individual_topological_sort(self->tables, 0);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 TableCollection_canonicalise(TableCollection *self, PyObject *args, PyObject *kwds)
 {
     int err;
@@ -7115,6 +7135,10 @@ static PyMethodDef TableCollection_methods[] = {
         .ml_meth = (PyCFunction) TableCollection_sort,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,
         .ml_doc = "Sorts the tables to satisfy tree sequence requirements." },
+    { .ml_name = "sort_individuals",
+        .ml_meth = (PyCFunction) TableCollection_sort_individuals,
+        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_doc = "Sorts the individual table topologically" },
     { .ml_name = "canonicalise",
         .ml_meth = (PyCFunction) TableCollection_canonicalise,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,

--- a/python/tests/data/svg/ts_multiroot.svg
+++ b/python/tests/data/svg/ts_multiroot.svg
@@ -196,7 +196,7 @@
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
 					<g class="c2 i1 node n15 p0 root" transform="translate(101.467 26.8)">
-						<g class="a15 c3 i9 m0 m2 node n6 p0 s1 s3" transform="translate(31.3333 75.68)">
+						<g class="a15 c3 i7 m0 m2 node n6 p0 s1 s3" transform="translate(31.3333 75.68)">
 							<g class="a6 i12 leaf m1 node n2 p0 s1 sample" transform="translate(-25.0667 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 								<g class="mut m1 s1 unknown_time" transform="translate(0 -9.46)">
@@ -253,7 +253,7 @@
 			</g>
 			<g class="tree t1" transform="translate(247.2 0)">
 				<g class="plotbox">
-					<g class="c3 i9 node n6 p0 root" transform="translate(57.6 102.48)">
+					<g class="c3 i7 node n6 p0 root" transform="translate(57.6 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -310,7 +310,7 @@
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
 					<g class="c2 i0 node n14 p0 root" transform="translate(101.467 26.8)">
-						<g class="a14 c3 i9 node n6 p0" transform="translate(31.3333 75.68)">
+						<g class="a14 c3 i7 node n6 p0" transform="translate(31.3333 75.68)">
 							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -362,7 +362,7 @@
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
 					<g class="c2 i0 node n14 p0 root" transform="translate(101.467 26.8)">
-						<g class="a14 c3 i9 node n6 p0" transform="translate(31.3333 75.68)">
+						<g class="a14 c3 i7 node n6 p0" transform="translate(31.3333 75.68)">
 							<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -440,7 +440,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">5</text>
 							</g>
-							<g class="a10 c2 i9 node n6 p0" transform="translate(-18.8 18.92)">
+							<g class="a10 c2 i7 node n6 p0" transform="translate(-18.8 18.92)">
 								<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.5333 18.92)">
 									<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 									<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -494,7 +494,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">13</text>
 					</g>
-					<g class="c2 i9 node n6 p0 root" transform="translate(145.333 102.48)">
+					<g class="c2 i7 node n6 p0 root" transform="translate(145.333 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.5333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -512,7 +512,7 @@
 			</g>
 			<g class="tree t6" transform="translate(1199.2 0)">
 				<g class="plotbox">
-					<g class="c3 i9 node n6 p0 root" transform="translate(57.6 102.48)">
+					<g class="c3 i7 node n6 p0 root" transform="translate(57.6 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -540,7 +540,7 @@
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">1</text>
 					</g>
-					<g class="c2 i7 node n8 p0 root" transform="translate(145.333 102.48)">
+					<g class="c2 i9 node n8 p0 root" transform="translate(145.333 102.48)">
 						<g class="a8 i10 leaf m8 node n0 p0 s8 sample" transform="translate(-12.5333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<g class="mut m8 s8 unknown_time" transform="translate(0 -9.46)">
@@ -563,7 +563,7 @@
 			</g>
 			<g class="tree t7" transform="translate(1389.6 0)">
 				<g class="plotbox">
-					<g class="c3 i9 node n6 p0 root" transform="translate(57.6 102.48)">
+					<g class="c3 i7 node n6 p0 root" transform="translate(57.6 102.48)">
 						<g class="a6 i12 leaf m9 node n2 p0 s9 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<g class="mut m9 s9 unknown_time" transform="translate(0 -9.46)">
@@ -593,7 +593,7 @@
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 							<text class="lab" transform="translate(0 11)">1</text>
 						</g>
-						<g class="a9 c2 i7 node n8 p0" transform="translate(-18.8 18.92)">
+						<g class="a9 c2 i9 node n8 p0" transform="translate(-18.8 18.92)">
 							<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.5333 18.92)">
 								<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -400,6 +400,10 @@ class TestTableCollection(LowLevelTestCase):
             with pytest.raises(TypeError):
                 tc.fromdict(bad_type)
 
+    def test_sort_individuals(self):
+        tc = _tskit.TableCollection(1)
+        tc.sort_individuals()
+
 
 class TestIbd:
     def test_uninitialised(self):

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -3204,12 +3204,10 @@ class TestSimplifyTables:
             shuffle_migrations=False,
         )
         # Check we have a mixed up order
-        with pytest.raises(
-            tskit.LibraryError,
-            match="Individuals must be provided in an order where"
-            " children are after their parent individuals",
-        ):
-            tables.tree_sequence()
+        tables2 = tables.copy()
+        tables2.sort_individuals()
+        with pytest.raises(AssertionError, match="IndividualTable row 0 differs"):
+            tables.assert_equals(tables2)
 
         tables.simplify()
         metadata = [

--- a/python/tests/test_text_formats.py
+++ b/python/tests/test_text_formats.py
@@ -156,7 +156,7 @@ class TestParseFam:
             FamEntry(iid="3", pat="1", mat="2"),
         ]
         tb = self.get_parsed_fam(entries=entries)
-        assert np.array_equal(tb[2].parents, [1, 0])
+        assert np.array_equal(tb[2].parents, [0, 1])
 
     def test_missing_parent_id(self):
         # KeyError raised if at least one parent (PAT) does not exist in dataset
@@ -243,7 +243,3 @@ class TestParseFam:
         for row in tb:
             tc.individuals.append(row)
         tc.tree_sequence()  # creating tree sequence should succeed
-
-        for idx in range(2):
-            assert np.array_equal(tb[idx].parents, [-1, -1])
-        assert np.array_equal(tb[2].parents, [1, 0])

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -1132,8 +1132,6 @@ def py_sort(tables, canonical=False):
                 )
             )
         tables.nodes.individual = [ind_id_map[i] for i in tables.nodes.individual]
-    else:
-        sort_individual_table(tables)
 
 
 def algorithm_T(ts):

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3140,8 +3140,7 @@ class TableCollection:
         given parent ID are adjacent, but we do not require that they be listed in
         sorted order.
 
-        Individuals are sorted so that parents come before children, and the
-        parent column remapped as required.
+        Individuals are not sorted.
 
         Sites are sorted by position, and sites with the same position retain
         their relative ordering.
@@ -3163,6 +3162,15 @@ class TableCollection:
             (default=0; must be <= len(edges)).
         """
         self._ll_tables.sort(edge_start)
+        # TODO add provenance
+
+    def sort_individuals(self):
+        """
+        Sorts the individual table in place, so that parents come before children,
+        and the parent column is remapped as required. Node references to individuals
+        are also updated.
+        """
+        self._ll_tables.sort_individuals()
         # TODO add provenance
 
     def canonicalise(self, remove_unreferenced=None):


### PR DESCRIPTION
Part of #1774 

I started ripping loads of code out, then realised that maybe this is a less destructive way to do this. (Commented out code will return when the individual sort method uses it.)

WIP for feedback, next is removing the requirement from checks