### PR TITLE
Reduce number of tests in treestats

### DIFF
--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -557,10 +557,6 @@ class TopologyExamplesMixin:
     actual tests.
     """
 
-    def test_single_tree(self):
-        ts = msprime.simulate(6, random_seed=1)
-        self.verify(ts)
-
     def test_single_tree_sequence_length(self):
         ts = msprime.simulate(6, length=10, random_seed=1)
         self.verify(ts)
@@ -575,10 +571,10 @@ class TopologyExamplesMixin:
         assert ts.num_trees > 2
         self.verify(ts)
 
-    def test_many_trees_sequence_length(self):
-        for L in [0.5, 3.3333]:
-            ts = msprime.simulate(6, length=L, recombination_rate=2, random_seed=1)
-            self.verify(ts)
+    def test_short_sequence_length(self):
+        ts = msprime.simulate(6, length=0.5, recombination_rate=2, random_seed=1)
+        assert ts.num_trees > 2
+        self.verify(ts)
 
     def test_wright_fisher_unsimplified(self):
         tables = wf.wf_sim(


### PR DESCRIPTION
This is an attempt to make the test suite a bit less painful to run. I've had to do something because we're regularly hitting timeouts on the CircleCI runs, which means we're not getting any updates on CodeCov.

We're not losing anything by removing these tests, and this makes things at least practical to run for now. We still need to do something about the TraitLinearModel tests, they are just too slow.
