### PR TITLE
Static analysis docs

### DIFF
--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -132,7 +132,7 @@ out:
 static int
 tsk_ld_calc_compute_r2(tsk_ld_calc_t *self, const tsk_site_t *target_site, double *r2)
 {
-    double n = (double) self->total_samples;
+    const double n = (double) self->total_samples;
     double f_a, f_b, f_ab, D, denom;
     tsk_id_t node;
     int ret = tsk_ld_calc_check_site(self, target_site);
@@ -141,7 +141,6 @@ tsk_ld_calc_compute_r2(tsk_ld_calc_t *self, const tsk_site_t *target_site, doubl
         goto out;
     }
     node = target_site->mutations[0].node;
-    n = (double) self->total_samples;
     f_a = ((double) self->focal_samples) / n;
     f_b = ((double) self->tree.num_samples[node]) / n;
     f_ab = ((double) self->tree.num_tracked_samples[node]) / n;

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3721,7 +3721,7 @@ tsk_tree_get_num_roots(const tsk_tree_t *self)
     const tsk_id_t *restrict right_sib = self->right_sib;
     const tsk_id_t *restrict left_child = self->left_child;
     tsk_size_t num_roots = 0;
-    tsk_id_t u = self->left_child[self->virtual_root];
+    tsk_id_t u;
 
     for (u = left_child[self->virtual_root]; u != TSK_NULL; u = right_sib[u]) {
         num_roots++;

--- a/docs/development.md
+++ b/docs/development.md
@@ -673,7 +673,6 @@ Vim users may find the
 [vim-clang-format](https://github.com/rhysd/vim-clang-format)
 plugin useful for automatically formatting code.
 
-
 ### Building
 
 We use [meson](https://mesonbuild.com) and [ninja-build](https://ninja-build.org) to
@@ -705,6 +704,32 @@ For vim users, the [mesonic](https://www.vim.org/scripts/script.php?script_id=53
 simplifies this process and allows code to be compiled seamlessly within the
 editor.
 
+(sec_development_c_static_analysis)=
+
+### Static analysis
+
+After running ``ninja -C build``, we can easily run some static analysis tools
+which are useful for detecting bugs (although there is usually a lot of
+false-positive noise also).
+
+We can run [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) like this:
+
+```bash
+$ clang-tidy -p build/compile_commands.json tskit/*.c
+```
+
+We can run [scan-build](https://github.com/rizsotto/scan-build) which also
+generates some HTML reports. First, install from ``pypi``:
+
+```bash
+$ python -m pip install scan-build
+```
+
+Then run
+
+```bash
+$ analyze-build --cdb build/compile_commands.json --exclude tests --exclude subprojects
+```
 
 ### Unit Tests
 


### PR DESCRIPTION
Documenting how to run some static analysis tools for future selves.

It's not worth running this stuff in CI, I think - it takes quite a while and I don't want to have to get rid of all the false negatives that are there.

For the record, it seems the only warnings we're getting are about using strcat et al, which are all in places where the inputs are guaranteed to be well formed (we're only processing statically allocated strings internal to the library), and there's one warning about reordering the fields in a struct to optimise it. Here they are:

```
../tskit/genotypes.c:99:9: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
        strcpy(self->user_alleles_mem + offset, alleles[j]);
        ^
../tskit/genotypes.c:99:9: note: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
../tskit/tables.c:48:9: warning: Excessive padding in 'read_table_ragged_col_t' (8 padding bytes, where 0 is optimal). 
Optimal fields order: 
name, 
data_array_dest, 
data_len_dest, 
offset_array_dest, 
offset_array_mem, 
data_type, 
options, 
consider reordering the fields or adding explicit padding members [clang-analyzer-optin.performance.Padding]
typedef struct {
        ^
../tskit/tables.c:48:9: note: Excessive padding in 'read_table_ragged_col_t' (8 padding bytes, where 0 is optimal). Optimal fields order: name, data_array_dest, data_len_dest, offset_array_dest, offset_array_mem, data_type, options, consider reordering the fields or adding explicit padding members
../tskit/tables.c:206:9: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
        strcpy(offset_col_name, col->name);
        ^
../tskit/tables.c:206:9: note: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
../tskit/tables.c:207:9: warning: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
        strcat(offset_col_name, "_offset");
        ^
../tskit/tables.c:207:9: note: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119
../tskit/tables.c:358:5: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
    strcpy(offset_col_name, col->name);
    ^
../tskit/tables.c:358:5: note: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
../tskit/tables.c:359:5: warning: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
    strcat(offset_col_name, "_offset");
    ^
../tskit/tables.c:359:5: note: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119
Suppressed 2 warnings (2 in non-user code).
```

We could reorder the ``read_table_ragged_col_t`` struct, but it's totally not perf sensitive, and it would require changing a bunch of code which depends on this order for declaring these columns. We'd probably change over to using named initialisers if so, since the recommended ordering is less readable.

So, it's totally doable to get us fully clang-tidy clean, but I'm not particularly bothered about it. Happy to review PRs though if someone is motivated.

cc @molpopgen @bhaller 