### PR TITLE
Refactor LD calculation

### DIFF
--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -1681,6 +1681,51 @@ test_caterpillar_tree_ld(void)
     free(ts);
 }
 
+static void
+test_ld_multi_mutations(void)
+{
+    tsk_treeseq_t *ts = caterpillar_tree(4, 2, 2);
+    tsk_ld_calc_t ld_calc;
+    double r2;
+    int ret = tsk_ld_calc_init(&ld_calc, ts);
+
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_ld_calc_get_r2(&ld_calc, 0, 1, &r2);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_ONLY_INFINITE_SITES);
+
+    tsk_ld_calc_free(&ld_calc);
+    tsk_treeseq_free(ts);
+    free(ts);
+}
+
+static void
+test_ld_silent_mutations(void)
+{
+    tsk_treeseq_t *base_ts = caterpillar_tree(4, 2, 1);
+    tsk_table_collection_t tables;
+    tsk_treeseq_t ts;
+    tsk_ld_calc_t ld_calc;
+    double r2;
+    int ret = tsk_table_collection_copy(base_ts->tables, &tables, 0);
+
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.mutations.derived_state[1] = '0';
+
+    ret = tsk_treeseq_init(&ts, &tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_ld_calc_init(&ld_calc, &ts);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_ld_calc_get_r2(&ld_calc, 0, 1, &r2);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SILENT_MUTATIONS_NOT_SUPPORTED);
+    tsk_ld_calc_free(&ld_calc);
+    tsk_treeseq_free(&ts);
+
+    tsk_table_collection_free(&tables);
+    tsk_treeseq_free(base_ts);
+    free(base_ts);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1750,6 +1795,8 @@ main(int argc, char **argv)
             test_nonbinary_ex_general_stat_errors },
 
         { "test_caterpillar_tree_ld", test_caterpillar_tree_ld },
+        { "test_ld_multi_mutations", test_ld_multi_mutations },
+        { "test_ld_silent_mutations", test_ld_silent_mutations },
 
         { NULL, NULL },
     };

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -112,7 +112,6 @@ verify_ld(tsk_treeseq_t *ts)
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
-            tsk_ld_calc_print_state(&ld_calc, _devnull);
             for (j = 0; j < (tsk_id_t) num_r2_values; j++) {
                 CU_ASSERT_EQUAL_FATAL(r2[j], r2_prime[j]);
                 ret = tsk_ld_calc_get_r2(&ld_calc, 0, j + 1, &x);
@@ -140,7 +139,6 @@ verify_ld(tsk_treeseq_t *ts)
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
         }
-        tsk_ld_calc_print_state(&ld_calc, _devnull);
 
         ret = tsk_ld_calc_get_r2_array(&ld_calc, (tsk_id_t) num_sites - 1,
             TSK_DIR_REVERSE, num_sites, DBL_MAX, r2_prime, &num_r2_values);
@@ -194,11 +192,11 @@ verify_ld(tsk_treeseq_t *ts)
     for (j = (tsk_id_t) num_sites; j < (tsk_id_t) num_sites + 2; j++) {
         ret = tsk_ld_calc_get_r2_array(
             &ld_calc, j, TSK_DIR_FORWARD, num_sites, DBL_MAX, r2, &num_r2_values);
-        CU_ASSERT_EQUAL(ret, TSK_ERR_OUT_OF_BOUNDS);
+        CU_ASSERT_EQUAL(ret, TSK_ERR_SITE_OUT_OF_BOUNDS);
         ret = tsk_ld_calc_get_r2(&ld_calc, j, 0, r2);
-        CU_ASSERT_EQUAL(ret, TSK_ERR_OUT_OF_BOUNDS);
+        CU_ASSERT_EQUAL(ret, TSK_ERR_SITE_OUT_OF_BOUNDS);
         ret = tsk_ld_calc_get_r2(&ld_calc, 0, j, r2);
-        CU_ASSERT_EQUAL(ret, TSK_ERR_OUT_OF_BOUNDS);
+        CU_ASSERT_EQUAL(ret, TSK_ERR_SITE_OUT_OF_BOUNDS);
     }
 
     tsk_ld_calc_free(&ld_calc);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -5601,8 +5601,8 @@ test_seek_multi_tree(void)
     tsk_treeseq_t ts;
     tsk_tree_t t;
     double breakpoints[] = { 0, 2, 7, 10 };
-    tsk_size_t num_trees = 3;
-    tsk_size_t j, k;
+    tsk_id_t num_trees = 3;
+    tsk_id_t j, k;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
         paper_ex_individuals, NULL, 0);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -5404,6 +5404,7 @@ test_single_tree_traversal(void)
     tsk_size_t num_nodes = 7;
     tsk_id_t preorder[] = { 6, 4, 0, 1, 5, 2, 3 };
     tsk_id_t preorder_vr[] = { 7, 6, 4, 0, 1, 5, 2, 3 };
+    tsk_id_t preorder_samples[] = { 0, 1, 2, 3 };
     tsk_id_t postorder[] = { 0, 1, 4, 2, 3, 5, 6 };
     tsk_id_t postorder_vr[] = { 0, 1, 4, 2, 3, 5, 6, 7 };
     tsk_id_t nodes[num_nodes + 1];
@@ -5427,10 +5428,25 @@ test_single_tree_traversal(void)
     CU_ASSERT_EQUAL_FATAL(n, num_nodes + 1);
     verify_node_lists(n, nodes, preorder_vr);
 
+    ret = tsk_tree_preorder_samples(&t, -1, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 4);
+    verify_node_lists(n, nodes, preorder_samples);
+
+    ret = tsk_tree_preorder_samples(&t, t.virtual_root, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 4);
+    verify_node_lists(n, nodes, preorder_samples);
+
     ret = tsk_tree_preorder(&t, 5, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, preorder + 4);
+
+    ret = tsk_tree_preorder_samples(&t, 5, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 2);
+    verify_node_lists(n, nodes, preorder_samples + 2);
 
     ret = tsk_tree_postorder(&t, -1, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5451,6 +5467,11 @@ test_single_tree_traversal(void)
     ret = tsk_tree_preorder(&t, -2, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     ret = tsk_tree_preorder(&t, 8, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+
+    ret = tsk_tree_preorder_samples(&t, -2, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    ret = tsk_tree_preorder_samples(&t, 8, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     ret = tsk_tree_postorder(&t, -2, nodes, &n);
@@ -5488,6 +5509,7 @@ test_multiroot_tree_traversal(void)
     tsk_tree_t t;
     tsk_id_t preorder[] = { 5, 9, 2, 7, 3, 4, 10, 0, 1 };
     tsk_id_t preorder_vr[] = { 12, 5, 9, 2, 7, 3, 4, 10, 0, 1 };
+    tsk_id_t preorder_samples[] = { 5, 2, 3, 4, 0, 1 };
     tsk_id_t postorder[] = { 5, 2, 3, 4, 7, 9, 0, 1, 10 };
     tsk_id_t postorder_vr[] = { 5, 2, 3, 4, 7, 9, 0, 1, 10, 12 };
     tsk_id_t nodes[13];
@@ -5516,6 +5538,26 @@ test_multiroot_tree_traversal(void)
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, preorder + 6);
 
+    ret = tsk_tree_preorder_samples(&t, -1, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 6);
+    verify_node_lists(n, nodes, preorder_samples);
+
+    ret = tsk_tree_preorder_samples(&t, t.virtual_root, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 6);
+    verify_node_lists(n, nodes, preorder_samples);
+
+    ret = tsk_tree_preorder_samples(&t, 5, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 1);
+    verify_node_lists(n, nodes, preorder_samples);
+
+    ret = tsk_tree_preorder_samples(&t, 10, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 2);
+    verify_node_lists(n, nodes, preorder_samples + 4);
+
     ret = tsk_tree_postorder(&t, -1, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 9);
@@ -5531,7 +5573,8 @@ test_multiroot_tree_traversal(void)
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, postorder + 6);
 
-    /* Nodes that aren't "in" the tree have singleton traversal lists */
+    /* Nodes that aren't "in" the tree have singleton traversal lists and
+     * connect to no samples */
 
     ret = tsk_tree_preorder(&t, 11, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5542,6 +5585,100 @@ test_multiroot_tree_traversal(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 1);
     CU_ASSERT_EQUAL_FATAL(nodes[0], 11);
+
+    ret = tsk_tree_preorder_samples(&t, 11, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 0);
+
+    tsk_tree_free(&t);
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_seek_multi_tree(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_tree_t t;
+    double breakpoints[] = { 0, 2, 7, 10 };
+    tsk_size_t num_trees = 3;
+    tsk_size_t j, k;
+
+    tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
+        paper_ex_individuals, NULL, 0);
+
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    for (j = 0; j < num_trees; j++) {
+        ret = tsk_tree_seek(&t, breakpoints[j], 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(t.index, j);
+        for (k = 0; k < num_trees; k++) {
+            ret = tsk_tree_seek(&t, breakpoints[k], 0);
+            CU_ASSERT_EQUAL_FATAL(ret, 0);
+            CU_ASSERT_EQUAL_FATAL(t.index, k);
+        }
+    }
+
+    ret = tsk_tree_seek(&t, 1.99999, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(t.index, 0);
+    ret = tsk_tree_seek(&t, 6.99999, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(t.index, 1);
+    ret = tsk_tree_seek(&t, 9.99999, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(t.index, 2);
+
+    tsk_tree_free(&t);
+
+    /* Seek to all positions from a new tree. */
+    for (j = 0; j < num_trees; j++) {
+        ret = tsk_tree_init(&t, &ts, 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        ret = tsk_tree_seek(&t, breakpoints[j], 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(t.index, j);
+        tsk_tree_free(&t);
+    }
+
+    /* Seek to all positions from a non-new tree in the null state*/
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    for (j = 0; j < num_trees; j++) {
+        ret = tsk_tree_seek(&t, 0, 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        ret = tsk_tree_prev(&t);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(t.index, -1);
+        ret = tsk_tree_seek(&t, breakpoints[j], 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL_FATAL(t.index, j);
+    }
+    tsk_tree_free(&t);
+
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_seek_errors(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_tree_t t;
+
+    tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, NULL, NULL,
+        paper_ex_individuals, NULL, 0);
+
+    ret = tsk_tree_init(&t, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_seek(&t, -1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SEEK_OUT_OF_BOUNDS);
+    ret = tsk_tree_seek(&t, 10, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SEEK_OUT_OF_BOUNDS);
+    ret = tsk_tree_seek(&t, 11, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_SEEK_OUT_OF_BOUNDS);
 
     tsk_tree_free(&t);
     tsk_treeseq_free(&ts);
@@ -6948,6 +7085,10 @@ main(int argc, char **argv)
         /* tree traversal orders */
         { "test_single_tree_traversal", test_single_tree_traversal },
         { "test_multiroot_tree_traversal", test_multiroot_tree_traversal },
+
+        /* Seek */
+        { "test_seek_multi_tree", test_seek_multi_tree },
+        { "test_seek_errors", test_seek_errors },
 
         /* KC distance tests */
         { "test_single_tree_kc", test_single_tree_kc },

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -216,6 +216,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_GENOME_COORDS_NONFINITE:
             ret = "Genome coordinates must be finite numbers";
             break;
+        case TSK_ERR_SEEK_OUT_OF_BOUNDS:
+            ret = "Tree seek position out of bounds";
+            break;
 
         /* Edge errors */
         case TSK_ERR_NULL_PARENT:

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -371,6 +371,9 @@ tsk_strerror_internal(int err)
         case TSK_ERR_CANNOT_EXTEND_FROM_SELF:
             ret = "Tables can only be extended using rows from a different table";
             break;
+        case TSK_ERR_SILENT_MUTATIONS_NOT_SUPPORTED:
+            ret = "Silent mutations not supported by this operation";
+            break;
 
         /* Stats errors */
         case TSK_ERR_BAD_NUM_WINDOWS:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -261,6 +261,7 @@ An unsupported type was provided for a column in the file.
 #define TSK_ERR_PROVENANCE_OUT_OF_BOUNDS                            -209
 #define TSK_ERR_TIME_NONFINITE                                      -210
 #define TSK_ERR_GENOME_COORDS_NONFINITE                             -211
+#define TSK_ERR_SEEK_OUT_OF_BOUNDS                                  -212
 
 /* Edge errors */
 #define TSK_ERR_NULL_PARENT                                         -300

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -319,6 +319,7 @@ An unsupported type was provided for a column in the file.
 #define TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -804
 #define TSK_ERR_MIGRATIONS_NOT_SUPPORTED                            -805
 #define TSK_ERR_CANNOT_EXTEND_FROM_SELF                             -806
+#define TSK_ERR_SILENT_MUTATIONS_NOT_SUPPORTED                      -807
 
 /* Stats errors */
 #define TSK_ERR_BAD_NUM_WINDOWS                                     -900

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -84,18 +84,13 @@ static int
 tsk_ld_calc_set_focal_samples(tsk_ld_calc_t *self)
 {
     int ret = 0;
-    tsk_size_t num_samples;
     tsk_id_t focal_node = self->focal_site.mutations[0].node;
 
-    ret = tsk_tree_preorder_samples(
-        &self->tree, focal_node, self->sample_buffer, &num_samples);
+    ret = tsk_tree_track_descendant_samples(&self->tree, focal_node);
     if (ret != 0) {
         goto out;
     }
-    ret = tsk_tree_set_tracked_samples(&self->tree, num_samples, self->sample_buffer);
-    /* Any errors must be a bug as all values are already checked */
-    tsk_bug_assert(ret == 0);
-    self->focal_samples = num_samples;
+    self->focal_samples = self->tree.num_tracked_samples[focal_node];
 out:
     return ret;
 }

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -71,11 +71,20 @@ static int
 tsk_ld_calc_check_site(tsk_ld_calc_t *TSK_UNUSED(self), const tsk_site_t *site)
 {
     int ret = 0;
+
+    /* These are both limitations in the current implementation, there's no
+     * fundamental reason why we can't support them */
     if (site->mutations_length != 1) {
         ret = TSK_ERR_ONLY_INFINITE_SITES;
         goto out;
     }
-    /* TODO check for silent mutations */
+    if (site->ancestral_state_length == site->mutations[0].derived_state_length
+        && tsk_memcmp(site->ancestral_state, site->mutations[0].derived_state,
+               site->ancestral_state_length)
+               == 0) {
+        ret = TSK_ERR_SILENT_MUTATIONS_NOT_SUPPORTED;
+        goto out;
+    }
 out:
     return ret;
 }

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2019-2021 Tskit Developers
  * Copyright (c) 2016-2017 University of Oxford
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,63 +30,214 @@
 
 #include <tskit/stats.h>
 
-static void
-tsk_ld_calc_check_state(const tsk_ld_calc_t *self)
-{
-    tsk_size_t u;
-    tsk_size_t num_nodes = tsk_treeseq_get_num_nodes(self->tree_sequence);
-    tsk_tree_t *tA = self->outer_tree;
-    tsk_tree_t *tB = self->inner_tree;
-
-    tsk_bug_assert(tA->index == tB->index);
-
-    /* The inner tree's mark values should all be zero. */
-    for (u = 0; u < num_nodes; u++) {
-        tsk_bug_assert(tA->marked[u] == 0);
-        tsk_bug_assert(tB->marked[u] == 0);
-    }
-}
-
 void
 tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out)
 {
-    fprintf(out, "tree_sequence = %p\n", (const void *) self->tree_sequence);
-    fprintf(out, "outer tree index = %lld\n", (long long) self->outer_tree->index);
-    fprintf(out, "outer tree interval = (%f, %f)\n", self->outer_tree->left,
-        self->outer_tree->right);
-    fprintf(out, "inner tree index = %lld\n", (long long) self->inner_tree->index);
-    fprintf(out, "inner tree interval = (%f, %f)\n", self->inner_tree->left,
-        self->inner_tree->right);
-    tsk_ld_calc_check_state(self);
+    fprintf(out, "tree = %p\n", (const void *) &self->tree);
+    fprintf(out, "direction = %d\n", self->direction);
+    fprintf(out, "max_sites = %d\n", (int) self->max_sites);
+    fprintf(out, "max_distance = %f\n", self->max_distance);
 }
 
 int TSK_WARN_UNUSED
 tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence)
 {
-    int ret = TSK_ERR_GENERIC;
+    int ret = 0;
+    tsk_memset(self, 0, sizeof(*self));
 
-    tsk_memset(self, 0, sizeof(tsk_ld_calc_t));
+    ret = tsk_tree_init(&self->tree, tree_sequence, 0);
+    if (ret != 0) {
+        goto out;
+    }
     self->tree_sequence = tree_sequence;
-    self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
-    self->outer_tree = tsk_malloc(sizeof(tsk_tree_t));
-    self->inner_tree = tsk_malloc(sizeof(tsk_tree_t));
-    if (self->outer_tree == NULL || self->inner_tree == NULL) {
+    self->total_samples = tsk_treeseq_get_num_samples(self->tree_sequence);
+out:
+    return ret;
+}
+
+int
+tsk_ld_calc_free(tsk_ld_calc_t *self)
+{
+    tsk_tree_free(&self->tree);
+    return 0;
+}
+
+static int
+tsk_ld_calc_check_site(tsk_ld_calc_t *TSK_UNUSED(self), const tsk_site_t *site)
+{
+    int ret = 0;
+    if (site->mutations_length != 1) {
+        ret = TSK_ERR_ONLY_INFINITE_SITES;
+        goto out;
+    }
+    /* TODO check for silent mutations */
+out:
+    return ret;
+}
+
+static int
+tsk_ld_calc_set_focal_samples(tsk_ld_calc_t *self)
+{
+    int ret = 0;
+    tsk_size_t num_samples;
+    tsk_id_t focal_node = self->focal_site.mutations[0].node;
+    tsk_id_t *samples = tsk_malloc(self->total_samples * sizeof(*samples));
+
+    if (samples == NULL) {
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
-    ret = tsk_tree_init(self->outer_tree, self->tree_sequence, TSK_SAMPLE_LISTS);
+    ret = tsk_tree_preorder_samples(&self->tree, focal_node, samples, &num_samples);
     if (ret != 0) {
         goto out;
     }
-    ret = tsk_tree_init(self->inner_tree, self->tree_sequence, 0);
+    ret = tsk_tree_set_tracked_samples(&self->tree, num_samples, samples);
     if (ret != 0) {
         goto out;
     }
-    ret = tsk_tree_first(self->outer_tree);
+    self->focal_samples = num_samples;
+out:
+    tsk_safe_free(samples);
+    return ret;
+}
+
+static int
+tsk_ld_calc_initialise(tsk_ld_calc_t *self, tsk_id_t a)
+{
+    int ret = 0;
+
+    ret = tsk_treeseq_get_site(self->tree_sequence, a, &self->focal_site);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_ld_calc_check_site(self, &self->focal_site);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_tree_seek(&self->tree, self->focal_site.position, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_ld_calc_set_focal_samples(self);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_ld_calc_compute_r2(tsk_ld_calc_t *self, const tsk_site_t *target_site, double *r2)
+{
+    double n = (double) self->total_samples;
+    double f_a, f_b, f_ab, D, denom;
+    tsk_id_t node;
+    int ret = tsk_ld_calc_check_site(self, target_site);
+
+    if (ret != 0) {
+        goto out;
+    }
+    node = target_site->mutations[0].node;
+    n = (double) self->total_samples;
+    f_a = ((double) self->focal_samples) / n;
+    f_b = ((double) self->tree.num_samples[node]) / n;
+    f_ab = ((double) self->tree.num_tracked_samples[node]) / n;
+    D = f_ab - f_a * f_b;
+    denom = f_a * f_b * (1 - f_a) * (1 - f_b);
+    *r2 = (D * D) / denom;
+out:
+    return ret;
+}
+
+static int
+tsk_ld_calc_compute_and_append(
+    tsk_ld_calc_t *self, const tsk_site_t *target_site, bool *ret_done)
+{
+    int ret = 0;
+    double r2;
+    double distance = fabs(self->focal_site.position - target_site->position);
+    bool done = true;
+
+    if (distance <= self->max_distance && self->result_length < self->max_sites) {
+        ret = tsk_ld_calc_compute_r2(self, target_site, &r2);
+        if (ret != 0) {
+            goto out;
+        }
+        self->result[self->result_length] = r2;
+        self->result_length++;
+        done = false;
+    }
+    *ret_done = done;
+out:
+    return ret;
+}
+
+static int
+tsk_ld_calc_run_forward(tsk_ld_calc_t *self)
+{
+    int ret = 0;
+    tsk_size_t j;
+    bool done = false;
+
+    for (j = 0; j < self->tree.sites_length; j++) {
+        if (self->tree.sites[j].id > self->focal_site.id) {
+            ret = tsk_ld_calc_compute_and_append(self, &self->tree.sites[j], &done);
+            if (ret != 0) {
+                goto out;
+            }
+            if (done) {
+                break;
+            }
+        }
+    }
+    while (((ret = tsk_tree_next(&self->tree)) == 1) && !done) {
+        for (j = 0; j < self->tree.sites_length; j++) {
+            ret = tsk_ld_calc_compute_and_append(self, &self->tree.sites[j], &done);
+            if (ret != 0) {
+                goto out;
+            }
+            if (done) {
+                break;
+            }
+        }
+    }
     if (ret < 0) {
         goto out;
     }
-    ret = tsk_tree_first(self->inner_tree);
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_ld_calc_run_reverse(tsk_ld_calc_t *self)
+{
+    int ret = 0;
+    tsk_id_t j;
+    bool done = false;
+
+    for (j = (tsk_id_t) self->tree.sites_length - 1; j >= 0; j--) {
+        if (self->tree.sites[j].id < self->focal_site.id) {
+            ret = tsk_ld_calc_compute_and_append(self, &self->tree.sites[j], &done);
+            if (ret != 0) {
+                goto out;
+            }
+            if (done) {
+                break;
+            }
+        }
+    }
+    while (((ret = tsk_tree_prev(&self->tree)) == 1) && !done) {
+        for (j = (tsk_id_t) self->tree.sites_length - 1; j >= 0; j--) {
+            ret = tsk_ld_calc_compute_and_append(self, &self->tree.sites[j], &done);
+            if (ret != 0) {
+                goto out;
+            }
+            if (done) {
+                break;
+            }
+        }
+    }
     if (ret < 0) {
         goto out;
     }
@@ -96,381 +247,57 @@ out:
 }
 
 int
-tsk_ld_calc_free(tsk_ld_calc_t *self)
-{
-    if (self->inner_tree != NULL) {
-        tsk_tree_free(self->inner_tree);
-        free(self->inner_tree);
-    }
-    if (self->outer_tree != NULL) {
-        tsk_tree_free(self->outer_tree);
-        free(self->outer_tree);
-    }
-    return 0;
-}
-
-/* Position the two trees so that the specified site is within their
- * interval.
- */
-static int TSK_WARN_UNUSED
-tsk_ld_calc_position_trees(tsk_ld_calc_t *self, tsk_id_t site_index)
-{
-    int ret = TSK_ERR_GENERIC;
-    tsk_site_t mut;
-    double x;
-    tsk_tree_t *tA = self->outer_tree;
-    tsk_tree_t *tB = self->inner_tree;
-
-    ret = tsk_treeseq_get_site(self->tree_sequence, site_index, &mut);
-    if (ret != 0) {
-        goto out;
-    }
-    x = mut.position;
-    tsk_bug_assert(tA->index == tB->index);
-    while (x >= tA->right) {
-        ret = tsk_tree_next(tA);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-        ret = tsk_tree_next(tB);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-    }
-    while (x < tA->left) {
-        ret = tsk_tree_prev(tA);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-        ret = tsk_tree_prev(tB);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-    }
-    ret = 0;
-    tsk_bug_assert(x >= tA->left && x < tB->right);
-    tsk_bug_assert(tA->index == tB->index);
-out:
-    return ret;
-}
-
-static double
-tsk_ld_calc_overlap_within_tree(tsk_ld_calc_t *self, tsk_site_t sA, tsk_site_t sB)
-{
-    const tsk_tree_t *t = self->inner_tree;
-    const tsk_node_table_t *nodes = &self->tree_sequence->tables->nodes;
-    tsk_id_t u, v;
-    tsk_size_t nAB;
-
-    tsk_bug_assert(sA.mutations_length == 1);
-    tsk_bug_assert(sB.mutations_length == 1);
-    u = sA.mutations[0].node;
-    v = sB.mutations[0].node;
-    if (nodes->time[u] > nodes->time[v]) {
-        v = sA.mutations[0].node;
-        u = sB.mutations[0].node;
-    }
-    while (u != v && u != TSK_NULL) {
-        u = t->parent[u];
-    }
-    nAB = 0;
-    if (u == v) {
-        nAB = TSK_MIN(
-            t->num_samples[sA.mutations[0].node], t->num_samples[sB.mutations[0].node]);
-    }
-    return (double) nAB;
-}
-
-static inline int TSK_WARN_UNUSED
-tsk_ld_calc_set_tracked_samples(tsk_ld_calc_t *self, tsk_site_t sA)
+tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2)
 {
     int ret = 0;
+    tsk_site_t target_site;
 
-    tsk_bug_assert(sA.mutations_length == 1);
-    ret = tsk_tree_set_tracked_samples_from_sample_list(
-        self->inner_tree, self->outer_tree, sA.mutations[0].node);
-    return ret;
-}
-
-static int TSK_WARN_UNUSED
-tsk_ld_calc_get_r2_array_forward(tsk_ld_calc_t *self, tsk_id_t source_index,
-    tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values)
-{
-    int ret = TSK_ERR_GENERIC;
-    tsk_site_t sA, sB;
-    double fA, fB, fAB, D;
-    int tracked_samples_set = 0;
-    tsk_tree_t *tA, *tB;
-    double n = (double) tsk_treeseq_get_num_samples(self->tree_sequence);
-    tsk_id_t j;
-    double nAB;
-
-    tA = self->outer_tree;
-    tB = self->inner_tree;
-    ret = tsk_treeseq_get_site(self->tree_sequence, source_index, &sA);
+    ret = tsk_ld_calc_initialise(self, a);
     if (ret != 0) {
         goto out;
     }
-    if (sA.mutations_length > 1) {
-        ret = TSK_ERR_ONLY_INFINITE_SITES;
+    ret = tsk_treeseq_get_site(self->tree_sequence, b, &target_site);
+    if (ret != 0) {
         goto out;
     }
-    fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
-    tsk_bug_assert(fA > 0);
-    tB->mark = 1;
-    for (j = 0; j < (tsk_id_t) max_sites; j++) {
-        if (source_index + j + 1 >= (tsk_id_t) self->num_sites) {
-            break;
-        }
-        ret = tsk_treeseq_get_site(self->tree_sequence, (source_index + j + 1), &sB);
-        if (ret != 0) {
-            goto out;
-        }
-        if (sB.mutations_length > 1) {
-            ret = TSK_ERR_ONLY_INFINITE_SITES;
-            goto out;
-        }
-        if (sB.position - sA.position > max_distance) {
-            break;
-        }
-        while (sB.position >= tB->right) {
-            ret = tsk_tree_next(tB);
-            if (ret < 0) {
-                goto out;
-            }
-            tsk_bug_assert(ret == 1);
-        }
-        fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
-        tsk_bug_assert(fB > 0);
-        if (sB.position < tA->right) {
-            nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
-        } else {
-            if (!tracked_samples_set && tB->marked[sA.mutations[0].node] == 1) {
-                tracked_samples_set = 1;
-                ret = tsk_ld_calc_set_tracked_samples(self, sA);
-                if (ret != 0) {
-                    goto out;
-                }
-            }
-            if (tracked_samples_set) {
-                nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
-            } else {
-                nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
-            }
-        }
-        fAB = nAB / n;
-        D = fAB - fA * fB;
-        r2[j] = D * D / (fA * fB * (1 - fA) * (1 - fB));
+    ret = tsk_tree_seek(&self->tree, target_site.position, 0);
+    if (ret != 0) {
+        goto out;
     }
-
-    /* Now rewind back the inner iterator and unmark all nodes that
-     * were set to 1 as we moved forward. */
-    tB->mark = 0;
-    while (tB->index > tA->index) {
-        ret = tsk_tree_prev(tB);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
+    ret = tsk_ld_calc_compute_r2(self, &target_site, r2);
+    if (ret != 0) {
+        goto out;
     }
-    *num_r2_values = (tsk_size_t) j;
-    ret = 0;
 out:
     return ret;
 }
 
-static int TSK_WARN_UNUSED
-tsk_ld_calc_get_r2_array_reverse(tsk_ld_calc_t *self, tsk_id_t source_index,
-    tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values)
-{
-    int ret = TSK_ERR_GENERIC;
-    tsk_site_t sA, sB;
-    double fA, fB, fAB, D;
-    int tracked_samples_set = 0;
-    tsk_tree_t *tA, *tB;
-    double n = (double) tsk_treeseq_get_num_samples(self->tree_sequence);
-    double nAB;
-    tsk_id_t j, site_index;
-
-    tA = self->outer_tree;
-    tB = self->inner_tree;
-    ret = tsk_treeseq_get_site(self->tree_sequence, source_index, &sA);
-    if (ret != 0) {
-        goto out;
-    }
-    if (sA.mutations_length > 1) {
-        ret = TSK_ERR_ONLY_INFINITE_SITES;
-        goto out;
-    }
-    fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
-    tsk_bug_assert(fA > 0);
-    tB->mark = 1;
-    for (j = 0; j < (tsk_id_t) max_sites; j++) {
-        site_index = source_index - j - 1;
-        if (site_index < 0) {
-            break;
-        }
-        ret = tsk_treeseq_get_site(self->tree_sequence, site_index, &sB);
-        if (ret != 0) {
-            goto out;
-        }
-        if (sB.mutations_length > 1) {
-            ret = TSK_ERR_ONLY_INFINITE_SITES;
-            goto out;
-        }
-        if (sA.position - sB.position > max_distance) {
-            break;
-        }
-        while (sB.position < tB->left) {
-            ret = tsk_tree_prev(tB);
-            if (ret < 0) {
-                goto out;
-            }
-            tsk_bug_assert(ret == 1);
-        }
-        fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
-        tsk_bug_assert(fB > 0);
-        if (sB.position >= tA->left) {
-            nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
-        } else {
-            if (!tracked_samples_set && tB->marked[sA.mutations[0].node] == 1) {
-                tracked_samples_set = 1;
-                ret = tsk_ld_calc_set_tracked_samples(self, sA);
-                if (ret != 0) {
-                    goto out;
-                }
-            }
-            if (tracked_samples_set) {
-                nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
-            } else {
-                nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
-            }
-        }
-        fAB = nAB / n;
-        D = fAB - fA * fB;
-        r2[j] = D * D / (fA * fB * (1 - fA) * (1 - fB));
-    }
-
-    /* Now fast forward the inner iterator and unmark all nodes that
-     * were set to 1 as we moved back. */
-    tB->mark = 0;
-    while (tB->index < tA->index) {
-        ret = tsk_tree_next(tB);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-    }
-    *num_r2_values = (tsk_size_t) j;
-    ret = 0;
-out:
-    return ret;
-}
-
-int TSK_WARN_UNUSED
+int
 tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
     tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values)
 {
-    int ret = TSK_ERR_GENERIC;
+    int ret = tsk_ld_calc_initialise(self, a);
 
-    if (a < 0 || a >= (tsk_id_t) self->num_sites) {
-        ret = TSK_ERR_OUT_OF_BOUNDS;
-        goto out;
-    }
-    ret = tsk_ld_calc_position_trees(self, a);
     if (ret != 0) {
         goto out;
     }
+
+    self->max_sites = max_sites;
+    self->max_distance = max_distance;
+    self->result_length = 0;
+    self->result = r2;
+
     if (direction == TSK_DIR_FORWARD) {
-        ret = tsk_ld_calc_get_r2_array_forward(
-            self, a, max_sites, max_distance, r2, num_r2_values);
+        ret = tsk_ld_calc_run_forward(self);
     } else if (direction == TSK_DIR_REVERSE) {
-        ret = tsk_ld_calc_get_r2_array_reverse(
-            self, a, max_sites, max_distance, r2, num_r2_values);
+        ret = tsk_ld_calc_run_reverse(self);
     } else {
         ret = TSK_ERR_BAD_PARAM_VALUE;
     }
-out:
-    return ret;
-}
-
-int TSK_WARN_UNUSED
-tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2)
-{
-    int ret = TSK_ERR_GENERIC;
-    tsk_site_t sA, sB;
-    double fA, fB, fAB, D;
-    tsk_tree_t *tA, *tB;
-    double n = (double) tsk_treeseq_get_num_samples(self->tree_sequence);
-    double nAB;
-    tsk_id_t tmp;
-
-    if (a < 0 || b < 0 || a >= (tsk_id_t) self->num_sites
-        || b >= (tsk_id_t) self->num_sites) {
-        ret = TSK_ERR_OUT_OF_BOUNDS;
-        goto out;
-    }
-    if (a > b) {
-        tmp = a;
-        a = b;
-        b = tmp;
-    }
-    ret = tsk_ld_calc_position_trees(self, a);
     if (ret != 0) {
         goto out;
     }
-    /* We can probably do a lot better than this implementation... */
-    tA = self->outer_tree;
-    tB = self->inner_tree;
-    ret = tsk_treeseq_get_site(self->tree_sequence, a, &sA);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = tsk_treeseq_get_site(self->tree_sequence, b, &sB);
-    if (ret != 0) {
-        goto out;
-    }
-    if (sA.mutations_length > 1 || sB.mutations_length > 1) {
-        ret = TSK_ERR_ONLY_INFINITE_SITES;
-        goto out;
-    }
-    tsk_bug_assert(sA.mutations_length == 1);
-    /* tsk_bug_assert(tA->parent[sA.mutations[0].node] != TSK_NULL); */
-    fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
-    tsk_bug_assert(fA > 0);
-    ret = tsk_ld_calc_set_tracked_samples(self, sA);
-    if (ret != 0) {
-        goto out;
-    }
-
-    while (sB.position >= tB->right) {
-        ret = tsk_tree_next(tB);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-    }
-    /* tsk_bug_assert(tB->parent[sB.mutations[0].node] != TSK_NULL); */
-    fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
-    tsk_bug_assert(fB > 0);
-    nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
-    fAB = nAB / n;
-    D = fAB - fA * fB;
-    *r2 = D * D / (fA * fB * (1 - fA) * (1 - fB));
-
-    /* Now rewind the inner iterator back. */
-    while (tB->index > tA->index) {
-        ret = tsk_tree_prev(tB);
-        if (ret < 0) {
-            goto out;
-        }
-        tsk_bug_assert(ret == 1);
-    }
-    ret = 0;
+    *num_r2_values = self->result_length;
 out:
     return ret;
 }

--- a/c/tskit/stats.h
+++ b/c/tskit/stats.h
@@ -33,11 +33,16 @@ extern "C" {
 #include <tskit/trees.h>
 
 typedef struct {
-    tsk_tree_t *outer_tree;
-    tsk_tree_t *inner_tree;
-    tsk_size_t num_sites;
-    int tree_changed;
     const tsk_treeseq_t *tree_sequence;
+    tsk_site_t focal_site;
+    tsk_size_t total_samples;
+    tsk_size_t focal_samples;
+    int direction;
+    double max_distance;
+    tsk_size_t max_sites;
+    tsk_tree_t tree;
+    double *result;
+    tsk_size_t result_length;
 } tsk_ld_calc_t;
 
 int tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence);

--- a/c/tskit/stats.h
+++ b/c/tskit/stats.h
@@ -37,10 +37,10 @@ typedef struct {
     tsk_site_t focal_site;
     tsk_size_t total_samples;
     tsk_size_t focal_samples;
-    int direction;
     double max_distance;
     tsk_size_t max_sites;
     tsk_tree_t tree;
+    tsk_id_t *sample_buffer;
     double *result;
     tsk_size_t result_length;
 } tsk_ld_calc_t;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -410,6 +410,7 @@ int tsk_tree_last(tsk_tree_t *self);
 int tsk_tree_next(tsk_tree_t *self);
 int tsk_tree_prev(tsk_tree_t *self);
 int tsk_tree_clear(tsk_tree_t *self);
+int tsk_tree_seek(tsk_tree_t *self, double position, tsk_flags_t options);
 
 void tsk_tree_print_state(const tsk_tree_t *self, FILE *out);
 
@@ -499,6 +500,8 @@ int tsk_tree_get_sites(
 int tsk_tree_preorder(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
 int tsk_tree_postorder(
+    const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
+int tsk_tree_preorder_samples(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
 
 typedef struct {

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -479,6 +479,8 @@ tsk_id_t tsk_tree_get_left_root(const tsk_tree_t *self);
 tsk_id_t tsk_tree_get_right_root(const tsk_tree_t *self);
 
 int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options);
+
+int tsk_tree_track_descendant_samples(tsk_tree_t *self, tsk_id_t node);
 int tsk_tree_set_tracked_samples(
     tsk_tree_t *self, tsk_size_t num_tracked_samples, const tsk_id_t *tracked_samples);
 int tsk_tree_set_tracked_samples_from_sample_list(

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -10988,10 +10988,8 @@ LdCalculator_get_r2(LdCalculator *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "nn", &a, &b)) {
         goto out;
     }
-    Py_BEGIN_ALLOW_THREADS err
-        = tsk_ld_calc_get_r2(self->ld_calc, (tsk_id_t) a, (tsk_id_t) b, &r2);
-    Py_END_ALLOW_THREADS if (err != 0)
-    {
+    err = tsk_ld_calc_get_r2(self->ld_calc, (tsk_id_t) a, (tsk_id_t) b, &r2);
+    if (err != 0) {
         handle_library_error(err);
         goto out;
     }
@@ -11000,30 +10998,27 @@ out:
     return ret;
 }
 
-/* TODO this implementation is brittle and cumbersome. Replace with something that
- * returns a numpy array directly. Passing in the memory is a premature optimisation.
- */
 static PyObject *
 LdCalculator_get_r2_array(LdCalculator *self, PyObject *args, PyObject *kwds)
 {
     int err;
     PyObject *ret = NULL;
+    PyArrayObject *array = NULL;
     static char *kwlist[]
-        = { "dest", "source_index", "direction", "max_mutations", "max_distance", NULL };
-    PyObject *dest = NULL;
-    Py_buffer buffer;
+        = { "source_index", "direction", "max_sites", "max_distance", NULL };
     Py_ssize_t source_index;
-    Py_ssize_t max_mutations = -1;
+    Py_ssize_t max_sites = -1;
     double max_distance = DBL_MAX;
     int direction = TSK_DIR_FORWARD;
+    double *data = NULL;
     tsk_size_t num_r2_values = 0;
-    int buffer_acquired = 0;
+    npy_intp dims;
 
     if (LdCalculator_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "On|ind", kwlist, &dest, &source_index,
-            &direction, &max_mutations, &max_distance)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "n|ind", kwlist, &source_index,
+            &direction, &max_sites, &max_distance)) {
         goto out;
     }
     if (direction != TSK_DIR_FORWARD && direction != TSK_DIR_REVERSE) {
@@ -11034,35 +11029,44 @@ LdCalculator_get_r2_array(LdCalculator *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(PyExc_ValueError, "max_distance must be >= 0");
         goto out;
     }
-    if (!PyObject_CheckBuffer(dest)) {
-        PyErr_SetString(
-            PyExc_TypeError, "dest buffer must support the Python buffer protocol.");
-        goto out;
-    }
-    if (PyObject_GetBuffer(dest, &buffer, PyBUF_SIMPLE | PyBUF_WRITABLE) != 0) {
-        goto out;
-    }
-    buffer_acquired = 1;
-    if (max_mutations == -1) {
-        max_mutations = buffer.len / sizeof(double);
-    } else if (max_mutations * sizeof(double) > (size_t) buffer.len) {
-        PyErr_SetString(PyExc_BufferError, "dest buffer is too small for the results");
+    if (max_sites == -1) {
+        max_sites = tsk_treeseq_get_num_sites(self->ld_calc->tree_sequence);
+    } else if (max_sites < 0) {
+        PyErr_SetString(PyExc_ValueError, "max_sites cannot be negative");
         goto out;
     }
 
-    Py_BEGIN_ALLOW_THREADS err = tsk_ld_calc_get_r2_array(self->ld_calc,
-        (tsk_id_t) source_index, direction, (tsk_size_t) max_mutations, max_distance,
-        (double *) buffer.buf, &num_r2_values);
-    Py_END_ALLOW_THREADS if (err != 0)
-    {
+    data = PyDataMem_NEW(max_sites * sizeof(*data));
+    if (data == NULL) {
+        ret = PyErr_NoMemory();
+        goto out;
+    }
+    err = tsk_ld_calc_get_r2_array(self->ld_calc, (tsk_id_t) source_index, direction,
+        (tsk_size_t) max_sites, max_distance, data, &num_r2_values);
+    if (err != 0) {
         handle_library_error(err);
         goto out;
     }
-    ret = Py_BuildValue("n", (Py_ssize_t) num_r2_values);
-out:
-    if (buffer_acquired) {
-        PyBuffer_Release(&buffer);
+    dims = (npy_intp) num_r2_values;
+    array = (PyArrayObject *) PyArray_SimpleNewFromData(1, &dims, NPY_FLOAT64, data);
+    if (array == NULL) {
+        goto out;
     }
+    /* Set the OWNDATA flag on that the data will be freed with the array */
+    PyArray_ENABLEFLAGS(array, NPY_ARRAY_OWNDATA);
+    /* Not strictly necessary since we're creating a new array, but let's
+     * keep the door open to future optimisations. */
+    PyArray_CLEARFLAGS(array, NPY_ARRAY_WRITEABLE);
+
+    ret = (PyObject *) array;
+    data = NULL;
+    array = NULL;
+out:
+    Py_XDECREF(array);
+    if (data != NULL) {
+        PyDataMem_FREE(data);
+    }
+
     return ret;
 }
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9399,6 +9399,29 @@ out:
 }
 
 static PyObject *
+Tree_seek(Tree *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    double position;
+    int err;
+
+    if (Tree_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "d", &position)) {
+        goto out;
+    }
+    err = tsk_tree_seek(self->tree, position, 0);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 Tree_clear(Tree *self)
 {
     PyObject *ret = NULL;
@@ -10410,6 +10433,10 @@ static PyMethodDef Tree_methods[] = {
         .ml_meth = (PyCFunction) Tree_next,
         .ml_flags = METH_NOARGS,
         .ml_doc = "Sets this tree to the next one in the sequence." },
+    { .ml_name = "seek",
+        .ml_meth = (PyCFunction) Tree_seek,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Seeks to the tree at the specified position" },
     { .ml_name = "clear",
         .ml_meth = (PyCFunction) Tree_clear,
         .ml_flags = METH_NOARGS,

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2551,6 +2551,16 @@ class TestTree(LowLevelTestCase):
         with pytest.raises(_tskit.LibraryError):
             tree.set_root_threshold(2)
 
+    def test_seek_errors(self):
+        ts = self.get_example_tree_sequence()
+        tree = _tskit.Tree(ts)
+        for bad_type in ["", "x", {}]:
+            with pytest.raises(TypeError):
+                tree.seek(bad_type)
+        for bad_pos in [-1, 1e6]:
+            with pytest.raises(_tskit.LibraryError):
+                tree.seek(bad_pos)
+
     def test_root_threshold(self):
         for ts in self.get_example_tree_sequences():
             tree = _tskit.Tree(ts)

--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -516,7 +516,7 @@ class TestLdCalculator:
         self.verify_matrix(ts)
         self.verify_max_distance(ts)
 
-    def test_deprecated_aliases(self):
+    def test_deprecated_get_aliases(self):
         ts = msprime.simulate(20, mutation_rate=10, random_seed=15)
         ts = tsutil.subsample_sites(ts, self.num_test_sites)
         ldc = tskit.LdCalculator(ts)
@@ -527,6 +527,12 @@ class TestLdCalculator:
         b = ldc.r2_array(0)
         assert np.array_equal(a, b)
         assert ldc.get_r2(0, 1) == ldc.r2(0, 1)
+
+    def test_deprecated_max_mutations_alias(self):
+        ts = msprime.simulate(2, mutation_rate=0.1, random_seed=15)
+        ldc = tskit.LdCalculator(ts)
+        with pytest.raises(ValueError, match="deprecated synonym"):
+            ldc.r2_array(0, max_sites=1, max_mutations=1)
 
     def test_single_tree_regular_mutations(self):
         ts = msprime.simulate(self.num_test_sites, length=self.num_test_sites)

--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -23,50 +23,397 @@
 """
 Test cases for stats calculations in tskit.
 """
+import contextlib
 import io
 import sys
-import unittest
 
 import msprime
 import numpy as np
 import pytest
 
 import _tskit
+import tests
 import tests.test_wright_fisher as wf
 import tests.tsutil as tsutil
 import tskit
 
 
+@contextlib.contextmanager
+def suppress_division_by_zero_warning():
+    with np.errstate(invalid="ignore", divide="ignore"):
+        yield
+
+
 def get_r2_matrix(ts):
     """
-    Returns the matrix for the specified tree sequence. This is computed
-    via a straightforward Python algorithm.
+    Simple site-based version assuming biallic sites.
     """
-    n = ts.get_sample_size()
-    m = ts.get_num_mutations()
-    A = np.zeros((m, m), dtype=float)
-    for t1 in ts.trees():
-        for sA in t1.sites():
-            assert len(sA.mutations) == 1
-            mA = sA.mutations[0]
-            A[sA.id, sA.id] = 1
-            fA = t1.get_num_samples(mA.node) / n
-            samples = list(t1.samples(mA.node))
-            for t2 in ts.trees(tracked_samples=samples):
-                for sB in t2.sites():
-                    assert len(sB.mutations) == 1
-                    mB = sB.mutations[0]
-                    if sB.position > sA.position:
-                        fB = t2.get_num_samples(mB.node) / n
-                        fAB = t2.get_num_tracked_samples(mB.node) / n
-                        D = fAB - fA * fB
-                        r2 = D * D / (fA * fB * (1 - fA) * (1 - fB))
-                        A[sA.id, sB.id] = r2
-                        A[sB.id, sA.id] = r2
+    A = np.zeros((ts.num_sites, ts.num_sites))
+    G = ts.genotype_matrix()
+    n = ts.num_samples
+    for a in range(ts.num_sites):
+        A[a, a] = 1
+        fA = np.sum(G[a] != 0) / n
+        for b in range(a + 1, ts.num_sites):
+            fB = np.sum(G[b] != 0) / n
+            nAB = np.sum(np.logical_and(G[a] != 0, G[b] != 0))
+            fAB = nAB / n
+            D = fAB - fA * fB
+            denom = fA * fB * (1 - fA) * (1 - fB)
+            A[a, b] = D * D
+            with suppress_division_by_zero_warning():
+                A[a, b] /= denom
+            A[b, a] = A[a, b]
     return A
 
 
-class TestLdCalculator(unittest.TestCase):
+def _compute_r2(tree, n, f_a, site_b):
+    assert len(site_b.mutations) == 1
+    assert site_b.ancestral_state != site_b.mutations[0].derived_state
+    f_b = tree.num_samples(site_b.mutations[0].node) / n
+    f_ab = tree.num_tracked_samples(site_b.mutations[0].node) / n
+    D2 = (f_ab - f_a * f_b) ** 2
+    denom = f_a * f_b * (1 - f_a) * (1 - f_b)
+    if denom == 0:
+        return np.nan
+    return D2 / denom
+
+
+def ts_r2(ts, a, b):
+    """
+    Returns the r2 value between sites a and b in the specified tree sequence.
+    """
+    a, b = (a, b) if a < b else (b, a)
+    site_a = ts.site(a)
+    site_b = ts.site(b)
+    assert len(site_a.mutations) == 1
+    assert len(site_b.mutations) == 1
+    n = ts.num_samples
+    tree = ts.at(site_a.position)
+    a_samples = list(tree.samples(site_a.mutations[0].node))
+    f_a = len(a_samples) / n
+    tree = ts.at(site_b.position, tracked_samples=a_samples)
+    return _compute_r2(tree, n, f_a, site_b)
+
+
+class LdArrayCalculator:
+    """
+    Utility class to help organise the state required when tracking all
+    the different termination conditions.
+    """
+
+    def __init__(self, ts, focal_site_id, direction, max_sites, max_distance):
+        self.ts = ts
+        self.focal_site = ts.site(focal_site_id)
+        self.direction = direction
+        self.max_sites = max_sites
+        self.max_distance = max_distance
+        self.result = []
+        self.tree = None
+
+    def _check_site(self, site):
+        assert len(site.mutations) == 1
+        assert site.ancestral_state != site.mutations[0].derived_state
+
+    def _compute_and_append(self, target_site):
+        self._check_site(target_site)
+
+        distance = abs(target_site.position - self.focal_site.position)
+        if distance > self.max_distance:
+            return True
+        r2 = _compute_r2(
+            self.tree, self.ts.num_samples, self.focal_frequency, target_site
+        )
+        self.result.append(r2)
+        return len(self.result) == self.max_sites
+
+    def _compute_forward(self):
+        done = False
+        for site in self.tree.sites():
+            if site.id > self.focal_site.id:
+                done = self._compute_and_append(site)
+                if done:
+                    break
+        while self.tree.next() and not done:
+            for site in self.tree.sites():
+                done = self._compute_and_append(site)
+                if done:
+                    break
+
+    def _compute_backward(self):
+        done = False
+        for site in reversed(list(self.tree.sites())):
+            if site.id < self.focal_site.id:
+                done = self._compute_and_append(site)
+                if done:
+                    break
+        while self.tree.prev() and not done:
+            for site in reversed(list(self.tree.sites())):
+                done = self._compute_and_append(site)
+                if done:
+                    break
+
+    def run(self):
+        self._check_site(self.focal_site)
+        self.tree = self.ts.at(self.focal_site.position)
+        a_samples = list(self.tree.samples(self.focal_site.mutations[0].node))
+        self.focal_frequency = len(a_samples) / self.ts.num_samples
+
+        # Now set the tracked samples on the tree. We don't have a python
+        # API for doing this, so we just create a new tree.
+        self.tree = self.ts.at(self.focal_site.position, tracked_samples=a_samples)
+        if self.direction == 1:
+            self._compute_forward()
+        else:
+            self._compute_backward()
+        return np.array(self.result)
+
+
+def ts_r2_array(ts, a, *, direction=1, max_sites=None, max_distance=None):
+    max_sites = ts.num_sites if max_sites is None else max_sites
+    max_distance = np.inf if max_distance is None else max_distance
+    calc = LdArrayCalculator(ts, a, direction, max_sites, max_distance)
+    return calc.run()
+
+
+class TestLdSingleTree:
+    # 2.00┊   4   ┊
+    #     ┊ ┏━┻┓  ┊
+    # 1.00┊ ┃  3  ┊
+    #     ┊ ┃ ┏┻┓ ┊
+    # 0.00┊ 0 1 2 ┊
+    #     0      10
+    #      | |  |
+    #  pos 2 4  9
+    # node 0 1  0
+    @tests.cached_example
+    def ts(self):
+        ts = tskit.Tree.generate_balanced(3, span=10).tree_sequence
+        tables = ts.dump_tables()
+        tables.sites.add_row(2, ancestral_state="A")
+        tables.sites.add_row(4, ancestral_state="A")
+        tables.sites.add_row(9, ancestral_state="T")
+        tables.mutations.add_row(site=0, node=0, derived_state="G")
+        tables.mutations.add_row(site=1, node=3, derived_state="C")
+        tables.mutations.add_row(site=2, node=0, derived_state="G")
+        return tables.tree_sequence()
+
+    @pytest.mark.parametrize(["a", "b", "expected"], [(0, 0, 1), (0, 1, 1), (0, 2, 1)])
+    def test_r2(self, a, b, expected):
+        ts = self.ts()
+        A = get_r2_matrix(ts)
+        ldc = tskit.LdCalculator(ts)
+        assert ldc.r2(a, b) == pytest.approx(expected)
+        assert ts_r2(ts, a, b) == pytest.approx(expected)
+        assert A[a, b] == pytest.approx(expected)
+        assert ldc.r2(b, a) == pytest.approx(expected)
+        assert ts_r2(ts, b, a) == pytest.approx(expected)
+        assert A[b, a] == pytest.approx(expected)
+
+    @pytest.mark.parametrize("a", [0, 1, 2])
+    @pytest.mark.parametrize("direction", [1, -1])
+    def test_r2_array(self, a, direction):
+        ts = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        lib_a = ldc.r2_array(a, direction=direction)
+        py_a = ts_r2_array(ts, a, direction=direction)
+        np.testing.assert_array_almost_equal(lib_a, py_a)
+
+
+class TestLdFixedSites:
+    # 2.00┊   4   ┊
+    #     ┊ ┏━┻┓  ┊
+    # 1.00┊ ┃  3  ┊
+    #     ┊ ┃ ┏┻┓ ┊
+    # 0.00┊ 0 1 2 ┊
+    #     0      10
+    #      | |  |
+    #  pos 2 4  9
+    # node 0 1  0
+    @tests.cached_example
+    def ts(self):
+        ts = tskit.Tree.generate_balanced(3, span=10).tree_sequence
+        tables = ts.dump_tables()
+        # First and last mutations are over the root
+        tables.sites.add_row(2, ancestral_state="A")
+        tables.sites.add_row(4, ancestral_state="A")
+        tables.sites.add_row(9, ancestral_state="T")
+        tables.mutations.add_row(site=0, node=4, derived_state="G")
+        tables.mutations.add_row(site=1, node=3, derived_state="C")
+        tables.mutations.add_row(site=2, node=4, derived_state="G")
+        return tables.tree_sequence()
+
+    def test_r2_fixed_fixed(self):
+        ts = self.ts()
+        A = get_r2_matrix(ts)
+        ldc = tskit.LdCalculator(ts)
+        assert np.isnan(ldc.r2(0, 2))
+        assert np.isnan(ts_r2(ts, 0, 2))
+        assert np.isnan(A[0, 2])
+
+    def test_r2_fixed_non_fixed(self):
+        ts = self.ts()
+        A = get_r2_matrix(ts)
+        ldc = tskit.LdCalculator(ts)
+        assert np.isnan(ldc.r2(0, 1))
+        assert np.isnan(ts_r2(ts, 0, 1))
+        assert np.isnan(A[0, 1])
+
+    def test_r2_non_fixed_fixed(self):
+        ts = self.ts()
+        A = get_r2_matrix(ts)
+        ldc = tskit.LdCalculator(ts)
+        assert np.isnan(ldc.r2(1, 0))
+        assert np.isnan(ts_r2(ts, 1, 0))
+        assert np.isnan(A[1, 0])
+
+
+class BaseTestLd:
+    """
+    Define a set of tests for LD calculations. Subclasses should be
+    concrete examples with at least two sites which implement a
+    method ts() which returns the tree sequence and the full LD
+    matrix.
+    """
+
+    def test_r2_first_sites(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        assert ldc.r2(0, 1) == ts_r2(ts, 0, 1)
+        assert ldc.r2(0, 1) == A[0, 1]
+
+    def test_r2_first_last_sites(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        b = ts.num_sites - 1
+        assert ldc.r2(0, b) == ts_r2(ts, 0, b)
+        assert ldc.r2(0, b) == A[0, b]
+
+    def test_r2_array_first_site_forward(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        A1 = ldc.r2_array(0, direction=1)
+        A2 = ts_r2_array(ts, 0, direction=1)
+        np.testing.assert_array_almost_equal(A2, A[0, 1:])
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_mid_forward(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        site = ts.num_sites // 2
+        A1 = ldc.r2_array(site, direction=1)
+        A2 = ts_r2_array(ts, site, direction=1)
+        np.testing.assert_array_almost_equal(A2, A[site, site + 1 :])
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_first_site_forward_max_sites(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        A1 = ldc.r2_array(0, direction=1, max_sites=2)
+        A2 = ts_r2_array(ts, 0, direction=1, max_sites=2)
+        np.testing.assert_array_almost_equal(A2, A[0, 1:3])
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_first_site_forward_max_distance(self):
+        ts, _ = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        A1 = ldc.r2_array(0, direction=1, max_distance=3)
+        A2 = ts_r2_array(ts, 0, direction=1, max_distance=3)
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_last_site_backward(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        a = ts.num_sites - 1
+        A1 = ldc.r2_array(a, direction=-1)
+        A2 = ts_r2_array(ts, a, direction=-1)
+        np.testing.assert_array_almost_equal(A2, A[-1, :-1][::-1])
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_mid_backward(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        site = ts.num_sites // 2
+        A1 = ldc.r2_array(site, direction=-1)
+        A2 = ts_r2_array(ts, site, direction=-1)
+        np.testing.assert_array_almost_equal(A2, A[site, :site][::-1])
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_last_site_backward_max_sites(self):
+        ts, A = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        a = ts.num_sites - 1
+        A1 = ldc.r2_array(a, direction=-1, max_sites=2)
+        A2 = ts_r2_array(ts, a, direction=-1, max_sites=2)
+        np.testing.assert_array_almost_equal(A2, A[-1, -3:-1][::-1])
+        np.testing.assert_array_almost_equal(A1, A2)
+
+    def test_r2_array_last_site_backward_max_distance(self):
+        ts, _ = self.ts()
+        ldc = tskit.LdCalculator(ts)
+        a = ts.num_sites - 1
+        A1 = ldc.r2_array(a, direction=-1, max_distance=3)
+        A2 = ts_r2_array(ts, a, direction=-1, max_distance=3)
+        np.testing.assert_array_almost_equal(A1, A2)
+
+
+class TestLdOneSitePerTree(BaseTestLd):
+    @tests.cached_example
+    def ts(self):
+        ts = msprime.sim_ancestry(
+            5, sequence_length=10, recombination_rate=0.1, random_seed=1234
+        )
+        assert ts.num_trees > 3
+
+        tables = ts.dump_tables()
+        for tree in ts.trees():
+            site = tables.sites.add_row(tree.interval[0], ancestral_state="A")
+            # Put the mutation somewhere deep in the tree
+            node = tree.preorder()[2]
+            tables.mutations.add_row(site=site, node=node, derived_state="B")
+        ts = tables.tree_sequence()
+        # Return the full f2 matrix also
+        return ts, get_r2_matrix(ts)
+
+
+class TestLdAllSitesOneTree(BaseTestLd):
+    @tests.cached_example
+    def ts(self):
+        ts = msprime.sim_ancestry(
+            5, sequence_length=10, recombination_rate=0.1, random_seed=1234
+        )
+        assert ts.num_trees > 3
+
+        tables = ts.dump_tables()
+        tree = ts.at(5)
+        pos = np.linspace(tree.interval[0], tree.interval[1], num=10, endpoint=False)
+        for x, node in zip(pos, tree.preorder()[1:]):
+            site = tables.sites.add_row(x, ancestral_state="A")
+            tables.mutations.add_row(site=site, node=node, derived_state="B")
+        ts = tables.tree_sequence()
+        return ts, get_r2_matrix(ts)
+
+
+class TestLdSitesEveryOtherTree(BaseTestLd):
+    @tests.cached_example
+    def ts(self):
+        ts = msprime.sim_ancestry(
+            5, sequence_length=20, recombination_rate=0.1, random_seed=1234
+        )
+        assert ts.num_trees > 5
+
+        tables = ts.dump_tables()
+        for tree in ts.trees():
+            if tree.index % 2 == 0:
+                pos = np.linspace(*tree.interval, num=2, endpoint=False)
+                for x, node in zip(pos, tree.preorder()[1:]):
+                    site = tables.sites.add_row(x, ancestral_state="A")
+                    tables.mutations.add_row(site=site, node=node, derived_state="B")
+        ts = tables.tree_sequence()
+        return ts, get_r2_matrix(ts)
+
+
+class TestLdCalculator:
     """
     Tests for the LdCalculator class.
     """
@@ -98,7 +445,7 @@ class TestLdCalculator(unittest.TestCase):
         # Now check every cell in the matrix in turn.
         for j in range(m):
             for k in range(m):
-                self.assertAlmostEqual(ldc.get_r2(j, k), A[j, k])
+                assert ldc.get_r2(j, k) == pytest.approx(A[j, k])
 
     def verify_max_distance(self, ts):
         """

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -83,7 +83,9 @@ class LdCalculator:
         # Deprecated alias for r2_array
         return self.r2_array(a, direction, max_mutations, max_distance)
 
-    def r2_array(self, a, direction=1, max_mutations=None, max_distance=None):
+    def r2_array(
+        self, a, direction=1, max_mutations=None, max_distance=None, max_sites=None
+    ):
         """
         Returns the value of the :math:`r^2` statistic between the focal
         mutation at index :math:`a` and a set of other mutations. The method
@@ -124,6 +126,10 @@ class LdCalculator:
             ``get_r2_array()`` for later processing you **must** take a
             copy of the array!
         """
+        if max_mutations is not None and max_sites is not None:
+            raise ValueError("max_mutations is a deprecated synonym for max_sites")
+        if max_sites is not None:
+            max_mutations = max_sites
         if max_mutations is None:
             max_mutations = -1
         if max_distance is None:

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -81,7 +81,12 @@ class LdCalculator:
 
     def get_r2_array(self, a, direction=1, max_mutations=None, max_distance=None):
         # Deprecated alias for r2_array
-        return self.r2_array(a, direction, max_mutations, max_distance)
+        return self.r2_array(
+            a,
+            direction=direction,
+            max_mutations=max_mutations,
+            max_distance=max_distance,
+        )
 
     def r2_array(
         self, a, direction=1, max_mutations=None, max_distance=None, max_sites=None

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2019 Tskit Developers
+# Copyright (c) 2018-2021 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,19 +35,20 @@ class LdCalculator:
     """
     Class for calculating `linkage disequilibrium
     <https://en.wikipedia.org/wiki/Linkage_disequilibrium>`_ coefficients
-    between pairs of mutations in a :class:`TreeSequence`. This class requires
-    the `numpy <http://www.numpy.org/>`_ library.
+    between pairs of sites in a :class:`TreeSequence`.
 
-    This class supports multithreaded access using the Python :mod:`threading`
-    module. Separate instances of :class:`LdCalculator` referencing the
-    same tree sequence can operate in parallel in multiple threads.
+    .. note:: This interface is deprecated and a replacement is planned.
+        Please see https://github.com/tskit-dev/tskit/issues/1900 for
+        more information. Note also that the current implementation is
+        quite limited (see warning below).
 
-    .. note:: This class does not currently support sites that have more than one
+    .. warning:: This class does not currently support sites that have more than one
         mutation. Using it on such a tree sequence will raise a LibraryError with
-        an "Unsupported operation" message.
+        an "Only infinite sites mutations supported" message.
 
-    :param TreeSequence tree_sequence: The tree sequence containing the
-        mutations we are interested in.
+        Silent mutations are also not supported and will result in a LibraryError.
+
+    :param TreeSequence tree_sequence: The tree sequence of interest.
     """
 
     def __init__(self, tree_sequence):
@@ -66,13 +67,13 @@ class LdCalculator:
     def r2(self, a, b):
         """
         Returns the value of the :math:`r^2` statistic between the pair of
-        mutations at the specified indexes. This method is *not* an efficient
-        method for computing large numbers of pairwise; please use either
+        sites at the specified indexes. This method is *not* an efficient
+        method for computing large numbers of pairwise LD values; please use either
         :meth:`.r2_array` or :meth:`.r2_matrix` for this purpose.
 
-        :param int a: The index of the first mutation.
-        :param int b: The index of the second mutation.
-        :return: The value of :math:`r^2` between the mutations at indexes
+        :param int a: The index of the first site.
+        :param int b: The index of the second site.
+        :return: The value of :math:`r^2` between the sites at indexes
             ``a`` and ``b``.
         :rtype: float
         """
@@ -93,13 +94,13 @@ class LdCalculator:
     ):
         """
         Returns the value of the :math:`r^2` statistic between the focal
-        mutation at index :math:`a` and a set of other mutations. The method
-        operates by starting at the focal mutation and iterating over adjacent
-        mutations (in either the forward or backwards direction) until either a
-        maximum number of other mutations have been considered (using the
-        ``max_mutations`` parameter), a maximum distance in sequence
+        site at index :math:`a` and a set of other sites. The method
+        operates by starting at the focal site and iterating over adjacent
+        sites (in either the forward or backwards direction) until either a
+        maximum number of other sites have been considered (using the
+        ``max_sites`` parameter), a maximum distance in sequence
         coordinates has been reached (using the ``max_distance`` parameter) or
-        the start/end of the sequence has been reached. For every mutation
+        the start/end of the sequence has been reached. For every site
         :math:`b` considered, we then insert the value of :math:`r^2` between
         :math:`a` and :math:`b` at the corresponding index in an array, and
         return the entire array. If the returned array is :math:`x` and
@@ -110,19 +111,20 @@ class LdCalculator:
         value of the statistic for :math:`a` and :math:`a - 1`, :math:`x[1]`
         the value for :math:`a` and :math:`a - 2`, etc.
 
-        :param int a: The index of the focal mutation.
+        :param int a: The index of the focal sites.
         :param int direction: The direction in which to travel when
-            examining other mutations. Must be either
+            examining other sites. Must be either
             :data:`tskit.FORWARD` or :data:`tskit.REVERSE`. Defaults
             to :data:`tskit.FORWARD`.
-        :param int max_mutations: The maximum number of mutations to return
-            :math:`r^2` values for. Defaults to as many mutations as
+        :param int max_sites: The maximum number of sites to return
+            :math:`r^2` values for. Defaults to as many sites as
             possible.
+        :param int max_mutations: Deprecated synonym for max_sites.
         :param float max_distance: The maximum absolute distance between
-            the focal mutation and those for which :math:`r^2` values
+            the focal sites and those for which :math:`r^2` values
             are returned.
         :return: An array of double precision floating point values
-            representing the :math:`r^2` values for mutations in the
+            representing the :math:`r^2` values for sites in the
             specified direction.
         :rtype: numpy.ndarray
         :warning: For efficiency reasons, the underlying memory used to
@@ -158,14 +160,14 @@ class LdCalculator:
     def r2_matrix(self):
         """
         Returns the complete :math:`m \\times m` matrix of pairwise
-        :math:`r^2` values in a tree sequence with :math:`m` mutations.
+        :math:`r^2` values in a tree sequence with :math:`m` sites.
 
         :return: An 2 dimensional square array of double precision
             floating point values representing the :math:`r^2` values for
-            all pairs of mutations.
+            all pairs of sites.
         :rtype: numpy.ndarray
         """
-        m = self._tree_sequence.get_num_mutations()
+        m = self._tree_sequence.num_sites
         A = np.ones((m, m), dtype=float)
         for j in range(m - 1):
             a = self.get_r2_array(j)

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -22,7 +22,6 @@
 """
 Module responsible for computing various statistics on tree sequences.
 """
-import struct
 import sys
 import threading
 
@@ -127,31 +126,21 @@ class LdCalculator:
             representing the :math:`r^2` values for sites in the
             specified direction.
         :rtype: numpy.ndarray
-        :warning: For efficiency reasons, the underlying memory used to
-            store the returned array is shared between calls. Therefore,
-            if you wish to store the results of a single call to
-            ``get_r2_array()`` for later processing you **must** take a
-            copy of the array!
         """
         if max_mutations is not None and max_sites is not None:
             raise ValueError("max_mutations is a deprecated synonym for max_sites")
-        if max_sites is not None:
-            max_mutations = max_sites
-        if max_mutations is None:
-            max_mutations = -1
+        if max_mutations is not None:
+            max_sites = max_mutations
+        max_sites = -1 if max_sites is None else max_sites
         if max_distance is None:
             max_distance = sys.float_info.max
-        item_size = struct.calcsize("d")
-        buffer = bytearray(self._tree_sequence.get_num_mutations() * item_size)
         with self._instance_lock:
-            num_values = self._ll_ld_calculator.get_r2_array(
-                buffer,
+            return self._ll_ld_calculator.get_r2_array(
                 a,
                 direction=direction,
-                max_mutations=max_mutations,
+                max_sites=max_sites,
                 max_distance=max_distance,
             )
-        return np.frombuffer(buffer, "d", num_values)
 
     def get_r2_matrix(self):
         # Deprecated alias for r2_matrix

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -848,12 +848,7 @@ class Tree:
         """
         if position < 0 or position >= self.tree_sequence.sequence_length:
             raise ValueError("Position out of bounds")
-        # This should be implemented in C efficiently using the indexes.
-        # No point in complicating the current implementation by trying
-        # to seek from the correct direction.
-        self.first()
-        while self.interval.right <= position:
-            self.next()
+        self._ll_tree.seek(position)
 
     def rank(self):
         """


### PR DESCRIPTION
Refactor the LD calculator to use standard tree operations. Most of the old complexity was tied up in trying to maintain state between calls, but this is fragile and most likely pointless.