### PR TITLE
Replace readthedocs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Tskit is a free and open-source project that welcomes contributions from everyone.
-The [Developer documentation](https://tskit.readthedocs.io/en/latest/development.html)
+The [Developer documentation](https://tskit.dev/tskit/docs/latest/development.html)
 will help you get started. 
 
 We have an active slack group where tskit and associated projects are discussed.

--- a/c/examples/Makefile
+++ b/c/examples/Makefile
@@ -11,7 +11,7 @@
 #
 # $ git clone git@github.com:tskit-dev/tskit.git --recurse-submodules
 #
-# See the documentation (https://tskit.readthedocs.io/en/stable/c-api.html)
+# See the documentation (https://tskit.dev/tskit/docs/stable/c-api.html)
 # for more details on how to use the C API, and the tskit build examples
 # repo (https://github.com/tskit-dev/tskit-build-examples) for examples
 # of how to set up a production-ready build with tskit.

--- a/docs/development.md
+++ b/docs/development.md
@@ -321,16 +321,22 @@ To bypass the checks (to save or get feedback on work-in-progress) use
 
 The documentation for tskit is written using
 [Sphinx](http://www.sphinx-doc.org/en/stable/)
-and contained in the `docs` directory. It is written in the
-[reStructuredText](http://docutils.sourceforge.net/rst.html) format and
-deployed automatically to [readthedocs](https://readthedocs.org/).
+and contained in the `docs` directory. The files in this directory are
+markdown files that serve as an input to [jupyterbook](https://jupyterbook.org/),
+which allows jupyter notebook code, primarily in Python, to be automatically
+executed and the output inserted before deployment. The docs are then
+deployed automatically to the [tskit.dev website](https://tskit.dev/).
 API documentation for both Python and C are generated automatically from
-source.
+source: documentation embedded in the source code makes use of sphinx and
+the [reStructuredText](http://docutils.sourceforge.net/rst.html) format to
+alloow formating and cross referencing.
 For the C code, a combination of [Doxygen](http://www.doxygen.nl/)
 and [breathe](https://breathe.readthedocs.io/en/latest/) is used to
 generate API documentation.
 
-Please help us to improve the documentation!
+Please help us to improve the documentation! You can check on the list of
+[documentation issues](https://github.com/tskit-dev/tskit/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation)
+on GitHub, and help us fix any, or add issues for anything that's wrong or missing.
 
 
 ### Small edits
@@ -673,6 +679,7 @@ Vim users may find the
 [vim-clang-format](https://github.com/rhysd/vim-clang-format)
 plugin useful for automatically formatting code.
 
+
 ### Building
 
 We use [meson](https://mesonbuild.com) and [ninja-build](https://ninja-build.org) to
@@ -704,32 +711,6 @@ For vim users, the [mesonic](https://www.vim.org/scripts/script.php?script_id=53
 simplifies this process and allows code to be compiled seamlessly within the
 editor.
 
-(sec_development_c_static_analysis)=
-
-### Static analysis
-
-After running ``ninja -C build``, we can easily run some static analysis tools
-which are useful for detecting bugs (although there is usually a lot of
-false-positive noise also).
-
-We can run [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) like this:
-
-```bash
-$ clang-tidy -p build/compile_commands.json tskit/*.c
-```
-
-We can run [scan-build](https://github.com/rizsotto/scan-build) which also
-generates some HTML reports. First, install from ``pypi``:
-
-```bash
-$ python -m pip install scan-build
-```
-
-Then run
-
-```bash
-$ analyze-build --cdb build/compile_commands.json --exclude tests --exclude subprojects
-```
 
 ### Unit Tests
 

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -461,7 +461,7 @@ def tree_sequence_html(ts):
                       <tr>
                         <th style="padding:0;line-height:21px;">
                           <img style="height: 32px;display: inline-block;padding: 3px 5px 3px 0;" src="https://raw.githubusercontent.com/tskit-dev/administrative/main/tskit_logo.svg"/>
-                          <a target="_blank" href="https://tskit.readthedocs.io/en/latest/python-api.html#the-treesequence-class"> Tree Sequence </a>
+                          <a target="_blank" href="https://tskit.dev/tskit/docs/latest/python-api.html#the-treesequence-class"> Tree Sequence </a>
                         </th>
                       </tr>
                     </thead>
@@ -516,7 +516,7 @@ def tree_html(tree):
                       <tr>
                         <th style="padding:0;line-height:21px;">
                           <img style="height: 32px;display: inline-block;padding: 3px 5px 3px 0;" src="https://raw.githubusercontent.com/tskit-dev/administrative/main/tskit_logo.svg"/>
-                          <a target="_blank" href="https://tskit.readthedocs.io/en/latest/python-api.html#the-tree-class"> Tree </a>
+                          <a target="_blank" href="https://tskit.dev/tskit/docs/latest/python-api.html#the-tree-class"> Tree </a>
                         </th>
                       </tr>
                     </thead>


### PR DESCRIPTION
Fixes #1943, and updates the developer info about readthedocs to mention jupyterbook.

Also put a link into the GitHub "documentation" issues page.