### PR TITLE
Convert nexus tests to use dendropy

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -37,6 +37,11 @@
 - For ``TreeSequence.samples`` all arguments after ``population`` are now keyword only
   (:user:`benjeffery`, :issue:`1715`, :pr:`1831`).
 
+- Fix bugs in the format produced by ``TreeSequence.to_nexus`` to make
+  it standards-compliant. (:user:`jeetsukumaran`, :user:`jeromekelleher`,
+  :issue:`1785`, :pr:`1835`, :pr:`1836`)
+  [FIXME MORE UPDATES HERE AS WE CHANGE THE LABELS ETC]
+
 **Features**
 
 - Allow skipping of site and mutation tables in ``TableCollection.sort``

--- a/python/requirements/CI-complete/requirements.txt
+++ b/python/requirements/CI-complete/requirements.txt
@@ -1,6 +1,7 @@
 biopython==1.79
 black==21.9b0
 coverage==6.0.2
+dendropy==4.5.2
 flake8==4.0.1
 h5py==3.4.0
 jsonschema==3.2.0

--- a/python/requirements/CI-tests-pip/requirements.txt
+++ b/python/requirements/CI-tests-pip/requirements.txt
@@ -6,6 +6,7 @@ svgwrite==1.4.1
 portion==2.1.6
 xmlunittest==0.5.0
 biopython==1.79
+dendropy==4.5.2
 kastore==0.3.1
 networkx==2.6.2
 msgpack==1.0.2

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -4,6 +4,7 @@ black
 breathe
 codecov
 coverage
+dendropy
 flake8
 h5py>=2.6.0
 jsonschema>=3.0.0

--- a/python/requirements/development.yml
+++ b/python/requirements/development.yml
@@ -10,6 +10,7 @@ dependencies:
   - codecov
   - coverage
   - cunit
+  - dendropy
   - doxygen
   - flake8
   - h5py>=2.6.0


### PR DESCRIPTION
Closes #1785

Add dendropy to various requirements lists and refactor the tests to use pytest a little better

Hopefully this sets the foundation for following up with label changes etc.

@jeetsukumaran would you mind taking a quick look and seeing if the dendropy usage looks OK to you please?