### PR TITLE
Density of coalescences / effective population size estimates

### DIFF
--- a/python/tests/test_coaltime_distribution.py
+++ b/python/tests/test_coaltime_distribution.py
@@ -1,0 +1,1093 @@
+# MIT License
+#
+# Copyright (c) 2018-2022 Tskit Developers
+# Copyright (C) 2016 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Test cases for coalescence time distribution objects in tskit.
+"""
+import msprime
+import numpy as np
+
+import tests
+import tskit
+
+
+class TestCoalescenceTimeDistribution:
+    """
+    Tree sequences used in tests of classes `CoalescenceTimeTable` and
+    `CoalescenceTimeDistribution`
+    """
+
+    @tests.cached_example
+    def ts_multimerger_six_leaves(self):
+        """
+        29.00┊    9        ┊
+             ┊ ┏━━┻━━┓     ┊
+        8.00 ┊ ┃     8     ┊
+             ┊ ┃   ┏━┻━━┓  ┊
+        5.00 ┊ ┃   7    ┃  ┊
+             ┊ ┃ ┏━╋━┓  ┃  ┊
+        1.00 ┊ ┃ ┃ ┃ ┃  6  ┊
+             ┊ ┃ ┃ ┃ ┃ ┏┻┓ ┊
+        0.00 ┊ 0 1 2 4 3 5 ┊
+             0            100
+        """
+        tables = tskit.TableCollection(sequence_length=100)
+        tables.nodes.set_columns(
+            time=np.array([0, 0, 0, 0, 0, 0, 1, 5, 8, 29]),
+            flags=np.array([1, 1, 1, 1, 1, 1, 0, 0, 0, 0], dtype="uint32"),
+        )
+        tables.edges.set_columns(
+            left=np.repeat([0.0], 9),
+            right=np.repeat([100.0], 9),
+            parent=np.array([6, 6, 7, 7, 7, 8, 8, 9, 9], dtype="int32"),
+            child=np.array([3, 5, 1, 2, 4, 6, 7, 0, 8], dtype="int32"),
+        )
+        return tables.tree_sequence()
+
+    @tests.cached_example
+    def ts_multimerger_eight_leaves(self):
+        """
+        10.00┊         13      ┊
+             ┊       ┏━━┻━━┓   ┊
+        8.00 ┊      12     ┃   ┊
+             ┊     ┏━┻━┓   ┃   ┊
+        6.00 ┊    11   ┃   ┃   ┊
+             ┊  ┏━━╋━┓ ┃   ┃   ┊
+        2.00 ┊ 10  ┃ ┃ ┃   9   ┊
+             ┊ ┏┻┓ ┃ ┃ ┃  ┏┻━┓ ┊
+        1.00 ┊ ┃ ┃ ┃ ┃ ┃  8  ┃ ┊
+             ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┊
+        0.00 ┊ 0 7 4 5 6 1 2 3 ┊
+             0                100
+        """
+        tables = tskit.TableCollection(sequence_length=100)
+        tables.nodes.set_columns(
+            time=np.array([0] * 8 + [1, 2, 2, 6, 8, 10]),
+            flags=np.repeat([1, 0], [8, 6]).astype("uint32"),
+        )
+        tables.edges.set_columns(
+            left=np.repeat([0], 13),
+            right=np.repeat([100], 13),
+            parent=np.array(
+                [8, 8, 9, 9, 10, 10, 11, 11, 11, 12, 12, 13, 13], dtype="int32"
+            ),
+            child=np.array([1, 2, 3, 8, 0, 7, 4, 5, 10, 6, 11, 9, 12], dtype="int32"),
+        )
+        return tables.tree_sequence()
+
+    @tests.cached_example
+    def ts_two_trees_four_leaves(self):
+        """
+        1.74┊   7     ┊   7     ┊
+            ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊
+        0.73┊ ┃   6   ┊ ┃   ┃   ┊
+            ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊
+        0.59┊ ┃ ┃  5  ┊ ┃   5   ┊
+            ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊
+        0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊
+            ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+        0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊
+          0.00      0.88      1.00
+        """
+        tables = tskit.TableCollection(sequence_length=1)
+        tables.nodes.set_columns(
+            time=np.array([0, 0, 0, 0, 0.54, 0.59, 0.73, 1.74]),
+            flags=np.array([1, 1, 1, 1, 0, 0, 0, 0], dtype="uint32"),
+        )
+        tables.edges.set_columns(
+            left=np.array([0.88, 0.88, 0, 0, 0.88, 0, 0, 0, 0.88, 0]),
+            right=np.array([1, 1, 0.88, 1, 1, 0.88, 0.88, 1, 1, 0.88]),
+            parent=np.array([4, 4, 5, 5, 5, 6, 6, 7, 7, 7], dtype="int32"),
+            child=np.array([1, 2, 2, 3, 4, 1, 5, 0, 5, 6], dtype="int32"),
+        )
+        return tables.tree_sequence()
+
+    @tests.cached_example
+    def ts_five_trees_three_leaves(self):
+        tables = tskit.TableCollection(sequence_length=1)
+        tables.nodes.set_columns(
+            time=np.array([0.0, 0.0, 0.0, 0.05, 0.15, 1.13, 4.21, 7.53]),
+            flags=np.array([1, 1, 1, 0, 0, 0, 0, 0], dtype="uint32"),
+        )
+        tables.edges.set_columns(
+            left=np.array([0.4, 0.4, 0, 0, 0.4, 0, 0, 0.2, 0.2, 0.1, 0.3, 0.1, 0.3]),
+            right=np.array([1, 1, 1, 0.4, 1, 0.1, 0.1, 0.3, 0.3, 0.2, 0.4, 0.2, 0.4]),
+            parent=np.array([3, 3, 4, 4, 4, 5, 5, 6, 6, 7, 7, 7, 7], dtype="int32"),
+            child=np.array([0, 2, 1, 2, 3, 0, 4, 0, 4, 0, 0, 4, 4], dtype="int32"),
+        )
+        return tables.tree_sequence()
+
+    @tests.cached_example
+    def ts_eight_trees_two_leaves(self):
+        tables = tskit.TableCollection(sequence_length=8)
+        tables.nodes.set_columns(
+            time=np.array([0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]),
+            flags=np.array([1, 1, 0, 0, 0, 0, 0, 0, 0], dtype="uint32"),
+        )
+        tables.edges.set_columns(
+            left=np.array([6, 6, 7, 7, 5, 5, 1, 1, 0, 2, 0, 2, 3, 3, 4, 4]),
+            right=np.array([7, 7, 8, 8, 6, 6, 2, 2, 1, 3, 1, 3, 4, 4, 5, 5]),
+            parent=np.array(
+                [2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 8, 8],
+                dtype="int32",
+            ),
+            child=np.array(
+                [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 1],
+                dtype="int32",
+            ),
+        )
+        return tables.tree_sequence()
+
+    @tests.cached_example
+    def ts_two_trees_ten_leaves(self):
+        tables = tskit.TableCollection(sequence_length=2)
+        tables.nodes.set_columns(
+            time=np.array([0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]),
+            flags=np.array([1, 1, 0, 0, 0, 0, 0, 0, 0], dtype="uint32"),
+        )
+        tables.edges.set_columns(
+            left=np.array([6, 6, 7, 7, 5, 5, 1, 1, 0, 2, 0, 2, 3, 3, 4, 4]),
+            right=np.array([7, 7, 8, 8, 6, 6, 2, 2, 1, 3, 1, 3, 4, 4, 5, 5]),
+            parent=np.array(
+                [2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 8, 8],
+                dtype="int32",
+            ),
+            child=np.array(
+                [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 1],
+                dtype="int32",
+            ),
+        )
+        return tables.tree_sequence()
+
+    @tests.cached_example
+    def ts_many_edge_diffs(self):
+        ts = msprime.sim_ancestry(
+            samples=75,
+            ploidy=1,
+            sequence_length=4,
+            recombination_rate=10,
+            random_seed=1234,
+        )
+        return ts
+
+
+class TestUnweightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+                         Block Weight C.Wght Quant
+                         -------------------------
+    29.00┊    9        ┊    0     1        4  1.00
+         ┊ ┏━━┻━━┓     ┊
+    8.00 ┊ ┃     8     ┊    0     1        3  0.75
+         ┊ ┃   ┏━┻━━┓  ┊
+    5.00 ┊ ┃   7    ┃  ┊    0     1        2  0.50
+         ┊ ┃ ┏━╋━┓  ┃  ┊
+    1.00 ┊ ┃ ┃ ┃ ┃  6  ┊    0     1        1  0.25
+         ┊ ┃ ┃ ┃ ┃ ┏┻┓ ┊
+    0.00 ┊ 0 1 2 4 3 5 ┊    0     0        0  0.00 < to catch OOR
+         0            100
+    Uniform weights on nodes
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_multimerger_six_leaves()
+        distr = ts.coalescence_time_distribution(span_normalise=False)
+        return distr
+
+    def test_time(self):
+        t = np.array([0, 1, 5, 8, 29])
+        distr = self.coalescence_time_distribution()
+        tt = distr.tables[0].time
+        assert np.allclose(t, tt)
+
+    def test_block(self):
+        b = np.array([0, 0, 0, 0, 0])
+        distr = self.coalescence_time_distribution()
+        tb = distr.tables[0].block
+        assert np.allclose(b, tb)
+
+    def test_weights(self):
+        w = np.array([[0, 1, 1, 1, 1]]).T
+        distr = self.coalescence_time_distribution()
+        tw = distr.tables[0].weights
+        assert np.allclose(w, tw)
+
+    def test_cum_weights(self):
+        c = np.array([[0, 1, 2, 3, 4]]).T
+        distr = self.coalescence_time_distribution()
+        tc = distr.tables[0].cum_weights
+        assert np.allclose(c, tc)
+
+    def test_quantile(self):
+        q = np.array([[0, 0.25, 0.50, 0.75, 1]]).T
+        distr = self.coalescence_time_distribution()
+        tq = distr.tables[0].quantile
+        assert np.allclose(q, tq)
+
+
+class TestPairWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+                                       Weights
+                         (A,A) (A,B) (A,C) (B,B) (B,C) (C,C)
+                         -----------------------------------
+    29.00┊    9        ┊    1     2     2     0     0     0
+         ┊ ┏━━┻━━┓     ┊
+    8.00 ┊ ┃     8     ┊    0     1     1     1     2     1
+         ┊ ┃   ┏━┻━━┓  ┊
+    5.00 ┊ ┃   7    ┃  ┊    0     1     1     0     1     0
+         ┊ ┃ ┏━╋━┓  ┃  ┊
+    1.00 ┊ ┃ ┃ ┃ ┃  6  ┊    0     0     0     0     1     0
+         ┊ ┃ ┃ ┃ ┃ ┏┻┓ ┊
+    0.00 ┊ 0 1 2 4 3 5 ┊
+         0            100
+     Pop.┊ A A B C B C ┊
+    Weights are number of pairs of a given population labelling that coalesce
+    in node
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_multimerger_six_leaves()
+        sample_sets = [[0, 1], [2, 3], [4, 5]]
+        distr = ts.coalescence_time_distribution(
+            sample_sets=sample_sets,
+            weight_func="pair_coalescence_events",
+            span_normalise=False,
+        )
+        return distr
+
+    def test_time(self):
+        t = np.array([0, 1, 5, 8, 29])
+        distr = self.coalescence_time_distribution()
+        tt = distr.tables[0].time
+        assert np.allclose(t, tt)
+
+    def test_block(self):
+        b = np.array([0, 0, 0, 0, 0])
+        distr = self.coalescence_time_distribution()
+        tb = distr.tables[0].block
+        assert np.allclose(b, tb)
+
+    def test_weights(self):
+        w = np.array(
+            [
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0],
+                [0, 1, 1, 0, 1, 0],
+                [0, 1, 1, 1, 2, 1],
+                [1, 2, 2, 0, 0, 0],
+            ]
+        )
+        distr = self.coalescence_time_distribution()
+        tw = distr.tables[0].weights
+        assert np.allclose(w, tw)
+
+    def test_cum_weights(self):
+        c = np.array(
+            [
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0],
+                [0, 1, 1, 0, 2, 0],
+                [0, 2, 2, 1, 4, 1],
+                [1, 4, 4, 1, 4, 1],
+            ]
+        )
+        distr = self.coalescence_time_distribution()
+        tc = distr.tables[0].cum_weights
+        assert np.allclose(c, tc)
+
+    def test_quantile(self):
+        q = np.array(
+            [
+                [0.0, 0.00, 0.00, 0.00, 0.00, 0.0],
+                [0.0, 0.00, 0.00, 0.00, 0.25, 0.0],
+                [0.0, 0.25, 0.25, 0.00, 0.50, 0.0],
+                [0.0, 0.50, 0.50, 1.00, 1.00, 1.0],
+                [1.0, 1.00, 1.00, 1.00, 1.00, 1.0],
+            ]
+        )
+        distr = self.coalescence_time_distribution()
+        tq = distr.tables[0].quantile
+        assert np.allclose(q, tq)
+
+
+class TestTrioFirstWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+                                             Weights
+                               AAA AAB AAC ABA ABB ABC ACA ACB ACC
+                               -----------------------------------
+    10.00┊         13      ┊     0   0   0   0   0   0   0   0   0
+         ┊       ┏━━┻━━┓   ┊
+    8.00 ┊      12     ┃   ┊     0   0   0   0   0   0   2   1   0
+         ┊     ┏━┻━┓   ┃   ┊
+    6.00 ┊    11   ┃   ┃   ┊     0   0   0   4   2   2   0   0   0
+         ┊  ┏━━╋━┓ ┃   ┃   ┊
+    2.00 ┊ 10  ┃ ┃ ┃   9   ┊(10) 0   0   0   0   0   0   2   3   1
+         ┊ ┏┻┓ ┃ ┃ ┃  ┏┻━┓ ┊( 9) 0   0   0   2   4   4   0   0   0
+    1.00 ┊ ┃ ┃ ┃ ┃ ┃  8  ┃ ┊     1   3   2   0   0   0   0   0   0
+         ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┊
+    0.00 ┊ 0 7 4 5 6 1 2 3 ┊
+         0                100  BBA BBB BBC BCA BCB BCC CCA CCB CCC
+     Pop.┊ A C B B C A A B ┊   -----------------------------------
+    10.00┊         13      ┊     0   0   0   0   0   0   0   0   0 <- removed
+         ┊       ┏━━┻━━┓   ┊
+    8.00 ┊      12     ┃   ┊     0   0   0   4   2   0   2   1   0
+         ┊     ┏━┻━┓   ┃   ┊
+    6.00 ┊    11   ┃   ┃   ┊     2   1   1   4   2   2   0   0   0
+         ┊  ┏━━╋━┓ ┃   ┃   ┊
+    2.00 ┊ 10  ┃ ┃ ┃   9   ┊(10) 0   0   0   0   0   0   0   0   0
+         ┊ ┏┻┓ ┃ ┃ ┃  ┏┻━┓ ┊( 9) 0   0   0   0   0   0   0   0   0
+    1.00 ┊ ┃ ┃ ┃ ┃ ┃  8  ┃ ┊     0   0   0   0   0   0   0   0   0
+         ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┊                                     ^empty
+    0.00 ┊ 0 7 4 5 6 1 2 3 ┊
+    Pop. ┊ A C B B C A A B ┊
+    Weights are number of trios of a given population labelling with first coalescence
+    in node; shorthand in table columns for newick is ABC = ((A,B):node,C)
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_multimerger_eight_leaves()
+        sample_sets = [[0, 1, 2], [3, 4, 5], [6, 7]]
+        distr = ts.coalescence_time_distribution(
+            sample_sets=sample_sets,
+            weight_func="trio_first_coalescence_events",
+            span_normalise=False,
+        )
+        return distr
+
+    def test_time(self):
+        t = np.array([0.0, 1.0, 2.0, 2.0, 6.0, 8.00])
+        distr = self.coalescence_time_distribution()
+        tt = distr.tables[0].time
+        assert np.allclose(t, tt)
+
+    def test_block(self):
+        b = np.array([0, 0, 0, 0, 0, 0])
+        distr = self.coalescence_time_distribution()
+        tb = distr.tables[0].block
+        assert np.allclose(b, tb)
+
+    def test_weights(self):
+        w = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 2, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 4, 2, 2, 0, 0, 0, 2, 1, 1, 4, 2, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 4, 2, 0, 2, 1, 0],
+            ]
+        )
+        distr = self.coalescence_time_distribution()
+        tw = distr.tables[0].weights
+        assert np.allclose(w, tw)
+
+    def test_cum_weights(self):
+        c = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 2, 4, 4, 2, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 6, 6, 6, 2, 3, 1, 2, 1, 1, 4, 2, 2, 0, 0, 0],
+                [1, 3, 2, 6, 6, 6, 4, 4, 1, 2, 1, 1, 8, 4, 2, 2, 1, 0],
+            ]
+        )
+        distr = self.coalescence_time_distribution()
+        tc = distr.tables[0].cum_weights
+        assert np.allclose(c, tc)
+
+    def test_quantile(self):
+        q = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 2, 4, 4, 2, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 3, 2, 6, 6, 6, 2, 3, 1, 2, 1, 1, 4, 2, 2, 0, 0],
+                [1, 3, 2, 6, 6, 6, 4, 4, 1, 2, 1, 1, 8, 4, 2, 2, 1],
+            ],
+            dtype="float",
+        )
+        q /= q[-1, :]
+        distr = self.coalescence_time_distribution()
+        tq = distr.tables[0].quantile
+        assert np.allclose(q, tq[:, :-1]) and np.all(np.isnan(tq[:, -1]))
+
+
+class TestSingleBlockCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+                                     Cum.
+                               Wght  Wght  Qntl
+                              -----------------
+    1.74┊   7     ┊   7     ┊     2     6  1.00
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊     1     4  0.67
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊     2     3  0.50
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊     1     1  0.17
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊
+      0.00      0.88      1.00
+    Uniform weights on nodes summed over trees
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+        distr = ts.coalescence_time_distribution(
+            span_normalise=False,
+        )
+        return distr
+
+    def test_time(self):
+        t = np.array([0.0, 0.54, 0.59, 0.73, 1.74])
+        distr = self.coalescence_time_distribution()
+        tt = distr.tables[0].time
+        assert np.allclose(t, tt)
+
+    def test_block(self):
+        b = np.array([0, 0, 0, 0, 0])
+        distr = self.coalescence_time_distribution()
+        tb = distr.tables[0].block
+        assert np.allclose(b, tb)
+
+    def test_weights(self):
+        w = np.array([[0, 1, 2, 1, 2]]).T
+        distr = self.coalescence_time_distribution()
+        tw = distr.tables[0].weights
+        assert np.allclose(w, tw)
+
+    def test_cum_weights(self):
+        c = np.array([[0, 1, 3, 4, 6]]).T
+        distr = self.coalescence_time_distribution()
+        tc = distr.tables[0].cum_weights
+        assert np.allclose(c, tc) and np.allclose(c, tc)
+
+    def test_quantile(self):
+        q = np.array([[0.0, 1 / 6, 3 / 6, 4 / 6, 1.0]]).T
+        distr = self.coalescence_time_distribution()
+        tq = distr.tables[0].quantile
+        assert np.allclose(q, tq)
+
+
+class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+      0.00  0.50          1.00    Window 0          Window 1
+    Wndw┊  0  ┊        1    ┊ Time  Wght  Blck  Time  Wght  Blck
+    Blck┊  0  ┊ 0 ┊    1    ┊ ----------------  ----------------
+    1.74┊   7     ┊   7     ┊ 1.74     1     0  1.74     1     1
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊                   1.74     1     0
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊ 0.73     1     0  0.73     1     0
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊ 0.59     1     0  0.59     1     1
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊                   0.59     1     0
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊                   0.54     1     1
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0.00     0     0  0.00     0     0 <to catch OOR
+      0.00      0.88      1.00
+    Uniform weights on nodes summed over trees in blocks
+    """
+
+    @tests.cached_example
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+        gen_breaks = np.array([0.0, 0.5, 1.0])
+        distr = ts.coalescence_time_distribution(
+            window_breaks=gen_breaks,
+            blocks_per_window=2,
+            span_normalise=False,
+        )
+        return distr
+
+    def test_time(self):
+        t1 = np.array([0.0, 0.59, 0.73, 1.74])
+        t2 = np.array([0.0, 0.54, 0.59, 0.59, 0.73, 1.74, 1.74])
+        distr = self.coalescence_time_distribution()
+        tt1 = distr.tables[0].time
+        tt2 = distr.tables[1].time
+        assert np.allclose(t1, tt1) and np.allclose(t2, tt2)
+
+    def test_block(self):
+        b1 = np.array([0, 0, 0, 0])
+        b2 = np.array([0, 1, 0, 1, 0, 0, 1])
+        distr = self.coalescence_time_distribution()
+        tb1 = distr.tables[0].block
+        tb2 = distr.tables[1].block
+        assert np.allclose(b1, tb1) and np.allclose(b2, tb2)
+
+    def test_weights(self):
+        w1 = np.array([[0, 1, 1, 1]]).T
+        w2 = np.array([[0, 1, 1, 1, 1, 1, 1]]).T
+        distr = self.coalescence_time_distribution()
+        tw1 = distr.tables[0].weights
+        tw2 = distr.tables[1].weights
+        assert np.allclose(w1, tw1) and np.allclose(w2, tw2)
+
+    def test_cum_weights(self):
+        c1 = np.array([[0, 1, 2, 3]]).T
+        c2 = np.array([[0, 1, 2, 3, 4, 5, 6]]).T
+        distr = self.coalescence_time_distribution()
+        tc1 = distr.tables[0].cum_weights
+        tc2 = distr.tables[1].cum_weights
+        assert np.allclose(c1, tc1) and np.allclose(c2, tc2)
+
+    def test_quantile(self):
+        e1 = np.array([[0.0, 1 / 3, 2 / 3, 1.0]]).T
+        e2 = np.array([[0.0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6, 1.0]]).T
+        distr = self.coalescence_time_distribution()
+        te1 = distr.tables[0].quantile
+        te2 = distr.tables[1].quantile
+        assert np.allclose(e1, te1) and np.allclose(e2, te2)
+
+
+class TestCoalescenceTimeDistributionPointMethods(TestCoalescenceTimeDistribution):
+    """
+                                    Cum.
+                              Time  Wght  ECDF   Coal.  Uncoal.
+                              ---------------------------------
+        ┊         ┊         ┊ 2.00        1.00       6        0
+    1.74┊   7     ┊   7     ┊ 1.74     6  1.00       6        0
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊ 1.00        0.67       4        2
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊ 0.73     4  0.67       4        2
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊ 0.65        0.50       3        3
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊ 0.59     3  0.50       3        3
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊ 0.57        0.17       1        5
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊ 0.54     1  0.17       1        5
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊ 0.25        0.00       0        6
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊ 0.00        0.00       0        6
+      0.00      0.88      1.00
+    Uniform weights on nodes summed over trees
+    """
+
+    @tests.cached_example
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+        distr = ts.coalescence_time_distribution(
+            span_normalise=False,
+        )
+        return distr
+
+    def test_ecdf(self):
+        e = np.array(
+            [0.0, 0.0, 1 / 6, 1 / 6, 3 / 6, 3 / 6, 4 / 6, 4 / 6, 1.0, 1.0],
+        ).reshape(1, 10, 1)
+        distr = self.coalescence_time_distribution()
+        et = distr.tables[0].time
+        t = np.array(
+            [0.0, 0.25, et[1], 0.57, et[2], 0.65, et[3], 1.00, et[4], 2.00],
+        )
+        te = distr.ecdf(t)
+        assert np.allclose(e, te)
+
+    def test_num_coalesced(self):
+        c = np.array([0, 0, 1, 1, 3, 3, 4, 4, 6, 6]).reshape(1, 10, 1)
+        distr = self.coalescence_time_distribution()
+        et = distr.tables[0].time
+        t = np.array(
+            [0.0, 0.25, et[1], 0.57, et[2], 0.65, et[3], 1.00, et[4], 2.00],
+        )
+        tc = distr.num_coalesced(t)
+        assert np.allclose(c, tc)
+
+    def test_num_uncoalesced(self):
+        u = np.array([6, 6, 5, 5, 3, 3, 2, 2, 0, 0]).reshape(1, 10, 1)
+        distr = self.coalescence_time_distribution()
+        et = distr.tables[0].time
+        t = np.array(
+            [0.0, 0.25, et[1], 0.57, et[2], 0.65, et[3], 1.00, et[4], 2.00],
+        )
+        tu = distr.num_uncoalesced(t)
+        assert np.allclose(u, tu)
+
+
+class TestCoalescenceTimeDistributionIntervalMethods(TestCoalescenceTimeDistribution):
+    """
+                               Time                     Kaplan-Meier
+                              Breaks   Coal.Prop.        Coal. Rate
+        ┊         ┊         ┊--3.00--  ----------  ----------------------
+        ┊         ┊         ┊             NaN               NaN
+        ┊         ┊         ┊--2.00--  ----------  ----------------------
+    1.74┊   7     ┊   7     ┊             2/2          2/(2*1.74-2*0.73)
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊--0.73--  ----------  ----------------------
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊             3/5      log(1-3/5)/(0.55-0.73)
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊--0.55--  ----------  ----------------------
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊             1/6      log(1-1/6)/(0.00-0.55)
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊--0.00--  ----------  ----------------------
+      0.00      0.88      1.00
+                               Time   Trunc. Trunc. Trunc.
+                             Lo.Bound  Mean   Mean   Mean
+        ┊         ┊         ┊-------- ------ ------ ------
+        ┊         ┊         ┊                         NaN
+        ┊         ┊         ┊--2.00--               ------
+    1.74┊   7     ┊   7     ┊
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊                0.4868
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊--0.59--        ------
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊         0.9893
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊--0.00-- ------
+      0.00      0.88      1.00
+    Uniform weights on nodes summed over trees, in half-closed time intervals
+    (lower, upper]
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+        distr = ts.coalescence_time_distribution(
+            span_normalise=False,
+        )
+        return distr
+
+    def test_coalescence_probability_in_intervals(self):
+        p = np.array([[[1 / 6], [3 / 5], [2 / 2]]])
+        distr = self.coalescence_time_distribution()
+        et = distr.tables[0].time
+        t = np.array([0.00, 0.55, et[3], 2.00])
+        tp = distr.coalescence_probability_in_intervals(t)
+        assert np.allclose(p, tp)
+
+    def test_coalescence_probability_in_intervals_oor(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([2.00, 3.00])
+        tp = distr.coalescence_probability_in_intervals(t)
+        assert np.all(np.isnan(tp))
+
+    def test_coalescence_rate_in_intervals(self):
+        c = np.array([[[0.3314937], [5.090504], [0.990099]]])
+        distr = self.coalescence_time_distribution()
+        et = distr.tables[0].time
+        t = np.array([0.00, 0.55, et[3], 2.00])
+        tc = distr.coalescence_rate_in_intervals(t)
+        assert np.allclose(c, tc)
+
+    def test_coalescence_rate_in_intervals_oor(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([2.00, 3.00])
+        tc = distr.coalescence_rate_in_intervals(t)
+        assert np.all(np.isnan(tc))
+
+    def test_mean(self):
+        m = np.array([[0.8133333]])
+        distr = self.coalescence_time_distribution()
+        et = distr.tables[0].time
+        tm = distr.mean(et[2])
+        assert np.allclose(m, tm)
+
+    def test_mean_oor(self):
+        distr = self.coalescence_time_distribution()
+        tm = distr.mean(10.0)
+        assert np.all(np.isnan(tm))
+
+
+class TestCoalescenceTimeDistributionBootstrap(TestCoalescenceTimeDistribution):
+    """
+      0.00  0.50          1.00
+    Wndw┊  0  ┊        1    ┊       Window 0            Window 1
+    Blck┊  0  ┊ 0 ┊    1    ┊ Time B.Wt*Wght Blck  Time B.Wt*Wght Blck
+    B.Wt┊  1  ┊ 0 ┊    2    ┊ -------------------  -------------------
+    1.74┊   7     ┊   7     ┊ 1.74         1    0  1.74         2    1
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊                      1.74         0    0
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊ 0.73         1    0  0.73         0    0
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊ 0.59         1    0  0.59         2    1
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊                      0.59         0    0
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊   Mean time: 1.02    0.54         2    1
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊                        Mean time: 0.96
+      0.00      0.88      1.00
+    Wndw┊  0  ┊        1    ┊     Window 0        Window 1
+    Blck┊  0  ┊ 0 ┊    1    ┊ Time C.Wgt ECDF  Time C.Wgt ECDF
+    B.Wt┊  1  ┊ 2 ┊    0    ┊ ---------------  ---------------
+    1.74┊   7     ┊   7     ┊ 1.74     3 1.00  1.74     6 1.00
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊                  1.74     4      <- edcf() skips
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊ 0.73     2 0.67  0.73     4 0.67
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊ 0.59     1 0.33  0.59     4 0.67
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊                  0.59     2      <- edcf() skips
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊                  0.54     2 0.33
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊
+      0.00      0.88      1.00
+    Uniform weights on nodes summed over trees in blocks, reweighted by block
+    weights that are multinomial RVs. Only cumulative weights are affected,
+    so that bootstrapping a bootstrap replicate is equivalent to bootstrapping
+    the original.
+    """
+
+    def coalescence_time_distribution_boot(self):
+        ts = self.ts_two_trees_four_leaves()
+        gen_breaks = np.array([0.0, 0.5, 1.0])
+        distr = ts.coalescence_time_distribution(
+            window_breaks=gen_breaks,
+            blocks_per_window=2,
+            span_normalise=False,
+        )
+        boot_distr = next(distr.block_bootstrap(1, 3))
+        return boot_distr
+
+    def test_cum_weights(self):
+        w1 = np.array([[0, 1, 2, 3]]).T
+        w2 = np.array([[0, 2, 2, 4, 4, 4, 6]]).T
+        boot_distr = self.coalescence_time_distribution_boot()
+        tw1 = boot_distr.tables[0].cum_weights
+        tw2 = boot_distr.tables[1].cum_weights
+        assert np.allclose(w1, tw1) and np.allclose(w2, tw2)
+
+    def test_ecdf(self):
+        e = np.array(
+            [
+                [0 / 3, 0 / 3, 1 / 3, 1 / 3, 2 / 3, 2 / 3, 3 / 3],
+                [2 / 6, 2 / 6, 4 / 6, 4 / 6, 4 / 6, 4 / 6, 6 / 6],
+            ]
+        ).T.reshape(1, 7, 2)
+        boot_distr = self.coalescence_time_distribution_boot()
+        t = np.array([0.54, 0.55, 0.59, 0.60, 0.73, 0.74, 1.74])
+        te = boot_distr.ecdf(t)
+        assert np.allclose(e, te)
+
+    def test_mean(self):
+        m = np.array([[1.02, 0.9566667]])
+        boot_distr = self.coalescence_time_distribution_boot()
+        tm = boot_distr.mean()
+        assert np.allclose(m, tm)
+
+    def test_boot_of_boot_equivalence(self):
+        boot_distr = self.coalescence_time_distribution_boot()
+        reboot_distr = next(boot_distr.block_bootstrap(1, 3))
+        cw1 = boot_distr.tables[1].cum_weights
+        cw2 = reboot_distr.tables[1].cum_weights
+        assert np.allclose(cw1, cw2)
+
+
+class TestCoalescenceTimeDistributionEmpty(TestCoalescenceTimeDistribution):
+    """
+    When weights are all zero ECDF table is empty, methods return NaN
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+
+        def null_weight(node, tree, sample_sets):
+            return np.array([0, 0])
+
+        distr = ts.coalescence_time_distribution(
+            weight_func=null_weight,
+            span_normalise=False,
+        )
+        return distr
+
+    def test_ecdf(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        te = distr.ecdf(t)
+        assert np.all(np.isnan(te))
+
+    def test_num_coalesced(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tc = distr.num_coalesced(t)
+        assert np.all(np.isnan(tc))
+
+    def test_num_uncoalesced(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tu = distr.num_uncoalesced(t)
+        assert np.all(np.isnan(tu))
+
+    def test_mean(self):
+        distr = self.coalescence_time_distribution()
+        tm = distr.mean()
+        assert np.all(np.isnan(tm))
+
+    def test_coalescence_probability_in_intervals(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tp = distr.coalescence_probability_in_intervals(t)
+        assert np.all(np.isnan(tp))
+
+    def test_coalescence_rate_in_intervals(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tc = distr.coalescence_rate_in_intervals(t)
+        assert np.all(np.isnan(tc))
+
+
+class TestCoalescenceTimeDistributionNullWeight(TestCoalescenceTimeDistribution):
+    """
+    Test method return behaviour when a particular weight is all zeros but
+    table is not empty. Methods should return NaN only for null weight.
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+
+        def half_empty(node, tree, sample_sets):
+            return np.array([1, 0])
+
+        distr = ts.coalescence_time_distribution(
+            weight_func=half_empty,
+            span_normalise=False,
+        )
+        return distr
+
+    def test_ecdf(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        te = distr.ecdf(t)
+        assert np.all(np.isnan(te[1, :])) and np.all(~np.isnan(te[0, :]))
+
+    def test_num_coalesced(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tc = distr.num_coalesced(t)
+        assert np.all(np.isnan(tc[1, :])) and np.all(~np.isnan(tc[0, :]))
+
+    def test_num_uncoalesced(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tu = distr.num_uncoalesced(t)
+        assert np.all(np.isnan(tu[1, :])) and np.all(~np.isnan(tu[0, :]))
+
+    def test_mean(self):
+        distr = self.coalescence_time_distribution()
+        tm = distr.mean()
+        assert np.isnan(tm[1]) and ~np.isnan(tm[0])
+
+    def test_coalescence_probability_in_intervals(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tp = distr.coalescence_probability_in_intervals(t)
+        assert np.all(np.isnan(tp[1, :])) and np.all(~np.isnan(tp[0, :]))
+
+    def test_coalescence_rate_in_intervals(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tr = distr.coalescence_rate_in_intervals(t)
+        assert np.all(np.isnan(tr[1, :])) and np.all(~np.isnan(tr[0, :]))
+
+
+class TestCoalescenceTimeDistributionTableResize(TestCoalescenceTimeDistribution):
+    """
+    If the initial allocation for the table is exceeded, the number of rows is
+    increased.
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_five_trees_three_leaves()
+        distr = ts.coalescence_time_distribution(
+            blocks_per_window=ts.num_trees,
+            span_normalise=False,
+        )
+        return distr
+
+    def test_table_resize(self):
+        distr = self.coalescence_time_distribution()
+        assert distr.tables[0].num_records > distr.buffer_size + 1
+
+
+class TestCoalescenceTimeDistributionBlocking(TestCoalescenceTimeDistribution):
+    """
+    Test assignment of blocks per window and trees per block. If window breaks
+    fall on recombination breakpoints, and the number of trees is divisible by
+    the number of windows, then there should be an equal number of trees per
+    window.
+    """
+
+    def coalescence_time_distribution(self):
+        # 2 trees/block, 2 blocks/window, 2 windows/ts
+        ts = self.ts_eight_trees_two_leaves()
+        bk = [t.interval.left for t in ts.trees()][::4] + [ts.sequence_length]
+
+        def count_root(node, tree, sample_sets):
+            weight = int(node == tree.get_root())
+            return np.array([weight])
+
+        distr = ts.coalescence_time_distribution(
+            weight_func=count_root,
+            window_breaks=np.array(bk),
+            blocks_per_window=2,
+            span_normalise=False,
+        )
+        return distr
+
+    def test_blocks_per_window(self):
+        distr = self.coalescence_time_distribution()
+        bpw = np.array([i.num_blocks for i in distr.tables])
+        assert np.allclose(bpw, 2)
+
+    def test_trees_per_window(self):
+        distr = self.coalescence_time_distribution()
+        tpw = np.array([np.sum(distr.tables[i].weights) for i in range(2)])
+        assert np.allclose(tpw, 4)
+
+    def test_trees_per_block(self):
+        distr = self.coalescence_time_distribution()
+        tpb = []
+        for table in distr.tables:
+            for block in range(2):
+                tpb += [np.sum(table.weights[table.block == block])]
+        assert np.allclose(tpb, 2)
+
+
+class TestCoalescenceTimeDistributionRunningUpdate(TestCoalescenceTimeDistribution):
+    """
+    When traversing trees, weights are updated for nodes whose descendant subtree
+    has changed. This is done by taking the parents of added edges, and tracing
+    ancestors down to the root. This class tests that this "running update"
+    scheme produces the same results as calculating weights separately for each
+    tree.
+    """
+
+    # TODO: when missing data handling is implemented, test here
+
+    def coalescence_time_distribution(self, ts):
+        brk = np.array([t.interval.left for t in ts.trees()] + [ts.sequence_length])
+        smp_set = np.arange(0, ts.num_samples)
+        smp_set = np.floor_divide((len(brk) - 1) * smp_set, ts.num_samples)
+        smp_set = [np.where(smp_set == i)[0].tolist() for i in range(len(brk) - 1)]
+        distr = ts.coalescence_time_distribution(
+            sample_sets=smp_set,
+            window_breaks=brk,
+            weight_func="trio_first_coalescence_events",
+            span_normalise=False,
+        )
+        distr_by_win = []
+        for left, right in zip(brk[:-1], brk[1:]):
+            ts_trim = ts.keep_intervals([[left, right]]).trim()
+            distr_by_win += [
+                ts_trim.coalescence_time_distribution(
+                    sample_sets=smp_set,
+                    weight_func="trio_first_coalescence_events",
+                )
+            ]
+        return distr, distr_by_win
+
+    def test_many_edge_diffs(self):
+        ts = self.ts_many_edge_diffs()
+        distr, distr_win = self.coalescence_time_distribution(ts)
+        time_breaks = np.array([np.inf])
+        updt = distr.num_coalesced(time_breaks)
+        sepr = np.zeros(updt.shape)
+        for i, d in enumerate(distr_win):
+            c = d.num_coalesced(time_breaks)
+            sepr[:, :, i] = c.reshape((c.shape[0], 1))
+        assert np.allclose(sepr, updt)
+
+
+class TestSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+                                         Cum.
+                                   Wght  Wght
+                              ---------------
+    1.74┊   7     ┊   7     ┊ 0.88+0.12  3.00
+        ┊ ┏━┻━┓   ┊ ┏━┻━┓   ┊
+    0.73┊ ┃   6   ┊ ┃   ┃   ┊ 0.88       2.00
+        ┊ ┃ ┏━┻┓  ┊ ┃   ┃   ┊
+    0.59┊ ┃ ┃  5  ┊ ┃   5   ┊ 0.88+0.12  1.12
+        ┊ ┃ ┃ ┏┻┓ ┊ ┃  ┏┻━┓ ┊
+    0.54┊ ┃ ┃ ┃ ┃ ┊ ┃  4  ┃ ┊      0.12  0.12
+        ┊ ┃ ┃ ┃ ┃ ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3 ┊ 0 1 2 3 ┊
+      0.00      0.88      1.00
+    SpnW┊   0.88  ┊  0.12   ┊
+    Uniform weights on nodes summed over trees, weighted by tree span
+    """
+
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+        distr = ts.coalescence_time_distribution(
+            span_normalise=True,
+        )
+        return distr
+
+    def test_weights(self):
+        w = np.array([[0, 0.12, 1.0, 0.88, 1.0]]).T
+        distr = self.coalescence_time_distribution()
+        tw = distr.tables[0].weights
+        assert np.allclose(w, tw)
+
+    def test_cum_weights(self):
+        c = np.array([[0, 0.12, 1.12, 2.00, 3.00]]).T
+        distr = self.coalescence_time_distribution()
+        tc = distr.tables[0].cum_weights
+        assert np.allclose(c, tc) and np.allclose(c, tc)
+
+
+class TestWindowedSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
+    """
+      0.00  0.50           1.00  Window 0    Window 1
+    Wndw┊  0  ┊         1    ┊  Time  Wght  Time  Wght
+    Blck┊  0  ┊ 0  ┊    1    ┊  ----------  ----------
+    1.74┊   7      ┊   7     ┊  1.74     1  1.74  0.24
+        ┊ ┏━┻━┓    ┊ ┏━┻━┓   ┊              1.74  0.76
+    0.73┊ ┃   6    ┊ ┃   ┃   ┊  0.73     1  0.73  0.76
+        ┊ ┃ ┏━┻┓   ┊ ┃   ┃   ┊
+    0.59┊ ┃ ┃  5   ┊ ┃   5   ┊  0.59     1  0.59  0.24
+        ┊ ┃ ┃ ┏┻┓  ┊ ┃  ┏┻━┓ ┊              0.59  0.76
+    0.54┊ ┃ ┃ ┃ ┃  ┊ ┃  4  ┃ ┊              0.54  0.24
+        ┊ ┃ ┃ ┃ ┃  ┊ ┃ ┏┻┓ ┃ ┊
+    0.00┊ 0 1 2 3  ┊ 0 1 2 3 ┊  0.00     0  0.00     0 <to catch OOR
+      0.00       0.88      1.00
+    Span┊ 0.5 ┊0.38┊   0.12  ┊
+    SpnW┊ 1.0 ┊0.76┊   0.24  ┊
+    Uniform weights on nodes summed over trees in blocks, normalised
+    by span within windows
+    """
+
+    @tests.cached_example
+    def coalescence_time_distribution(self):
+        ts = self.ts_two_trees_four_leaves()
+        gen_breaks = np.array([0.0, 0.5, 1.0])
+        distr = ts.coalescence_time_distribution(
+            window_breaks=gen_breaks,
+            blocks_per_window=2,
+            span_normalise=True,
+        )
+        return distr
+
+    def test_time(self):
+        t1 = np.array([0.0, 0.59, 0.73, 1.74])
+        t2 = np.array([0.0, 0.54, 0.59, 0.59, 0.73, 1.74, 1.74])
+        distr = self.coalescence_time_distribution()
+        tt1 = distr.tables[0].time
+        tt2 = distr.tables[1].time
+        assert np.allclose(t1, tt1) and np.allclose(t2, tt2)
+
+    def test_block(self):
+        b1 = np.array([0, 0, 0, 0])
+        b2 = np.array([0, 1, 0, 1, 0, 0, 1])
+        distr = self.coalescence_time_distribution()
+        tb1 = distr.tables[0].block
+        tb2 = distr.tables[1].block
+        assert np.allclose(b1, tb1) and np.allclose(b2, tb2)
+
+    def test_weights(self):
+        w1 = np.array([[0, 1.0, 1.0, 1.0]]).T
+        w2 = np.array([[0, 0.24, 0.76, 0.24, 0.76, 0.76, 0.24]]).T
+        distr = self.coalescence_time_distribution()
+        tw1 = distr.tables[0].weights
+        tw2 = distr.tables[1].weights
+        assert np.allclose(w1, tw1) and np.allclose(w2, tw2)

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2021 Tskit Developers
+# Copyright (c) 2018-2022 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,12 +22,16 @@
 """
 Module responsible for computing various statistics on tree sequences.
 """
+import copy
+import itertools
 import sys
 import threading
 
 import numpy as np
 
 import _tskit
+import tskit
+import tskit.trees as trees
 
 
 class LdCalculator:
@@ -163,3 +167,511 @@ class LdCalculator:
             A[j, j + 1 :] = a
             A[j + 1 :, j] = a
         return A
+
+
+class CoalescenceTimeTable:
+    """
+    Container for sorted coalescence times, weights, and block assignments.
+    """
+
+    def __init__(self, time, block, weights):
+        assert time.shape[0] == weights.shape[0] == block.shape[0]
+        assert time.ndim == block.ndim == 1
+        assert weights.ndim == 2
+        self.num_weights = weights.shape[1]
+        # remove empty records
+        not_empty = np.sum(weights, 1) > 0
+        self.num_records = sum(not_empty)
+        self.time = time[not_empty]
+        self.block = block[not_empty]
+        self.weights = weights[not_empty, :]
+        # add left boundary at time 0
+        self.num_records += 1
+        self.time = np.pad(self.time, (0, 1))
+        self.block = np.pad(self.block, (0, 1))
+        self.weights = np.pad(self.weights, ((0, 1), (0, 0)))
+        # sort by node time
+        time_order = np.argsort(self.time)
+        self.time = self.time[time_order]
+        self.block = self.block[time_order]
+        self.weights = self.weights[time_order, :]
+        # calculate quantiles
+        self.num_blocks = 1 + np.max(self.block) if self.num_records > 0 else 0
+        self.block_multiplier = np.ones(self.num_blocks)
+        self.cum_weights = np.cumsum(self.weights, 0)
+        self.quantile = np.empty((self.num_records, self.num_weights))
+        self.quantile[:] = np.nan
+        for i in range(self.num_weights):
+            if self.cum_weights[-1, i] > 0:
+                self.quantile[:, i] = self.cum_weights[:, i] / self.cum_weights[-1, i]
+
+    def resample_blocks(self, block_multiplier):
+        assert block_multiplier.shape[0] == self.num_blocks
+        assert np.sum(block_multiplier) == self.num_blocks
+        self.block_multiplier = block_multiplier
+        for i in range(self.num_weights):
+            self.cum_weights[:, i] = np.cumsum(
+                self.weights[:, i] * self.block_multiplier[self.block], 0
+            )
+            if self.cum_weights[-1, i] > 0:
+                self.quantile[:, i] = self.cum_weights[:, i] / self.cum_weights[-1, i]
+
+
+class CoalescenceTimeDistribution:
+    """
+    Class to precompute a table of sorted/weighted node times, from which to calculate
+    the empirical distribution function and estimate coalescence rates in time windows.
+    """
+
+    @staticmethod
+    def _count_coalescence_events(node, tree, sample_sets):
+        # TODO this will count unary nodes: should it count nodes
+        # with >1 child instead?
+        return np.array([1], dtype=np.int32)
+
+    @staticmethod
+    def _count_pair_coalescence_events(node, tree, sample_sets):
+        """
+        Count the number of pairs that coalesce in node, within and between the
+        sets of samples in ``sample_sets``. The count of pairs with members that
+        belong to sets :math:`a` and :math:`b` is:
+
+        .. math:
+
+            \\sum_{i \\neq j} (C_i(a) C_j(b) + C_i(b) C_j(a))/(1 - \\mathbb{I}[a = b])
+
+        where :math:`C_i(a)` is the number of samples from set :math:`a`
+        descended from child :math:`i`.  The values in the output are ordered
+        canonically; e.g. if ``len(sample_sets) == 2`` then the values would
+        correspond to counts of pairs with set labels ``[(0,0), (0,1), (1,1)]``.
+        """
+
+        # TODO needs to be optimized, use np.intersect1d
+        children = tree.children(node)
+        samples_per_child = [set(list(tree.samples(c))) for c in children]
+        sample_counts = np.zeros((len(sample_sets), len(children)), dtype=np.int32)
+        for i, s1 in enumerate(samples_per_child):
+            for a, s2 in enumerate([set(s) for s in sample_sets]):
+                sample_counts[a, i] = len(s1 & s2)
+
+        pair_counts = []
+        for a, b in itertools.combinations_with_replacement(
+            range(sample_counts.shape[0]), 2
+        ):
+            count = 0
+            for i, j in itertools.combinations(range(sample_counts.shape[1]), 2):
+                count += (
+                    sample_counts[a, i] * sample_counts[b, j]
+                    + sample_counts[a, j] * sample_counts[b, i]
+                ) / (1 + int(a == b))
+            pair_counts.append(count)
+
+        return np.array(pair_counts, dtype=np.int32)
+
+    @staticmethod
+    def _count_trio_first_coalescence_events(node, tree, sample_sets):
+        """
+        Count the number of pairs that coalesce in node with an outgroup,
+        within and between the sets of samples in ``sample_sets``. In other
+        words, count topologies of the form ``((A,B):node,C)`` where ``A,B,C``
+        are labels and `node` is the node ID.  The count of pairs with members
+        that belong to sets :math:`a` and :math:`b` with outgroup :math:`c` is:
+
+        .. math:
+
+            \\sum_{i \\neq j} (C_i(a) C_j(b) + C_i(b) C_j(a)) \\times
+            O(c) / (1 - \\mathbb{I}[a = b])
+
+        where :math:`C_i(a)` is the number of samples from set :math:`a`
+        descended from child :math:`i` of the node, and :math:`O(c)` is the
+        number of samples from set :math:`c` that are *not* descended from the
+        node.  The values in the output are ordered canonically by pair then
+        outgroup; e.g. if ``len(sample_sets) == 2`` then the values would
+        correspond to counts of pairs with set labels,
+        ``[((0,0),0), ((0,0),1), ..., ((0,1),0), ((0,1),1), ...]``.
+        """
+        samples = list(tree.samples(node))
+        outg_counts = [len(s) - len(np.intersect1d(samples, s)) for s in sample_sets]
+        pair_counts = CoalescenceTimeDistribution._count_pair_coalescence_events(
+            node, tree, sample_sets
+        )
+        trio_counts = []
+        for i in pair_counts:
+            for j in outg_counts:
+                trio_counts.append(i * j)
+        return np.array(trio_counts, dtype=np.int32)
+
+    def _update_weights_by_edge_diff(self, tree, edge_diff, running_weights):
+        """
+        Update ``running_weights`` to reflect ``tree`` using edge differences
+        ``edge_diff`` with the previous tree.
+        """
+
+        assert edge_diff.interval == tree.interval
+
+        # nodes that have been removed from tree
+        removed = {i.child for i in edge_diff.edges_out if tree.is_isolated(i.child)}
+        # TODO: What if sample is removed from tree? In that case should all
+        # nodes be updated for trio first coalescences?
+
+        # nodes where descendant subtree has been altered
+        modified = {i.parent for i in edge_diff.edges_in}
+        for i in copy.deepcopy(modified):
+            while tree.parent(i) != tskit.NULL and not tree.parent(i) in modified:
+                i = tree.parent(i)
+                modified.add(i)
+
+        # recalculate weights for current tree
+        for i in removed:
+            running_weights[i, :] = 0
+        for i in modified:
+            running_weights[i, :] = self.weight_func(i, tree, self.sample_sets)
+        self.weight_func_evals += len(modified)
+
+    def _build_ecdf_table_for_window(
+        self, left, right, tree, edge_diffs, running_weights
+    ):
+        """
+        Construct ECDF table for genomic interval [left, right]. Update ``tree``,
+        ``edge_diffs``, and ``running_weights`` for input for next window. Trees are
+        counted as belonging to any interval with which they overlap, and thus
+        can be used in several intervals. Thus, the concatenation of ECDF
+        tables across multiple intervals is not the same as the ECDF table
+        for the union of those intervals. Trees within intervals are chunked
+        into roughly equal-sized blocks for bootstrapping.
+        """
+
+        assert tree.interval.left <= left and right > left
+
+        # assign trees in window to equal-sized blocks with unique id
+        other_tree = tree.copy()
+        # TODO: is a full copy of the tree needed, given that the original is
+        # mutated below?
+        if right >= other_tree.tree_sequence.sequence_length:
+            other_tree.last()
+        else:
+            # other_tree.seek(right) won't work if `right` is recomb breakpoint
+            while other_tree.interval.right < right:
+                other_tree.next()
+        tree_idx = np.arange(tree.index, other_tree.index + 1) - tree.index
+        tree_offset = tree.index
+        num_blocks = min(self.num_blocks, len(tree_idx))
+        tree_blocks = np.floor_divide(num_blocks * tree_idx, len(tree_idx))
+
+        # calculate span weights
+        # TODO: if bootstrapping, does block span need to be tracked
+        # and used to renormalise each replicate?
+        other_tree.seek(tree.interval.left)
+        tree_span = [
+            min(other_tree.interval.right, right) - max(other_tree.interval.left, left)
+        ]
+        while other_tree.index < tree_offset + tree_idx[-1]:
+            other_tree.next()
+            tree_span.append(
+                min(other_tree.interval.right, right)
+                - max(other_tree.interval.left, left)
+            )
+        tree_span = np.array(tree_span) / sum(tree_span)
+
+        # storage if using single window, block for entire tree sequence
+        buffer_size = self.buffer_size
+        table_size = buffer_size
+        time = np.zeros(table_size)
+        block = np.zeros(table_size, dtype=np.int32)
+        weights = np.zeros((table_size, self.num_weights))
+
+        # assemble table of coalescence times in window
+        indices = np.zeros(tree.tree_sequence.num_nodes, dtype=np.int32) - 1
+        last_block = np.zeros(tree.tree_sequence.num_nodes, dtype=np.int32) - 1
+        num_record = 0
+        while tree.index != tskit.NULL:
+            if tree.interval.right > left:
+                current_block = tree_blocks[tree.index - tree_offset]
+                if self.span_normalise:
+                    span_weight = tree_span[tree.index - tree_offset]
+                else:
+                    span_weight = 1.0
+                nodes_in_tree = np.array(
+                    [i for i in tree.nodes() if tree.is_internal(i)]
+                )
+                # TODO this will fail if all nodes are isolated (masked tree)
+                nodes_to_add = nodes_in_tree[
+                    np.where(last_block[nodes_in_tree] != current_block)
+                ]
+                if len(nodes_to_add) > 0:
+                    idx = np.arange(num_record, num_record + len(nodes_to_add))
+                    last_block[nodes_to_add] = current_block
+                    indices[nodes_to_add] = idx
+                    if table_size < num_record + len(nodes_to_add):
+                        table_size += buffer_size
+                        time = np.pad(time, (0, buffer_size))
+                        block = np.pad(block, (0, buffer_size))
+                        weights = np.pad(weights, ((0, buffer_size), (0, 0)))
+                    time[idx] = [tree.time(i) for i in nodes_to_add]
+                    block[idx] = current_block
+                    num_record += len(nodes_to_add)
+                weights[indices[nodes_in_tree], :] += (
+                    span_weight * running_weights[nodes_in_tree, :]
+                )
+
+            if tree.interval.right < right:
+                # if current tree does not cross window boundary, move to next
+                tree.next()
+                self._update_weights_by_edge_diff(
+                    tree, next(edge_diffs), running_weights
+                )
+            else:
+                # use current tree as initial tree for next window
+                break
+
+        return CoalescenceTimeTable(time, block, weights)
+
+    def _generate_ecdf_tables(self, ts, window_breaks):
+        """
+        Return generator for ECDF tables across genomic windows defined by
+        ``window_breaks``.
+
+        ..note:: This could be used in methods in place of loops over
+            pre-assembled tables.
+        """
+
+        tree = ts.first()
+        edge_diffs = ts.edge_diffs()
+        running_weights = np.zeros((ts.num_nodes, self.num_weights))
+        self._update_weights_by_edge_diff(tree, next(edge_diffs), running_weights)
+        for left, right in zip(window_breaks[:-1], window_breaks[1:]):
+            yield self._build_ecdf_table_for_window(
+                left, right, tree, edge_diffs, running_weights
+            )
+
+    def __init__(
+        self,
+        ts,
+        sample_sets=None,
+        weight_func=None,
+        window_breaks=None,
+        blocks_per_window=None,
+        span_normalise=True,
+    ):
+
+        assert isinstance(ts, trees.TreeSequence)
+
+        if sample_sets is None:
+            sample_sets = [list(ts.samples())]
+        assert all([isinstance(i, list) for i in sample_sets])
+        assert all([i in ts.samples() for j in sample_sets for i in j])
+        self.sample_sets = sample_sets
+
+        if weight_func is None or weight_func == "coalescence_events":
+            self.weight_func = self._count_coalescence_events
+        elif weight_func == "pair_coalescence_events":
+            self.weight_func = self._count_pair_coalescence_events
+        elif weight_func == "trio_first_coalescence_events":
+            self.weight_func = self._count_trio_first_coalescence_events
+        else:
+            assert callable(weight_func)
+            self.weight_func = weight_func
+        _weight_func_eval = self.weight_func(0, ts.first(), self.sample_sets)
+        assert isinstance(_weight_func_eval, np.ndarray)
+        assert _weight_func_eval.ndim == 1
+        self.num_weights = len(_weight_func_eval)
+
+        if window_breaks is None:
+            window_breaks = np.array([0.0, ts.sequence_length])
+        assert isinstance(window_breaks, np.ndarray)
+        assert window_breaks.ndim == 1
+        assert np.min(window_breaks) >= 0.0
+        assert np.max(window_breaks) <= ts.sequence_length
+        window_breaks = np.sort(np.unique(window_breaks))
+        self.windows = [
+            trees.Interval(left, right)
+            for left, right in zip(window_breaks[:-1], window_breaks[1:])
+        ]
+        self.num_windows = len(self.windows)
+
+        if blocks_per_window is None:
+            blocks_per_window = 1
+        assert isinstance(blocks_per_window, int)
+        assert blocks_per_window > 0
+        self.num_blocks = blocks_per_window
+
+        assert isinstance(span_normalise, bool)
+        self.span_normalise = span_normalise
+
+        self.buffer_size = ts.num_nodes
+        self.weight_func_evals = 0
+        self.tables = [table for table in self._generate_ecdf_tables(ts, window_breaks)]
+
+    # TODO
+    #
+    # def __str__(self):
+    #    return self.useful_text_summary()
+    #
+    # def __repr_html__(self):
+    #    return self.useful_html_summary()
+
+    def copy(self):
+        return copy.deepcopy(self)
+
+    def ecdf(self, times):
+        """
+        Returns the empirical distribution function evaluated at the time
+        points in ``times``.
+
+        The output array has shape ``(self.num_weights, len(times),
+        self.num_windows)``.
+        """
+
+        assert isinstance(times, np.ndarray)
+        assert times.ndim == 1
+
+        values = np.empty((self.num_weights, len(times), self.num_windows))
+        values[:] = np.nan
+        for k, table in enumerate(self.tables):
+            indices = np.searchsorted(table.time, times, side="right") - 1
+            assert all([0 <= i < table.num_records for i in indices])
+            values[:, :, k] = table.quantile[indices, :].T
+        return values
+
+    # TODO
+    #
+    # def quantile(self, times):
+    #   """
+    #   Return interpolated quantiles of coalescence times, using the same
+    #   approach as numpy.quantile(..., method="linear")
+    #   """
+
+    def num_coalesced(self, times):
+        """
+        Returns number of coalescence events that have occured by the time
+        points in ``times``.
+
+        The output array has shape ``(self.num_weights, len(times),
+        self.num_windows)``.
+        """
+
+        assert isinstance(times, np.ndarray)
+        assert times.ndim == 1
+
+        values = self.ecdf(times)
+        for k, table in enumerate(self.tables):
+            weight_totals = table.cum_weights[-1, :].reshape(values.shape[0], 1)
+            values[:, :, k] *= np.tile(weight_totals, (1, values.shape[1]))
+        return values
+
+    def num_uncoalesced(self, times):
+        """
+        Returns the number of coalescence events remaining by the time points
+        in ``times``.
+
+        The output array has shape ``(self.num_weights, len(times),
+        self.num_windows)``.
+        """
+
+        values = 1.0 - self.ecdf(times)
+        for k, table in enumerate(self.tables):
+            weight_totals = table.cum_weights[-1, :].reshape(values.shape[0], 1)
+            values[:, :, k] *= np.tile(weight_totals, (1, values.shape[1]))
+        return values
+
+    def mean(self, since=0.0):
+        """
+        Returns the average time between ``since`` and the coalescence events
+        that occurred after ``since``.
+
+        Note that ``1/self.mean(left)`` is an estimate of the coalescence rate
+        over the interval (left, infinity).
+
+        The output array has shape ``(self.num_weights, self.num_windows)``.
+
+        ..note:: Check for overflow in ``np.average``.
+        """
+
+        assert isinstance(since, float) and since >= 0.0
+
+        values = np.empty((self.num_weights, self.num_windows))
+        values[:] = np.nan
+        for k, table in enumerate(self.tables):
+            index = np.searchsorted(table.time, since, side="right")
+            if index == table.num_records:
+                values[:, k] = np.nan
+            else:
+                for i in range(self.num_weights):
+                    if table.cum_weights[-1, i] > 0:
+                        multiplier = table.block_multiplier[table.block[index:]]
+                        values[i, k] = np.average(
+                            table.time[index:] - since,
+                            weights=table.weights[index:, i] * multiplier,
+                        )
+        return values
+
+    def coalescence_probability_in_intervals(self, time_breaks):
+        """
+        Returns the proportion of coalescence events occurring in the time
+        intervals defined by ``time_breaks``, out of events that have not
+        yet occurred by the intervals' left boundaries.
+
+        The output array has shape ``(self.num_weights, len(time_breaks)-1,
+        self.num_windows)``.
+        """
+
+        assert isinstance(time_breaks, np.ndarray)
+
+        time_breaks = np.sort(np.unique(time_breaks))
+        num_coalesced = self.num_coalesced(time_breaks)
+        num_uncoalesced = self.num_uncoalesced(time_breaks)
+        numer = num_coalesced[:, 1:, :] - num_coalesced[:, :-1, :]
+        denom = num_uncoalesced[:, :-1, :]
+        return numer / np.where(np.isclose(denom, 0.0), np.nan, denom)
+
+    def coalescence_rate_in_intervals(self, time_breaks):
+        """
+        Returns the interval-censored Kaplan-Meier estimate of the hazard rate for
+        coalesence events within the time intervals defined by ``time_breaks``. The
+        estimator is,
+
+        .. math::
+            \\hat{c}_{l,r} = \\begin{cases}
+              \\log(1 - x_{l,r}/k_{l})/(l - r) & \\mathrm{if~} x_{l,r} < k_{l} \\\\
+              \\hat{c}_{l,r} = k_{l} / t_{l,r} & \\mathrm{if~} x_{l,r} = k_{l}
+            \\end{cases}
+
+        and is undefined where :math:`k_{l} = 0`. Here, :math:`x_{l,r}` is the
+        number of events occuring in time interval :math:`(l, r]`,
+        :math:`k_{l}` is the number of events remaining at time :math:`l`, and
+        :math:`t_{l,r}` is the sum of event times occurring in the interval
+        :math:`(l, r]`.
+
+        The output array has shape ``(self.num_weights, len(time_breaks)-1,
+        self.num_windows)``.
+        """
+
+        assert isinstance(time_breaks, np.ndarray)
+
+        time_breaks = np.sort(np.unique(time_breaks))
+        phi = self.coalescence_probability_in_intervals(time_breaks)
+        duration = np.reshape(time_breaks[1:] - time_breaks[:-1], (1, phi.shape[1], 1))
+        numer = -np.log(1.0 - np.where(np.isclose(phi, 1.0), np.nan, phi))
+        denom = np.tile(duration, (self.num_weights, 1, self.num_windows))
+        for i, j, k in np.argwhere(np.isclose(phi, 1.0)):
+            numer[i, j, k] = 1.0
+            denom[i, j, k] = self.mean(time_breaks[j])[i, k]
+        return numer / denom
+
+    def block_bootstrap(self, num_replicates=1, random_seed=None):
+        """
+        Return a generator that produces ``num_replicates`` copies of the
+        object where blocks within genomic windows are randomly resampled.
+
+        ..note:: Copying could be expensive.
+        """
+
+        rng = np.random.default_rng(random_seed)
+        for _i in range(num_replicates):
+            replicate = self.copy()
+            for table in replicate.tables:
+                block_multiplier = rng.multinomial(
+                    table.num_blocks, [1.0 / table.num_blocks] * table.num_blocks
+                )
+                table.resample_blocks(block_multiplier)
+            yield replicate

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -46,6 +46,7 @@ import tskit
 import tskit.combinatorics as combinatorics
 import tskit.drawing as drawing
 import tskit.metadata as metadata_module
+import tskit.stats as stats
 import tskit.tables as tables
 import tskit.text_formats as text_formats
 import tskit.util as util
@@ -8718,6 +8719,26 @@ class TreeSequence:
             min_span=min_span,
             store_segments=store_segments,
             store_pairs=store_pairs,
+        )
+
+    def coalescence_time_distribution(
+        self,
+        *,
+        sample_sets=None,
+        weight_func=None,
+        window_breaks=None,
+        blocks_per_window=None,
+        span_normalise=False,
+    ):
+        # TODO docstring, not yet in API
+
+        return stats.CoalescenceTimeDistribution(
+            self,
+            sample_sets=sample_sets,
+            weight_func=weight_func,
+            window_breaks=window_breaks,
+            blocks_per_window=blocks_per_window,
+            span_normalise=span_normalise,
         )
 
     ############################################


### PR DESCRIPTION
WIP related to #1315. Edited 14 Feb 22 into something resembling a usable API. @petrelharp @gregorgorjanc

This mock-up consists of a class in `test_stats.py` that: (a) walks over nodes in marginal trees; (b) assigns nodes to "blocks" of adjacent trees that can be easily resampled; (c) calculates weights for node times according to a user-provided function -- for example, calculating the number of pairs/trios of a particular population labelling that coalesce in a particular node -- then sums these across trees for each unique node/block combination; (d) provides member functions for the ecdf of the resulting distribution of event times, and a simple estimator of average event rate in time intervals; (e) provides a generator for  bootstrapping that reweights nodes by resampling blocks of trees. Conceptually, this is a concise representation of a distribution of event times; the distribution of what exactly depends on the choice of how nodes are weighted. Special cases include pairwise coalescence times, pairwise cross-coalescence times, and first coalescence times of trios/quartets. Applications for these include the fitting of single- or multi-population demographic models with time-varying Ne/migration, but they are likely interesting in their own right as summary statistics (e.g. in sliding windows across the genome).

This could easily be refactored as a standalone function (still allowing arbitrary weighting) or several functions (with defined weights, e.g. for pairwise coalescence). The reason it's written as a class is to allow quick recomputation of coalescence rates for different discritizations of time, or fast querying of specific event times w/ the accompanying weight. This allows some interactivity in selecting the resolution of the time discritization, without having to pass over the marginal trees each time. The idea is that the reduction to a single record per unique node id keeps the storage requirements low. But this design might not translate very easily to local estimates on genomic windows.

### usage example
``` python
sample_sets = [population1, population2, population3] # distinct sets of samples
time_distr = CoalescenceTimeDistribution(ts, sample_sets, 
                weight_func = count_leaf_pairs, num_blocks = 100)

time_grid = numpy.linspace(0., max_time, num_time_points)

# returns array with shape ( length_of_weighting_function_output , num_time_points )
time_distr.ecdf(time_grid)
time_distr.num_coalesced(time_grid)
time_distr.num_uncoalesced(time_grid)

# returns array with shape ( length_of_weighting_function_output , num_time_points - 1)
# e.g. "time_grid" is used as breaks for windows wherein time-average rates are calculated
time_distr.interval_coalescence_rate(time_grid)
# for this choice of weight_func, the inverse of the coalescence rate is an estimate of haploid Ne
1./time_distr.interval_coalescence_rate(time_grid)
 
# generates copies with node weights adjusted according to a block resampling scheme
time_distr_boot = time_distr.block_bootstrap(num_replicates, random_seed)
next(time_distr_boot).interval_coalescence_rate(time_grid) # resampled summary statistics
```
where
``` python
def count_leaf_pairs(nd, tr, sample_sets):
    ss = sample_sets
    wts = np.array([0]*len(ss), dtype="int32")
    if tr.is_internal(nd):
       # number of descendants per child across sample sets
       ch = tr.children(nd)
       nd = [[len([j for j in tr.leaves(c) if j in s]) for s in ss] for c in ch]
       # weights are the number of pairs with a TMRCA at node
       for s in range(len(ss)):
           for i in range(len(ch)-1):
               for j in range(i+1, len(ch)):
                   wts[s] += nd[i][s] * nd[j][s]
    return wts
```
is one possible weighting function, that returns the number of pairs of samples that coalesce at the node across different sets of samples (e.g. populations). More complex choices could include counting of topologies matching a particular population labeling and position of focal node, for example counting embedded topologies of the form `((A,B):node,C)` where `A,B,C` are population labels and `node` is the node ID.

### Ne estimation and confidence intervals
This only really applies to pairwise coalescence rates, but could serve as the starting point for a tutorial. Assume a single population with piecewise-constant effective population size through time. The `i`th epoch has duration `d_i` and effective population size `n_i`. The probability that a pair of lineages will coalesce by the end of epoch `i` is `p_i = 1 - exp(-d_i / n_i)` (conditional on the pair having not already coalesced by the beginning of the epoch). Let there be `k_i` independent pairs of lineages that haven't coalesced by the start of epoch `i` -- for example, genealogies for independently segregating tracts of DNA that have been split by non-overlapping pairs of samples. Let the number of pairs that coalesce during epoch `i` be `x_i`. Because sample pairs/genealogies are independent, `x_i` follows a binomial distribution with size `k_i` and probability `p_i`. Then, the MLE for `n_i` is `-d_i/log(1 - x_i/k_i)`. Its standard error can be calculated from by twice-differentiating the binomial pmf with regard to `n_i`, evaluating at the MLE, etc. Confidence intervals could then be calculated using the normal approximation, or by inverting the endpoints of a more accurate binomial confidence interval (because there's a 1-to-1 relationship between `n_i` and `p_i`).

### Validation
Here are single-population Ne trajectories estimated using the method described above, for 100 simulations from a "sin wave" demography. These are calculated using `x_i, k_i` summed over 10 pairs of samples. Each simulation uses 10000 independent genealogies (so `k_0` is 100000 for each simulation). The black line is the truth, colors are estimates across simulations.

<img src="https://user-images.githubusercontent.com/5767783/152696424-fd1a6436-3213-4822-aa9e-ed51034f4f71.png" width=40% height=40%>

Here is bias / RMSE / confidence interval coverage from the same set of simulations, summing `x_i, k_i` across
 different numbers of sample pairs. The estimates are unbiased regardless of the number of sample pairs used, but are more accurate with more sample pairs. For estimates calculated with a single sample pair, confidence intervals have the desired 95% coverage. However coverage declines rapidly when more sample pairs are used, especially for older windows. I think this is because older coalescence events get counted multiple times like described my comment below, so the binomial model no longer applies. Block bootstrapping produces CIs with much better coverage (not shown).

<img src="https://user-images.githubusercontent.com/5767783/152696987-a915fd35-25dc-4136-a231-1e98f3f0ff62.png" width=80% height=80%>

