### PR TITLE
Remove tree.left_root

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -13,12 +13,19 @@
   (:user:`benjeffery`, :issue:`1723`, :pr:`1727`)
 
 - The previously deprecated option ``TSK_SAMPLE_COUNTS`` has been removed. (:user:`benjeffery`, :issue:`1744`, :pr:`1761`).
-
-- FIXME breaking changes for tree API and virtual root
-
-- Individuals are no longer guaranteed or required to be topologically sorted in a tree sequence. 
+- Individuals are no longer guaranteed or required to be topologically sorted in a tree sequence.
   ``tsk_table_collection_sort`` no longer sorts individuals.
   (:user:`benjeffery`, :issue:`1774`, :pr:`1789`)
+
+- FIXME breaking changes for tree API and virtual root.
+
+- The ``tsk_tree_t.left_root`` member has been removed. Client code can be updated
+  most easily by using the equivalent ``tsk_tree_get_left_root`` function. However,
+  it may be worth considering updating code to use either the standard traversal
+  functions (which automatically iterate over roots) or to use the ``virtual_root``
+  member (which may lead to more concise code). (:user:`jeromekelleher`, :issue:`1796`,
+  :pr:`1862`)
+
 
 **Features**
 

--- a/c/dev-tools/dev-cli.c
+++ b/c/dev-tools/dev-cli.c
@@ -122,12 +122,8 @@ print_ld_matrix(tsk_treeseq_t *ts)
             if (ret != 0) {
                 fatal_library_error(ret, "get_site");
             }
-            printf("%d\t%f\t%d\t%f\t%.3f\n",
-                (int) sA.id,
-                sA.position,
-                (int) sB.id,
-                sB.position,
-                r2[k]);
+            printf("%d\t%f\t%d\t%f\t%.3f\n", (int) sA.id, sA.position, (int) sB.id,
+                sB.position, r2[k]);
         }
     }
     free(r2);
@@ -156,8 +152,8 @@ print_newick_trees(tsk_treeseq_t *ts)
         fatal_error("ERROR: %d: %s\n", ret, tsk_strerror(ret));
     }
     for (ret = tsk_tree_first(&tree); ret == 1; ret = tsk_tree_next(&tree)) {
-        ret = tsk_convert_newick(
-            &tree, tree.left_root, precision, 0, newick_buffer_size, newick);
+        ret = tsk_convert_newick(&tree, tsk_tree_get_left_root(&tree), precision, 0,
+            newick_buffer_size, newick);
         if (ret != 0) {
             fatal_library_error(ret, "newick");
         }
@@ -187,9 +183,7 @@ print_tree_sequence(tsk_treeseq_t *ts, int verbose)
         }
         for (ret = tsk_tree_first(&tree); ret == 1; ret = tsk_tree_next(&tree)) {
             printf("-------------------------\n");
-            printf("New tree: %d: %f (%d)\n",
-                (int) tree.index,
-                tree.right - tree.left,
+            printf("New tree: %d: %f (%d)\n", (int) tree.index, tree.right - tree.left,
                 (int) tree.num_nodes);
             printf("-------------------------\n");
             tsk_tree_print_state(&tree, stdout);
@@ -242,11 +236,8 @@ run_newick(const char *filename, int TSK_UNUSED(verbose))
 }
 
 static void
-run_simplify(const char *input_filename,
-    const char *output_filename,
-    size_t num_samples,
-    bool filter_sites,
-    int verbose)
+run_simplify(const char *input_filename, const char *output_filename, size_t num_samples,
+    bool filter_sites, int verbose)
 {
     tsk_treeseq_t ts, subset;
     const tsk_id_t *samples;
@@ -290,9 +281,7 @@ main(int argc, char **argv)
     /* SYNTAX 1: simplify [-vi] [-s] <input-file> <output-file> */
     struct arg_rex *cmd1 = arg_rex1(NULL, NULL, "simplify", NULL, REG_ICASE, NULL);
     struct arg_lit *verbose1 = arg_lit0("v", "verbose", NULL);
-    struct arg_int *num_samples1 = arg_int0("s",
-        "sample-size",
-        "<sample-size>",
+    struct arg_int *num_samples1 = arg_int0("s", "sample-size", "<sample-size>",
         "Number of samples to keep in the simplified tree sequence.");
     struct arg_lit *filter_sites1
         = arg_lit0("i", "filter-invariant-sites", "<filter-invariant-sites>");
@@ -348,10 +337,8 @@ main(int argc, char **argv)
     nerrors5 = arg_parse(argc, argv, argtable5);
 
     if (nerrors1 == 0) {
-        run_simplify(infiles1->filename[0],
-            outfiles1->filename[0],
-            (size_t) num_samples1->ival[0],
-            (bool) filter_sites1->count,
+        run_simplify(infiles1->filename[0], outfiles1->filename[0],
+            (size_t) num_samples1->ival[0], (bool) filter_sites1->count,
             verbose1->count);
     } else if (nerrors2 == 0) {
         run_ld(infiles2->filename[0], verbose2->count);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -58,7 +58,6 @@ check_trees_identical(tsk_tree_t *self, tsk_tree_t *other)
     tsk_size_t N = self->num_nodes;
 
     check_trees_equal(self, other);
-    CU_ASSERT_FATAL(self->left_root == other->left_root);
     CU_ASSERT_FATAL(self->left_index == other->left_index);
     CU_ASSERT_FATAL(self->right_index == other->right_index);
     CU_ASSERT_FATAL(self->direction == other->direction);
@@ -725,7 +724,7 @@ verify_sample_counts(tsk_treeseq_t *ts, tsk_size_t num_tests, sample_count_test_
         ret = tsk_tree_get_num_tracked_samples(&tree, 0, &num_samples);
         CU_ASSERT_EQUAL(ret, TSK_ERR_UNSUPPORTED_OPERATION);
         /* The root should be NULL */
-        CU_ASSERT_EQUAL(tree.left_root, TSK_NULL);
+        CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), TSK_NULL);
     }
     tsk_tree_free(&tree);
 
@@ -747,7 +746,7 @@ verify_sample_counts(tsk_treeseq_t *ts, tsk_size_t num_tests, sample_count_test_
         CU_ASSERT_EQUAL(ret, 0);
         CU_ASSERT_EQUAL(num_samples, 0);
         /* The root should not be NULL */
-        CU_ASSERT_NOT_EQUAL(tree.left_root, TSK_NULL);
+        CU_ASSERT_NOT_EQUAL(tree.virtual_root, TSK_NULL);
     }
     tsk_tree_free(&tree);
 
@@ -1326,7 +1325,8 @@ test_simplest_degenerate_multiple_root_records(void)
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL(ret, 1);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&t), 2);
-    CU_ASSERT_EQUAL(t.left_root, 2);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), 2);
+    CU_ASSERT_EQUAL(tsk_tree_get_right_root(&t), 3);
     CU_ASSERT_EQUAL(t.num_edges, 2);
     CU_ASSERT_EQUAL(t.right_sib[2], 3);
     CU_ASSERT_EQUAL(t.right_sib[3], TSK_NULL);
@@ -1418,7 +1418,8 @@ test_simplest_zero_root_tree(void)
     CU_ASSERT_EQUAL(ret, 1);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&t), 0);
     CU_ASSERT_EQUAL(t.num_edges, 4);
-    CU_ASSERT_EQUAL(t.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_right_root(&t), TSK_NULL);
     CU_ASSERT_EQUAL(t.right_sib[2], 3);
     CU_ASSERT_EQUAL(t.right_sib[3], TSK_NULL);
 
@@ -1449,7 +1450,7 @@ test_simplest_multi_root_tree(void)
     tsk_tree_print_state(&t, _devnull);
 
     /* Make sure the initial roots are set correctly */
-    CU_ASSERT_EQUAL(t.left_root, 0);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), 0);
     CU_ASSERT_EQUAL(t.left_sib[0], TSK_NULL);
     CU_ASSERT_EQUAL(t.right_sib[0], 1);
     CU_ASSERT_EQUAL(t.left_sib[1], 0);
@@ -1461,7 +1462,7 @@ test_simplest_multi_root_tree(void)
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL(ret, 1);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&t), 2);
-    CU_ASSERT_EQUAL(t.left_root, 0);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), 0);
     CU_ASSERT_EQUAL(t.right_sib[0], 3);
     CU_ASSERT_EQUAL(t.num_edges, 2);
 
@@ -1478,7 +1479,7 @@ test_simplest_multi_root_tree(void)
     ret = tsk_tree_next(&t);
     CU_ASSERT_EQUAL(ret, 1);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&t), 1);
-    CU_ASSERT_EQUAL(t.left_root, 3);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), 3);
 
     tsk_tree_free(&t);
     tsk_treeseq_free(&ts);
@@ -1805,11 +1806,11 @@ test_simplest_initial_gap_zero_roots(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_tree_first(&tree);
     CU_ASSERT_EQUAL(ret, 1);
-    CU_ASSERT_EQUAL(tree.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), TSK_NULL);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&tree), 0);
     ret = tsk_tree_next(&tree);
     CU_ASSERT_EQUAL(ret, 1);
-    CU_ASSERT_EQUAL(tree.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), TSK_NULL);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&tree), 0);
     CU_ASSERT_EQUAL(tree.parent[0], 2);
     CU_ASSERT_EQUAL(tree.parent[1], 2);
@@ -1858,19 +1859,19 @@ test_simplest_holey_tsk_treeseq_zero_roots(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_tree_first(&tree);
     CU_ASSERT_EQUAL(ret, 1);
-    CU_ASSERT_EQUAL(tree.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), TSK_NULL);
     CU_ASSERT_EQUAL(tree.parent[0], 2);
     CU_ASSERT_EQUAL(tree.parent[1], 2);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&tree), 0);
 
     ret = tsk_tree_next(&tree);
     CU_ASSERT_EQUAL(ret, 1);
-    CU_ASSERT_EQUAL(tree.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), TSK_NULL);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&tree), 0);
 
     ret = tsk_tree_next(&tree);
     CU_ASSERT_EQUAL(ret, 1);
-    CU_ASSERT_EQUAL(tree.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), TSK_NULL);
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&tree), 0);
     CU_ASSERT_EQUAL(tree.parent[0], 2);
     CU_ASSERT_EQUAL(tree.parent[1], 2);
@@ -3055,10 +3056,10 @@ test_simplest_map_mutations(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(ancestral_state, 0);
     CU_ASSERT_EQUAL_FATAL(num_transitions, 2);
-    CU_ASSERT_EQUAL_FATAL(transitions[0].node, 0);
+    CU_ASSERT_EQUAL_FATAL(transitions[0].node, 1);
     CU_ASSERT_EQUAL_FATAL(transitions[0].parent, TSK_NULL);
     CU_ASSERT_EQUAL_FATAL(transitions[0].state, 1);
-    CU_ASSERT_EQUAL_FATAL(transitions[1].node, 1);
+    CU_ASSERT_EQUAL_FATAL(transitions[1].node, 0);
     CU_ASSERT_EQUAL_FATAL(transitions[1].parent, TSK_NULL);
     CU_ASSERT_EQUAL_FATAL(transitions[1].state, 1);
     free(transitions);
@@ -3830,7 +3831,7 @@ test_single_nonbinary_tree_iter(void)
     CU_ASSERT_EQUAL(tree.left_sib[6], TSK_NULL);
 
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&tree), 1);
-    CU_ASSERT_EQUAL(tree.left_root, 9);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&tree), 9);
 
     ret = tsk_tree_get_mrca(&tree, 0, 1, &w);
     CU_ASSERT_EQUAL(ret, 0);
@@ -5253,7 +5254,7 @@ test_virtual_root_properties(void)
     tsk_treeseq_t ts;
     tsk_tree_t t;
     int depth;
-    double time;
+    double time, length;
     tsk_id_t node;
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
@@ -5281,6 +5282,9 @@ test_virtual_root_properties(void)
 
     CU_ASSERT_EQUAL_FATAL(tsk_tree_get_parent(&t, t.virtual_root, &node), 0)
     CU_ASSERT_EQUAL(node, TSK_NULL);
+
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_get_branch_length(&t, t.virtual_root, &length), 0)
+    CU_ASSERT_EQUAL(length, 0);
 
     /* The definition of "descendant" is that node v is on the path from
      * u to a root. Since there is no parent link from roots to the
@@ -5505,7 +5509,7 @@ test_isolated_node_kc(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    CU_ASSERT_EQUAL_FATAL(t.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_get_left_root(&t), TSK_NULL);
     ret = tsk_tree_kc_distance(&t, &t, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_ROOTS);
     tsk_treeseq_free(&ts);
@@ -5634,7 +5638,7 @@ test_empty_tree_kc(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    CU_ASSERT_EQUAL_FATAL(t.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_get_left_root(&t), TSK_NULL);
     CU_ASSERT_EQUAL_FATAL(t.left, 0);
     CU_ASSERT_EQUAL_FATAL(t.right, 1);
     CU_ASSERT_EQUAL_FATAL(t.parent[0], TSK_NULL);
@@ -6147,6 +6151,8 @@ test_tree_errors(void)
         CU_ASSERT_EQUAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
         ret = tsk_tree_get_time(&t, u, NULL);
         CU_ASSERT_EQUAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+        ret = tsk_tree_get_branch_length(&t, u, NULL);
+        CU_ASSERT_EQUAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
         ret = tsk_tree_get_mrca(&t, u, 0, NULL);
         CU_ASSERT_EQUAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
         ret = tsk_tree_get_mrca(&t, 0, u, NULL);
@@ -6498,7 +6504,7 @@ test_empty_tree_sequence(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    CU_ASSERT_EQUAL_FATAL(t.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_get_left_root(&t), TSK_NULL);
     CU_ASSERT_EQUAL_FATAL(t.left, 0);
     CU_ASSERT_EQUAL_FATAL(t.right, 1);
     CU_ASSERT_EQUAL_FATAL(t.num_edges, 0);
@@ -6511,7 +6517,7 @@ test_empty_tree_sequence(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_tree_last(&t);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
-    CU_ASSERT_EQUAL_FATAL(t.left_root, TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_get_left_root(&t), TSK_NULL);
     CU_ASSERT_EQUAL_FATAL(t.left, 0);
     CU_ASSERT_EQUAL_FATAL(t.right, 1);
     CU_ASSERT_EQUAL_FATAL(tsk_tree_get_parent(&t, 1, &v), TSK_ERR_NODE_OUT_OF_BOUNDS);
@@ -6561,7 +6567,7 @@ test_zero_edges(void)
     CU_ASSERT_EQUAL(t.num_edges, 0);
     CU_ASSERT_EQUAL(t.parent[0], TSK_NULL);
     CU_ASSERT_EQUAL(t.parent[1], TSK_NULL);
-    CU_ASSERT_EQUAL(t.left_root, 0);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), 0);
     CU_ASSERT_EQUAL(t.left_sib[0], TSK_NULL);
     CU_ASSERT_EQUAL(t.right_sib[0], 1);
     tsk_tree_print_state(&t, _devnull);
@@ -6575,7 +6581,7 @@ test_zero_edges(void)
     CU_ASSERT_EQUAL(t.right, 2);
     CU_ASSERT_EQUAL(t.parent[0], TSK_NULL);
     CU_ASSERT_EQUAL(t.parent[1], TSK_NULL);
-    CU_ASSERT_EQUAL(t.left_root, 0);
+    CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), 0);
     CU_ASSERT_EQUAL(t.left_sib[0], TSK_NULL);
     CU_ASSERT_EQUAL(t.right_sib[0], 1);
     tsk_tree_print_state(&t, _devnull);

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -462,10 +462,11 @@ tsk_vargen_mark_missing_i16(tsk_vargen_t *self)
     const tsk_id_t *restrict left_child = self->tree.left_child;
     const tsk_id_t *restrict right_sib = self->tree.right_sib;
     const tsk_id_t *restrict sample_index_map = self->sample_index_map;
+    const tsk_id_t N = self->tree.virtual_root;
     int16_t *restrict genotypes = self->variant.genotypes.i16;
     tsk_id_t root, sample_index;
 
-    for (root = self->tree.left_root; root != TSK_NULL; root = right_sib[root]) {
+    for (root = left_child[N]; root != TSK_NULL; root = right_sib[root]) {
         if (left_child[root] == TSK_NULL) {
             sample_index = sample_index_map[root];
             if (sample_index != TSK_NULL) {
@@ -484,10 +485,11 @@ tsk_vargen_mark_missing_i8(tsk_vargen_t *self)
     const tsk_id_t *restrict left_child = self->tree.left_child;
     const tsk_id_t *restrict right_sib = self->tree.right_sib;
     const tsk_id_t *restrict sample_index_map = self->sample_index_map;
+    const tsk_id_t N = self->tree.virtual_root;
     int8_t *restrict genotypes = self->variant.genotypes.i8;
     tsk_id_t root, sample_index;
 
-    for (root = self->tree.left_root; root != TSK_NULL; root = right_sib[root]) {
+    for (root = left_child[N]; root != TSK_NULL; root = right_sib[root]) {
         if (left_child[root] == TSK_NULL) {
             sample_index = sample_index_map[root];
             if (sample_index != TSK_NULL) {

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -123,11 +123,6 @@ typedef struct {
      */
     const tsk_treeseq_t *tree_sequence;
     /**
-     * @brief The leftmost root in the tree. Roots are siblings, and
-     * other roots can be found using right_sib.
-     */
-    tsk_id_t left_root;
-    /**
      @brief The ID of the "virtual root" whose children are the roots of the
      tree.
      */
@@ -476,14 +471,19 @@ bool tsk_tree_equals(const tsk_tree_t *self, const tsk_tree_t *other);
 bool tsk_tree_is_descendant(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v);
 bool tsk_tree_is_sample(const tsk_tree_t *self, tsk_id_t u);
 
+tsk_id_t tsk_tree_get_left_root(const tsk_tree_t *self);
+tsk_id_t tsk_tree_get_right_root(const tsk_tree_t *self);
+
 int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options);
 int tsk_tree_set_tracked_samples(
     tsk_tree_t *self, tsk_size_t num_tracked_samples, const tsk_id_t *tracked_samples);
 int tsk_tree_set_tracked_samples_from_sample_list(
     tsk_tree_t *self, tsk_tree_t *other, tsk_id_t node);
 
-int tsk_tree_get_parent(const tsk_tree_t *self, tsk_id_t u, tsk_id_t *parent);
+int tsk_tree_get_branch_length(
+    const tsk_tree_t *self, tsk_id_t u, double *branch_length);
 int tsk_tree_get_time(const tsk_tree_t *self, tsk_id_t u, double *t);
+int tsk_tree_get_parent(const tsk_tree_t *self, tsk_id_t u, tsk_id_t *parent);
 int tsk_tree_get_depth(const tsk_tree_t *self, tsk_id_t u, int *depth);
 int tsk_tree_get_mrca(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca);
 int tsk_tree_get_num_samples(

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2998,10 +2998,12 @@ class TestTree(LowLevelTestCase):
         genotypes = np.arange(n, dtype=np.int8)
         ancestral_state, transitions = tree.map_mutations(genotypes)
         assert ancestral_state == 0
+        assert len(transitions) == n - 1
         for j in range(n - 1):
-            assert transitions[j][0] == j + 1
+            x = n - j - 1
+            assert transitions[j][0] == x
             assert transitions[j][1] == -1
-            assert transitions[j][2] == j + 1
+            assert transitions[j][2] == x
 
     def test_map_mutations(self):
         ts = self.get_example_tree_sequence()

--- a/python/tests/test_parsimony.py
+++ b/python/tests/test_parsimony.py
@@ -230,6 +230,8 @@ def hartigan_map_mutations(tree, genotypes, alleles, ancestral_state=None):
 
     if ancestral_state is None:
         ancestral_state = np.argmax(optimal_set[tree.virtual_root])
+    else:
+        optimal_set[tree.virtual_root] = 1
 
     @dataclasses.dataclass
     class StackElement:
@@ -238,7 +240,7 @@ def hartigan_map_mutations(tree, genotypes, alleles, ancestral_state=None):
         mutation_parent: int
 
     mutations = []
-    stack = [StackElement(root, ancestral_state, -1) for root in reversed(tree.roots)]
+    stack = [StackElement(tree.virtual_root, ancestral_state, -1)]
     while len(stack) > 0:
         s = stack.pop()
         if optimal_set[s.node, s.state] == 0:
@@ -538,6 +540,9 @@ class TestParsimonyBase:
             )
             assert ancestral_state1 == ancestral_state2
             assert len(transitions1) == len(transitions2)
+            sorted_t1 = sorted([(m.node, m.derived_state) for m in transitions1])
+            sorted_t2 = sorted([(m.node, m.derived_state) for m in transitions2])
+            assert sorted_t1 == sorted_t2
             assert transitions1 == transitions2
         return ancestral_state1, transitions1
 


### PR DESCRIPTION
Stacked on #1861

Closes #1796

The cases where we actually do want to explicitly iterate over the roots are rare; it's much better to push the virtual root onto a stack and let the general tree algorithms take care of things. So, there will be a bit of breakage in user code, but I think it's worth it to move them onto better ways of doing things.

TODO - the examples need updating here and we need some changelogging