### PR TITLE
Zero-copy loading for tree-sequences

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -2292,11 +2292,6 @@ test_simplest_bad_edges(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_treeseq_free(&ts);
 
-    /* NULL for tables should be an error */
-    ret = tsk_treeseq_init(&ts, NULL, load_flags);
-    CU_ASSERT_EQUAL(ret, TSK_ERR_BAD_PARAM_VALUE);
-    tsk_treeseq_free(&ts);
-
     /* Bad population ID */
     tables.nodes.population[0] = -2;
     ret = tsk_treeseq_init(&ts, &tables, load_flags);
@@ -5831,11 +5826,11 @@ test_empty_tree_kc(void)
 
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES | TSK_SAMPLE_LISTS);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SEQUENCE_LENGTH);
     tsk_treeseq_free(&ts);
     tables.sequence_length = 1.0;
-    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES | TSK_SAMPLE_LISTS);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     verify_empty_tree_sequence(&ts, 1.0);

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -715,14 +715,18 @@ typedef struct {
 
 /* Flags for load tables */
 #define TSK_BUILD_INDEXES (1 << 0)
+#define TSK_TAKE_TABLES (1 << 1)
 
 /* Flags for dump tables */
 /* We may not want to document this flag, but it's useful for testing
  * so we put it high up in the bit space */
 #define TSK_DUMP_FORCE_OFFSET_64 (1 << 30)
 
-/* Flags for table collection init */
+/* Flags for table collection init/copy */
+/* TODO: need to careful about what flags get passed to init, from other
+ * functions. Review as part of #1720 */
 #define TSK_NO_EDGE_METADATA (1 << 0)
+#define TSK_COPY_FILE_UUID (1 << 1)
 
 /* Flags for table collection load */
 /* This shares an interface with table collection init.


### PR DESCRIPTION
Fixes #2132 

Here's the basic idea for what we're thinking about regarding ``tsk_treeseq_init`` and ``tsk_treeseq_load`` @molpopgen 

This should avoid one of the copies we get, passing ownership of the tables to the tree sequence.

There's some details here around the exact semantics of exactly who owns what when (which is why the tests are failing, I thing), but I'm sure it can be worked out.

Will this work in Rust-land?