### PR TITLE
Remove jsonschema-objects development dependency

### DIFF
--- a/python/requirements/CI-complete/requirements.txt
+++ b/python/requirements/CI-complete/requirements.txt
@@ -16,7 +16,6 @@ pysam==0.17.0
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-xdist==2.4.0
-python-jsonschema-objects==0.4.0
 PyVCF==0.6.8
 svgwrite==1.4.1
 xmlunittest==0.5.0

--- a/python/requirements/CI-tests-pip/requirements.txt
+++ b/python/requirements/CI-tests-pip/requirements.txt
@@ -1,7 +1,6 @@
 numpy==1.21.2
 pytest==6.2.5
 pytest-xdist==2.3.0
-jsonschema==3.2.0
 h5py==3.4.0
 svgwrite==1.4.1
 portion==2.1.6
@@ -10,6 +9,5 @@ biopython==1.79
 kastore==0.3.1
 networkx==2.6.2
 msgpack==1.0.2
-python-jsonschema-objects==0.4.0
 newick==1.3.0
 PyVCF==0.6.8

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -25,7 +25,6 @@ pysam
 pytest
 pytest-cov
 pytest-xdist
-python_jsonschema_objects
 PyVCF
 sphinx<=4.0.1
 sphinx-argparse

--- a/python/requirements/development.yml
+++ b/python/requirements/development.yml
@@ -39,4 +39,3 @@ dependencies:
     - newick
     - xmlunittest
     - msgpack>=1.0.0
-    - python_jsonschema_objects

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -37,7 +37,6 @@ import msgpack
 import msprime
 import numpy as np
 import pytest
-import python_jsonschema_objects as pjs
 
 import tskit
 import tskit.exceptions as exceptions
@@ -168,37 +167,6 @@ class TestMetadataPickleDecoding:
         unpickled = pickle.loads(mutation.metadata)
         assert unpickled.one == metadata.one
         assert unpickled.two == metadata.two
-
-
-class TestJSONSchemaDecoding:
-    """
-    Tests in which use json-schema to decode the metadata.
-    """
-
-    schema = """{
-        "title": "Example Metadata",
-        "type": "object",
-        "properties": {
-            "one": {"type": "string"},
-            "two": {"type": "string"}
-        },
-        "required": ["one", "two"]
-    }"""
-
-    def test_nodes(self):
-        tables = tskit.TableCollection(sequence_length=1)
-        builder = pjs.ObjectBuilder(json.loads(self.schema))
-        ns = builder.build_classes()
-        metadata = ns.ExampleMetadata(one="node1", two="node2")
-        encoded = json.dumps(metadata.as_dict()).encode()
-        tables.nodes.add_row(time=0.125, metadata=encoded)
-        ts = tables.tree_sequence()
-        node = ts.node(0)
-        assert node.time == 0.125
-        assert node.metadata == encoded
-        decoded = ns.ExampleMetadata.from_json(node.metadata.decode())
-        assert decoded.one == metadata.one
-        assert decoded.two == metadata.two
 
 
 class TestLoadTextMetadata:


### PR DESCRIPTION
It was only used in one test, and wasn't worth the dependency problems.

