### PR TITLE
read metadata without loading tables

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -56,6 +56,10 @@
   tree sequence. This is then used to geerate an error if ``time_units`` is ``uncalibrated`` when
   using the branch lengths in statistics. (:user:`benjeffery`, :issue:`1644`, :pr:`1760`)
 
+- Add the TSK_LOAD_SKIP_TABLES option to load just the top-level information from a
+  file. Also add the TSK_CMP_IGNORE_TABLES option to compare only the top-level
+  information in two table collections. (:user:`clwgg`, :pr:`1882`, :issue:`1854`).
+
 - Add reference sequence to table collection (:user:`benjeffery`, :issue:`146`, :pr:`1911`)
 
 - FIXME add features for virtual root, num_edges, stack allocation size etc

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -279,6 +279,41 @@ test_table_collection_equals_options(void)
 
     tsk_table_collection_free(&tc1);
     tsk_table_collection_free(&tc2);
+
+    // Ignore tables
+    ret = tsk_table_collection_init(&tc1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_init(&tc2, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_set_metadata(
+        &tc1, example_metadata, example_metadata_length);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = tsk_table_collection_set_metadata(
+        &tc2, example_metadata, example_metadata_length);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
+    // Add one row for each table we're ignoring
+    ret_id
+        = tsk_individual_table_add_row(&tc1.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    ret_id = tsk_node_table_add_row(&tc1.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, 0, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    ret_id = tsk_edge_table_add_row(&tc1.edges, 0.0, 1.0, 1, 0, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    ret_id = tsk_migration_table_add_row(&tc1.migrations, 0, 0, 0, 0, 0, 0, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    ret_id = tsk_site_table_add_row(&tc1.sites, 0.2, "A", 1, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    ret_id = tsk_mutation_table_add_row(
+        &tc1.mutations, 0, 0, TSK_NULL, TSK_UNKNOWN_TIME, NULL, 0, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    ret_id = tsk_population_table_add_row(&tc1.populations, NULL, 0);
+    CU_ASSERT(ret_id >= 0);
+    CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, TSK_CMP_IGNORE_TABLES));
+
+    tsk_table_collection_free(&tc1);
+    tsk_table_collection_free(&tc2);
 }
 
 static void

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -724,6 +724,11 @@ typedef struct {
 /* Flags for table collection init */
 #define TSK_NO_EDGE_METADATA (1 << 0)
 
+/* Flags for table collection load */
+/* This shares an interface with table collection init.
+   TODO: review as part of #1720 */
+#define TSK_LOAD_SKIP_TABLES (1 << 1)
+
 /* Flags for table init. */
 #define TSK_NO_METADATA (1 << 0)
 
@@ -736,6 +741,7 @@ typedef struct {
 #define TSK_CMP_IGNORE_PROVENANCE (1 << 1)
 #define TSK_CMP_IGNORE_METADATA (1 << 2)
 #define TSK_CMP_IGNORE_TIMESTAMPS (1 << 3)
+#define TSK_CMP_IGNORE_TABLES (1 << 4)
 
 /* Flags for table collection clear */
 #define TSK_CLEAR_METADATA_SCHEMAS (1 << 0)
@@ -3412,6 +3418,9 @@ TSK_CMP_IGNORE_TS_METADATA
 TSK_CMP_IGNORE_TIMESTAMPS
     Do not include the timestamp information when comparing the provenance
     tables. This has no effect if TSK_CMP_IGNORE_PROVENANCE is specified.
+TSK_CMP_IGNORE_TABLES
+    Do not include any tables in the comparison, thus comparing only the
+    top-level information of the table collections being compared.
 @endrst
 
 @param self A pointer to a tsk_table_collection_t object.
@@ -3470,6 +3479,9 @@ If the file contains multiple table collections, this function will load
 the first. Please see the :c:func:`tsk_table_collection_loadf` for details
 on how to sequentially load table collections from a stream.
 
+If the TSK_LOAD_SKIP_TABLES option is set, only the top-level
+information of the table collection will be read, leaving all tables empty.
+
 **Options**
 
 Options can be specified by providing one or more of the following bitwise
@@ -3477,6 +3489,8 @@ flags:
 
 TSK_NO_INIT
     Do not initialise this :c:type:`tsk_table_collection_t` before loading.
+TSK_LOAD_SKIP_TABLES
+    Skip reading tables, and only load top-level information.
 
 **Examples**
 
@@ -3524,6 +3538,14 @@ different error conditions. Please see the
 :ref:`sec_c_api_examples_file_streaming` section for an example of how to
 sequentially load tree sequences from a stream.
 
+Please note that this streaming behaviour is not supported if the
+TSK_LOAD_SKIP_TABLES option is set. With this option, only the top-level
+information of the table collection will be read, leaving all tables empty. When
+attempting to read from a stream with multiple table collection definitions and
+the TSK_LOAD_SKIP_TABLES option set, only the top-level information of the first
+table collection will be read on the first call to
+:c:func:`tsk_table_collection_loadf`, with subsequent calls leading to errors.
+
 **Options**
 
 Options can be specified by providing one or more of the following bitwise
@@ -3531,6 +3553,8 @@ flags:
 
 TSK_NO_INIT
     Do not initialise this :c:type:`tsk_table_collection_t` before loading.
+TSK_LOAD_SKIP_TABLES
+    Skip reading tables, and only load top-level information.
 
 @endrst
 

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -492,15 +492,14 @@ tsk_treeseq_copy_tables(
 }
 
 int TSK_WARN_UNUSED
-tsk_treeseq_load(
-    tsk_treeseq_t *self, const char *filename, tsk_flags_t TSK_UNUSED(options))
+tsk_treeseq_load(tsk_treeseq_t *self, const char *filename, tsk_flags_t options)
 {
     int ret = 0;
     tsk_table_collection_t tables;
 
     /* Need to make sure that we're zero'd out in case of error */
     tsk_memset(self, 0, sizeof(*self));
-    ret = tsk_table_collection_load(&tables, filename, 0);
+    ret = tsk_table_collection_load(&tables, filename, options);
     if (ret != 0) {
         goto out;
     }
@@ -518,14 +517,14 @@ out:
 }
 
 int TSK_WARN_UNUSED
-tsk_treeseq_loadf(tsk_treeseq_t *self, FILE *file, tsk_flags_t TSK_UNUSED(options))
+tsk_treeseq_loadf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options)
 {
     int ret = 0;
     tsk_table_collection_t tables;
 
     /* Need to make sure that we're zero'd out in case of error */
     tsk_memset(self, 0, sizeof(*self));
-    ret = tsk_table_collection_loadf(&tables, file, 0);
+    ret = tsk_table_collection_loadf(&tables, file, options);
     if (ret != 0) {
         goto out;
     }

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -97,6 +97,11 @@
 - Add the ``discrete_time`` property to the TreeSequence class which is true if
   all time coordinates are discrete or unknown (:user:`benjeffery`, :issue:`1839`, :pr:`1890`)
 
+- Add the ``skip_tables`` option to ``load`` to support only loading
+  top-level information from a file. Also add the ``ignore_tables`` option to
+  to the ``TableCollection.equals`` and ``TableCollection.assert_equals`` to
+  compare only top-level information. (:user:`clwgg`, :pr:`1882`, :issue:`1854`).
+
 **Fixes**
 
 - `dump_tables` omitted individual parents. (:user:`benjeffery`, :issue:`1828`, :pr:`1884`)

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6887,15 +6887,16 @@ TableCollection_equals(TableCollection *self, PyObject *args, PyObject *kwds)
     int ignore_ts_metadata = false;
     int ignore_provenance = false;
     int ignore_timestamps = true;
+    int ignore_tables = false;
     static char *kwlist[] = { "other", "ignore_metadata", "ignore_ts_metadata",
-        "ignore_provenance", "ignore_timestamps", NULL };
+        "ignore_provenance", "ignore_timestamps", "ignore_tables", NULL };
 
     if (TableCollection_check_state(self)) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|iiii", kwlist, &TableCollectionType,
-            &other, &ignore_metadata, &ignore_ts_metadata, &ignore_provenance,
-            &ignore_timestamps)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|iiiii", kwlist,
+            &TableCollectionType, &other, &ignore_metadata, &ignore_ts_metadata,
+            &ignore_provenance, &ignore_timestamps, &ignore_tables)) {
         goto out;
     }
     if (ignore_metadata) {
@@ -6909,6 +6910,9 @@ TableCollection_equals(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     if (ignore_timestamps) {
         options |= TSK_CMP_IGNORE_TIMESTAMPS;
+    }
+    if (ignore_tables) {
+        options |= TSK_CMP_IGNORE_TABLES;
     }
     if (TableCollection_check_state(other) != 0) {
         goto out;
@@ -6999,10 +7003,16 @@ TableCollection_load(TableCollection *self, PyObject *args, PyObject *kwds)
     PyObject *ret = NULL;
     PyObject *py_file;
     FILE *file = NULL;
-    static char *kwlist[] = { "file", NULL };
+    tsk_flags_t options = 0;
+    int skip_tables = false;
+    static char *kwlist[] = { "file", "skip_tables", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &py_file)) {
+    if (!PyArg_ParseTupleAndKeywords(
+            args, kwds, "O|i", kwlist, &py_file, &skip_tables)) {
         goto out;
+    }
+    if (skip_tables) {
+        options |= TSK_LOAD_SKIP_TABLES;
     }
     file = make_file(py_file, "rb");
     if (file == NULL) {
@@ -7021,7 +7031,7 @@ TableCollection_load(TableCollection *self, PyObject *args, PyObject *kwds)
     if (err != 0) {
         goto out;
     }
-    err = tsk_table_collection_loadf(self->tables, file, 0);
+    err = tsk_table_collection_loadf(self->tables, file, options);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -7383,10 +7393,16 @@ TreeSequence_load(TreeSequence *self, PyObject *args, PyObject *kwds)
     PyObject *ret = NULL;
     PyObject *py_file;
     FILE *file = NULL;
-    static char *kwlist[] = { "file", NULL };
+    tsk_flags_t options = 0;
+    int skip_tables = false;
+    static char *kwlist[] = { "file", "skip_tables", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &py_file)) {
+    if (!PyArg_ParseTupleAndKeywords(
+            args, kwds, "O|i", kwlist, &py_file, &skip_tables)) {
         goto out;
+    }
+    if (skip_tables) {
+        options |= TSK_LOAD_SKIP_TABLES;
     }
     file = make_file(py_file, "rb");
     if (file == NULL) {
@@ -7405,7 +7421,7 @@ TreeSequence_load(TreeSequence *self, PyObject *args, PyObject *kwds)
     if (err != 0) {
         goto out;
     }
-    err = tsk_treeseq_loadf(self->tree_sequence, file, 0);
+    err = tsk_treeseq_loadf(self->tree_sequence, file, options);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -2301,6 +2301,23 @@ class TestTreeSequence(HighLevelTestCase):
         assert t1.equals(t2)
         assert t2.equals(t1)
 
+        # Empty out tables to test ignore_tables flag
+        tc = t2.dump_tables()
+        tc.individuals.truncate(0)
+        tc.nodes.truncate(0)
+        tc.edges.truncate(0)
+        tc.migrations.truncate(0)
+        tc.sites.truncate(0)
+        tc.mutations.truncate(0)
+        tc.populations.truncate(0)
+        t2 = tc.tree_sequence()
+        assert not t1.equals(t2)
+        assert t1.equals(t2, ignore_tables=True)
+        # Make t1 and t2 equal again
+        t2 = t1.dump_tables().tree_sequence()
+        assert t1.equals(t2)
+        assert t2.equals(t1)
+
     def test_tree_node_edges(self):
         for ts in get_example_tree_sequences():
             edge_visited = np.zeros(ts.num_edges, dtype=bool)

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -4003,6 +4003,21 @@ class TestTableCollectionAssertEquals:
         t1.assert_equals(t2, ignore_provenance=True)
         t1.assert_equals(t2, ignore_timestamps=True)
 
+    def test_ignore_tables(self, t1, t2):
+        t2.individuals.truncate(0)
+        t2.nodes.truncate(0)
+        t2.edges.truncate(0)
+        t2.migrations.truncate(0)
+        t2.sites.truncate(0)
+        t2.mutations.truncate(0)
+        t2.populations.truncate(0)
+        with pytest.raises(
+            AssertionError,
+            match="EdgeTable number of rows differ: self=390 other=0",
+        ):
+            t1.assert_equals(t2)
+        t1.assert_equals(t2, ignore_tables=True)
+
 
 class TestTableCollectionMethodSignatures:
     tc = msprime.simulate(10, random_seed=1234).dump_tables()

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2747,6 +2747,7 @@ class TableCollection:
         ignore_ts_metadata=False,
         ignore_provenance=False,
         ignore_timestamps=False,
+        ignore_tables=False,
     ):
         """
         Returns True if  `self` and `other` are equal. By default, two table
@@ -2775,6 +2776,8 @@ class TableCollection:
         :param bool ignore_timestamps: If True the provenance timestamp column
             is ignored in the comparison. If ``ignore_provenance`` is True, this
             parameter has no effect.
+        :param bool ignore_tables: If True no tables are included in the
+            comparison, thus comparing only the top-level information.
         :return: True if other is equal to this table collection; False otherwise.
         :rtype: bool
         """
@@ -2787,6 +2790,7 @@ class TableCollection:
                     ignore_ts_metadata=bool(ignore_ts_metadata),
                     ignore_provenance=bool(ignore_provenance),
                     ignore_timestamps=bool(ignore_timestamps),
+                    ignore_tables=bool(ignore_tables),
                 )
             )
         return ret
@@ -2799,6 +2803,7 @@ class TableCollection:
         ignore_ts_metadata=False,
         ignore_provenance=False,
         ignore_timestamps=False,
+        ignore_tables=False,
     ):
         """
         Raise an AssertionError for the first found difference between
@@ -2816,6 +2821,8 @@ class TableCollection:
         :param bool ignore_timestamps: If True the provenance timestamp column
             is ignored in the comparison. If ``ignore_provenance`` is True, this
             parameter has no effect.
+        :param bool ignore_tables: If True no tables are included in the
+            comparison, thus comparing only the top-level information.
         """
         if type(other) is not type(self):
             raise AssertionError(f"Types differ: self={type(self)} other={type(other)}")
@@ -2827,6 +2834,7 @@ class TableCollection:
             ignore_ts_metadata=ignore_ts_metadata,
             ignore_provenance=ignore_provenance,
             ignore_timestamps=ignore_timestamps,
+            ignore_tables=ignore_tables,
         ):
             return
 
@@ -2876,10 +2884,10 @@ class TableCollection:
         return self.asdict()
 
     @classmethod
-    def load(cls, file_or_path):
+    def load(cls, file_or_path, *, skip_tables=False):
         file, local_file = util.convert_file_like_to_open_file(file_or_path, "rb")
         ll_tc = _tskit.TableCollection(1)
-        ll_tc.load(file)
+        ll_tc.load(file, skip_tables=skip_tables)
         tc = TableCollection(1)
         tc._ll_tables = ll_tc
         return tc

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2931,7 +2931,7 @@ class Tree:
         )
 
 
-def load(file):
+def load(file, *, skip_tables=False):
     """
     Loads a tree sequence from the specified file object or path. The file must be in the
     :ref:`tree sequence file format <sec_tree_sequence_file_format>` produced by the
@@ -2939,11 +2939,16 @@ def load(file):
 
     :param str file: The file object or path of the ``.trees`` file containing the
         tree sequence we wish to load.
+    :param bool skip_tables: If True, no tables are read from the ``.trees``
+        file and only the top-level information is populated in the tree sequence object.
+        Please note that with this option set, it is not possible to load data from
+        a stream of multiple tree sequences using consecutive calls to
+        :meth:`tskit.load`.
     :return: The tree sequence object containing the information
         stored in the specified file path.
     :rtype: :class:`tskit.TreeSequence`
     """
-    return TreeSequence.load(file)
+    return TreeSequence.load(file, skip_tables=skip_tables)
 
 
 def parse_individuals(
@@ -3555,6 +3560,7 @@ class TreeSequence:
         ignore_ts_metadata=False,
         ignore_provenance=False,
         ignore_timestamps=False,
+        ignore_tables=False,
     ):
         """
         Returns True if  `self` and `other` are equal. Uses the underlying table
@@ -3566,6 +3572,7 @@ class TreeSequence:
             ignore_ts_metadata=ignore_ts_metadata,
             ignore_provenance=ignore_provenance,
             ignore_timestamps=ignore_timestamps,
+            ignore_tables=ignore_tables,
         )
 
     @property
@@ -3593,11 +3600,11 @@ class TreeSequence:
         return [tree.copy() for tree in self.trees(**kwargs)]
 
     @classmethod
-    def load(cls, file_or_path):
+    def load(cls, file_or_path, *, skip_tables=False):
         file, local_file = util.convert_file_like_to_open_file(file_or_path, "rb")
         try:
             ts = _tskit.TreeSequence()
-            ts.load(file)
+            ts.load(file, skip_tables=skip_tables)
             return TreeSequence(ts)
         finally:
             if local_file:


### PR DESCRIPTION
## Description

This is a first stab at https://github.com/tskit-dev/tskit/issues/1854. I think there are a couple of decisions to make here that I don't feel qualified to make, so I would greatly appreciate any feedback. I've tried to document the process in the commit log as best I could, but to avoid everyone having to stumble through those I thought I'd put a little write-up here as well.

The main decision point I hit early on is whether `tsk_table_collection_load_indexes` should be part of the conditional within `tsk_table_collection_loadf_inited` or not. Without any further changes, either decision leads to errors, but ONLY if a table_collection loaded with `TSK_LOAD_SKIP_TABLES` is ever attempted to be put into a tree sequence (which I implemented but ended up reverting for this PR since I don't know if its necessary for the use cases we envision -- more on this below).

Let me walk you through each of these cases, assuming that `TSK_LOAD_SKIP_TABLES` is set:

If `tsk_table_collection_load_indexes` is **not** called, the table collection won't have it's indexes set, so if we attempt to load this table collection into a tree sequence we encounter an error in `tsk_table_collection_check_integrity`.

If `tsk_table_collection_load_indexes` is called and we attempt to add indexes to a table collection without having loaded its tables, we encounter an error within the `..._load_indexes` function when checking whether `(num_rows != self->edges.num_rows)` since we never actually loaded the edge table.

What I ended up doing is to call the `..._load_indexes` function, but pass the `TSK_LOAD_SKIP_TABLES` option to it to skip the `(num_rows != self->edges.num_rows)` check in case the option is set. My motivation was that it feels cleaner to have an empty but indexed table collection, than an empty, un-indexed table collection that throws an error whenever it tries to touch a tree sequence. Please note though that I'm not totally sure if there's any unwanted consequences of skipping that check (it seems to just check if the edge table was loaded correctly or was malformed in some way), so I rely on your advice here.

I then exposed this flag to the python `TableCollection` class through its C interface. I ended up reverting a change that allowed to also pass this option all the way through a TreeSequence since I don't really see the use case of that, but of course I'd be happy to re-revert this if needed. What I did instead is add a top-level `tskit.load_metadata` function which just calls `TableCollection.load(file, skip_tables=True)` and returns the metadata. I added this mostly as a proof-of-principle of what I am envisioning the use-case of this flag to be.

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
