### PR TITLE
Insert min version for pydata_sphinx_theme

### DIFF
--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -31,5 +31,6 @@ sphinx>=4.3
 sphinx-argparse
 sphinx-issues
 sphinx-jupyterbook-latex
+pydata_sphinx_theme>=0.7.2
 svgwrite>=1.1.10
 xmlunittest


### PR DESCRIPTION
Required for sphinx 0.4.3 compatibility. See https://github.com/pydata/pydata-sphinx-theme/issues/508

