### PR TITLE
Add options flags to string setters

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -33,6 +33,10 @@
 - ``kastore`` is now vendored into this repo instead of being a git submodule. Developers need to run
   ``git submodule update``. (:user:`jeromekelleher`, :issue:`1687`, :pr:`1973`)
 
+- All string setting methods (e.g. `tsk_table_collection_set_metadata`) now take an extra
+  "options" argument (:user:`jeromekelleher`, :pr:`1990`, :issue:`1979`). To
+  retain the current behaviour set options=0 for all calls.
+
 
 **Features**
 

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -190,12 +190,12 @@ test_table_collection_equals_options(void)
 
     // Equivalent except for time_units
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_time_units, example_time_units_length);
+        &tc1, example_time_units, example_time_units_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
 
     // Equivalent except for metadata
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_metadata, example_metadata_length);
+        &tc1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_equals(&tc1, &tc2, TSK_CMP_IGNORE_TS_METADATA);
     CU_ASSERT_TRUE(ret);
@@ -207,19 +207,19 @@ test_table_collection_equals_options(void)
     ret = tsk_table_collection_equals(&tc1, &tc2, TSK_CMP_IGNORE_PROVENANCE);
     CU_ASSERT_FALSE(ret);
     ret = tsk_table_collection_set_metadata(
-        &tc2, example_metadata, example_metadata_length);
+        &tc2, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_equals(&tc1, &tc2, 0);
     CU_ASSERT_TRUE(ret);
     ret = tsk_table_collection_set_metadata_schema(
-        &tc1, example_metadata_schema, example_metadata_schema_length);
+        &tc1, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_equals(&tc1, &tc2, TSK_CMP_IGNORE_TS_METADATA);
     CU_ASSERT_TRUE(ret);
     ret = tsk_table_collection_equals(&tc1, &tc2, 0);
     CU_ASSERT_FALSE(ret);
     ret = tsk_table_collection_set_metadata_schema(
-        &tc2, example_metadata_schema, example_metadata_schema_length);
+        &tc2, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_equals(&tc1, &tc2, 0);
     CU_ASSERT_TRUE(ret);
@@ -254,7 +254,7 @@ test_table_collection_equals_options(void)
     CU_ASSERT_EQUAL(ret, 0);
     example_metadata[0] = 'J';
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_metadata, example_metadata_length);
+        &tc1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_equals(&tc1, &tc2, 0);
     CU_ASSERT_FALSE(ret);
@@ -286,10 +286,10 @@ test_table_collection_equals_options(void)
     ret = tsk_table_collection_init(&tc2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_metadata, example_metadata_length);
+        &tc1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_set_metadata(
-        &tc2, example_metadata, example_metadata_length);
+        &tc2, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
     // Add one row for each table we're ignoring
@@ -372,52 +372,52 @@ test_reference_sequence_state_machine(void)
     CU_ASSERT_EQUAL(r1.metadata_schema, NULL);
     CU_ASSERT_TRUE(tsk_reference_sequence_is_null(&r1));
 
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
     /* Setting the value back to NULL makes the reference whole object NULL */
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, NULL, 0), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, NULL, 0, 0), 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_is_null(&r1));
     tsk_reference_sequence_free(&r1);
     CU_ASSERT_TRUE(tsk_reference_sequence_is_null(&r1));
 
     /* Any empty string is the same thing. */
     tsk_reference_sequence_init(&r1, 0);
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "", 0), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "", 0, 0), 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_is_null(&r1));
     tsk_reference_sequence_free(&r1);
 
     tsk_reference_sequence_init(&r1, 0);
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_url(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_url(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
     tsk_reference_sequence_free(&r1);
 
     tsk_reference_sequence_init(&r1, 0);
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
     tsk_reference_sequence_free(&r1);
 
     tsk_reference_sequence_init(&r1, 0);
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata_schema(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata_schema(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
     tsk_reference_sequence_free(&r1);
 
     tsk_reference_sequence_init(&r1, 0);
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata_schema(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata_schema(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_url(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_url(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "x", 1), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "x", 1, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
 
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata(&r1, "", 0), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata(&r1, "", 0, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata_schema(&r1, "", 0), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_metadata_schema(&r1, "", 0, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_url(&r1, "", 0), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_url(&r1, "", 0, 0), 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_is_null(&r1));
-    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "", 0), 0);
+    CU_ASSERT_EQUAL(tsk_reference_sequence_set_data(&r1, "", 0, 0), 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_is_null(&r1));
 
     tsk_reference_sequence_free(&r1);
@@ -445,51 +445,51 @@ test_reference_sequence(void)
     /* NULL sequences are initially equal */
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_data(&r1, example_data, example_data_length);
+    ret = tsk_reference_sequence_set_data(&r1, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_data(&r1, "", 0);
+    ret = tsk_reference_sequence_set_data(&r1, "", 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_data(&r2, "", 0);
+    ret = tsk_reference_sequence_set_data(&r2, "", 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_data(&r1, example_data, example_data_length);
+    ret = tsk_reference_sequence_set_data(&r1, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_data(&r2, example_data, example_data_length);
+    ret = tsk_reference_sequence_set_data(&r2, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_url(&r1, example_url, example_url_length);
+    ret = tsk_reference_sequence_set_url(&r1, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_equals(&r1, &r2, 0));
-    ret = tsk_reference_sequence_set_url(&r2, example_url, example_url_length);
+    ret = tsk_reference_sequence_set_url(&r2, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
     ret = tsk_reference_sequence_set_metadata(
-        &r1, example_metadata, example_metadata_length);
+        &r1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_equals(&r1, &r2, 0));
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, TSK_CMP_IGNORE_METADATA));
     ret = tsk_reference_sequence_set_metadata(
-        &r2, example_metadata, example_metadata_length);
+        &r2, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, TSK_CMP_IGNORE_METADATA));
 
     ret = tsk_reference_sequence_set_metadata_schema(
-        &r1, example_schema, example_schema_length);
+        &r1, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_reference_sequence_equals(&r1, &r2, 0));
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, TSK_CMP_IGNORE_METADATA));
     ret = tsk_reference_sequence_set_metadata_schema(
-        &r2, example_schema, example_schema_length);
+        &r2, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, TSK_CMP_IGNORE_METADATA));
@@ -499,27 +499,27 @@ test_reference_sequence(void)
     tsk_reference_sequence_free(&r2);
 
     tsk_reference_sequence_init(&r1, 0);
-    ret = tsk_reference_sequence_set_data(&r1, example_data, example_data_length);
+    ret = tsk_reference_sequence_set_data(&r1, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_copy(&r1, &r2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
-    ret = tsk_reference_sequence_set_url(&r1, example_url, example_url_length);
+    ret = tsk_reference_sequence_set_url(&r1, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_copy(&r1, &r2, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
     ret = tsk_reference_sequence_set_metadata(
-        &r1, example_metadata, example_metadata_length);
+        &r1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_copy(&r1, &r2, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_reference_sequence_equals(&r1, &r2, 0));
 
     ret = tsk_reference_sequence_set_metadata_schema(
-        &r1, example_schema, example_schema_length);
+        &r1, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_copy(&r1, &r2, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -552,39 +552,39 @@ test_table_collection_reference_sequence(void)
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_data(
-        &tc1.reference_sequence, example_data, example_data_length);
+        &tc1.reference_sequence, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_data(
-        &tc2.reference_sequence, example_data, example_data_length);
+        &tc2.reference_sequence, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_url(
-        &tc1.reference_sequence, example_url, example_url_length);
+        &tc1.reference_sequence, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_reference_sequence_set_url(
-        &tc2.reference_sequence, example_url, example_url_length);
+        &tc2.reference_sequence, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_metadata(
-        &tc1.reference_sequence, example_metadata, example_metadata_length);
+        &tc1.reference_sequence, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_reference_sequence_set_metadata(
-        &tc2.reference_sequence, example_metadata, example_metadata_length);
+        &tc2.reference_sequence, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_metadata_schema(
-        &tc1.reference_sequence, example_schema, example_schema_length);
+        &tc1.reference_sequence, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_reference_sequence_set_metadata_schema(
-        &tc2.reference_sequence, example_schema, example_schema_length);
+        &tc2.reference_sequence, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
@@ -595,28 +595,28 @@ test_table_collection_reference_sequence(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_reference_sequence_set_data(
-        &tc1.reference_sequence, example_data, example_data_length);
+        &tc1.reference_sequence, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_copy(&tc1, &tc2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_url(
-        &tc1.reference_sequence, example_url, example_url_length);
+        &tc1.reference_sequence, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_copy(&tc1, &tc2, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_metadata(
-        &tc1.reference_sequence, example_metadata, example_metadata_length);
+        &tc1.reference_sequence, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_copy(&tc1, &tc2, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_reference_sequence_set_metadata_schema(
-        &tc1.reference_sequence, example_schema, example_schema_length);
+        &tc1.reference_sequence, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_copy(&tc1, &tc2, TSK_NO_INIT);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -629,16 +629,16 @@ test_table_collection_reference_sequence(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tc1.sequence_length = 1.0;
     ret = tsk_reference_sequence_set_data(
-        &tc1.reference_sequence, example_data, example_data_length);
+        &tc1.reference_sequence, example_data, example_data_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_set_url(
-        &tc1.reference_sequence, example_url, example_url_length);
+        &tc1.reference_sequence, example_url, example_url_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_set_metadata(
-        &tc1.reference_sequence, example_metadata, example_metadata_length);
+        &tc1.reference_sequence, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_reference_sequence_set_metadata_schema(
-        &tc1.reference_sequence, example_schema, example_schema_length);
+        &tc1.reference_sequence, example_schema, example_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_dump(&tc1, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -660,12 +660,12 @@ test_table_collection_has_reference_sequence(void)
     tc.sequence_length = 1.0;
 
     CU_ASSERT_FALSE(tsk_table_collection_has_reference_sequence(&tc));
-    ret = tsk_reference_sequence_set_data(&tc.reference_sequence, "A", 1);
+    ret = tsk_reference_sequence_set_data(&tc.reference_sequence, "A", 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_has_reference_sequence(&tc));
     /* Goes back to NULL by setting a empty string. See
      * test_reference_sequence_state_machine for detailed tests. */
-    ret = tsk_reference_sequence_set_data(&tc.reference_sequence, "", 0);
+    ret = tsk_reference_sequence_set_data(&tc.reference_sequence, "", 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_has_reference_sequence(&tc));
 
@@ -692,19 +692,19 @@ test_table_collection_metadata(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_metadata, example_metadata_length);
+        &tc1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_table_collection_set_metadata(
-        &tc2, example_metadata, example_metadata_length);
+        &tc2, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_table_collection_set_metadata_schema(
-        &tc1, example_metadata_schema, example_metadata_schema_length);
+        &tc1, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_table_collection_set_metadata_schema(
-        &tc2, example_metadata_schema, example_metadata_schema_length);
+        &tc2, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
@@ -714,14 +714,14 @@ test_table_collection_metadata(void)
     ret = tsk_table_collection_init(&tc1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_metadata, example_metadata_length);
+        &tc1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_copy(&tc1, &tc2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
     ret = tsk_table_collection_set_metadata_schema(
-        &tc1, example_metadata_schema, example_metadata_schema_length);
+        &tc1, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_table_collection_free(&tc2);
     ret = tsk_table_collection_copy(&tc1, &tc2, 0);
@@ -747,10 +747,10 @@ test_table_collection_metadata(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tc1.sequence_length = 1.0;
     ret = tsk_table_collection_set_metadata(
-        &tc1, example_metadata, example_metadata_length);
+        &tc1, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_metadata_schema(
-        &tc1, example_metadata_schema, example_metadata_schema_length);
+        &tc1, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_dump(&tc1, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -777,11 +777,11 @@ test_table_collection_time_units(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_table_collection_set_time_units(
-        &tc1, example_time_units, example_time_units_length);
+        &tc1, example_time_units, example_time_units_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
     ret = tsk_table_collection_set_time_units(
-        &tc2, example_time_units, example_time_units_length);
+        &tc2, example_time_units, example_time_units_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
 
@@ -791,7 +791,7 @@ test_table_collection_time_units(void)
     ret = tsk_table_collection_init(&tc1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_time_units(
-        &tc1, example_time_units, example_time_units_length);
+        &tc1, example_time_units, example_time_units_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_copy(&tc1, &tc2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -817,7 +817,7 @@ test_table_collection_time_units(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tc1.sequence_length = 1.0;
     ret = tsk_table_collection_set_time_units(
-        &tc1, example_time_units, example_time_units_length);
+        &tc1, example_time_units, example_time_units_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_dump(&tc1, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1151,7 +1151,7 @@ test_node_table(void)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    tsk_node_table_set_metadata_schema(&table, example, example_length);
+    tsk_node_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
 
@@ -1159,9 +1159,9 @@ test_node_table(void)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    tsk_node_table_set_metadata_schema(&table2, example, example_length);
+    tsk_node_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_TRUE(tsk_node_table_equals(&table, &table2, 0));
-    tsk_node_table_set_metadata_schema(&table2, example2, example2_length);
+    tsk_node_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_FALSE(tsk_node_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(tsk_node_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
 
@@ -1637,7 +1637,7 @@ test_edge_table_with_options(tsk_flags_t options)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    ret = tsk_edge_table_set_metadata_schema(&table, example, example_length);
+    ret = tsk_edge_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
@@ -1647,10 +1647,10 @@ test_edge_table_with_options(tsk_flags_t options)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    ret = tsk_edge_table_set_metadata_schema(&table2, example, example_length);
+    ret = tsk_edge_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_TRUE(tsk_edge_table_equals(&table, &table2, 0));
-    ret = tsk_edge_table_set_metadata_schema(&table2, example2, example2_length);
+    ret = tsk_edge_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FALSE(tsk_edge_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(tsk_edge_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
@@ -2350,7 +2350,7 @@ test_site_table(void)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    tsk_site_table_set_metadata_schema(&table, example, example_length);
+    tsk_site_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
 
@@ -2358,9 +2358,9 @@ test_site_table(void)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    tsk_site_table_set_metadata_schema(&table2, example, example_length);
+    tsk_site_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_TRUE(tsk_site_table_equals(&table, &table2, 0));
-    tsk_site_table_set_metadata_schema(&table2, example2, example2_length);
+    tsk_site_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_FALSE(tsk_site_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(tsk_site_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
 
@@ -2856,7 +2856,7 @@ test_mutation_table(void)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    tsk_mutation_table_set_metadata_schema(&table, example, example_length);
+    tsk_mutation_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
 
@@ -2864,9 +2864,9 @@ test_mutation_table(void)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    tsk_mutation_table_set_metadata_schema(&table2, example, example_length);
+    tsk_mutation_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_TRUE(tsk_mutation_table_equals(&table, &table2, 0));
-    tsk_mutation_table_set_metadata_schema(&table2, example2, example2_length);
+    tsk_mutation_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_FALSE(tsk_mutation_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(tsk_mutation_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
 
@@ -3355,7 +3355,7 @@ test_migration_table(void)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    tsk_migration_table_set_metadata_schema(&table, example, example_length);
+    tsk_migration_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
 
@@ -3363,9 +3363,9 @@ test_migration_table(void)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    tsk_migration_table_set_metadata_schema(&table2, example, example_length);
+    tsk_migration_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_TRUE(tsk_migration_table_equals(&table, &table2, 0));
-    tsk_migration_table_set_metadata_schema(&table2, example2, example2_length);
+    tsk_migration_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_FALSE(tsk_migration_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(tsk_migration_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
 
@@ -3911,7 +3911,7 @@ test_individual_table(void)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    tsk_individual_table_set_metadata_schema(&table, example, example_length);
+    tsk_individual_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
 
@@ -3919,9 +3919,9 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    tsk_individual_table_set_metadata_schema(&table2, example, example_length);
+    tsk_individual_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_TRUE(tsk_individual_table_equals(&table, &table2, 0));
-    tsk_individual_table_set_metadata_schema(&table2, example2, example2_length);
+    tsk_individual_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_FALSE(tsk_individual_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(
         tsk_individual_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
@@ -4286,7 +4286,7 @@ test_population_table(void)
     tsk_size_t example_length = (tsk_size_t) strlen(example);
     const char *example2 = "A different example 🎄🌳🌴🌲🎋";
     tsk_size_t example2_length = (tsk_size_t) strlen(example);
-    tsk_population_table_set_metadata_schema(&table, example, example_length);
+    tsk_population_table_set_metadata_schema(&table, example, example_length, 0);
     CU_ASSERT_EQUAL(table.metadata_schema_length, example_length);
     CU_ASSERT_EQUAL(tsk_memcmp(table.metadata_schema, example, example_length), 0);
 
@@ -4294,9 +4294,9 @@ test_population_table(void)
     CU_ASSERT_EQUAL(table.metadata_schema_length, table2.metadata_schema_length);
     CU_ASSERT_EQUAL(
         tsk_memcmp(table.metadata_schema, table2.metadata_schema, example_length), 0);
-    tsk_population_table_set_metadata_schema(&table2, example, example_length);
+    tsk_population_table_set_metadata_schema(&table2, example, example_length, 0);
     CU_ASSERT_TRUE(tsk_population_table_equals(&table, &table2, 0));
-    tsk_population_table_set_metadata_schema(&table2, example2, example2_length);
+    tsk_population_table_set_metadata_schema(&table2, example2, example2_length, 0);
     CU_ASSERT_FALSE(tsk_population_table_equals(&table, &table2, 0));
     CU_ASSERT_TRUE(
         tsk_population_table_equals(&table, &table2, TSK_CMP_IGNORE_METADATA));
@@ -7416,19 +7416,19 @@ test_dump_load_metadata_schema(void)
     char example[100] = "An example of metadata schema with unicode 🎄🌳🌴🌲🎋";
     tsk_size_t example_length = (tsk_size_t) strlen(example) + 4;
     tsk_node_table_set_metadata_schema(
-        &t1.nodes, strcat(example, "node"), example_length);
+        &t1.nodes, strcat(example, "node"), example_length, 0);
     tsk_edge_table_set_metadata_schema(
-        &t1.edges, strcat(example, "edge"), example_length);
+        &t1.edges, strcat(example, "edge"), example_length, 0);
     tsk_site_table_set_metadata_schema(
-        &t1.sites, strcat(example, "site"), example_length);
+        &t1.sites, strcat(example, "site"), example_length, 0);
     tsk_mutation_table_set_metadata_schema(
-        &t1.mutations, strcat(example, "muta"), example_length);
+        &t1.mutations, strcat(example, "muta"), example_length, 0);
     tsk_migration_table_set_metadata_schema(
-        &t1.migrations, strcat(example, "migr"), example_length);
+        &t1.migrations, strcat(example, "migr"), example_length, 0);
     tsk_individual_table_set_metadata_schema(
-        &t1.individuals, strcat(example, "indi"), example_length);
+        &t1.individuals, strcat(example, "indi"), example_length, 0);
     tsk_population_table_set_metadata_schema(
-        &t1.populations, strcat(example, "popu"), example_length);
+        &t1.populations, strcat(example, "popu"), example_length, 0);
     ret = tsk_table_collection_dump(&t1, _tmp_file_name, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_load(&t2, _tmp_file_name, 0);
@@ -8626,7 +8626,7 @@ test_table_collection_union(void)
 
     // does not error on empty tables but that differ on top level metadata
     ret = tsk_table_collection_set_metadata(
-        &tables, example_metadata, example_metadata_length);
+        &tables, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL(ret, 0);
     ret = tsk_table_collection_union(&tables, &tables_empty, node_mapping, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -9032,26 +9032,26 @@ test_table_collection_clear_with_options(tsk_flags_t options)
     ret = tsk_table_collection_build_index(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_individual_table_set_metadata_schema(&tables.individuals, "test", 4);
+    ret = tsk_individual_table_set_metadata_schema(&tables.individuals, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_node_table_set_metadata_schema(&tables.nodes, "test", 4);
+    ret = tsk_node_table_set_metadata_schema(&tables.nodes, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_edge_table_set_metadata_schema(&tables.edges, "test", 4);
+    ret = tsk_edge_table_set_metadata_schema(&tables.edges, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_migration_table_set_metadata_schema(&tables.migrations, "test", 4);
+    ret = tsk_migration_table_set_metadata_schema(&tables.migrations, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_site_table_set_metadata_schema(&tables.sites, "test", 4);
+    ret = tsk_site_table_set_metadata_schema(&tables.sites, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_mutation_table_set_metadata_schema(&tables.mutations, "test", 4);
+    ret = tsk_mutation_table_set_metadata_schema(&tables.mutations, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_population_table_set_metadata_schema(&tables.populations, "test", 4);
+    ret = tsk_population_table_set_metadata_schema(&tables.populations, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = tsk_table_collection_set_time_units(&tables, "test", 4);
+    ret = tsk_table_collection_set_time_units(&tables, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_set_metadata(&tables, "test", 4);
+    ret = tsk_table_collection_set_metadata(&tables, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_set_metadata_schema(&tables, "test", 4);
+    ret = tsk_table_collection_set_metadata_schema(&tables, "test", 4, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret_id = tsk_provenance_table_add_row(&tables.provenances, "today", 5, "test", 4);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -6832,13 +6832,13 @@ test_tree_sequence_metadata(void)
     ret = tsk_table_collection_build_index(&tc, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_metadata(
-        &tc, example_metadata, example_metadata_length);
+        &tc, example_metadata, example_metadata_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_metadata_schema(
-        &tc, example_metadata_schema, example_metadata_schema_length);
+        &tc, example_metadata_schema, example_metadata_schema_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_set_time_units(
-        &tc, example_time_units, example_time_units_length);
+        &tc, example_time_units, example_time_units_length, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_init(&ts, &tc, 0);
@@ -6900,7 +6900,7 @@ test_time_uncalibrated(void)
     tsk_treeseq_free(&ts);
 
     ret = tsk_table_collection_set_time_units(
-        &tables, TSK_TIME_UNITS_UNCALIBRATED, strlen(TSK_TIME_UNITS_UNCALIBRATED));
+        &tables, TSK_TIME_UNITS_UNCALIBRATED, strlen(TSK_TIME_UNITS_UNCALIBRATED), 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6910,7 +6910,7 @@ test_time_uncalibrated(void)
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
     ret = tsk_table_collection_set_time_units(
-        ts.tables, TSK_TIME_UNITS_UNCALIBRATED, strlen(TSK_TIME_UNITS_UNCALIBRATED));
+        ts.tables, TSK_TIME_UNITS_UNCALIBRATED, strlen(TSK_TIME_UNITS_UNCALIBRATED), 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_init(&ts2, ts.tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6965,7 +6965,7 @@ test_reference_sequence(void)
     CU_ASSERT_FALSE(tsk_treeseq_has_reference_sequence(&ts));
     tsk_treeseq_free(&ts);
 
-    ret = tsk_reference_sequence_set_data(&tables.reference_sequence, "abc", 3);
+    ret = tsk_reference_sequence_set_data(&tables.reference_sequence, "abc", 3, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -820,30 +820,30 @@ caterpillar_tree(tsk_size_t n, tsk_size_t num_sites, tsk_size_t num_mutations)
 
     tables.sequence_length = 1.0;
 
-    tsk_table_collection_set_metadata(&tables, ts_metadata, strlen(ts_metadata));
+    tsk_table_collection_set_metadata(&tables, ts_metadata, strlen(ts_metadata), 0);
     tsk_table_collection_set_metadata_schema(
-        &tables, ts_metadata_schema, strlen(ts_metadata_schema));
+        &tables, ts_metadata_schema, strlen(ts_metadata_schema), 0);
     tsk_reference_sequence_set_metadata_schema(
-        &tables.reference_sequence, ts_metadata_schema, strlen(ts_metadata_schema));
+        &tables.reference_sequence, ts_metadata_schema, strlen(ts_metadata_schema), 0);
     tsk_reference_sequence_set_metadata(
-        &tables.reference_sequence, ts_metadata, strlen(ts_metadata));
-    tsk_reference_sequence_set_data(&tables.reference_sequence, "A", 1);
-    tsk_reference_sequence_set_url(&tables.reference_sequence, "B", 1);
+        &tables.reference_sequence, ts_metadata, strlen(ts_metadata), 0);
+    tsk_reference_sequence_set_data(&tables.reference_sequence, "A", 1, 0);
+    tsk_reference_sequence_set_url(&tables.reference_sequence, "B", 1, 0);
 
     tsk_population_table_set_metadata_schema(
-        &tables.populations, metadata_schema, strlen(metadata_schema));
+        &tables.populations, metadata_schema, strlen(metadata_schema), 0);
     tsk_individual_table_set_metadata_schema(
-        &tables.individuals, metadata_schema, strlen(metadata_schema));
+        &tables.individuals, metadata_schema, strlen(metadata_schema), 0);
     tsk_node_table_set_metadata_schema(
-        &tables.nodes, metadata_schema, strlen(metadata_schema));
+        &tables.nodes, metadata_schema, strlen(metadata_schema), 0);
     tsk_edge_table_set_metadata_schema(
-        &tables.edges, metadata_schema, strlen(metadata_schema));
+        &tables.edges, metadata_schema, strlen(metadata_schema), 0);
     tsk_site_table_set_metadata_schema(
-        &tables.sites, metadata_schema, strlen(metadata_schema));
+        &tables.sites, metadata_schema, strlen(metadata_schema), 0);
     tsk_mutation_table_set_metadata_schema(
-        &tables.mutations, metadata_schema, strlen(metadata_schema));
+        &tables.mutations, metadata_schema, strlen(metadata_schema), 0);
     tsk_migration_table_set_metadata_schema(
-        &tables.migrations, metadata_schema, strlen(metadata_schema));
+        &tables.migrations, metadata_schema, strlen(metadata_schema), 0);
 
     for (j = 0; j < (tsk_id_t) n; j++) {
         position[0] = j;

--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -705,21 +705,21 @@ tsk_reference_sequence_copy(const tsk_reference_sequence_t *self,
         /* This is a simple way to get any input into the NULL state */
         tsk_reference_sequence_free(dest);
     } else {
-        ret = tsk_reference_sequence_set_data(dest, self->data, self->data_length);
+        ret = tsk_reference_sequence_set_data(dest, self->data, self->data_length, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_reference_sequence_set_url(dest, self->url, self->url_length);
+        ret = tsk_reference_sequence_set_url(dest, self->url, self->url_length, 0);
         if (ret != 0) {
             goto out;
         }
         ret = tsk_reference_sequence_set_metadata(
-            dest, self->metadata, self->metadata_length);
+            dest, self->metadata, self->metadata_length, 0);
         if (ret != 0) {
             goto out;
         }
         ret = tsk_reference_sequence_set_metadata_schema(
-            dest, self->metadata_schema, self->metadata_schema_length);
+            dest, self->metadata_schema, self->metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -729,22 +729,22 @@ out:
 }
 
 int
-tsk_reference_sequence_set_data(
-    tsk_reference_sequence_t *self, const char *data, tsk_size_t data_length)
+tsk_reference_sequence_set_data(tsk_reference_sequence_t *self, const char *data,
+    tsk_size_t data_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->data, &self->data_length, data, data_length);
 }
 
 int
-tsk_reference_sequence_set_url(
-    tsk_reference_sequence_t *self, const char *url, tsk_size_t url_length)
+tsk_reference_sequence_set_url(tsk_reference_sequence_t *self, const char *url,
+    tsk_size_t url_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->url, &self->url_length, url, url_length);
 }
 
 int
-tsk_reference_sequence_set_metadata(
-    tsk_reference_sequence_t *self, const char *metadata, tsk_size_t metadata_length)
+tsk_reference_sequence_set_metadata(tsk_reference_sequence_t *self, const char *metadata,
+    tsk_size_t metadata_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(
         &self->metadata, &self->metadata_length, metadata, metadata_length);
@@ -752,7 +752,8 @@ tsk_reference_sequence_set_metadata(
 
 int
 tsk_reference_sequence_set_metadata_schema(tsk_reference_sequence_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length)
+    const char *metadata_schema, tsk_size_t metadata_schema_length,
+    tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -894,7 +895,7 @@ tsk_individual_table_init(tsk_individual_table_t *self, tsk_flags_t TSK_UNUSED(o
     self->max_location_length_increment = 0;
     self->max_parents_length_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_individual_table_set_metadata_schema(self, NULL, 0);
+    tsk_individual_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -918,7 +919,7 @@ tsk_individual_table_copy(const tsk_individual_table_t *self,
         goto out;
     }
     ret = tsk_individual_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -1344,7 +1345,8 @@ out:
 
 int
 tsk_individual_table_set_metadata_schema(tsk_individual_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length)
+    const char *metadata_schema, tsk_size_t metadata_schema_length,
+    tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -1514,7 +1516,7 @@ tsk_individual_table_load(tsk_individual_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_individual_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -1613,7 +1615,7 @@ tsk_node_table_init(tsk_node_table_t *self, tsk_flags_t TSK_UNUSED(options))
     self->metadata_offset[0] = 0;
     self->max_rows_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_node_table_set_metadata_schema(self, NULL, 0);
+    tsk_node_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -1636,7 +1638,7 @@ tsk_node_table_copy(
         goto out;
     }
     ret = tsk_node_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -1942,7 +1944,7 @@ tsk_node_table_print_state(const tsk_node_table_t *self, FILE *out)
 
 int
 tsk_node_table_set_metadata_schema(tsk_node_table_t *self, const char *metadata_schema,
-    tsk_size_t metadata_schema_length)
+    tsk_size_t metadata_schema_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -2103,7 +2105,7 @@ tsk_node_table_load(tsk_node_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_node_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -2213,7 +2215,7 @@ tsk_edge_table_init(tsk_edge_table_t *self, tsk_flags_t options)
     }
     self->max_rows_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_edge_table_set_metadata_schema(self, NULL, 0);
+    tsk_edge_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -2368,7 +2370,7 @@ tsk_edge_table_copy(
         goto out;
     }
     ret = tsk_edge_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -2578,7 +2580,7 @@ tsk_edge_table_print_state(const tsk_edge_table_t *self, FILE *out)
 
 int
 tsk_edge_table_set_metadata_schema(tsk_edge_table_t *self, const char *metadata_schema,
-    tsk_size_t metadata_schema_length)
+    tsk_size_t metadata_schema_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -2736,7 +2738,7 @@ tsk_edge_table_load(tsk_edge_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_edge_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -2897,7 +2899,7 @@ tsk_site_table_init(tsk_site_table_t *self, tsk_flags_t TSK_UNUSED(options))
     self->max_rows_increment = 0;
     self->max_ancestral_state_length_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_site_table_set_metadata_schema(self, NULL, 0);
+    tsk_site_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -3113,7 +3115,7 @@ tsk_site_table_copy(
         goto out;
     }
     ret = tsk_site_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -3300,7 +3302,7 @@ out:
 
 int
 tsk_site_table_set_metadata_schema(tsk_site_table_t *self, const char *metadata_schema,
-    tsk_size_t metadata_schema_length)
+    tsk_size_t metadata_schema_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -3401,7 +3403,7 @@ tsk_site_table_load(tsk_site_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_site_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -3531,7 +3533,7 @@ tsk_mutation_table_init(tsk_mutation_table_t *self, tsk_flags_t TSK_UNUSED(optio
     self->max_rows_increment = 0;
     self->max_derived_state_length_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_mutation_table_set_metadata_schema(self, NULL, 0);
+    tsk_mutation_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -3770,7 +3772,7 @@ tsk_mutation_table_copy(
         goto out;
     }
     ret = tsk_mutation_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -3967,7 +3969,8 @@ out:
 
 int
 tsk_mutation_table_set_metadata_schema(tsk_mutation_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length)
+    const char *metadata_schema, tsk_size_t metadata_schema_length,
+    tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -4079,7 +4082,7 @@ tsk_mutation_table_load(tsk_mutation_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_mutation_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -4189,7 +4192,7 @@ tsk_migration_table_init(tsk_migration_table_t *self, tsk_flags_t TSK_UNUSED(opt
     self->metadata_offset[0] = 0;
     self->max_rows_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_migration_table_set_metadata_schema(self, NULL, 0);
+    tsk_migration_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -4271,7 +4274,7 @@ tsk_migration_table_copy(
         goto out;
     }
     ret = tsk_migration_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -4532,7 +4535,8 @@ out:
 
 int
 tsk_migration_table_set_metadata_schema(tsk_migration_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length)
+    const char *metadata_schema, tsk_size_t metadata_schema_length,
+    tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -4670,7 +4674,7 @@ tsk_migration_table_load(tsk_migration_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_migration_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -4754,7 +4758,7 @@ tsk_population_table_init(tsk_population_table_t *self, tsk_flags_t TSK_UNUSED(o
     self->metadata_offset[0] = 0;
     self->max_rows_increment = 0;
     self->max_metadata_length_increment = 0;
-    tsk_population_table_set_metadata_schema(self, NULL, 0);
+    tsk_population_table_set_metadata_schema(self, NULL, 0, 0);
 out:
     return ret;
 }
@@ -4777,7 +4781,7 @@ tsk_population_table_copy(const tsk_population_table_t *self,
         goto out;
     }
     ret = tsk_population_table_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
 out:
     return ret;
 }
@@ -5064,7 +5068,8 @@ out:
 
 int
 tsk_population_table_set_metadata_schema(tsk_population_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length)
+    const char *metadata_schema, tsk_size_t metadata_schema_length,
+    tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -5172,7 +5177,7 @@ tsk_population_table_load(tsk_population_table_t *self, kastore_t *store)
     }
     if (metadata_schema != NULL) {
         ret = tsk_population_table_set_metadata_schema(
-            self, metadata_schema, metadata_schema_length);
+            self, metadata_schema, metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -9907,7 +9912,7 @@ tsk_table_collection_init(tsk_table_collection_t *self, tsk_flags_t options)
 
     /* Set default time_units value */
     ret = tsk_table_collection_set_time_units(
-        self, TSK_TIME_UNITS_UNKNOWN, strlen(TSK_TIME_UNITS_UNKNOWN));
+        self, TSK_TIME_UNITS_UNKNOWN, strlen(TSK_TIME_UNITS_UNKNOWN), 0);
     if (ret != 0) {
         goto out;
     }
@@ -10023,16 +10028,16 @@ tsk_table_collection_equals(const tsk_table_collection_t *self,
 }
 
 int
-tsk_table_collection_set_time_units(
-    tsk_table_collection_t *self, const char *time_units, tsk_size_t time_units_length)
+tsk_table_collection_set_time_units(tsk_table_collection_t *self, const char *time_units,
+    tsk_size_t time_units_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(
         &self->time_units, &self->time_units_length, time_units, time_units_length);
 }
 
 int
-tsk_table_collection_set_metadata(
-    tsk_table_collection_t *self, const char *metadata, tsk_size_t metadata_length)
+tsk_table_collection_set_metadata(tsk_table_collection_t *self, const char *metadata,
+    tsk_size_t metadata_length, tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(
         &self->metadata, &self->metadata_length, metadata, metadata_length);
@@ -10040,7 +10045,8 @@ tsk_table_collection_set_metadata(
 
 int
 tsk_table_collection_set_metadata_schema(tsk_table_collection_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length)
+    const char *metadata_schema, tsk_size_t metadata_schema_length,
+    tsk_flags_t TSK_UNUSED(options))
 {
     return replace_string(&self->metadata_schema, &self->metadata_schema_length,
         metadata_schema, metadata_schema_length);
@@ -10216,16 +10222,17 @@ tsk_table_collection_copy(const tsk_table_collection_t *self,
         }
     }
     ret = tsk_table_collection_set_time_units(
-        dest, self->time_units, self->time_units_length);
+        dest, self->time_units, self->time_units_length, 0);
     if (ret != 0) {
         goto out;
     }
-    ret = tsk_table_collection_set_metadata(dest, self->metadata, self->metadata_length);
+    ret = tsk_table_collection_set_metadata(
+        dest, self->metadata, self->metadata_length, 0);
     if (ret != 0) {
         goto out;
     }
     ret = tsk_table_collection_set_metadata_schema(
-        dest, self->metadata_schema, self->metadata_schema_length);
+        dest, self->metadata_schema, self->metadata_schema_length, 0);
     if (ret != 0) {
         goto out;
     }
@@ -10338,7 +10345,7 @@ tsk_table_collection_read_format_data(tsk_table_collection_t *self, kastore_t *s
             goto out;
         }
         ret = tsk_table_collection_set_time_units(
-            self, time_units, (tsk_size_t) time_units_length);
+            self, time_units, (tsk_size_t) time_units_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -10357,7 +10364,7 @@ tsk_table_collection_read_format_data(tsk_table_collection_t *self, kastore_t *s
             goto out;
         }
         ret = tsk_table_collection_set_metadata(
-            self, metadata, (tsk_size_t) metadata_length);
+            self, metadata, (tsk_size_t) metadata_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -10376,7 +10383,7 @@ tsk_table_collection_read_format_data(tsk_table_collection_t *self, kastore_t *s
             goto out;
         }
         ret = tsk_table_collection_set_metadata_schema(
-            self, metadata_schema, (tsk_size_t) metadata_schema_length);
+            self, metadata_schema, (tsk_size_t) metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -10480,28 +10487,28 @@ tsk_table_collection_load_reference_sequence(
     }
     if (data != NULL) {
         ret = tsk_reference_sequence_set_data(
-            &self->reference_sequence, data, (tsk_size_t) data_length);
+            &self->reference_sequence, data, (tsk_size_t) data_length, 0);
         if (ret != 0) {
             goto out;
         }
     }
     if (metadata != NULL) {
         ret = tsk_reference_sequence_set_metadata(
-            &self->reference_sequence, metadata, (tsk_size_t) metadata_length);
+            &self->reference_sequence, metadata, (tsk_size_t) metadata_length, 0);
         if (ret != 0) {
             goto out;
         }
     }
     if (metadata_schema != NULL) {
         ret = tsk_reference_sequence_set_metadata_schema(&self->reference_sequence,
-            metadata_schema, (tsk_size_t) metadata_schema_length);
+            metadata_schema, (tsk_size_t) metadata_schema_length, 0);
         if (ret != 0) {
             goto out;
         }
     }
     if (url != NULL) {
         ret = tsk_reference_sequence_set_url(
-            &self->reference_sequence, url, (tsk_size_t) url_length);
+            &self->reference_sequence, url, (tsk_size_t) url_length, 0);
         if (ret != 0) {
             goto out;
         }
@@ -11418,42 +11425,42 @@ tsk_table_collection_clear(tsk_table_collection_t *self, tsk_flags_t options)
     }
 
     if (clear_metadata_schemas) {
-        ret = tsk_individual_table_set_metadata_schema(&self->individuals, "", 0);
+        ret = tsk_individual_table_set_metadata_schema(&self->individuals, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_node_table_set_metadata_schema(&self->nodes, "", 0);
+        ret = tsk_node_table_set_metadata_schema(&self->nodes, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_edge_table_set_metadata_schema(&self->edges, "", 0);
+        ret = tsk_edge_table_set_metadata_schema(&self->edges, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_migration_table_set_metadata_schema(&self->migrations, "", 0);
+        ret = tsk_migration_table_set_metadata_schema(&self->migrations, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_site_table_set_metadata_schema(&self->sites, "", 0);
+        ret = tsk_site_table_set_metadata_schema(&self->sites, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_mutation_table_set_metadata_schema(&self->mutations, "", 0);
+        ret = tsk_mutation_table_set_metadata_schema(&self->mutations, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_population_table_set_metadata_schema(&self->populations, "", 0);
+        ret = tsk_population_table_set_metadata_schema(&self->populations, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
     }
 
     if (clear_ts_metadata) {
-        ret = tsk_table_collection_set_metadata(self, "", 0);
+        ret = tsk_table_collection_set_metadata(self, "", 0, 0);
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_table_collection_set_metadata_schema(self, "", 0);
+        ret = tsk_table_collection_set_metadata_schema(self, "", 0, 0);
         if (ret != 0) {
             goto out;
         }

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -975,10 +975,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_individual_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_individual_table_set_metadata_schema(tsk_individual_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1003,7 +1004,7 @@ The metadata schema is not affected.
 
 @param self A pointer to a tsk_individual_table_t object.
 @param num_rows The number of rows to copy from the specifed arrays.
-@param flags The array of tsk_flag_t flag values to be copied.
+@param flags The array of tsk_flags_t flag values to be copied.
 @param location The array of double location values to be copied.
 @param location_offset The array of tsk_size_t location offset values to be copied.
 @param parents The array of tsk_id_t parent values to be copied.
@@ -1028,7 +1029,7 @@ metadata schema is not affected.
 
 @param self A pointer to a tsk_individual_table_t object.
 @param num_rows The number of rows to copy from the specifed arrays
-@param flags The array of tsk_flag_t flag values to be copied.
+@param flags The array of tsk_flags_t flag values to be copied.
 @param location The array of double location values to be copied.
 @param location_offset The array of tsk_size_t location offset values to be copied.
 @param parents The array of tsk_id_t parent values to be copied.
@@ -1319,10 +1320,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_node_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_node_table_set_metadata_schema(tsk_node_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1347,7 +1349,7 @@ The metadata schema is not affected.
 
 @param self A pointer to a tsk_node_table_t object.
 @param num_rows The number of rows to copy from the specifed arrays.
-@param flags The array of tsk_flag_t values to be copied.
+@param flags The array of tsk_flags_t values to be copied.
 @param time The array of double time values to be copied.
 @param population The array of tsk_id_t population values to be copied.
 @param individual The array of tsk_id_t individual values to be copied.
@@ -1370,7 +1372,7 @@ metadata schema is not affected.
 
 @param self A pointer to a tsk_node_table_t object.
 @param num_rows The number of rows to copy from the specifed arrays
-@param flags The array of tsk_flag_t values to be copied.
+@param flags The array of tsk_flags_t values to be copied.
 @param time The array of double time values to be copied.
 @param population The array of tsk_id_t population values to be copied.
 @param individual The array of tsk_id_t individual values to be copied.
@@ -1635,10 +1637,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_edge_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_edge_table_set_metadata_schema(tsk_edge_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -1949,10 +1952,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_migration_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_migration_table_set_metadata_schema(tsk_migration_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -2259,10 +2263,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_site_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_site_table_set_metadata_schema(tsk_site_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -2591,10 +2596,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_mutation_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_mutation_table_set_metadata_schema(tsk_mutation_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -2916,10 +2922,11 @@ Copies the metadata schema string to this table, replacing any existing.
 @param self A pointer to a tsk_population_table_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_population_table_set_metadata_schema(tsk_population_table_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Print out the state of this table to the specified stream.
@@ -3950,10 +3957,11 @@ Copies the time_units string to this table collection, replacing any existing.
 @param self A pointer to a tsk_table_collection_t object.
 @param time_units A pointer to a char array
 @param time_units_length The size of the time units string in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
-int tsk_table_collection_set_time_units(
-    tsk_table_collection_t *self, const char *time_units, tsk_size_t time_units_length);
+int tsk_table_collection_set_time_units(tsk_table_collection_t *self,
+    const char *time_units, tsk_size_t time_units_length, tsk_flags_t options);
 
 /**
 @brief Set the metadata
@@ -3963,10 +3971,11 @@ Copies the metadata string to this table collection, replacing any existing.
 @param self A pointer to a tsk_table_collection_t object.
 @param metadata A pointer to a char array
 @param metadata_length The size of the metadata in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
-int tsk_table_collection_set_metadata(
-    tsk_table_collection_t *self, const char *metadata, tsk_size_t metadata_length);
+int tsk_table_collection_set_metadata(tsk_table_collection_t *self, const char *metadata,
+    tsk_size_t metadata_length, tsk_flags_t options);
 
 /**
 @brief Set the metadata schema
@@ -3976,10 +3985,11 @@ Copies the metadata schema string to this table collection, replacing any existi
 @param self A pointer to a tsk_table_collection_t object.
 @param metadata_schema A pointer to a char array
 @param metadata_schema_length The size of the metadata schema in bytes.
+@param options Bitwise option flags.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_table_collection_set_metadata_schema(tsk_table_collection_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @brief Returns true if this table collection is indexed.
@@ -4148,14 +4158,14 @@ bool tsk_reference_sequence_equals(const tsk_reference_sequence_t *self,
     const tsk_reference_sequence_t *other, tsk_flags_t options);
 int tsk_reference_sequence_copy(const tsk_reference_sequence_t *self,
     tsk_reference_sequence_t *dest, tsk_flags_t options);
-int tsk_reference_sequence_set_data(
-    tsk_reference_sequence_t *self, const char *data, tsk_size_t data_length);
-int tsk_reference_sequence_set_url(
-    tsk_reference_sequence_t *self, const char *url, tsk_size_t url_length);
-int tsk_reference_sequence_set_metadata(
-    tsk_reference_sequence_t *self, const char *metadata, tsk_size_t metadata_length);
+int tsk_reference_sequence_set_data(tsk_reference_sequence_t *self, const char *data,
+    tsk_size_t data_length, tsk_flags_t options);
+int tsk_reference_sequence_set_url(tsk_reference_sequence_t *self, const char *url,
+    tsk_size_t url_length, tsk_flags_t options);
+int tsk_reference_sequence_set_metadata(tsk_reference_sequence_t *self,
+    const char *metadata, tsk_size_t metadata_length, tsk_flags_t options);
 int tsk_reference_sequence_set_metadata_schema(tsk_reference_sequence_t *self,
-    const char *metadata_schema, tsk_size_t metadata_schema_length);
+    const char *metadata_schema, tsk_size_t metadata_schema_length, tsk_flags_t options);
 
 /**
 @defgroup TABLE_SORTER_API_GROUP Low-level table sorter API.

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -1474,7 +1474,7 @@ IndividualTable_set_metadata_schema(IndividualTable *self, PyObject *arg, void *
         goto out;
     }
     err = tsk_individual_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -2041,7 +2041,7 @@ NodeTable_set_metadata_schema(NodeTable *self, PyObject *arg, void *closure)
         goto out;
     }
     err = tsk_node_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -2612,7 +2612,7 @@ EdgeTable_set_metadata_schema(EdgeTable *self, PyObject *arg, void *closure)
         goto out;
     }
     err = tsk_edge_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -3197,7 +3197,7 @@ MigrationTable_set_metadata_schema(MigrationTable *self, PyObject *arg, void *cl
         goto out;
     }
     err = tsk_migration_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -3739,7 +3739,7 @@ SiteTable_set_metadata_schema(SiteTable *self, PyObject *arg, void *closure)
         goto out;
     }
     err = tsk_site_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -4331,7 +4331,7 @@ MutationTable_set_metadata_schema(MutationTable *self, PyObject *arg, void *clos
         goto out;
     }
     err = tsk_mutation_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -4828,7 +4828,7 @@ PopulationTable_set_metadata_schema(PopulationTable *self, PyObject *arg, void *
         goto out;
     }
     err = tsk_population_table_set_metadata_schema(
-        self->table, metadata_schema, metadata_schema_length);
+        self->table, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -5908,7 +5908,7 @@ out:
 }
 
 typedef int(refseq_string_setter_func)(
-    tsk_reference_sequence_t *obj, const char *str, tsk_size_t len);
+    tsk_reference_sequence_t *obj, const char *str, tsk_size_t len, tsk_flags_t options);
 
 static int
 ReferenceSequence_set_string_attr(ReferenceSequence *self, PyObject *arg,
@@ -5935,7 +5935,7 @@ ReferenceSequence_set_string_attr(ReferenceSequence *self, PyObject *arg,
     if (str == NULL) {
         goto out;
     }
-    err = setter_func(self->reference_sequence, str, (tsk_size_t) length);
+    err = setter_func(self->reference_sequence, str, (tsk_size_t) length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6031,7 +6031,7 @@ ReferenceSequence_set_metadata(ReferenceSequence *self, PyObject *arg, void *clo
         goto out;
     }
     err = tsk_reference_sequence_set_metadata(
-        self->reference_sequence, metadata, metadata_length);
+        self->reference_sequence, metadata, metadata_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6447,7 +6447,7 @@ TableCollection_set_time_units(TableCollection *self, PyObject *arg, void *closu
         goto out;
     }
     err = tsk_table_collection_set_time_units(
-        self->tables, time_units, time_units_length);
+        self->tables, time_units, time_units_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6491,7 +6491,7 @@ TableCollection_set_metadata(TableCollection *self, PyObject *arg, void *closure
     if (err != 0) {
         goto out;
     }
-    err = tsk_table_collection_set_metadata(self->tables, metadata, metadata_length);
+    err = tsk_table_collection_set_metadata(self->tables, metadata, metadata_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -6531,7 +6531,7 @@ TableCollection_set_metadata_schema(TableCollection *self, PyObject *arg, void *
         goto out;
     }
     err = tsk_table_collection_set_metadata_schema(
-        self->tables, metadata_schema, metadata_schema_length);
+        self->tables, metadata_schema, metadata_schema_length, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/python/lwt_interface/tskit_lwt_interface.h
+++ b/python/lwt_interface/tskit_lwt_interface.h
@@ -358,7 +358,7 @@ parse_individual_table_dict(
             goto out;
         }
         err = tsk_individual_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -498,7 +498,7 @@ parse_node_table_dict(tsk_node_table_t *table, PyObject *dict, bool clear_table)
             goto out;
         }
         err = tsk_node_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -628,7 +628,7 @@ parse_edge_table_dict(tsk_edge_table_t *table, PyObject *dict, bool clear_table)
             goto out;
         }
         err = tsk_edge_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -779,7 +779,7 @@ parse_migration_table_dict(
             goto out;
         }
         err = tsk_migration_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -908,7 +908,7 @@ parse_site_table_dict(tsk_site_table_t *table, PyObject *dict, bool clear_table)
             goto out;
         }
         err = tsk_site_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1075,7 +1075,7 @@ parse_mutation_table_dict(tsk_mutation_table_t *table, PyObject *dict, bool clea
             goto out;
         }
         err = tsk_mutation_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1157,7 +1157,7 @@ parse_population_table_dict(
             goto out;
         }
         err = tsk_population_table_set_metadata_schema(
-            table, metadata_schema, metadata_schema_length);
+            table, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1346,7 +1346,7 @@ parse_reference_sequence_dict(tsk_reference_sequence_t *ref, PyObject *dict)
             goto out;
         }
         err = tsk_reference_sequence_set_metadata_schema(
-            ref, metadata_schema, (tsk_size_t) metadata_schema_length);
+            ref, metadata_schema, (tsk_size_t) metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1363,7 +1363,7 @@ parse_reference_sequence_dict(tsk_reference_sequence_t *ref, PyObject *dict)
         if (err != 0) {
             goto out;
         }
-        err = tsk_reference_sequence_set_metadata(ref, metadata, metadata_length);
+        err = tsk_reference_sequence_set_metadata(ref, metadata, metadata_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1380,7 +1380,7 @@ parse_reference_sequence_dict(tsk_reference_sequence_t *ref, PyObject *dict)
         if (data == NULL) {
             goto out;
         }
-        err = tsk_reference_sequence_set_data(ref, data, (tsk_size_t) data_length);
+        err = tsk_reference_sequence_set_data(ref, data, (tsk_size_t) data_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1397,7 +1397,7 @@ parse_reference_sequence_dict(tsk_reference_sequence_t *ref, PyObject *dict)
         if (url == NULL) {
             goto out;
         }
-        err = tsk_reference_sequence_set_url(ref, url, (tsk_size_t) url_length);
+        err = tsk_reference_sequence_set_url(ref, url, (tsk_size_t) url_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1440,7 +1440,7 @@ parse_table_collection_dict(tsk_table_collection_t *tables, PyObject *tables_dic
             goto out;
         }
         err = tsk_table_collection_set_metadata_schema(
-            tables, metadata_schema, metadata_schema_length);
+            tables, metadata_schema, metadata_schema_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1457,7 +1457,7 @@ parse_table_collection_dict(tsk_table_collection_t *tables, PyObject *tables_dic
         if (err != 0) {
             goto out;
         }
-        err = tsk_table_collection_set_metadata(tables, metadata, metadata_length);
+        err = tsk_table_collection_set_metadata(tables, metadata, metadata_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;
@@ -1474,7 +1474,8 @@ parse_table_collection_dict(tsk_table_collection_t *tables, PyObject *tables_dic
         if (time_units == NULL) {
             goto out;
         }
-        err = tsk_table_collection_set_time_units(tables, time_units, time_units_length);
+        err = tsk_table_collection_set_time_units(
+            tables, time_units, time_units_length, 0);
         if (err != 0) {
             handle_tskit_error(err);
             goto out;


### PR DESCRIPTION
Closes #1979

The idea of this was to open the ground for #1977, but I'm having second thoughts now because the ``x_table_set_columns`` doesn't have an options value (which I forgot).

I guess we could add an option to ``tsk_x_table_init(table, options)`` which is like ``TSK_EXTERNAL_MEMORY`` or something, which flicks a switch were we store pointers in ``set_columns`` and ``set_metadata_schema``, ``set_reference_sequence_data`` etc. So then, we don't need these options values.

I guess the alternative is to add ``options`` to all the ``x_tables_set_columns``.

Any thoughts @benjeffery?