### PR TITLE
Doc restructure

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,11 +31,13 @@ sphinx:
     extra_extensions:
     - breathe
     - sphinx.ext.autodoc
+    - sphinx.ext.autosummary
     - sphinx.ext.todo
     - sphinx.ext.viewcode
     - sphinx.ext.intersphinx
     - sphinx_issues
     - sphinxarg.ext
+    - sphinxcontrib.prettyspecialmethods
 
     config:
       myst_enable_extensions:

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -18,7 +18,11 @@ kernelspec:
 
 # Python API
 
-This page provides detailed documentation for the `tskit` Python API.
+This page documents the full tskit Python API. Brief thematic summaries of common
+classes and methods are presented first. The {ref}`sec_reference_api` at the end
+then contains full details which aim to be concise, precise and exhaustive.
+Note that this may not therefore be the best place to start if you are new
+to a particular piece of functionality. 
 
 (sec_python_api_trees_and_tree_sequences)=
 
@@ -29,90 +33,34 @@ evolutionary trees along a genome. The {class}`Tree` class represents a
 single tree in this sequence. These classes are the interfaces used to
 interact with the trees and mutational information stored in a tree sequence,
 for example as returned from a simulation or inferred from a set of DNA
-sequences. This library also provides methods for loading stored tree
-sequences, for example using {func}`tskit.load`.
+sequences.
 
 
-### The `TreeSequence` class
+(sec_python_api_tree_sequences)=
+
+### The {class}`TreeSequence` class
+
+
+(sec_python_api_tree_sequences_properties)=
+
+#### General properties
 
 ```{eval-rst}
-.. autoclass:: TreeSequence()
-    :members:
+.. autosummary::
+  TreeSequence.time_units
+  TreeSequence.nbytes
+  TreeSequence.sequence_length
+  TreeSequence.max_root_time
+  TreeSequence.discrete_genome
+  TreeSequence.discrete_time
+  TreeSequence.metadata
+  TreeSequence.metadata_schema
 ```
 
 
-### The `Tree` class
+(sec_python_api_tree_sequences_loading_and_saving)=
 
-Trees in a tree sequence can be obtained by iterating over
-{meth}`TreeSequence.trees` and specific trees can be accessed using methods
-such as {meth}`TreeSequence.first`, {meth}`TreeSequence.at` and
-{meth}`TreeSequence.at_index`. Each tree is an instance of the following
-class which provides methods, for example, to access information
-about particular nodes in the tree.
-
-```{eval-rst}
-.. autoclass:: Tree()
-    :members:
-```
-
-### Simple container classes
-
-These classes are simple shallow containers representing the entities defined
-in the {ref}`sec_data_model_definitions`. These classes are not intended to be
-instantiated directly, but are the return types for the various iterators provided
-by the {class}`TreeSequence` and {class}`Tree` classes.
-
-```{eval-rst}
-.. autoclass:: Individual()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Node()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Edge()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Interval()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Site()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Mutation()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Variant()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Migration()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Population()
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: Provenance()
-    :members:
-```
-
-### Loading data
+#### Loading and saving
 
 There are several methods for loading data into a {class}`TreeSequence`
 instance. The simplest and most convenient is the use the {func}`tskit.load`
@@ -120,17 +68,533 @@ function to load a {ref}`tree sequence file <sec_tree_sequence_file_format>`. Fo
 scale data and debugging, it is often convenient to use the {func}`tskit.load_text`
 function to read data in the {ref}`text file format<sec_text_file_format>`.
 The {meth}`TableCollection.tree_sequence` function
-efficiently creates a {class}`TreeSequence` object from a set of tables
+efficiently creates a {class}`TreeSequence` object from a
+{class}`collection of tables<TableCollection>`
 using the {ref}`Tables API <sec_tables_api>`.
 
-
 ```{eval-rst}
-.. autofunction:: load
+Load a tree sequence
+    .. autosummary::
+      load
+      load_text
+      TableCollection.tree_sequence
+
+Save a tree sequence
+    .. autosummary::
+      TreeSequence.dump
 ```
 
+:::{seealso}
+Tree sequences with a single simple topology can also be created from scratch by
+{ref}`generating<sec_python_api_trees_creating>` a {class}`Tree` and accessing its
+{attr}`~Tree.tree_sequence` property.
+:::
+
+(sec_python_api_tree_sequences_obtaining_trees)=
+
+#### Obtaining trees
+
+The following properties and methods return information about the
+{class}`trees<Tree>` that are generated along a tree sequence.
+
 ```{eval-rst}
-.. autofunction:: load_text
+.. autosummary::
+
+  TreeSequence.num_trees
+  TreeSequence.trees
+  TreeSequence.breakpoints
+  TreeSequence.coiterate
+  TreeSequence.first
+  TreeSequence.last
+  TreeSequence.aslist
+  TreeSequence.at
+  TreeSequence.at_index
 ```
+
+#### Obtaining other objects
+
+(sec_python_api_tree_sequences_obtaining_other_objects)=
+
+Various components make up a tree sequence, such as nodes and edges, sites and
+mutations, and populations and individuals. These can be counted or converted into
+Python objects using the following classes, properties, and methods.
+
+##### Tree topology
+
+```{eval-rst}
+Nodes
+    .. autosummary::
+      Node
+      TreeSequence.num_nodes
+      TreeSequence.nodes
+      TreeSequence.node
+      TreeSequence.num_samples
+      TreeSequence.samples
+
+Edges
+    .. autosummary::
+      Edge
+      TreeSequence.num_edges
+      TreeSequence.edges
+      TreeSequence.edge
+```
+
+##### Genetic variation
+
+```{eval-rst}
+Sites
+    .. autosummary::
+      Site
+      TreeSequence.num_sites
+      TreeSequence.sites
+      TreeSequence.site
+      Variant
+      TreeSequence.variants
+      TreeSequence.genotype_matrix
+      TreeSequence.haplotypes
+      TreeSequence.alignments
+
+Mutations
+    .. autosummary::
+      Mutation
+      TreeSequence.num_mutations
+      TreeSequence.mutations
+      TreeSequence.mutation
+```
+
+##### Demography
+
+```{eval-rst}
+Populations
+    .. autosummary::
+      Population
+      TreeSequence.num_populations
+      TreeSequence.populations
+      TreeSequence.population
+
+Migrations
+    .. autosummary::
+      Migration
+      TreeSequence.num_migrations
+      TreeSequence.migrations
+      TreeSequence.migration
+```
+
+##### Other
+
+```{eval-rst}
+Individuals
+    .. autosummary::
+      Individual
+      TreeSequence.num_individuals
+      TreeSequence.individuals
+      TreeSequence.individual
+
+
+Provenance entries (also see :ref:`sec_provenance_api`)
+    .. autosummary::
+      Provenance
+      TreeSequence.num_provenances
+      TreeSequence.provenances
+      TreeSequence.provenance
+```
+
+(sec_python_api_tree_sequences_modification)=
+
+#### Tree sequence modification
+
+Although tree sequences are immutable, several methods will taken an existing tree
+sequence and return a modifed version. These are thin wrappers around the
+{ref}`identically named methods of a TableCollection<sec_tables_api_modification>`,
+which perform the same actions but modify the {class}`TableCollection` in place.
+
+```{eval-rst}
+.. autosummary::
+  TreeSequence.simplify
+  TreeSequence.subset
+  TreeSequence.union
+  TreeSequence.keep_intervals
+  TreeSequence.delete_intervals
+  TreeSequence.delete_sites
+  TreeSequence.trim
+```
+
+
+(sec_python_api_tree_sequences_tables)=
+
+#### Tables
+
+The underlying data in a tree sequence is stored in a 
+{ref}`collection of tables<sec_tables_api>`. The following methods give access
+to tables and associated functionality. Since tables can be modified, this
+allows tree sequences to be edited: see the {ref}`sec_tables` tutorial for
+an introduction.
+
+```{eval-rst}
+.. autosummary::
+  TreeSequence.tables
+  TreeSequence.dump_tables
+  TreeSequence.table_metadata_schemas
+  TreeSequence.tables_dict
+```
+
+
+(sec_python_api_tree_sequences_statistics)=
+
+#### Statistics
+
+```{eval-rst}
+
+Single site
+    .. autosummary::
+      TreeSequence.allele_frequency_spectrum
+      TreeSequence.divergence
+      TreeSequence.diversity
+      TreeSequence.f2
+      TreeSequence.f3
+      TreeSequence.f4
+      TreeSequence.Fst
+      TreeSequence.genealogical_nearest_neighbours
+      TreeSequence.genetic_relatedness
+      TreeSequence.general_stat
+      TreeSequence.segregating_sites
+      TreeSequence.sample_count_stat
+      TreeSequence.mean_descendants
+      TreeSequence.Tajimas_D
+      TreeSequence.trait_correlation
+      TreeSequence.trait_covariance
+      TreeSequence.trait_linear_model
+      TreeSequence.Y2
+      TreeSequence.Y3
+
+Comparative
+    .. autosummary::
+      TreeSequence.kc_distance
+```
+
+(sec_python_api_tree_sequences_topological_analysis)=
+
+#### Topological analysis
+
+The topology of a tree in a tree sequence refers to the relationship among
+samples ignoring branch lengths. Functionality as described in
+{ref}`sec_combinatorics` is mainly provided via
+{ref}`methods on trees<sec_python_api_trees_topological_analysis>`, but more
+efficient methods sometimes exist for entire tree sequences:
+
+```{eval-rst}
+.. autosummary::
+  TreeSequence.count_topologies
+  
+```
+
+(sec_python_api_tree_sequences_display)=
+
+#### Display
+
+```{eval-rst}
+.. autosummary::
+  TreeSequence.draw_svg
+  TreeSequence.draw_text
+  TreeSequence.__str__
+  TreeSequence._repr_html_
+```
+
+
+(sec_python_api_tree_sequences_export)=
+
+#### Export
+```{eval-rst}
+.. autosummary::
+  TreeSequence.as_fasta
+  TreeSequence.as_nexus
+  TreeSequence.dump_text
+  TreeSequence.to_macs
+  TreeSequence.write_fasta
+  TreeSequence.write_nexus
+  TreeSequence.write_vcf
+```
+
+
+(sec_python_api_trees)=
+
+### The {class}`Tree<Tree>` class
+
+A tree is an instance of the {class}`Tree` class. These trees cannot exist
+independently of the {class}`TreeSequence` from which they are generated.
+Usually, therefore, a {class}`Tree` instance is created by
+{ref}`sec_python_api_tree_sequences_obtaining_trees` from an existing tree
+sequence (although it is also possible to generate a new instance of a
+{class}`Tree` belonging to the same tree sequence using {meth}`Tree.copy`).
+
+:::{note}
+For efficiency, each instance of a {class}`Tree` is a state-machine
+whose internal state corresponds to one of the trees in the parent tree sequence:
+{ref}`sec_python_api_trees_moving_to` in the tree sequence does not require a
+new instance to be created, but simply the internal state to be changed.
+:::
+
+(sec_python_api_trees_general_properties)=
+
+#### General properties
+
+
+```{eval-rst}
+.. autosummary::
+  Tree.tree_sequence
+  Tree.total_branch_length
+  Tree.root_threshold
+  Tree.virtual_root
+  Tree.num_edges
+  Tree.num_roots
+  Tree.has_single_root
+  Tree.has_multiple_roots
+  Tree.root
+  Tree.roots
+  Tree.index
+  Tree.interval
+  Tree.span
+```
+
+
+(sec_python_api_trees_creating)=
+
+#### Creating new trees
+
+It is sometimes useful to create an entirely new tree sequence consisting
+of just a single tree (a "one-tree sequence"). The follow methods create such an
+object and return a {class}`Tree` instance corresponding to that tree.
+The new tree sequence to which the tree belongs is available through the
+{attr}`~Tree.tree_sequence` property. 
+
+```{eval-rst}
+Creating a new tree
+    .. autosummary::
+      Tree.generate_balanced
+      Tree.generate_comb
+      Tree.generate_random_binary
+      Tree.generate_star
+
+Creating a new tree from an existing tree
+    .. autosummary::
+      Tree.split_polytomies
+```
+
+:::{seealso}
+{meth}`Tree.unrank` for creating a new one-tree sequence from its
+{ref}`topological rank<sec_python_api_trees_topological_analysis>`.
+:::
+
+:::{note}
+Several of these methods are {func}`static<python:staticmethod>`, so should
+be called e.g. as `tskit.Tree.generate_balanced(4)` rather than used on
+a specific {class}`Tree` instance.
+:::
+
+
+(sec_python_api_trees_node_measures)=
+
+#### Node measures
+
+Often it is useful to access information pertinant to a specific node or set of nodes
+but which might also change from tree to tree in the tree sequence. Examples include
+the encoding of the tree via `parent`, `left_child`, etc.
+(see {ref}`sec_data_model_tree_structure`), the number of samples under a node,
+or the most recent common ancestor (MRCA) of two nodes. This sort of information is
+available via simple and high performance {class}`Tree` methods
+
+##### Simple measures
+
+These return a simple number, or (usually) short list of numbers relevant to a specific
+node or limited set of nodes. 
+
+```{eval-rst}
+Node information
+    .. autosummary::
+      Tree.is_sample
+      Tree.is_isolated
+      Tree.is_leaf
+      Tree.is_internal
+      Tree.parent
+      Tree.num_children
+      Tree.time
+      Tree.branch_length
+      Tree.depth
+      Tree.population
+      Tree.right_sib
+      Tree.left_sib
+      Tree.right_child
+      Tree.left_child
+
+      Tree.children
+
+Descendant nodes
+    .. autosummary::
+      Tree.leaves
+      Tree.samples
+      Tree.num_samples
+      Tree.num_tracked_samples
+     
+Multiple nodes
+    .. autosummary::
+      Tree.is_descendant
+      Tree.mrca
+      Tree.tmrca
+```
+
+##### Array access
+
+These all return a numpy array whose length corresponds to
+the total number of nodes in the tree sequence. They provide direct access
+to the underlying memory structures, and are thus very efficient, providing a
+high performance interface which can be used in conjunction with the equivalent
+{ref}`traversal methods<sec_python_api_trees_traversal>`.
+
+```{eval-rst}
+.. autosummary::
+  Tree.parent_array
+  Tree.left_child_array
+  Tree.right_child_array
+  Tree.left_sib_array
+  Tree.right_sib_array
+```
+
+
+(sec_python_api_trees_traversal)=
+
+#### Tree traversal
+
+Moving around within a tree usually involves visiting the tree nodes in some sort of
+order. Often, given a particular order, it is convenient to iterate over each node
+using the :meth:`Tree.nodes` method. However, for high performance algorithms, it
+may be more convenient to access the node indices for a particular order as
+an array, and use this, for example, to index into one of the node arrays.
+
+```{eval-rst}
+General
+    .. autosummary::
+
+      Tree.nodes
+
+High performance
+    .. autosummary::
+
+      Tree.postorder
+      Tree.preorder
+      Tree.timeasc
+      Tree.timedesc
+```
+
+Here's an example which calculates the average number of descendants (the "arity)
+over all the nodes in a tree:
+
+```{code-cell} ipython3
+import msprime
+import numpy as np
+import tskit
+
+# Use a multiple merger process to make a tree where some nodes have >2 children
+ts = msprime.sim_ancestry(10, random_seed=1, model=msprime.BetaCoalescent(alpha=1.001))
+tree = ts.first()
+# Order doesn't matter in this example, so use tree.preorder, which is fastest
+parent_id, count = np.unique(tree.parent_array[tree.preorder()], return_counts=True)
+print(f"Average arity is {count[parent_id != tskit.NULL].mean()}")
+```
+
+:::{todo}
+Move this example into the "combinatorics" chapter, renaming the chapter
+"topological analysis"
+:::
+
+
+(sec_python_api_trees_topological_analysis)=
+
+#### Topological analysis
+
+The topology of a tree refers to the simple relationship among samples
+(i.e. ignoring branch lengths), see {ref}`sec_combinatorics` for more details. These
+methods provide ways to enumerate and count tree topologies.
+
+Briefly, the position of a tree in the enumeration `all_trees` can be obtained using
+the tree's {meth}`~Tree.rank` method. Inversely, a {class}`Tree` can be constructed
+from a position in the enumeration with {meth}`Tree.unrank`.
+
+
+```{eval-rst}
+Methods of a tree
+    .. autosummary::
+      Tree.rank
+      Tree.count_topologies
+
+Functions and static methods
+    .. autosummary::
+      Tree.unrank
+      all_tree_shapes
+      all_tree_labellings
+      all_trees
+```
+
+
+(sec_python_api_trees_comparing)=
+
+#### Comparing trees
+
+```{eval-rst}
+.. autosummary::
+  Tree.kc_distance
+```
+
+
+(sec_python_api_trees_sites_mutations)=
+
+#### Sites and mutations
+
+```{eval-rst}
+.. autosummary::
+  Tree.sites
+  Tree.num_sites
+  Tree.mutations
+  Tree.num_mutations
+  Tree.map_mutations
+```
+
+
+(sec_python_api_trees_moving_to)=
+
+#### Moving to other trees
+
+```{eval-rst}
+.. autosummary::
+
+  Tree.next
+  Tree.prev
+  Tree.first
+  Tree.last
+  Tree.seek
+  Tree.seek_index
+  Tree.clear
+```
+
+#### Display
+
+```{eval-rst}
+.. autosummary::
+
+  Tree.draw_svg
+  Tree.draw_text
+  Tree.__str__
+  Tree._repr_html_
+```
+
+#### Export
+
+```{eval-rst}
+.. autosummary::
+
+  Tree.as_dict_of_dicts
+  Tree.as_newick
+```
+
 
 (sec_tables_api)=
 
@@ -139,35 +603,109 @@ using the {ref}`Tables API <sec_tables_api>`.
 The information required to construct a tree sequence is stored in a collection
 of *tables*, each defining a different aspect of the structure of a tree
 sequence. These tables are described individually in
-{ref}`the next section<sec_tables_api_tables>`. However, these are interrelated,
+{ref}`the next section<sec_tables_api_table>`. However, these are interrelated,
 and so many operations work
-on the entire collection of tables, known as a `TableCollection`.
-The {class}`TableCollection` and {class}`TreeSequence` classes are
-deeply related. A `TreeSequence` instance is based on the information
-encoded in a `TableCollection`. Tree sequences are **immutable**, and
-provide methods for obtaining trees from the sequence. A `TableCollection`
-is **mutable**, and does not have any methods for obtaining trees.
-The `TableCollection` class thus allows dynamic creation and modification of
-tree sequences.
-
+on the entire collection of tables, known as a *table collection*.
 
 (sec_tables_api_table_collection)=
 
 ### The `TableCollection` class
 
-Note that several `TableCollection` methods have identical names to methods of a
-`TreeSequence`. These tree sequence methods are often a simple wrapper around the
-equivalent table collection method, acting on a copy of the tree sequence's table
-collection.
+The {class}`TableCollection` and {class}`TreeSequence` classes are
+deeply related. A `TreeSequence` instance is based on the information
+encoded in a `TableCollection`. Tree sequences are **immutable**, and
+provide methods for obtaining trees from the sequence. A `TableCollection`
+is **mutable**, and does not have any methods for obtaining trees.
+The `TableCollection` class thus allows creation and modification of
+tree sequences (see the {ref}`sec_tables` tutorial).
 
+
+#### General properties
 ```{eval-rst}
-.. autoclass:: tskit.TableCollection(sequence_length=0)
-    :members:
+.. autosummary::
+  TableCollection.nbytes
+  TableCollection.name_map
+  TableCollection.metadata
+  TableCollection.metadata_bytes
+  TableCollection.metadata_schema
+  TableCollection.time_units
 ```
 
-(sec_tables_api_tables)=
+#### Sorting and indexing
 
-### Tables
+```{eval-rst}
+.. autosummary::
+  TableCollection.sort
+  TableCollection.sort_individuals
+  TableCollection.canonicalise
+  TableCollection.compute_mutation_parents
+  TableCollection.compute_mutation_times
+  TableCollection.deduplicate_sites
+  TableCollection.has_index
+  TableCollection.build_index
+  TableCollection.drop_index
+```
+
+```{eval-rst}
+  TableCollection.clear
+  TableCollection.copy
+  TableCollection.equals
+  TableCollection.ibd_segments
+  TableCollection.indexes
+  TableCollection.link_ancestors
+```
+
+#### Export
+```{eval-rst}
+  TableCollection.tree_sequence
+  TableCollection.dump
+```
+
+(sec_tables_api_modification)=
+
+#### Modification
+
+These methods act in-place to modify the contents of a {class}`TableCollection`
+(also see the
+{ref}`equivalent methods of a tree sequence<sec_python_api_tree_sequences_modification>`,
+which are simple wrappers for the methods below)
+
+```{eval-rst}
+.. autosummary::
+  TableCollection.simplify
+  TableCollection.subset
+  TableCollection.delete_intervals
+  TableCollection.keep_intervals
+  TableCollection.delete_sites
+  TableCollection.trim
+  TableCollection.union
+```
+
+
+(sec_tables_api_table)=
+
+### Table classes
+
+Here we outline the table classes and the common methods and variables available for
+each. For description and definition of each table's meaning
+and use, see {ref}`the table definitions <sec_table_definitions>`.
+
+```{eval-rst}
+.. autosummary::
+
+  IndividualTable
+  NodeTable
+  EdgeTable
+  MigrationTable
+  SiteTable
+  MutationTable
+  PopulationTable
+  ProvenanceTable
+```
+
+(sec_tables_api_accessing_table_data)=
+
+#### Accessing table data
 
 The {ref}`tables API <sec_binary_interchange>` provides an efficient way of working
 with and interchanging {ref}`tree sequence data <sec_data_model>`. Each table class
@@ -254,10 +792,14 @@ print(t2)
 t == t2
 ```
 
+:::{todo}
+Move some or all of these examples into a suitable alternative chapter.
+:::
+
 
 (sec_tables_api_text_columns)=
 
-#### Text columns
+##### Text columns
 
 As described in the {ref}`sec_encoding_ragged_columns`, working with
 variable length columns is somewhat more involved. Columns
@@ -337,9 +879,14 @@ t_m.set_columns(site=site, node=node, derived_state=d, derived_state_offset=off)
 print(t_m)
 ```
 
+:::{todo}
+Move some or all of these examples into a suitable alternative chapter.
+:::
+
+
 (sec_tables_api_binary_columns)=
 
-#### Binary columns
+##### Binary columns
 
 Columns storing binary data take the same approach as
 {ref}`sec_tables_api_text_columns` to encoding
@@ -405,145 +952,27 @@ print(t.metadata_offset)
 The {func}`tskit.pack_bytes` and {func}`tskit.unpack_bytes` functions are
 also useful for encoding data in these columns.
 
-### Table classes
+:::{todo}
+Move some or all of these examples into a suitable alternative chapter.
+:::
 
-This section describes the methods and variables available for each
-table class. For description and definition of each table's meaning
-and use, see {ref}`the table definitions <sec_table_definitions>`.
 
-% Overriding the default signatures for the tables here as they will be
-% confusing to most users.
 
-```{eval-rst}
-.. autoclass:: IndividualTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
+#### Table functions
 
 ```{eval-rst}
-.. autoclass:: NodeTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
+.. autosummary::
 
-```{eval-rst}
-.. autoclass:: EdgeTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
-
-```{eval-rst}
-.. autoclass:: MigrationTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
-
-```{eval-rst}
-.. autoclass:: SiteTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
-
-```{eval-rst}
-.. autoclass:: MutationTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
-
-```{eval-rst}
-.. autoclass:: PopulationTable()
-    :members:
-    :inherited-members:
-    :special-members: __getitem__
-```
-
-```{eval-rst}
-.. autoclass:: ProvenanceTable()
-    :members:
-    :inherited-members:
-```
-
-### Table functions
-
-```{eval-rst}
-.. autofunction:: parse_nodes
-```
-
-```{eval-rst}
-.. autofunction:: parse_edges
-```
-
-```{eval-rst}
-.. autofunction:: parse_sites
-```
-
-```{eval-rst}
-.. autofunction:: parse_mutations
-```
-
-```{eval-rst}
-.. autofunction:: parse_individuals
-```
-
-```{eval-rst}
-.. autofunction:: parse_populations
-```
-
-```{eval-rst}
-.. autofunction:: pack_strings
-```
-
-```{eval-rst}
-.. autofunction:: unpack_strings
-```
-
-```{eval-rst}
-.. autofunction:: pack_bytes
-```
-
-```{eval-rst}
-.. autofunction:: unpack_bytes
-```
-
-
-(sec_constants_api)=
-
-## Constants
-
-The following constants are used throughout the `tskit` API.
-
-```{eval-rst}
-.. autodata:: NULL
-```
-
-```{eval-rst}
-.. autodata:: NODE_IS_SAMPLE
-```
-
-```{eval-rst}
-.. autodata:: MISSING_DATA
-```
-
-```{eval-rst}
-.. autodata:: FORWARD
-```
-
-```{eval-rst}
-.. autodata:: REVERSE
-```
-
-```{eval-rst}
-.. autodata:: ALLELES_ACGT
-```
-
-```{eval-rst}
-.. autodata:: UNKNOWN_TIME
+  parse_nodes
+  parse_edges
+  parse_sites
+  parse_mutations
+  parse_individuals
+  parse_populations
+  pack_strings
+  unpack_strings
+  pack_bytes
+  unpack_bytes
 ```
 
 
@@ -556,55 +985,19 @@ using a schema. See {ref}`sec_metadata`, {ref}`sec_metadata_api_overview` and
 {ref}`sec_tutorial_metadata`.
 
 ```{eval-rst}
-.. autoclass:: MetadataSchema
-    :members:
-    :inherited-members:
+.. autosummary::
+  MetadataSchema
+  register_metadata_codec
 ```
 
-```{eval-rst}
-.. autofunction:: register_metadata_codec
-```
-
-(sec_combinatorics_api)=
-
-## Combinatorics API
-
-The combinatorics API deals with tree topologies, allowing them to be counted,
-listed and generated: see {ref}`sec_combinatorics` for a detailed description. Briefly,
-the position of a tree in the enumeration `all_trees` can be obtained using the tree's
-{meth}`~Tree.rank` method. Inversely, a {class}`Tree` can be constructed from a position
-in the enumeration with {meth}`Tree.unrank`. Generated trees are associated with a new
-tree sequence containing only that tree for the entire genome (i.e. with
-{attr}`~TreeSequence.num_trees` = 1 and a {attr}`~TreeSequence.sequence_length` equal to
-the {attr}`~Tree.span` of the tree).
-
-```{eval-rst}
-.. autofunction:: all_trees
-```
-
-```{eval-rst}
-.. autofunction:: all_tree_shapes
-```
-
-```{eval-rst}
-.. autofunction:: all_tree_labellings
-```
-
-```{eval-rst}
-.. autoclass:: TopologyCounter
-```
-
-## Linkage disequilibrium
-
-:::{note}
-This API will soon be deprecated in favour of multi-site extensions
-to the {ref}`sec_stats` API.
+:::{seealso}
+Refer to the top level metadata-related properties of TreeSequences and TableCollections,
+such as {attr}`TreeSequence.metadata` and {attr}`TreeSequence.metadata_schema`. Also the
+metadata fields of
+{ref}`objects accessed<sec_python_api_tree_sequences_obtaining_other_objects>` through
+the {class}`TreeSequence` API.
 :::
 
-```{eval-rst}
-.. autoclass:: LdCalculator(tree_sequence)
-    :members:
-```
 
 (sec_provenance_api)=
 
@@ -614,24 +1007,186 @@ We provide some preliminary support for validating JSON documents against the
 {ref}`provenance schema <sec_provenance>`. Programmatic access to provenance
 information is planned for future versions.
 
-```{eval-rst}
-.. autofunction:: validate_provenance
-```
 
 ```{eval-rst}
-.. autoexception:: ProvenanceValidationError
+.. autosummary::
+  validate_provenance
 ```
 
 (sec_utility_api)=
 
 ## Utility functions
 
-Some top-level utility functions.
+Miscellaneous top-level utility functions.
 
 ```{eval-rst}
+.. autosummary::
+  is_unknown_time
+  random_nucleotides
+```
+
+
+(sec_reference_api)=
+
+## Reference documentation
+
+(sec_constants_api)=
+
+### Constants
+
+The following constants are used throughout the `tskit` API.
+
+```{eval-rst}
+.. automodule:: tskit
+   :members:
+```
+
+### Exceptions
+
+```{eval-rst}
+.. autoexception:: DuplicatePositionsError
+.. autoexception:: MetadataEncodingError
+.. autoexception:: MetadataSchemaValidationError
+.. autoexception:: MetadataValidationError
+.. autoexception:: ProvenanceValidationError
+```
+
+### Top-level functions
+
+```{eval-rst}
+.. autofunction:: all_trees
+.. autofunction:: all_tree_shapes
+.. autofunction:: all_tree_labellings
 .. autofunction:: is_unknown_time
+.. autofunction:: load
+.. autofunction:: load_text
+.. autofunction:: pack_bytes
+.. autofunction:: pack_strings
+.. autofunction:: parse_edges
+.. autofunction:: parse_individuals
+.. autofunction:: parse_mutations
+.. autofunction:: parse_nodes
+.. autofunction:: parse_populations
+.. autofunction:: parse_sites
+.. autofunction:: random_nucleotides
+.. autofunction:: register_metadata_codec
+.. autofunction:: validate_provenance
+.. autofunction:: unpack_bytes
+.. autofunction:: unpack_strings
+
 ```
 
+### Tree and tree sequence classes
+
 ```{eval-rst}
-.. autofunction:: random_nucleotides
+.. autoclass:: Tree()
+    :members:
+    :special-members: __str__
+    :private-members: _repr_html_
+
+.. autoclass:: TreeSequence()
+    :members:
+    :special-members: __str__
+    :private-members: _repr_html_
 ```
+
+### Simple container classes
+
+```{eval-rst}
+.. autoclass:: Individual()
+    :members:
+
+.. autoclass:: Node()
+    :members:
+
+.. autoclass:: Edge()
+    :members:
+
+.. autoclass:: Site()
+    :members:
+
+.. autoclass:: Mutation()
+    :members:
+
+.. autoclass:: Variant()
+    :members:
+
+.. autoclass:: Migration()
+    :members:
+
+.. autoclass:: Population()
+    :members:
+
+.. autoclass:: Provenance()
+    :members:
+
+.. autoclass:: Interval()
+    :members:
+
+```
+
+### TableCollection and Table classes
+
+```{eval-rst}
+.. autoclass:: TableCollection
+    :members:
+```
+
+% Overriding the default signatures for the tables here as they will be
+% confusing to most users.
+
+```{eval-rst}
+.. autoclass:: IndividualTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: NodeTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: EdgeTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: MigrationTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: SiteTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: MutationTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: PopulationTable()
+    :members:
+    :inherited-members:
+    :special-members: __getitem__
+
+.. autoclass:: ProvenanceTable()
+    :members:
+    :inherited-members:
+```
+
+### Miscellaneous classes
+
+```{eval-rst}
+
+.. autoclass:: MetadataSchema
+    :members:
+    :inherited-members:
+
+.. autoclass:: TopologyCounter
+
+.. autoclass:: LdCalculator
+    :members:
+```
+

--- a/python/requirements/CI-docs/requirements.txt
+++ b/python/requirements/CI-docs/requirements.txt
@@ -1,5 +1,4 @@
 breathe==4.31.0
-autodocsumm==0.2.7
 jupyter-book==0.12.1
 jupyter-sphinx==0.3.2
 h5py==3.5.0
@@ -10,4 +9,5 @@ PyGithub==1.55
 sphinx==4.3.0
 sphinx-argparse==0.3.1
 sphinx-issues==1.2.0
+sphinxcontrib-prettyspecialmethods==0.1.0
 svgwrite==1.4.1

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2927,8 +2927,8 @@ class TableCollection:
 
     def tree_sequence(self):
         """
-        Returns a :class:`TreeSequence` instance with the structure defined by the
-        tables in this :class:`TableCollection`. If the table collection is not
+        Returns a :class:`TreeSequence` instance from the tables defined in
+        this :class:`TableCollection`. If the table collection is not
         in canonical form (i.e., does not meet sorting requirements) or cannot be
         interpreted as a tree sequence an exception is raised. The
         :meth:`.sort` method may be used to ensure that input sorting requirements

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -479,9 +479,9 @@ class Population(util.Dataclass):
 @dataclass
 class Variant(util.Dataclass):
     """
-    A variant represents the observed variation among samples
-    for a given site. A variant consists (a) of a reference to the
-    :class:`Site` instance in question; (b) the **alleles** that may be
+    A variant in a tree sequence, describing the observed genetic variation
+    among samples for a given site. A variant consists (a) of a reference to
+    the :class:`Site` instance in question; (b) the **alleles** that may be
     observed at the samples for this site; and (c) the **genotypes**
     mapping sample IDs to the observed alleles.
 
@@ -2062,7 +2062,7 @@ class Tree:
 
     def num_samples(self, u=None):
         """
-        Returns the number of samples in this tree underneath the specified
+        Returns the number of sample nodes in this tree underneath the specified
         node (including the node itself). If u is not specified return
         the total number of samples in the tree.
 
@@ -2577,6 +2577,9 @@ class Tree:
         return pi
 
     def __str__(self):
+        """
+        Return a plain text summary of a tree in a tree sequence
+        """
         tree_rows = [
             ["Index", str(self.index)],
             [
@@ -2593,7 +2596,8 @@ class Tree:
 
     def _repr_html_(self):
         """
-        Called by jupyter notebooks to render tables
+        Return an html summary of a tree in a tree sequence. Called by jupyter
+        notebooks to render trees
         """
         return util.tree_html(self)
 
@@ -2968,9 +2972,10 @@ class Tree:
 
 def load(file, *, skip_tables=False):
     """
-    Loads a tree sequence from the specified file object or path. The file must be in the
-    :ref:`tree sequence file format <sec_tree_sequence_file_format>` produced by the
-    :meth:`TreeSequence.dump` method.
+    Return a :class:`TreeSequence` instance loaded from the specified file object or
+    path. The file must be in the
+    :ref:`tree sequence file format <sec_tree_sequence_file_format>`
+    produced by the :meth:`TreeSequence.dump` method.
 
     :param str file: The file object or path of the ``.trees`` file containing the
         tree sequence we wish to load.
@@ -3352,8 +3357,8 @@ def load_text(
     base64_metadata=True,
 ):
     """
-    Parses the tree sequence data from the specified file-like objects, and
-    returns the resulting :class:`TreeSequence` object. The format
+    Return a :class:`TreeSequence` instance parsed from tabulated text data
+    contained in the specified file-like objects. The format
     for these files is documented in the :ref:`sec_text_file_format` section,
     and is produced by the :meth:`TreeSequence.dump_text` method. Further
     properties required for an input tree sequence are described in the
@@ -3910,9 +3915,19 @@ class TreeSequence:
                 print(row, file=provenances)
 
     def __str__(self):
+        """
+        Return a plain text summary of the contents of a tree sequence
+        """
         ts_rows = [
             ["Trees", str(self.num_trees)],
-            ["Sequence Length", str(self.sequence_length)],
+            [
+                "Sequence Length",
+                str(
+                    int(self.sequence_length)
+                    if self.discrete_genome
+                    else self.sequence_length
+                ),
+            ],
             ["Time Units", self.time_units],
             ["Sample Nodes", str(self.num_samples)],
             ["Total Size", util.naturalsize(self.nbytes)],
@@ -3939,7 +3954,8 @@ class TreeSequence:
 
     def _repr_html_(self):
         """
-        Called by jupyter notebooks to render a TreeSequence
+        Return an html summary of a tree sequence. Called by jupyter notebooks
+        to render a TreeSequence.
         """
         return util.tree_sequence_html(self)
 
@@ -3948,8 +3964,8 @@ class TreeSequence:
     @property
     def num_samples(self):
         """
-        Returns the number of samples in this tree sequence. This is the number
-        of sample nodes in each tree.
+        Returns the number of sample nodes in this tree sequence. This is also the
+        number of sample nodes in each tree.
 
         :return: The number of sample nodes in this tree sequence.
         :rtype: int
@@ -4277,9 +4293,9 @@ class TreeSequence:
 
     def edge_diffs(self, include_terminal=False):
         """
-        Returns an iterator over all the edges that are inserted and removed to
-        build the trees as we move from left-to-right along the tree sequence.
-        Each iteration yields a named tuple consisting of 3 values,
+        Returns an iterator over all the :ref:`edges <sec_edge_table_definition>` that
+        are inserted and removed to build the trees as we move from left-to-right along
+        the tree sequence. Each iteration yields a named tuple consisting of 3 values,
         ``(interval, edges_out, edges_in)``. The first value, ``interval``, is the
         genomic interval ``(left, right)`` covered by the incoming tree
         (see :attr:`Tree.interval`). The second, ``edges_out`` is a list of the edges
@@ -4372,8 +4388,8 @@ class TreeSequence:
 
     def breakpoints(self, as_array=False):
         """
-        Returns the breakpoints along the chromosome, including the two extreme points
-        0 and L. This is equivalent to
+        Returns the breakpoints that separate trees along the chromosome, including the
+        two extreme points 0 and L. This is equivalent to
 
         >>> iter([0] + [t.interval.right for t in self.trees()])
 
@@ -4692,7 +4708,8 @@ class TreeSequence:
         impute_missing_data=None,
     ):
         """
-        Returns an iterator over the variants in this tree sequence. See the
+        Returns an iterator over the variants (each site with its genotypes
+        and alleles) in this tree sequence. See the
         :class:`Variant` class for details on the fields of each returned
         object. The ``genotypes`` for the variants are numpy arrays,
         corresponding to indexes into the ``alleles`` attribute in the
@@ -4753,7 +4770,7 @@ class TreeSequence:
         :param bool impute_missing_data:
             *Deprecated in 0.3.0. Use ``isolated_as_missing``, but inverting value.
             Will be removed in a future version*
-        :return: An iterator of all variants this tree sequence.
+        :return: An iterator over all variants in this tree sequence.
         :rtype: iter(:class:`Variant`)
         """
         if impute_missing_data is not None:
@@ -5123,6 +5140,10 @@ class TreeSequence:
         )
 
     def provenance(self, id_):
+        """
+        Returns the :ref:`provenance <sec_provenance_table_definition>`
+        in this tree sequence with the specified ID.
+        """
         timestamp, record = self._ll_tree_sequence.get_provenance(id_)
         return Provenance(id=id_, timestamp=timestamp, record=record)
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -765,10 +765,10 @@ class Tree:
     def next(self):  # noqa A002
         """
         Seeks to the next tree in the sequence. If the tree is in the initial
-        null state we seek to the first tree (equivalent to calling :meth:`.first`).
+        null state we seek to the first tree (equivalent to calling :meth:`~Tree.first`).
         Calling ``next`` on the last tree in the sequence results in the tree
         being cleared back into the null initial state (equivalent to calling
-        :meth:`clear`). The return value of the function indicates whether the
+        :meth:`~Tree.clear`). The return value of the function indicates whether the
         tree is in a non-null state, and can be used to loop over the trees::
 
             # Iterate over the trees from left-to-right
@@ -788,10 +788,10 @@ class Tree:
     def prev(self):
         """
         Seeks to the previous tree in the sequence. If the tree is in the initial
-        null state we seek to the last tree (equivalent to calling :meth:`.last`).
+        null state we seek to the last tree (equivalent to calling :meth:`~Tree.last`).
         Calling ``prev`` on the first tree in the sequence results in the tree
         being cleared back into the null initial state (equivalent to calling
-        :meth:`clear`). The return value of the function indicates whether the
+        :meth:`~Tree.clear`). The return value of the function indicates whether the
         tree is in a non-null state, and can be used to loop over the trees::
 
             # Iterate over the trees from right-to-left


### PR DESCRIPTION
Before I go too much further, here's the start of a suggestion to address #1951. I've only really looked at structuring the methods in the TreeSequence class. I haven't even got onto the Tree class and others yet. It looks a bit like this (note the use of definition lists to break down topics within a section - not sure if this is a good way to do it or not, but I wanted to avoid even greater subsection depth).

Is this the sort of thing you had in mind @jeromekelleher ?

```
#### Loading and saving
Load a tree sequence
    .. autosummary::
      load
      load_text
      TableCollection.tree_sequence

Save a tree sequence
    .. autosummary::
      TreeSequence.dump

#### Obtaining trees

.. autosummary::

  TreeSequence.num_trees
  TreeSequence.trees
  TreeSequence.breakpoints
  TreeSequence.coiterate
  TreeSequence.first
  TreeSequence.last
  TreeSequence.aslist
  TreeSequence.at
  TreeSequence.at_index

#### Obtaining other objects
##### Tree topology

Nodes
    .. autosummary::
      Node
      TreeSequence.num_nodes
      TreeSequence.nodes
      TreeSequence.node
      TreeSequence.num_samples
      TreeSequence.samples

Edges
    .. autosummary::
      Edge
      TreeSequence.num_edges
      TreeSequence.edges
      TreeSequence.edge

##### Genetic variation
Sites
    .. autosummary::
      Site
      TreeSequence.num_sites
      TreeSequence.sites
      TreeSequence.site
      Variant
      TreeSequence.variants
      TreeSequence.genotype_matrix
      TreeSequence.haplotypes
      TreeSequence.alignments

Mutations
    .. autosummary::
      Mutation
      TreeSequence.num_mutations
      TreeSequence.mutations
      TreeSequence.mutation

##### Demography

Populations
    .. autosummary::
      Population
      TreeSequence.num_populations
      TreeSequence.populations
      TreeSequence.population

Migrations
    .. autosummary::
      Migration
      TreeSequence.num_migrations
      TreeSequence.migrations
      TreeSequence.migration

##### Other

Individuals
    .. autosummary::
      Individual
      TreeSequence.num_individuals
      TreeSequence.individuals
      TreeSequence.individual


Provenance entries (also see :ref:`sec_provenance_api`)
    .. autosummary::
      Provenance
      TreeSequence.num_provenances
      TreeSequence.provenances
      TreeSequence.provenance

#### Tree sequence manipulation
 .. autosummary::
  TreeSequence.simplify
  TreeSequence.subset
  TreeSequence.union
  TreeSequence.keep_intervals
  TreeSequence.delete_intervals
  TreeSequence.delete_sites
  TreeSequence.trim

#### Tables

.. autosummary::
  TreeSequence.tables
  TreeSequence.dump_tables
  TreeSequence.table_metadata_schemas
  TreeSequence.tables_dict

#### Statistics

Single site
    .. autosummary::
      TreeSequence.allele_frequency_spectrum
      TreeSequence.divergence
      TreeSequence.diversity
      TreeSequence.f2
      TreeSequence.f3
      TreeSequence.f4
      TreeSequence.Fst
      TreeSequence.genealogical_nearest_neighbours
      TreeSequence.genetic_relatedness
      TreeSequence.general_stat
      TreeSequence.segregating_sites
      TreeSequence.sample_count_stat
      TreeSequence.mean_descendants
      TreeSequence.Tajimas_D
      TreeSequence.trait_correlation
      TreeSequence.trait_covariance
      TreeSequence.trait_linear_model
      TreeSequence.Y2
      TreeSequence.Y3

Comparative
    .. autosummary::
      TreeSequence.kc_distance

also see {meth}`TreeSequence.count_topologies` in the {ref}`sec_combinatorics_api`
section

#### Visualization

.. autosummary::
  TreeSequence.draw_svg
  TreeSequence.draw_text
  TreeSequence.__str__
  TreeSequence._repr_html_

#### Export
.. autosummary::
  TreeSequence.as_fasta
  TreeSequence.as_nexus
  TreeSequence.dump_text
  TreeSequence.to_macs
  TreeSequence.write_fasta
  TreeSequence.write_nexus
  TreeSequence.write_vcf


#### General properties

.. autosummary::
  TreeSequence.time_units
  TreeSequence.nbytes
  TreeSequence.sequence_length
  TreeSequence.max_root_time
  TreeSequence.discrete_genome
  TreeSequence.discrete_time
  TreeSequence.metadata
  TreeSequence.metadata_schema
```
