### PR TITLE
Ibd data structures

### DIFF
--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -184,7 +184,7 @@ class AncestrySegmentList:
         assert prev == self.tail
 
 
-class IbdFinder:
+class IbdFinderBroken:
     """
     Finds all IBD relationships between specified sample pairs in a tree sequence.
     """
@@ -224,8 +224,6 @@ class IbdFinder:
         print("min_length = ", self.min_length)
         print("max_time   = ", self.max_time)
         print("finding_between = ", self.finding_between)
-        print("u\tset_id\tA = ")
-
         print("u\tset_id\tD = ")
         for u, a in enumerate(self.D):
             print(u, self.sample_set_id[u], a, sep="\t")
@@ -319,8 +317,85 @@ class IbdFinder:
             return True
 
 
-class IbdFinderItervalTrees:
+class IbdFinderIntervalTrees:
     """"""
+
+    def __init__(self, ts, *, within=None, between=None, min_length=0, max_time=None):
+        self.ts = ts
+
+        if within is not None and between is not None:
+            raise ValueError("within and between are mutually exclusive")
+
+        self.sample_set_id = np.zeros(ts.num_nodes, dtype=int) - 1
+        self.finding_between = False
+        if between is not None:
+            self.finding_between = True
+            for set_id, samples in enumerate(between):
+                self.sample_set_id[samples] = set_id
+        else:
+            if within is None:
+                within = ts.samples()
+            self.sample_set_id[within] = 0
+        self.min_length = min_length
+        self.max_time = np.inf if max_time is None else max_time
+        self.tables = self.ts.tables
+        self.A = [intervaltree.IntervalTree() for _ in range(ts.num_nodes)]
+
+        for u in range(ts.num_nodes):
+            if self.sample_set_id[u] != -1:
+                self.A[u][0 : ts.sequence_length] = u
+
+    def print_state(self):
+        print("IBD Finder")
+        print("min_length = ", self.min_length)
+        print("max_time   = ", self.max_time)
+        print("finding_between = ", self.finding_between)
+        print("u\tset_id\tI = ")
+        for u, i in enumerate(self.A):
+            print(u, self.sample_set_id[u], len(i), i, sep="\t")
+
+    def keep_pair(self, a, b):
+        if self.finding_between:
+            return self.sample_set_id[a] != self.sample_set_id[b]
+        return True
+
+    def run(self):
+        result = collections.defaultdict(list)
+        node_times = self.tables.nodes.time
+        L = self.ts.sequence_length
+        for e in self.ts.edges():
+            if node_times[e.parent] > self.max_time:
+                # Stop looking for IBD segments once the
+                # processed nodes are older than the max time.
+                break
+            t_child = self.A[e.child].copy()
+            # print(e)
+            # There's no operation to "keep" an interval
+            t_child.chop(0, e.left)
+            t_child.chop(e.right, L)
+            t_parent = self.A[e.parent].copy()
+            t_parent.chop(0, e.left)
+            t_parent.chop(e.right, L)
+
+            for int1, int2 in itertools.product(t_parent, t_child):
+                if int1.overlap_size(int2) > self.min_length:
+                    key = tuple(sorted([int1.data, int2.data]))
+                    intersection = (
+                        max(int1.begin, int2.begin),
+                        min(int1.end, int2.end),
+                    )
+                    if self.keep_pair(*key):
+                        result[key].append(tskit.IbdSegment(*intersection, e.parent))
+
+            # Update parent's intervals
+            self.A[e.parent] |= t_child
+        return result
+
+
+class IbdFinderOld:
+    """
+    Finds all IBD relationships between specified sample pairs in a tree sequence.
+    """
 
     def __init__(self, ts, *, within=None, between=None, min_length=0, max_time=None):
         self.ts = ts
@@ -340,23 +415,11 @@ class IbdFinderItervalTrees:
             self.sample_set_id[within] = 0
         self.min_length = min_length
         self.max_time = np.inf if max_time is None else max_time
-        self.tables = self.ts.tables
-        self.I = [intervaltree.IntervalTree() for _ in range(ts.num_nodes)]
-
+        self.A = [SegmentList() for _ in range(ts.num_nodes)]  # Descendant segments
         for u in range(ts.num_nodes):
             if self.sample_set_id[u] != -1:
-                self.I[u][0 : ts.sequence_length] = u
-
-        # self.D = [None for _ in range(ts.num_nodes)]
-        # for u in range(ts.num_nodes):
-        #     head = AncestrySegment(-1, 0)
-        #     tail = AncestrySegment(ts.sequence_length, ts.sequence_length + 1)
-        #     lst = AncestrySegment(0, ts.sequence_length, prev=head, next=tail)
-        #     head.next = lst
-        #     tail.prev = lst
-        #     self.D[u] = AncestrySegmentList(head, tail)
-        #     if self.sample_set_id[u] != -1:
-        #         lst.samples.append(u)
+                self.A[u].append(Segment(0, ts.sequence_length, u))
+        self.tables = self.ts.tables
 
     def print_state(self):
         print("IBD Finder")
@@ -364,49 +427,67 @@ class IbdFinderItervalTrees:
         print("max_time   = ", self.max_time)
         print("finding_between = ", self.finding_between)
         print("u\tset_id\tA = ")
-
-        print("u\tset_id\tI = ")
-        for u, i in enumerate(self.I):
-            print(u, self.sample_set_id[u], i, sep="\t")
+        for u, a in enumerate(self.A):
+            n = 0
+            x = self.A[u].head
+            while x is not None:
+                n += 1
+                x = x.next
+            print(u, self.sample_set_id[u], n, a, sep="\t")
 
     def run(self):
-        self.print_state()
         node_times = self.tables.nodes.time
-        L = self.ts.sequence_length
         for e in self.ts.edges():
-            if node_times[e.parent] > self.max_time:
+            time = node_times[e.parent]
+            if time > self.max_time:
                 # Stop looking for IBD segments once the
                 # processed nodes are older than the max time.
                 break
-            t_child = self.I[e.child].copy()
-            print(e)
-            # There's no operation to "keep" an interval
-            t_child.chop(0, e.left)
-            t_child.chop(e.right, L)
-            t_parent = self.I[e.parent].copy()
-            t_parent.chop(0, e.left)
-            t_parent.chop(e.right, L)
-            print(list(t_child))
-
-            # Update parent's intervals
-            self.I[e.parent] |= t_child
-
-            # print("postchop", t)
-            # print("processing", e)
-            # for interval in self.I[e.child].slice(e.left,e.right):
-            #     print(interval)
-            #     # overlap = (
-            #     #     max(e.left, s.left),
-            #     #     min(e.right, s.right),
-            #     # )
-            # # print("processing edge", e)
-            # s = self.D[e.child].head.next
-            # while s is not None:
-            #     interval = (
-            #         max(e.left, s.left),
-            #         min(e.right, s.right),
-            #     )
-            #     self.update_ancestry(*interval, e.parent, s.samples)
-            #     s = s.next
-        # self.check_state()
+            child_segs = SegmentList()
+            s = self.A[e.child].head
+            while s is not None:
+                intvl = (
+                    max(e.left, s.left),
+                    min(e.right, s.right),
+                )
+                if intvl[1] - intvl[0] > self.min_length:
+                    child_segs.append(Segment(intvl[0], intvl[1], s.node))
+                s = s.next
+            self.record_ibd(e.parent, child_segs)
+            self.A[e.parent].extend(child_segs)
         return self.result.segments
+
+    def record_ibd(self, current_parent, child_segs):
+        """
+        Given the specified set of child segments for the current parent
+        record the IBD segments that will occur as a result of adding these
+        new segments into the existing list.
+        """
+        # Note the implementation here is O(n^2) because we have to compare
+        # every segment with every other one. If the segments were stored in
+        # left-to-right sorted order, we could avoid and merge them more
+        # efficiently. There is some added complexity in doing this, however.
+        seg0 = self.A[current_parent].head
+        while seg0 is not None:
+            seg1 = child_segs.head
+            while seg1 is not None:
+                left = max(seg0.left, seg1.left)
+                right = min(seg0.right, seg1.right)
+                # If there are any overlapping segments, record as a new
+                # IBD relationship.
+                if self.passes_filters(seg0.node, seg1.node, left, right):
+                    self.result.add_segment(
+                        seg0.node, seg1.node, Segment(left, right, current_parent)
+                    )
+                seg1 = seg1.next
+            seg0 = seg0.next
+
+    def passes_filters(self, a, b, left, right):
+        if a == b:
+            return False
+        if right - left <= self.min_length:
+            return False
+        if self.finding_between:
+            return self.sample_set_id[a] != self.sample_set_id[b]
+        else:
+            return True

--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -155,11 +155,6 @@ class AncestrySegment:
     def __repr__(self):
         return repr((self.left, self.right, self.samples))
 
-    def add_ibd_samples(self, new_samples):
-        print("adding", new_samples, "to ", self.samples, "on", self.left, self.right)
-
-        self.samples.extend(new_samples)
-
 
 @dataclasses.dataclass
 class AncestrySegmentList:
@@ -186,70 +181,6 @@ class AncestrySegmentList:
             prev = u
             u = u.next
         assert prev == self.tail
-
-    def insert(self, left, right, samples):
-        """
-        Insert the specified sample node into the segment list for the
-        specified interval.
-        """
-        # print("INSERT", left, right, node, "::", repr(self))
-        # Skip ahead until we intersect with the left edge
-        u = self.head
-        while left >= u.right:
-            u = u.next
-        if u.left < left:
-            #             left
-            #     u.left   |    u.right
-            # ----|--------------|
-            #
-            # ->
-            #         v       u
-            # ----|--------|-----|
-            v = AncestrySegment(u.left, left, list(u.samples), prev=u.prev, next=u)
-            u.left = left
-            u.prev.next = v
-            u.prev = v
-        # Update segments completely contained in the interval
-        while u.right <= right:
-            # print("updating u", repr(u), left, right)
-            # u.samples.append(node)
-            # u.samples.extend(samples)
-            u.add_ibd_samples(samples)
-            u = u.next
-        # Update and trim the last segment overlapping the interval
-        if right > u.left:
-            #             right
-            #     u.left   |    u.right
-            # ----|--------------|
-            #
-            # ->
-            #         u       v
-            # ----|--------|-----|
-            v = AncestrySegment(right, u.right, list(u.samples), prev=u, next=u.next)
-            u.right = right
-            u.next.prev = v
-            u.next = v
-            # u.samples.append(node)
-            u.add_ibd_samples(samples)
-            # u.samples.extend(samples)
-        # print("DONE:", repr(self))
-        # print()
-
-    def update2(self, segs):
-        # seg = segs.head
-        # while seg is not None:
-        for seg in segs:
-            print(seg)
-            self.insert(seg.left, seg.right, seg.samples)
-            seg = seg.next
-            # self.check()
-
-    def update(self, segs):
-        seg = segs.head
-        while seg is not None:
-            self.insert(seg.left, seg.right, seg.node)
-            seg = seg.next
-            self.check()
 
 
 class IbdFinder:
@@ -299,31 +230,6 @@ class IbdFinder:
             print(u, self.sample_set_id[u], a, sep="\t")
 
         # self.check_state()
-
-    def check_state(self):
-        L = int(self.tables.sequence_length)
-        for u in range(len(self.tables.nodes)):
-            # print("CHECK", u)
-            a_set = [[] for _ in range(L)]
-            seg = self.A[u].head
-            while seg is not None:
-                for j in range(int(seg.left), int(seg.right)):
-                    a_set[j].append(seg.node)
-                # a_set[(seg.left, seg.right)].append(seg.node)
-                seg = seg.next
-            # print(a_set)
-            d_set = [[] for _ in range(L)]
-            seg = self.D[u].head.next
-            while seg is not self.D[u].tail:
-                for j in range(int(seg.left), int(seg.right)):
-                    d_set[j] = list(sorted(seg.samples))
-                seg = seg.next
-            # print(d_set)
-            assert len(a_set) == len(d_set)
-            for j in range(L):
-                a_samples = list(sorted(a_set[j]))
-                # print(d_set[j], a_samples)
-                assert d_set[j] == a_samples
 
     def add_ibd_samples(self, parent, segment, samples):
 

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -58,7 +58,7 @@ def ibd_segments(
     Calculates IBD segments using Python and converts output to lists of segments.
     Also compares result with C library.
     """
-    ibd_f = ibd.IbdFinder(
+    ibd_f = ibd.IbdFinderIntervalTrees(
         ts, within=within, between=between, max_time=max_time, min_length=min_length
     )
     ibd_segs = ibd_f.run()

--- a/python/tests/test_ibd.py
+++ b/python/tests/test_ibd.py
@@ -148,6 +148,7 @@ class TestIbdImplementations:
     @pytest.mark.parametrize("ts", get_example_tree_sequences())
     def test_all_pairs(self, ts):
         # Automatically compares the two implementations
+        # print(ts.draw_text())
         ibd_segments(ts)
 
 
@@ -160,9 +161,11 @@ def assert_ibd_equal(dict1, dict2):
     assert len(dict1) == len(dict2)
     for key, val in dict1.items():
         assert key in dict2
-        assert len(val) == len(dict2[key])
         segs1 = list(sorted(val))
         segs2 = list(sorted(dict2[key]))
+        # print(segs1)
+        # print(segs2)
+        # assert len(val) == len(dict2[key])
         assert segs1 == segs2
 
 


### PR DESCRIPTION
The IBD finder is currently getting hit pretty badly by a O(n^2) loop in which we compare every segment of ancestry inherited by an ancestor with every other segment. Profiling shows that nearly all the time is being spent in the "add ibd_segments" loop where we do this. We can definitely do better, as there's no need to compare *every* segment with every other one.

This is a first attempt, where we store the store the samples associated with each interval along the genome for each node. This is a much nicer data structure, but unfortunately it doesn't quite compute what we want, and ends up breaking up IBD segments too much. (So, we have the right ancestry relationships, but we don't collapse together adjacent equal intervals in the right way).

I'll have another go, mainly just putting this up here in case anyone wants to comment.