### PR TITLE
Implement TreeSequence.discrete_genome

### DIFF
--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -68,6 +68,8 @@ typedef struct {
     tsk_id_t *samples;
     /* Does this tree sequence have time_units == "uncalibrated" */
     bool time_uncalibrated;
+    /* Are all genome coordinates discrete? */
+    bool discrete_genome;
     /* Breakpoints along the sequence, including 0 and L. */
     double *breakpoints;
     /* If a node is a sample, map to its index in the samples list */
@@ -268,6 +270,7 @@ const double *tsk_treeseq_get_breakpoints(const tsk_treeseq_t *self);
 const tsk_id_t *tsk_treeseq_get_samples(const tsk_treeseq_t *self);
 const tsk_id_t *tsk_treeseq_get_sample_index_map(const tsk_treeseq_t *self);
 bool tsk_treeseq_is_sample(const tsk_treeseq_t *self, tsk_id_t u);
+bool tsk_treeseq_get_discrete_genome(const tsk_treeseq_t *self);
 
 int tsk_treeseq_get_node(const tsk_treeseq_t *self, tsk_id_t index, tsk_node_t *node);
 int tsk_treeseq_get_edge(const tsk_treeseq_t *self, tsk_id_t index, tsk_edge_t *edge);

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -63,6 +63,9 @@
 - Substantial performance improvement for ``Tree.total_branch_length``
   (:user:`jeromekelleher`, :issue:`1794` :pr:`1799`)
 
+- Add the ``discrete_genome`` property to the TreeSequence class which is true if
+  all coordinates are discrete (:user:`jeromekelleher`, :issue:`1144`, :pr:`1819`)
+
 --------------------
 [0.3.7] - 2021-07-08
 --------------------

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7813,6 +7813,19 @@ out:
 }
 
 static PyObject *
+TreeSequence_get_discrete_genome(TreeSequence *self)
+{
+    PyObject *ret = NULL;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    ret = Py_BuildValue("i", tsk_treeseq_get_discrete_genome(self->tree_sequence));
+out:
+    return ret;
+}
+
+static PyObject *
 TreeSequence_get_breakpoints(TreeSequence *self)
 {
     PyObject *ret = NULL;
@@ -9017,6 +9030,10 @@ static PyMethodDef TreeSequence_methods[] = {
         .ml_meth = (PyCFunction) TreeSequence_get_sequence_length,
         .ml_flags = METH_NOARGS,
         .ml_doc = "Returns the sequence length in bases." },
+    { .ml_name = "get_discrete_genome",
+        .ml_meth = (PyCFunction) TreeSequence_get_discrete_genome,
+        .ml_flags = METH_NOARGS,
+        .ml_doc = "Returns True if this TreeSequence has discrete coordinates" },
     { .ml_name = "get_breakpoints",
         .ml_meth = (PyCFunction) TreeSequence_get_breakpoints,
         .ml_flags = METH_NOARGS,

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -1241,6 +1241,22 @@ class TestTreeSequence(HighLevelTestCase):
     Tests for the tree sequence object.
     """
 
+    @pytest.mark.parametrize("ts", get_example_tree_sequences())
+    def test_discrete_genome(self, ts):
+        def is_discrete(a):
+            return np.all(np.floor(a) == a)
+
+        tables = ts.tables
+        discrete_genome = (
+            is_discrete([tables.sequence_length])
+            and is_discrete(tables.edges.left)
+            and is_discrete(tables.edges.right)
+            and is_discrete(tables.sites.position)
+            and is_discrete(tables.migrations.left)
+            and is_discrete(tables.migrations.right)
+        )
+        assert ts.discrete_genome == discrete_genome
+
     def test_trees(self):
         for ts in get_example_tree_sequences():
             self.verify_trees(ts)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -3843,6 +3843,22 @@ class TreeSequence:
         return self._ll_tree_sequence.get_file_uuid()
 
     @property
+    def discrete_genome(self):
+        """
+        Returns True if all genome coordinates in this TreeSequence are
+        discrete integer values. This is true iff all the following are true:
+
+        - The sequence length is discrete
+        - All site positions are discrete
+        - All left and right edge coordinates are discrete
+        - All migration left and right coordinates are discrete
+
+        :return: True if this TreeSequence uses discrete genome coordinates.
+        :rtype: bool
+        """
+        return bool(self._ll_tree_sequence.get_discrete_genome())
+
+    @property
     def sequence_length(self):
         """
         Returns the sequence length in this tree sequence. This defines the


### PR DESCRIPTION
Closes #1144

This should unplug a few outstanding issues. We could make things a bit more granular and just focus on discrete sites/breakpoints etc, but I don't think it's worth the bother. Tree sequences mixing discrete and continuous coordinates are going to be rare, and probably a result of a mistake somewhere along the way.