### PR TITLE
Add the skip_reference_sequence and ignore_reference_sequence options

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -65,6 +65,11 @@
 
 - Add reference sequence to table collection (:user:`benjeffery`, :issue:`146`, :pr:`1911`)
 
+- Add the TSK_LOAD_SKIP_REFERENCE_SEQUENCE option to load a table collection
+  without the reference sequence. Also add the TSK_CMP_IGNORE_REFERENCE_SEQUENCE
+  option to compare two table collections without comparing their reference
+  sequence. (:user:`clwgg`, :pr:`2019`, :issue:`1971`).
+
 - FIXME add features for virtual root, num_edges, stack allocation size etc
 
 **Fixes**

--- a/c/tests/test_file_format.c
+++ b/c/tests/test_file_format.c
@@ -1338,6 +1338,67 @@ test_skip_tables(void)
     free(ts1);
 }
 
+static void
+test_skip_reference_sequence(void)
+{
+    int ret;
+    tsk_treeseq_t *ts1 = caterpillar_tree(5, 3, 3);
+    tsk_treeseq_t ts2;
+    tsk_table_collection_t t1, t2;
+    FILE *f;
+
+    CU_ASSERT_TRUE(tsk_treeseq_has_reference_sequence(ts1));
+
+    ret = tsk_treeseq_dump(ts1, _tmp_file_name, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_load(
+        &t1, _tmp_file_name, TSK_LOAD_SKIP_REFERENCE_SEQUENCE);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    CU_ASSERT_FALSE(tsk_table_collection_equals(&t1, ts1->tables, 0));
+    CU_ASSERT_TRUE(tsk_table_collection_equals(
+        &t1, ts1->tables, TSK_CMP_IGNORE_REFERENCE_SEQUENCE));
+    CU_ASSERT_FALSE(tsk_table_collection_has_reference_sequence(&t1));
+
+    /* Test _loadf code path as well */
+    f = fopen(_tmp_file_name, "r+");
+    ret = tsk_table_collection_loadf(&t2, f, TSK_LOAD_SKIP_REFERENCE_SEQUENCE);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&t1, &t2, 0));
+    fclose(f);
+    tsk_table_collection_free(&t2);
+
+    /* Setting TSK_LOAD_SKIP_REFERENCE_SEQUENCE only reads part of the file */
+    f = fopen(_tmp_file_name, "r+");
+    ret = tsk_table_collection_loadf(&t2, f, TSK_LOAD_SKIP_REFERENCE_SEQUENCE);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_NOT_EQUAL(fgetc(f), EOF);
+    fclose(f);
+    tsk_table_collection_free(&t2);
+
+    /* We should be able to make a tree sequence */
+    ret = tsk_treeseq_init(&ts2, &t1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tsk_treeseq_free(&ts2);
+
+    /* Do the same thing with treeseq API */
+    ret = tsk_treeseq_load(&ts2, _tmp_file_name, TSK_LOAD_SKIP_REFERENCE_SEQUENCE);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&t1, ts2.tables, 0));
+    tsk_treeseq_free(&ts2);
+
+    f = fopen(_tmp_file_name, "r+");
+    ret = tsk_treeseq_loadf(&ts2, f, TSK_LOAD_SKIP_REFERENCE_SEQUENCE);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&t1, ts2.tables, 0));
+    fclose(f);
+    tsk_treeseq_free(&ts2);
+
+    tsk_table_collection_free(&t1);
+    tsk_treeseq_free(ts1);
+    free(ts1);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1362,6 +1423,7 @@ main(int argc, char **argv)
         { "test_multiple_round_trip", test_multiple_round_trip },
         { "test_copy_store_drop_columns", test_copy_store_drop_columns },
         { "test_skip_tables", test_skip_tables },
+        { "test_skip_reference_sequence", test_skip_reference_sequence },
         { NULL, NULL },
     };
 

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -314,6 +314,27 @@ test_table_collection_equals_options(void)
 
     tsk_table_collection_free(&tc1);
     tsk_table_collection_free(&tc2);
+
+    // Ignore reference sequence
+    ret = tsk_table_collection_init(&tc1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_init(&tc2, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_table_collection_set_metadata(
+        &tc1, example_metadata, example_metadata_length);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = tsk_table_collection_set_metadata(
+        &tc2, example_metadata, example_metadata_length);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(&tc1, &tc2, 0));
+    ret = tsk_reference_sequence_set_data(&tc1.reference_sequence, "A", 1);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_FALSE(tsk_table_collection_equals(&tc1, &tc2, 0));
+    CU_ASSERT_TRUE(
+        tsk_table_collection_equals(&tc1, &tc2, TSK_CMP_IGNORE_REFERENCE_SEQUENCE));
+
+    tsk_table_collection_free(&tc1);
+    tsk_table_collection_free(&tc2);
 }
 
 static void

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -728,6 +728,7 @@ typedef struct {
 /* This shares an interface with table collection init.
    TODO: review as part of #1720 */
 #define TSK_LOAD_SKIP_TABLES (1 << 1)
+#define TSK_LOAD_SKIP_REFERENCE_SEQUENCE (1 << 2)
 
 /* Flags for table init. */
 #define TSK_NO_METADATA (1 << 0)
@@ -742,6 +743,7 @@ typedef struct {
 #define TSK_CMP_IGNORE_METADATA (1 << 2)
 #define TSK_CMP_IGNORE_TIMESTAMPS (1 << 3)
 #define TSK_CMP_IGNORE_TABLES (1 << 4)
+#define TSK_CMP_IGNORE_REFERENCE_SEQUENCE (1 << 5)
 
 /* Flags for table collection clear */
 #define TSK_CLEAR_METADATA_SCHEMAS (1 << 0)
@@ -3421,6 +3423,8 @@ TSK_CMP_IGNORE_TIMESTAMPS
 TSK_CMP_IGNORE_TABLES
     Do not include any tables in the comparison, thus comparing only the
     top-level information of the table collections being compared.
+TSK_CMP_IGNORE_REFERENCE_SEQUENCE
+    Do not include the reference sequence in the comparison.
 @endrst
 
 @param self A pointer to a tsk_table_collection_t object.
@@ -3479,8 +3483,11 @@ If the file contains multiple table collections, this function will load
 the first. Please see the :c:func:`tsk_table_collection_loadf` for details
 on how to sequentially load table collections from a stream.
 
-If the TSK_LOAD_SKIP_TABLES option is set, only the top-level
-information of the table collection will be read, leaving all tables empty.
+If the TSK_LOAD_SKIP_TABLES option is set, only the non-table information from
+the table collection will be read, leaving all tables with zero rows and no
+metadata or schema.
+If the TSK_LOAD_SKIP_REFERENCE_SEQUENCE option is set, the table collection is
+read without loading the reference sequence.
 
 **Options**
 
@@ -3491,6 +3498,8 @@ TSK_NO_INIT
     Do not initialise this :c:type:`tsk_table_collection_t` before loading.
 TSK_LOAD_SKIP_TABLES
     Skip reading tables, and only load top-level information.
+TSK_LOAD_SKIP_REFERENCE_SEQUENCE
+    Do not load reference sequence.
 
 **Examples**
 
@@ -3539,10 +3548,14 @@ different error conditions. Please see the
 sequentially load tree sequences from a stream.
 
 Please note that this streaming behaviour is not supported if the
-TSK_LOAD_SKIP_TABLES option is set. With this option, only the top-level
-information of the table collection will be read, leaving all tables empty. When
-attempting to read from a stream with multiple table collection definitions and
-the TSK_LOAD_SKIP_TABLES option set, only the top-level information of the first
+TSK_LOAD_SKIP_TABLES or TSK_LOAD_SKIP_REFERENCE_SEQUENCE option is set.
+If the TSK_LOAD_SKIP_TABLES option is set, only the non-table information from
+the table collection will be read, leaving all tables with zero rows and no
+metadata or schema.
+If the TSK_LOAD_SKIP_REFERENCE_SEQUENCE option is set, the table collection is
+read without loading the reference sequence.
+When attempting to read from a stream with multiple table collection definitions
+and either of these two options set, the requested information from the first
 table collection will be read on the first call to
 :c:func:`tsk_table_collection_loadf`, with subsequent calls leading to errors.
 
@@ -3555,6 +3568,8 @@ TSK_NO_INIT
     Do not initialise this :c:type:`tsk_table_collection_t` before loading.
 TSK_LOAD_SKIP_TABLES
     Skip reading tables, and only load top-level information.
+TSK_LOAD_SKIP_REFERENCE_SEQUENCE
+    Do not load reference sequence.
 
 @endrst
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -104,8 +104,13 @@
 
 - Add the ``skip_tables`` option to ``load`` to support only loading
   top-level information from a file. Also add the ``ignore_tables`` option to
-  to the ``TableCollection.equals`` and ``TableCollection.assert_equals`` to
+  ``TableCollection.equals`` and ``TableCollection.assert_equals`` to
   compare only top-level information. (:user:`clwgg`, :pr:`1882`, :issue:`1854`).
+
+- Add the ``skip_reference_sequence`` option to ``load``. Also add the
+  ``ignore_reference_sequence`` option ``equals`` to compare two table
+  collections without comparing their reference sequence. (:user:`clwgg`,
+  :pr:`2019`, :issue:`1971`).
 
 - tskit now supports python 3.10 (:user:`benjeffery`, :issue:`1895`, :pr:`1949`)
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7205,15 +7205,18 @@ TableCollection_equals(TableCollection *self, PyObject *args, PyObject *kwds)
     int ignore_provenance = false;
     int ignore_timestamps = true;
     int ignore_tables = false;
-    static char *kwlist[] = { "other", "ignore_metadata", "ignore_ts_metadata",
-        "ignore_provenance", "ignore_timestamps", "ignore_tables", NULL };
+    int ignore_reference_sequence = false;
+    static char *kwlist[]
+        = { "other", "ignore_metadata", "ignore_ts_metadata", "ignore_provenance",
+              "ignore_timestamps", "ignore_tables", "ignore_reference_sequence", NULL };
 
     if (TableCollection_check_state(self)) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|iiiii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|iiiiii", kwlist,
             &TableCollectionType, &other, &ignore_metadata, &ignore_ts_metadata,
-            &ignore_provenance, &ignore_timestamps, &ignore_tables)) {
+            &ignore_provenance, &ignore_timestamps, &ignore_tables,
+            &ignore_reference_sequence)) {
         goto out;
     }
     if (ignore_metadata) {
@@ -7230,6 +7233,9 @@ TableCollection_equals(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     if (ignore_tables) {
         options |= TSK_CMP_IGNORE_TABLES;
+    }
+    if (ignore_reference_sequence) {
+        options |= TSK_CMP_IGNORE_REFERENCE_SEQUENCE;
     }
     if (TableCollection_check_state(other) != 0) {
         goto out;
@@ -7322,14 +7328,18 @@ TableCollection_load(TableCollection *self, PyObject *args, PyObject *kwds)
     FILE *file = NULL;
     tsk_flags_t options = 0;
     int skip_tables = false;
-    static char *kwlist[] = { "file", "skip_tables", NULL };
+    int skip_reference_sequence = false;
+    static char *kwlist[] = { "file", "skip_tables", "skip_reference_sequence", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "O|i", kwlist, &py_file, &skip_tables)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ii", kwlist, &py_file, &skip_tables,
+            &skip_reference_sequence)) {
         goto out;
     }
     if (skip_tables) {
         options |= TSK_LOAD_SKIP_TABLES;
+    }
+    if (skip_reference_sequence) {
+        options |= TSK_LOAD_SKIP_REFERENCE_SEQUENCE;
     }
     file = make_file(py_file, "rb");
     if (file == NULL) {
@@ -7719,14 +7729,18 @@ TreeSequence_load(TreeSequence *self, PyObject *args, PyObject *kwds)
     FILE *file = NULL;
     tsk_flags_t options = 0;
     int skip_tables = false;
-    static char *kwlist[] = { "file", "skip_tables", NULL };
+    int skip_reference_sequence = false;
+    static char *kwlist[] = { "file", "skip_tables", "skip_reference_sequence", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "O|i", kwlist, &py_file, &skip_tables)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ii", kwlist, &py_file, &skip_tables,
+            &skip_reference_sequence)) {
         goto out;
     }
     if (skip_tables) {
         options |= TSK_LOAD_SKIP_TABLES;
+    }
+    if (skip_reference_sequence) {
+        options |= TSK_LOAD_SKIP_REFERENCE_SEQUENCE;
     }
     file = make_file(py_file, "rb");
     if (file == NULL) {

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -2313,6 +2313,12 @@ class TestTreeSequence(HighLevelTestCase):
         t2 = tc.tree_sequence()
         assert not t1.equals(t2)
         assert t1.equals(t2, ignore_tables=True)
+        # Empty out reference to test ignore_reference_sequence flag
+        tc = t1.dump_tables()
+        tc.reference_sequence.clear()
+        t2 = tc.tree_sequence()
+        assert not t1.equals(t2)
+        assert t1.equals(t2, ignore_reference_sequence=True)
         # Make t1 and t2 equal again
         t2 = t1.dump_tables().tree_sequence()
         assert t1.equals(t2)

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -186,6 +186,26 @@ class TestTableCollection(LowLevelTestCase):
                 with pytest.raises(TypeError):
                     tc_skip.load(f, skip_tables=bad_bool)
 
+    def test_skip_reference_sequence(self, tmp_path):
+        tc = _tskit.TableCollection(1)
+        self.get_example_tree_sequence().dump_tables(tc)
+        tc.reference_sequence.data = "ACGT"
+        with open(tmp_path / "tmp.trees", "wb") as f:
+            tc.dump(f)
+
+        for good_bool in [1, True]:
+            with open(tmp_path / "tmp.trees", "rb") as f:
+                tc_skip = _tskit.TableCollection()
+                tc_skip.load(f, skip_reference_sequence=good_bool)
+            assert not tc.equals(tc_skip)
+            assert tc.equals(tc_skip, ignore_reference_sequence=True)
+
+        for bad_bool in ["x", 0.5, {}]:
+            with open(tmp_path / "tmp.trees", "rb") as f:
+                tc_skip = _tskit.TableCollection()
+                with pytest.raises(TypeError):
+                    tc_skip.load(f, skip_reference_sequence=bad_bool)
+
     def test_file_errors(self):
         tc1 = _tskit.TableCollection(1)
         self.get_example_tree_sequence().dump_tables(tc1)
@@ -411,6 +431,8 @@ class TestTableCollection(LowLevelTestCase):
             tc.equals(tc, ignore_timestamps=bad_bool)
         with pytest.raises(TypeError):
             tc.equals(tc, ignore_tables=bad_bool)
+        with pytest.raises(TypeError):
+            tc.equals(tc, ignore_reference_sequence=bad_bool)
 
     def test_asdict(self):
         for ts in self.get_example_tree_sequences():
@@ -1104,6 +1126,30 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
                 ts_skip = _tskit.TreeSequence()
                 with pytest.raises(TypeError):
                     ts_skip.load(f, skip_tables=bad_bool)
+
+    def test_skip_reference_sequence(self, tmp_path):
+        tc = _tskit.TableCollection(1)
+        self.get_example_tree_sequence().dump_tables(tc)
+        tc.reference_sequence.data = "ACGT"
+        ts = _tskit.TreeSequence()
+        ts.load_tables(tc, build_indexes=True)
+        with open(tmp_path / "tmp.trees", "wb") as f:
+            ts.dump(f)
+
+        for good_bool in [1, True]:
+            with open(tmp_path / "tmp.trees", "rb") as f:
+                ts_skip = _tskit.TreeSequence()
+                ts_skip.load(f, skip_reference_sequence=good_bool)
+            tc_skip = _tskit.TableCollection()
+            ts_skip.dump_tables(tc_skip)
+            assert not tc.equals(tc_skip)
+            assert tc.equals(tc_skip, ignore_reference_sequence=True)
+
+        for bad_bool in ["x", 0.5, {}]:
+            with open(tmp_path / "tmp.trees", "rb") as f:
+                ts_skip = _tskit.TreeSequence()
+                with pytest.raises(TypeError):
+                    ts_skip.load(f, skip_reference_sequence=bad_bool)
 
     def test_file_errors(self):
         ts1 = self.get_example_tree_sequence()

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -4018,6 +4018,18 @@ class TestTableCollectionAssertEquals:
             t1.assert_equals(t2)
         t1.assert_equals(t2, ignore_tables=True)
 
+    def test_ignore_reference_sequence(self, t1, t2):
+        t2.reference_sequence.clear()
+        with pytest.raises(
+            AssertionError,
+            match=re.escape(
+                "Metadata schemas differ: "
+                "self=OrderedDict([('codec', 'json')]) other=None"
+            ),
+        ):
+            t1.assert_equals(t2)
+        t1.assert_equals(t2, ignore_reference_sequence=True)
+
 
 class TestTableCollectionMethodSignatures:
     tc = msprime.simulate(10, random_seed=1234).dump_tables()

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -2965,6 +2965,7 @@ class TableCollection(metadata.MetadataProvider):
         ignore_provenance=False,
         ignore_timestamps=False,
         ignore_tables=False,
+        ignore_reference_sequence=False,
     ):
         """
         Returns True if  `self` and `other` are equal. By default, two table
@@ -2995,6 +2996,8 @@ class TableCollection(metadata.MetadataProvider):
             parameter has no effect.
         :param bool ignore_tables: If True no tables are included in the
             comparison, thus comparing only the top-level information.
+        :param bool ignore_reference_sequence: If True the reference sequence
+            is not included in the comparison.
         :return: True if other is equal to this table collection; False otherwise.
         :rtype: bool
         """
@@ -3008,6 +3011,7 @@ class TableCollection(metadata.MetadataProvider):
                     ignore_provenance=bool(ignore_provenance),
                     ignore_timestamps=bool(ignore_timestamps),
                     ignore_tables=bool(ignore_tables),
+                    ignore_reference_sequence=bool(ignore_reference_sequence),
                 )
             )
         return ret
@@ -3021,6 +3025,7 @@ class TableCollection(metadata.MetadataProvider):
         ignore_provenance=False,
         ignore_timestamps=False,
         ignore_tables=False,
+        ignore_reference_sequence=False,
     ):
         """
         Raise an AssertionError for the first found difference between
@@ -3040,6 +3045,8 @@ class TableCollection(metadata.MetadataProvider):
             parameter has no effect.
         :param bool ignore_tables: If True no tables are included in the
             comparison, thus comparing only the top-level information.
+        :param bool ignore_reference_sequence: If True the reference sequence
+            is not included in the comparison.
         """
         if type(other) is not type(self):
             raise AssertionError(f"Types differ: self={type(self)} other={type(other)}")
@@ -3052,15 +3059,17 @@ class TableCollection(metadata.MetadataProvider):
             ignore_provenance=ignore_provenance,
             ignore_timestamps=ignore_timestamps,
             ignore_tables=ignore_tables,
+            ignore_reference_sequence=ignore_reference_sequence,
         ):
             return
 
         if not ignore_metadata or ignore_ts_metadata:
             super().assert_equals(other)
 
-        self.reference_sequence.assert_equals(
-            other.reference_sequence, ignore_metadata=ignore_metadata
-        )
+        if not ignore_reference_sequence:
+            self.reference_sequence.assert_equals(
+                other.reference_sequence, ignore_metadata=ignore_metadata
+            )
 
         if self.time_units != other.time_units:
             raise AssertionError(
@@ -3097,10 +3106,14 @@ class TableCollection(metadata.MetadataProvider):
         return self.asdict()
 
     @classmethod
-    def load(cls, file_or_path, *, skip_tables=False):
+    def load(cls, file_or_path, *, skip_tables=False, skip_reference_sequence=False):
         file, local_file = util.convert_file_like_to_open_file(file_or_path, "rb")
         ll_tc = _tskit.TableCollection(1)
-        ll_tc.load(file, skip_tables=skip_tables)
+        ll_tc.load(
+            file,
+            skip_tables=skip_tables,
+            skip_reference_sequence=skip_reference_sequence,
+        )
         tc = TableCollection(1)
         tc._ll_tables = ll_tc
         return tc


### PR DESCRIPTION
## Description

Fixes #1971

Adds two new C flags: `TSK_LOAD_SKIP_REFERENCE_SEQUENCE` and `TSK_CMP_IGNORE_REFERENCE_SEQUENCE`.
These are exposed to python as the `skip_reference_sequence` flag to `TableCollection.load` and `TreeSequence.load`, as well as the `ignore_reference_sequence` flag to `TableCollection.equals` and `TreeSequence.equals`.
Since the flags were written this way in the issue I kept them "written out", though I think an argument could be made to shorten `reference_sequence` to `refseq` in all four cases (your call @jeromekelleher, @benjeffery).

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
