### PR TITLE
Output alignments

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -611,3 +611,7 @@ Some top-level utility functions.
 ```{eval-rst}
 .. autofunction:: is_unknown_time
 ```
+
+```{eval-rst}
+.. autofunction:: random_nucleotides
+```

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -82,6 +82,10 @@
 - Add the ``discrete_genome`` property to the TreeSequence class which is true if
   all coordinates are discrete (:user:`jeromekelleher`, :issue:`1144`, :pr:`1819`)
 
+- Add a ``random_nucleotides`` function. (user:`jeromekelleher`, :pr:`1825`)
+
+- Add the ``TreeSequence.alignments`` method. (user:`jeromekelleher`, :pr:`1825`)
+
 **Fixes**
 
 - `dump_tables` omitted individual parents. (:user:`benjeffery`, :issue:`1828`, :pr:`1884`)

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -359,3 +359,19 @@ def base64_encode(metadata):
     string.
     """
     return base64.b64encode(metadata).decode("utf8")
+
+
+def cached_example(ts_func):
+    """
+    Utility decorator to cache the result of a single function call
+    returning a tree sequence example.
+    """
+    cache = None
+
+    def f(*args):
+        nonlocal cache
+        if cache is None:
+            cache = ts_func(*args)
+        return cache
+
+    return f

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -304,7 +304,15 @@ def get_example_tree_sequences(back_mutations=True, gaps=True, internal_samples=
             random_seed=seed,
             model=msprime.InfiniteSites(msprime.NUCLEOTIDES),
         )
-    ts = msprime.simulate(15, length=4, recombination_rate=1, random_seed=seed)
+    ts = msprime.sim_ancestry(
+        8, sequence_length=40, recombination_rate=0.1, random_seed=seed
+    )
+    # FIXME various tests in this file assume bytes as metadata. Also
+    # see this bug in the text file format:
+    # https://github.com/tskit-dev/tskit/issues/1860
+    tables = ts.dump_tables()
+    tables.populations.metadata_schema = tskit.MetadataSchema(None)
+    ts = tables.tree_sequence()
     assert ts.num_trees > 1
     if back_mutations:
         yield tsutil.insert_branch_mutations(ts, mutations_per_branch=2)

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -9,6 +9,7 @@ import msprime
 import numpy as np
 import pytest
 
+import tests
 import tests.ibd as ibd
 import tests.test_wright_fisher as wf
 import tskit
@@ -22,23 +23,7 @@ from tests.test_highlevel import get_example_tree_sequences
 # or something.
 
 
-def cached_example(ts_func):
-    """
-    Utility decorator to cache the result of a single function call
-    returning a tree sequence example.
-    """
-    cache = None
-
-    def f(*args):
-        nonlocal cache
-        if cache is None:
-            cache = ts_func(*args)
-        return cache
-
-    return f
-
-
-@cached_example
+@tests.cached_example
 def example_ts():
     return [msprime.sim_ancestry(2, random_seed=1)]
 
@@ -167,7 +152,7 @@ def assert_ibd_equal(dict1, dict2):
 
 
 class TestIbdSingleBinaryTree:
-    @cached_example
+    @tests.cached_example
     def ts(self):
         #
         # 2        4
@@ -309,7 +294,7 @@ class TestIbdTwoSamplesTwoTrees:
     # |------------|----------|
     # 0.0          0.4        1.0
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -357,7 +342,7 @@ class TestIbdUnrelatedSamples:
     #    |   |
     #    0   1
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
 
         nodes = io.StringIO(
@@ -400,7 +385,7 @@ class TestIbdNoSamples:
     #  /     \
     # (0)   (1)
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -441,7 +426,7 @@ class TestIbdSamplesAreDescendants:
     # |     |
     # 0     1
     #
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -504,7 +489,7 @@ class TestIbdSimpleInternalSampleChain:
     # |
     # 0
     #
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -546,7 +531,7 @@ class TestIbdDifferentPaths:
     #                |              |
     #                0.2            0.7
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -607,7 +592,7 @@ class TestIbdDifferentPaths2:
     #                  |
     #                  0.2
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -649,7 +634,7 @@ class TestIbdDifferentPaths3:
     #     ┊ ┃ ┃   ┊ ┃ ┃   ┊
     # 0.00┊ 0 1   ┊ 0 1   ┊
     #     0       5      10
-    @cached_example
+    @tests.cached_example
     def ts(self):
         t = tskit.TableCollection(sequence_length=10)
         t.nodes.add_row(flags=1, time=0)
@@ -686,7 +671,7 @@ class TestIbdPolytomies:
     #                    |
     #                   0.3
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -767,7 +752,7 @@ class TestIbdInternalSamples:
     #   /     \
     #  0      (1)
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\
@@ -809,7 +794,7 @@ class TestIbdLengthThreshold:
     # |------------|----------|
     # 0.0          0.4        1.0
 
-    @cached_example
+    @tests.cached_example
     def ts(self):
         nodes = io.StringIO(
             """\

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -489,3 +489,54 @@ def test_set_printoptions():
     assert tskit._print_options == {"max_lines": 40}
     with pytest.raises(TypeError):
         util.set_print_options(40)
+
+
+class TestRandomNuceotides:
+    @pytest.mark.parametrize("length", [0, 1, 10, 10.0, np.array([10])[0]])
+    def test_length(self, length):
+        s = tskit.random_nucleotides(length, seed=42)
+        assert len(s) == length
+        assert isinstance(s, str)
+
+    def test_default_alphabet(self):
+        s = tskit.random_nucleotides(100, seed=42)
+        assert "".join(sorted(set(s))) == "ACGT"
+
+    def test_length_keyword(self):
+        s1 = tskit.random_nucleotides(length=10, seed=42)
+        s2 = tskit.random_nucleotides(length=10, seed=42)
+        assert s1 == s2
+
+    def test_length_required(self):
+        with pytest.raises(TypeError, match="required positional"):
+            tskit.random_nucleotides()
+
+    def test_seed_keyword_only(self):
+        with pytest.raises(TypeError, match="1 positional"):
+            tskit.random_nucleotides(10, 42)
+
+    @pytest.mark.parametrize("seed", [1, 2, 3])
+    def test_seed_equality(self, seed):
+        s1 = tskit.random_nucleotides(10, seed=seed)
+        s2 = tskit.random_nucleotides(10, seed=seed)
+        assert s1 == s2
+
+    def test_different_seed_not_equal(self):
+        s1 = tskit.random_nucleotides(20, seed=1)
+        s2 = tskit.random_nucleotides(20, seed=2)
+        assert s1 != s2
+
+    def test_no_seed_different_values(self):
+        s1 = tskit.random_nucleotides(20)
+        s2 = tskit.random_nucleotides(20)
+        assert s1 != s2
+
+    @pytest.mark.parametrize("length", ["0", 0.1, np.array([1.1])[0]])
+    def test_length_bad_value(self, length):
+        with pytest.raises(ValueError, match="must be an integer"):
+            tskit.random_nucleotides(length)
+
+    @pytest.mark.parametrize("length", [{}, None])
+    def test_length_bad_type(self, length):
+        with pytest.raises(TypeError, match="argument must be a string"):
+            tskit.random_nucleotides(length)

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -24,7 +24,9 @@ Module responsible for various utility functions used in other modules.
 """
 import dataclasses
 import json
+import numbers
 import os
+from typing import Union
 
 import numpy as np
 
@@ -572,3 +574,21 @@ def set_print_options(*, max_lines=40):
     this number the middle of the table will be skipped.
     """
     tskit._print_options = {"max_lines": max_lines}
+
+
+def random_nucleotides(length: numbers.Number, *, seed: Union[int, None] = None) -> str:
+    """
+    Returns a random string of nucleotides of the specified length. Characters
+    are drawn uniformly from the alphabet "ACTG".
+
+    :param int length: The length of the random sequence.
+    :return: A string of the specified length consisting of random nucleotide
+       characters.
+    :rtype: str
+    """
+    if int(length) != length:
+        raise ValueError("length must be an integer")
+    rng = np.random.RandomState(seed)
+    encoded_nucleotides = np.array(list(map(ord, "ACTG")), dtype=np.int8)
+    a = rng.choice(encoded_nucleotides, size=int(length))
+    return a.tobytes().decode("ascii")


### PR DESCRIPTION
Laying the groundwork for #353, this adds the ability to output a full sequence for each sample optionally using some reference genome. Since we'll often want to do this some some basic random reference, I've added a simple utility function to generate random reference sequences (which we could make more complicated, if we wanted).

It works like this:
```python

import msprime

ts = msprime.sim_ancestry(4, sequence_length=45, random_seed=234)
ts = msprime.sim_mutations(ts, rate=1e-1, random_seed=2345)

print("L = ", ts.sequence_length, ts.num_sites)
reference = tskit.random_nucleotides(ts.sequence_length, seed=42)
print(reference)
print()
for a in ts.alignments(reference_sequence=reference):
    print(a)
```
giving
```
L =  45.0 37
TGATTGAATCTTTTGAGGGTCACGGCCCGGAAGCCAGAATTTCGG

TCATTCTCCGACCCTGCGATCAGTTATTACTAGTCAAATGTTCTC
TAATTTTCAACCGCGGAAGTCATCTATGTCTAGTCTAAGGTCCCC
TATTTCTCCACCGCTGCGGTTCTCTACTAGTAGTCAAATGTCCTA
TCATTCTCCGACCCTGCGATCAGTTATTACTAGTCAAATGTTCTC
AGATTTACTGAACCTTCGGTCGTCGTTTACGAGTTAGAGATACTC
TATTTTTGAATCGGTGCAGTCGTCCATGACCAGGCAAAGGTTCGC
AGATTTACTGAACCTTCGGTCGTCGTTTACGAGTTAGAGATACTC
TATTTTTGAAACGGTGCAGTCGTCCACGACTAGGCAAAGGTTCGC
```

It's built on existing technology, so the semantics of tricky stuff like missing data should be clear. Hopefully the limited context of a discrete genome and simple mutations should make this semantically straightforward also. I've called it ``alignments`` as we can imagine actually dealing with indels and stuff at some point and outputtting them like this. Also, some time in the future we can imagine automatically using the tree sequence's own reference sequence by default (#146), if it's present.

I haven't written any tests, as I wanted to see what the basic reaction to the idea was.

Any thoughts @benjeffery @hyanwong @petrelharp ?