### PR TITLE
Use pattern rules in C examples Makefile

### DIFF
--- a/c/examples/Makefile
+++ b/c/examples/Makefile
@@ -20,19 +20,15 @@
 CFLAGS=-I../ -I../subprojects/kastore
 TSKIT_SOURCE=../tskit/*.c ../subprojects/kastore/kastore.c
 
-all: tree_iteration haploid_wright_fisher tree_traversal streaming
+targets = api_structure error_handling \
+	haploid_wright_fisher streaming \
+	tree_iteration tree_traversal
 
-tree_iteration: tree_iteration.c
-	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
+all: $(targets)
 
-tree_traversal: tree_traversal.c
-	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
-
-streaming: streaming.c
-	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
-
-haploid_wright_fisher: haploid_wright_fisher.c
+$(targets): %: %.c
 	${CC} ${CFLAGS} -o $@ $< ${TSKIT_SOURCE} -lm
 
 clean:
-	rm -f haploid_wright_fisher tree_iteration
+	rm -f $(targets)
+


### PR DESCRIPTION
## Description

While playing with the C-API for the first time I found the example code in `c/examples/` extremely helpful. To avoid having to touch the build system for the API I used the `Makefile` in this folder to compile my custom examples. To make this easier I changed the Makefile to use pattern rules. This way, a new compile target simply has to be added to the `targets`, without any other manual changes. This PR contains these changes (without the addition of any other custom examples) in case it is helpful or of interest for the project. If not, feel free to dismiss the PR.