### PR TITLE
Reinstate nitpick

### DIFF
--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -160,7 +160,8 @@ typedef struct {
      the tree's genomic interval.
      */
     tsk_size_t num_edges;
-    /**
+    /* FIXME Undocumenting this for now to resolve some sphinx/doxygen issues */
+    /*
      @brief Left and right coordinates of the genomic interval that this
      tree covers. The left coordinate is inclusive and the right coordinate
      exclusive.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,8 +31,6 @@ sphinx:
     extra_extensions:
     - breathe
     - sphinx.ext.autodoc
-    - sphinx.ext.autosummary
-    - autodocsumm
     - sphinx.ext.todo
     - sphinx.ext.viewcode
     - sphinx.ext.intersphinx
@@ -59,9 +57,9 @@ sphinx:
       breathe_domain_by_extension: {"h": "c"}
       breathe_show_define_initializer: True
 
-      # TODO these are not ignored, see https://github.com/sphinx-doc/sphinx/issues/9748
-      # so currently nitpicky is turned off when building the jupyterbook in build.sh
-      nitpick_ignore: [
+      # Note we have to use the regex version here because of
+      # https://github.com/sphinx-doc/sphinx/issues/9748
+      nitpick_ignore_regex: [
           ["c:identifier", "int32_t"],
           ["c:identifier", "uint32_t"],
           ["c:identifier", "uint64_t"],
@@ -69,9 +67,6 @@ sphinx:
           ["c:type", "int32_t"],
           ["c:type", "uint32_t"],
           ["c:type", "uint64_t"],
-          ["c:type", "bool"],
-          ["py:class", "tskit.metadata.AbstractMetadataCodec"],
-          ["py:class", "tskit.trees.Site"],
           # TODO these have been triaged here to make the docs compile, but we should
           # sort them out properly. https://github.com/tskit-dev/tskit/issues/336
           ["py:class", "array_like"],
@@ -84,7 +79,7 @@ sphinx:
           ["py:class", "dtype=np.float64"],
           ["py:class", "dtype=np.int64"],
       ]
-      
+
       autodoc_member_order: bysource
 
       # Without this option, autodoc tries to put links for all return types

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -6,7 +6,7 @@
 
 REPORTDIR=${BUILDDIR}/html/reports
 
-jupyter-book build -W --keep-going .
+jupyter-book build -Wn --keep-going .
 RETVAL=$?
 if [ $RETVAL -ne 0 ]; then
     if [ -e $REPORTDIR ]; then

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -125,13 +125,13 @@ Memory allocation strategy
 --------------------------
 
 To reduce the frequency of memory allocations tskit pre-allocates space for
-additional table rows in each table, along with space for the contents of 
+additional table rows in each table, along with space for the contents of
 ragged columns. The default behaviour is to start with space for 1,024 rows
 in each table and 65,536 bytes in each ragged column. The table then grows
 as needed by doubling, until a maximum pre-allocation of 2,097,152 rows for
 a table or 104,857,600 bytes for a ragged column. This behaviour can be
 disabled and a fixed increment used, on a per-table and per-ragged-column
-basis using the ``tsk_X_table_set_max_rows_increment`` and 
+basis using the ``tsk_X_table_set_max_rows_increment`` and
 ``tsk_provenance_table_set_max_X_length_increment`` methods where ``X`` is
 the name of the table or column.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -38,7 +38,6 @@ sequences, for example using {func}`tskit.load`.
 ```{eval-rst}
 .. autoclass:: TreeSequence()
     :members:
-    :autosummary:
 ```
 
 
@@ -54,7 +53,6 @@ about particular nodes in the tree.
 ```{eval-rst}
 .. autoclass:: Tree()
     :members:
-    :autosummary:
 ```
 
 ### Simple container classes
@@ -163,9 +161,8 @@ equivalent table collection method, acting on a copy of the tree sequence's tabl
 collection.
 
 ```{eval-rst}
-.. autoclass:: TableCollection(sequence_length=0)
+.. autoclass:: tskit.TableCollection(sequence_length=0)
     :members:
-    :autosummary:
 ```
 
 (sec_tables_api_tables)=
@@ -356,7 +353,7 @@ store and retrieve raw `bytes`. (See {ref}`sec_metadata` for details):
 Below, we add two rows to a {class}`NodeTable`, with different
 {ref}`metadata <sec_metadata_definition>`. The first row contains a simple
 byte string, and the second contains a Python dictionary serialised using
-{mod}`pickle`. 
+{mod}`pickle`.
 
 ```{code-cell} ipython3
 t = tskit.NodeTable()

--- a/python/requirements/CI-docs/requirements.txt
+++ b/python/requirements/CI-docs/requirements.txt
@@ -1,14 +1,13 @@
 breathe==4.31.0
 autodocsumm==0.2.7
-jupyter-book==0.12.0
+jupyter-book==0.12.1
 jupyter-sphinx==0.3.2
 h5py==3.5.0
 jsonschema==3.2.0
 msprime==1.0.0
 numpy==1.21.3
 PyGithub==1.55
-sphinx==4.0.1
+sphinx==4.3.0
 sphinx-argparse==0.3.1
 sphinx-issues==1.2.0
-sphinx_rtd_theme==1.0.0
 svgwrite==1.4.1

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -8,7 +8,7 @@ dendropy
 flake8
 h5py>=2.6.0
 jsonschema>=3.0.0
-jupyter-book>=0.12.0
+jupyter-book>=0.12.1
 kastore
 # More recent meson is too strict. See #1515.
 meson<=0.56
@@ -27,10 +27,9 @@ pytest
 pytest-cov
 pytest-xdist
 PyVCF
-sphinx<=4.0.1
+sphinx>=4.3
 sphinx-argparse
 sphinx-issues
 sphinx-jupyterbook-latex
-sphinx_rtd_theme
 svgwrite>=1.1.10
 xmlunittest


### PR DESCRIPTION
We need to get nitpick mode working on the docs again, so here's some work towards that.

It looks like we can use ``nitpick_ignore_regex`` rather than ``nitpick_ignore`` and this will work. This is because it looks like ``nitpick_ignore`` searches for a literal tuple, where as the regex version iterates (more sensibly): https://github.com/sphinx-doc/sphinx/blob/aea2af418ea8d10dead88537ad560643325a583c/sphinx/transforms/post_transforms/__init__.py#L178

This does require a newer version of sphinx, so  there'll be some mucking about with version pinning.