### PR TITLE
Change name combinatorics to topological analysis

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -12,7 +12,7 @@ parts:
 - caption: Analysis
   chapters:
   - file: stats
-  - file: combinatorics
+  - file: topological-analysis
 - caption: Interfaces
   chapters:
   - file: python-api

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -278,14 +278,13 @@ Comparative
 
 The topology of a tree in a tree sequence refers to the relationship among
 samples ignoring branch lengths. Functionality as described in
-{ref}`sec_combinatorics` is mainly provided via
+{ref}`sec_topological_analysis` is mainly provided via
 {ref}`methods on trees<sec_python_api_trees_topological_analysis>`, but more
 efficient methods sometimes exist for entire tree sequences:
 
 ```{eval-rst}
 .. autosummary::
   TreeSequence.count_topologies
-
 ```
 
 (sec_python_api_tree_sequences_display)=
@@ -403,6 +402,9 @@ the encoding of the tree via `parent`, `left_child`, etc.
 or the most recent common ancestor (MRCA) of two nodes. This sort of information is
 available via simple and high performance {class}`Tree` methods
 
+
+(sec_python_api_trees_node_measures_simple)=
+
 ##### Simple measures
 
 These return a simple number, or (usually) short list of numbers relevant to a specific
@@ -425,7 +427,6 @@ Node information
       Tree.left_sib
       Tree.right_child
       Tree.left_child
-
       Tree.children
 
 Descendant nodes
@@ -441,6 +442,9 @@ Multiple nodes
       Tree.mrca
       Tree.tmrca
 ```
+
+
+(sec_python_api_trees_node_measures_array)=
 
 ##### Array access
 
@@ -468,15 +472,16 @@ Moving around within a tree usually involves visiting the tree nodes in some sor
 order. Often, given a particular order, it is convenient to iterate over each node
 using the :meth:`Tree.nodes` method. However, for high performance algorithms, it
 may be more convenient to access the node indices for a particular order as
-an array, and use this, for example, to index into one of the node arrays.
+an array, and use this, for example, to index into one of the node arrays (see
+{ref}`sec_topological_analysis_traversal`).
 
 ```{eval-rst}
-General
+Iterator access
     .. autosummary::
 
       Tree.nodes
 
-High performance
+Array access
     .. autosummary::
 
       Tree.postorder
@@ -484,27 +489,6 @@ High performance
       Tree.timeasc
       Tree.timedesc
 ```
-
-Here's an example which calculates the average number of descendants (the "arity)
-over all the nodes in a tree:
-
-```{code-cell} ipython3
-import msprime
-import numpy as np
-import tskit
-
-# Use a multiple merger process to make a tree where some nodes have >2 children
-ts = msprime.sim_ancestry(10, random_seed=1, model=msprime.BetaCoalescent(alpha=1.001))
-tree = ts.first()
-# Order doesn't matter in this example, so use tree.preorder, which is fastest
-parent_id, count = np.unique(tree.parent_array[tree.preorder()], return_counts=True)
-print(f"Average arity is {count[parent_id != tskit.NULL].mean()}")
-```
-
-:::{todo}
-Move this example into the "combinatorics" chapter, renaming the chapter
-"topological analysis"
-:::
 
 
 (sec_python_api_trees_topological_analysis)=

--- a/docs/topological-analysis.md
+++ b/docs/topological-analysis.md
@@ -14,9 +14,117 @@ kernelspec:
 ```{currentmodule} tskit
 ```
 
+(sec_topological_analysis)=
+
+# Topological analysis
+
+The branching structure of a tree is known as the tree *topology*. Dealing with the
+topological structure of trees is of key importance in dealing with genealogies
+such as those encoded in the tree sequence structure.
+
+
+(sec_topological_analysis_traversal)=
+
+## Visiting nodes
+
+
+(sec_topological_analysis_descending)=
+
+### Descendant traversal
+
+A basic thing to want to do is to visit all the nodes in a tree under a focal node
+(i.e. the focal node and all its descendants). This can be done in various
+*traversal orders*. The `tskit` library provides several methods to do this, such
+as {meth}`Tree.nodes` in the {ref}`sec_python_api`. By default, this method
+iterates over all the descendant nodes of the root(s) of the tree, and hence
+visits all the tree's nodes:
+
+```{code-cell} ipython3
+import tskit
+from IPython.display import SVG, display
+
+tree = tskit.Tree.generate_balanced(10, arity=3)
+display(SVG(tree.draw_svg()))
+
+for order in ["preorder", "inorder", "postorder"]:
+    print(f"{order}:\t", list(tree.nodes(order=order)))
+```
+
+Providing a focal node ID allows us to traverse through that node's descendants.
+For instance, here we visit node 13 and its descendants:
+
+```{code-cell} ipython3
+print("Nodes under node 13:", [u for u in tree.nodes(13)])
+```
+
+The node IDs returned by traversal methods allow us to to access node information.
+Below, for example, we use the {meth}`Tree.num_children` method to find the number of
+children (the "arity") of every non-leaf node, and take the average. Since the
+specific ordering of descendant nodes is not important in this case, we can leave
+it out (defaulting to preorder traversal, the most efficient order):
+
+```{code-cell} ipython3
+import numpy as np
+av_arity = np.mean([tree.num_children(u) for u in tree.nodes() if not tree.is_leaf(u)])
+print(f"Average arity of internal nodes: {av_arity}")
+```
+
+:::{note}
+In `tskit`, a tree can have multiple {ref}`sec_data_model_tree_roots`, each with a
+descendant topology.  However, for some algorithms, instead of traversing through
+the descendants of each root of a tree in turn, it can be helpful to start at a
+single node and traverse downwards through the entire genealogy. The
+{ref}`virtual root<sec_data_model_tree_virtual_root>` is provided for this purpose.
+:::
+
+#### Array methods
+
+The {meth}`Tree.nodes` iterator provides a convenient way of looping over descendant
+node IDs, but it can be more efficient to deal with all the IDs at once, as a
+single array of values. This can be combined with
+{ref}`direct memory access<sec_python_api_trees_node_measures_array>` resulting in a
+high performance approach. Here, for example, is an equivalent
+array-based method to find the average arity of internal nodes, by counting
+how many times a node is referenced as a parent:
+
+```{code-cell} ipython3
+parent_id, count = np.unique(tree.parent_array[tree.preorder()], return_counts=True)
+print(f"Average arity is {count[parent_id != tskit.NULL].mean()}")
+```
+
+:::{seealso}
+The {ref}`sec_analysing_trees` tutorial provides a number of additional examples
+of tree traversal techniques, with different performance characteristics.
+:::
+
+
+(sec_topological_analysis_ascending)=
+
+### Ascending traversal
+
+For many applications it is useful to be able to traverse upwards from a node or set
+of nodes, such as the leaves. We can do this by iterating over parents. Here, for
+example, we traverse upwards from each of the samples in the tree:
+
+```{code-cell} ipython3
+for u in tree.samples():
+    path = []
+    v = u
+    while v != tskit.NULL:
+        path.append(v)
+        v = tree.parent(v)
+    print(u, "->", path)
+```
+
+:::{todo}
+Indicate that this can be made performant using `numba`, and link out to a tutorial
+on high performance methods including the `numba` approach.
+:::
+
+
 (sec_combinatorics)=
 
-# Combinatorics
+## Identifying and counting topologies
 
 tskit uses a combinatorial approach to identify unique topologies of
 rooted, leaf-labelled trees. It provides methods
@@ -39,9 +147,23 @@ rather, they cover general, rooted trees without unary nodes.
   - Return a generator over all labellings of the given tree's shape.
 ```
 
+:::{note}
+As the number of nodes increases, the number of different topologies rises
+extremely rapidly (see its entry in the
+[On-Line Encyclopedia of Integer Sequences](https://oeis.org/A000311)). This
+combinatorial explosion is a major limitation in any analysis that attempts to
+explore possible topologies. For example, although the {func}`tskit.all_trees`
+function above will happily start generating topologies for (say) a tree of 50
+leaves, the total number of possible topologies is over $6^81$, which is of
+the same order as the number of atoms in the observable universe. Generating
+all the topologies of a tree with anything much more than 10 tips is likely
+to be impracticable.
+:::
+
+
 (sec_tree_ranks)=
 
-## Interpreting Tree Ranks
+### Interpreting Tree Ranks
 
 To understand tree ranks we must look at how leaf-labelled tree topologies
 are enumerated. For example, we can use {func}`tskit.all_trees`
@@ -95,7 +217,7 @@ for rank in [(0, 0), (1, 0), (1, 1), (1, 2)]:
     display(SVG(t.draw_svg(node_labels={0: 0, 1: 1, 2: 2}, order="tree", size=(120, 120))))
 ```
 
-## Examples
+#### Examples
 
 One application of tree ranks is to count the different
 leaf-labelled topologies in a tree sequence. Since the ranks
@@ -118,7 +240,7 @@ display(SVG(most_freq_topology.draw_svg(node_labels={0: 0, 1: 1, 2: 2, 3: 3})))
 
 (sec_enumerating_topologies)=
 
-## Enumerating Topologies
+### Enumerating Topologies
 
 This section expands briefly on the approach used to enumerate
 tree topologies that serves as the basis for {meth}`Tree.rank`
@@ -127,7 +249,7 @@ To enumerate all rooted, leaf-labelled tree topologies, we first
 formulate a system of ordering and enumerating tree shapes. Then
 we define an enumeration of labellings given an arbitrary tree shape.
 
-### Enumerating Tree Shapes
+#### Enumerating Tree Shapes
 
 Starting with $n = 1$, we see that the only shape for a tree
 with a single leaf is a single root leaf. A tree with $n > 1$
@@ -163,7 +285,7 @@ This is important because it prevents us from repeating trees that are
 topologically the same but whose children are ordered differently.
 ```
 
-### Labelling Tree Shapes
+#### Labelling Tree Shapes
 
 Tree shapes are useful in and of themselves, but we can use the enumeration
 formulated above to go further and assign labels to the leaves of each shape.


### PR DESCRIPTION
And add example of traversal. This will somewhat replace the [current section in the tutorial](https://tskit.dev/tutorials/analysing_trees.html#tree-traversals), but we decided it would be sensible to have a basic introduction in the docs.

Fixes #1951 