### PR TITLE
Document table row classes & provenance classes

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1234,7 +1234,8 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
 % Overriding the default signatures for the tables here as they will be
 % confusing to most users.
 
-#### The {class}`IndividualTable` class
+
+#### {class}`IndividualTable` classes
 
 ```{eval-rst}
 .. autoclass:: IndividualTable()
@@ -1243,7 +1244,20 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`NodeTable` class
+##### Associated row class
+
+A row returned from an {class}`IndividualTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Individual` class.
+
+```{eval-rst}
+.. autoclass:: IndividualTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`NodeTable` classes
 
 ```{eval-rst}
 .. autoclass:: NodeTable()
@@ -1252,7 +1266,20 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`EdgeTable` class
+##### Associated row class
+
+A row returned from a {class}`NodeTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Node` class.
+
+```{eval-rst}
+.. autoclass:: NodeTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`EdgeTable` classes
 
 ```{eval-rst}
 .. autoclass:: EdgeTable()
@@ -1261,7 +1288,20 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`MigrationTable` class
+##### Associated row class
+
+A row returned from an {class}`EdgeTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Edge` class.
+
+```{eval-rst}
+.. autoclass:: EdgeTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`MigrationTable` classes
 
 ```{eval-rst}
 .. autoclass:: MigrationTable()
@@ -1270,7 +1310,20 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`SiteTable` class
+##### Associated row class
+
+A row returned from a {class}`MigrationTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Migration` class.
+
+```{eval-rst}
+.. autoclass:: MigrationTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`SiteTable` classes
 
 ```{eval-rst}
 .. autoclass:: SiteTable()
@@ -1279,7 +1332,20 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`MutationTable` class
+##### Associated row class
+
+A row returned from a {class}`SiteTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Site` class.
+
+```{eval-rst}
+.. autoclass:: SiteTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`MutationTable` classes
 
 ```{eval-rst}
 .. autoclass:: MutationTable()
@@ -1288,7 +1354,20 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`PopulationTable` class
+##### Associated row class
+
+A row returned from a {class}`MutationTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Mutation` class.
+
+```{eval-rst}
+.. autoclass:: MutationTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`PopulationTable` classes
 
 ```{eval-rst}
 .. autoclass:: PopulationTable()
@@ -1297,15 +1376,42 @@ Also see the {ref}`sec_tables_api_table_collection` summary.
     :special-members: __getitem__
 ```
 
-#### The {class}`ProvenanceTable` class
+##### Associated row class
 
-Also see the {ref}`sec_python_api_provenance` summary.
+A row returned from a {class}`PopulationTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Population` class.
+
+```{eval-rst}
+.. autoclass:: PopulationTableRow()
+    :members:
+    :inherited-members:
+```
+
+
+#### {class}`ProvenanceTable` classes
+
+Also see the {ref}`sec_provenance` and
+{ref}`provenance API methods<sec_python_api_provenance>`.
 
 ```{eval-rst}
 .. autoclass:: ProvenanceTable()
     :members:
     :inherited-members:
 ```
+
+##### Associated row class
+
+A row returned from a {class}`ProvenanceTable` is an instance of the following
+basic class, where each attribute matches an identically named attribute in the
+{class}`Provenance` class.
+
+```{eval-rst}
+.. autoclass:: ProvenanceTableRow()
+    :members:
+    :inherited-members:
+```
+
 
 ### Miscellaneous classes
 

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -64,11 +64,27 @@ class NOTSET(metaclass=NotSetMeta):
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class IndividualTableRow(util.Dataclass):
+    """
+    A row in an :class:`IndividualTable`.
+    """
+
     __slots__ = ["flags", "location", "parents", "metadata"]
     flags: int
+    """
+    See :attr:`Individual.flags`
+    """
     location: np.ndarray
+    """
+    See :attr:`Individual.location`
+    """
     parents: np.ndarray
+    """
+    See :attr:`Individual.parents`
+    """
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Individual.metadata`
+    """
 
     # We need a custom eq for the numpy arrays
     def __eq__(self, other):
@@ -84,57 +100,155 @@ class IndividualTableRow(util.Dataclass):
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class NodeTableRow(util.Dataclass):
+    """
+    A row in a :class:`NodeTable`.
+    """
+
     __slots__ = ["flags", "time", "population", "individual", "metadata"]
     flags: int
+    """
+    See :attr:`Node.flags`
+    """
     time: float
+    """
+    See :attr:`Node.time`
+    """
     population: int
+    """
+    See :attr:`Node.population`
+    """
     individual: int
+    """
+    See :attr:`Node.individual`
+    """
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Node.metadata`
+    """
 
 
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class EdgeTableRow(util.Dataclass):
+    """
+    A row in an :class:`EdgeTable`.
+    """
+
     __slots__ = ["left", "right", "parent", "child", "metadata"]
     left: float
+    """
+    See :attr:`Edge.left`
+    """
     right: float
+    """
+    See :attr:`Edge.right`
+    """
     parent: int
+    """
+    See :attr:`Edge.parent`
+    """
     child: int
+    """
+    See :attr:`Edge.child`
+    """
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Edge.metadata`
+    """
 
 
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class MigrationTableRow(util.Dataclass):
+    """
+    A row in a :class:`MigrationTable`.
+    """
+
     __slots__ = ["left", "right", "node", "source", "dest", "time", "metadata"]
     left: float
+    """
+    See :attr:`Migration.left`
+    """
     right: float
+    """
+    See :attr:`Migration.right`
+    """
     node: int
+    """
+    See :attr:`Migration.node`
+    """
     source: int
+    """
+    See :attr:`Migration.source`
+    """
     dest: int
+    """
+    See :attr:`Migration.dest`
+    """
     time: float
+    """
+    See :attr:`Migration.time`
+    """
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Migration.metadata`
+    """
 
 
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class SiteTableRow(util.Dataclass):
+    """
+    A row in a :class:`SiteTable`.
+    """
+
     __slots__ = ["position", "ancestral_state", "metadata"]
     position: float
+    """
+    See :attr:`Site.position`
+    """
     ancestral_state: str
+    """
+    See :attr:`Site.ancestral_state`
+    """
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Site.metadata`
+    """
 
 
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class MutationTableRow(util.Dataclass):
+    """
+    A row in a :class:`MutationTable`.
+    """
+
     __slots__ = ["site", "node", "derived_state", "parent", "metadata", "time"]
     site: int
+    """
+    See :attr:`Mutation.site`
+    """
     node: int
+    """
+    See :attr:`Mutation.node`
+    """
     derived_state: str
+    """
+    See :attr:`Mutation.derived_state`
+    """
     parent: int
+    """
+    See :attr:`Mutation.parent`
+    """
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Mutation.metadata`
+    """
     time: float
+    """
+    See :attr:`Mutation.time`
+    """
 
     # We need a custom eq here as we have unknown times (nans) to check
     def __eq__(self, other):
@@ -157,15 +271,32 @@ class MutationTableRow(util.Dataclass):
 @metadata.lazy_decode
 @dataclass(**dataclass_options)
 class PopulationTableRow(util.Dataclass):
+    """
+    A row in a :class:`PopulationTable`.
+    """
+
     __slots__ = ["metadata"]
     metadata: Optional[Union[bytes, dict]]
+    """
+    See :attr:`Population.metadata`
+    """
 
 
 @dataclass(**dataclass_options)
 class ProvenanceTableRow(util.Dataclass):
+    """
+    A row in a :class:`ProvenanceTable`.
+    """
+
     __slots__ = ["timestamp", "record"]
     timestamp: str
+    """
+    See :attr:`Provenance.timestamp`
+    """
     record: str
+    """
+    See :attr:`Provenance.record`
+    """
 
 
 @dataclass(**dataclass_options)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -604,8 +604,8 @@ class Edgeset(util.Dataclass):
 @dataclass
 class Provenance(util.Dataclass):
     """
-    A provenance entry in a tree sequence, detailing what how this tree
-    sequence was generated, or what has been done to it (see :ref:`sec_provenance`).
+    A provenance entry in a tree sequence, detailing how this tree
+    sequence was generated, or subsequent operations on it (see :ref:`sec_provenance`).
     """
 
     __slots__ = ["id", "timestamp", "record"]

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -603,10 +603,22 @@ class Edgeset(util.Dataclass):
 
 @dataclass
 class Provenance(util.Dataclass):
+    """
+    A provenance entry in a tree sequence, detailing what how this tree
+    sequence was generated, or what has been done to it (see :ref:`sec_provenance`).
+    """
+
     __slots__ = ["id", "timestamp", "record"]
     id: int  # noqa A003
     timestamp: str
+    """
+    The time that this entry was made
+    """
     record: str
+    """
+    A JSON string giving details of the provenance (see :ref:`sec_provenance_example`
+    for an example JSON string)
+    """
 
 
 class Tree:


### PR DESCRIPTION
A proposal for fixing #1921. Not point in repeating documentation here, I reckon, so I'm just pointing to the equivalent attributes in the tree sequence container class.