### PR TITLE
Provide direction argument to edge_diffs.

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -63,6 +63,12 @@
 - Add Colless tree imbalance index.
   (:user:`jeremyguez`, :user:`jeromekelleher`, :issue:`2250`, :pr:`2266`, :pr:`2344`).
 
+- Add ``direction`` argument to ``TreeSequence.edge_diffs``, allowing iteration
+  over diffs in the reverse direction. NOTE: this comes with a ~10% performance
+  regression as the implementation was moved from C to Python for simplicity
+  and maintainability. Please open an issue if this affects your application.
+  (:user:`jeromekelleher`, :user:`benjeffery`, :pr:`2120`).
+
 **Breaking Changes**
 
 - The JSON metadata codec now interprets the empty string as an empty object. This means

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -178,41 +178,6 @@ class PythonTreeSequence:
                 )
             )
 
-    def edge_diffs(self):
-        M = self._tree_sequence.num_edges
-        sequence_length = self._tree_sequence.sequence_length
-        edges = list(self._tree_sequence.edges())
-        time = [self._tree_sequence.node(edge.parent).time for edge in edges]
-        in_order = sorted(
-            range(M),
-            key=lambda j: (edges[j].left, time[j], edges[j].parent, edges[j].child),
-        )
-        out_order = sorted(
-            range(M),
-            key=lambda j: (edges[j].right, -time[j], -edges[j].parent, -edges[j].child),
-        )
-        j = 0
-        k = 0
-        left = 0.0
-        while j < M or left < sequence_length:
-            e_out = []
-            e_in = []
-            while k < M and edges[out_order[k]].right == left:
-                h = out_order[k]
-                e_out.append(edges[h])
-                k += 1
-            while j < M and edges[in_order[j]].left == left:
-                h = in_order[j]
-                e_in.append(edges[h])
-                j += 1
-            right = sequence_length
-            if j < M:
-                right = min(right, edges[in_order[j]].left)
-            if k < M:
-                right = min(right, edges[out_order[k]].right)
-            yield (left, right), e_out, e_in
-            left = right
-
     def trees(self):
         pt = PythonTree(self._tree_sequence.get_num_nodes())
         pt.index = 0

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2288,34 +2288,6 @@ class TestGeneralStatsInterface(LowLevelTestCase, StatsInterfaceMixin):
                 ts.general_stat(W, lambda x: bad_array, 1, ts.get_breakpoints())
 
 
-class TestTreeDiffIterator(LowLevelTestCase):
-    """
-    Tests for the low-level tree diff iterator.
-    """
-
-    def test_uninitialised_tree_sequence(self):
-        ts = _tskit.TreeSequence()
-        with pytest.raises(ValueError):
-            _tskit.TreeDiffIterator(ts)
-
-    def test_constructor(self):
-        with pytest.raises(TypeError):
-            _tskit.TreeDiffIterator()
-        with pytest.raises(TypeError):
-            _tskit.TreeDiffIterator(None)
-        ts = self.get_example_tree_sequence()
-        before = list(_tskit.TreeDiffIterator(ts))
-        iterator = _tskit.TreeDiffIterator(ts)
-        del ts
-        # We should keep a reference to the tree sequence.
-        after = list(iterator)
-        assert before == after
-
-    def test_iterator(self):
-        ts = self.get_example_tree_sequence()
-        self.verify_iterator(_tskit.TreeDiffIterator(ts))
-
-
 class TestVariant(LowLevelTestCase):
     """
     Tests for the Variant class.
@@ -2938,7 +2910,6 @@ class TestTree(LowLevelTestCase):
 
     def test_count_all_samples(self):
         for ts in self.get_example_tree_sequences():
-            self.verify_iterator(_tskit.TreeDiffIterator(ts))
             st = _tskit.Tree(ts)
             # Without initialisation we should be 0 samples for every node
             # that is not a sample.

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -61,7 +61,7 @@ class NOTSET(metaclass=NotSetMeta):
     pass
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class IndividualTableRow(util.Dataclass):
     """
@@ -97,7 +97,7 @@ class IndividualTableRow(util.Dataclass):
         )
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class NodeTableRow(util.Dataclass):
     """
@@ -127,7 +127,7 @@ class NodeTableRow(util.Dataclass):
     """
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class EdgeTableRow(util.Dataclass):
     """
@@ -157,7 +157,7 @@ class EdgeTableRow(util.Dataclass):
     """
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class MigrationTableRow(util.Dataclass):
     """
@@ -195,7 +195,7 @@ class MigrationTableRow(util.Dataclass):
     """
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class SiteTableRow(util.Dataclass):
     """
@@ -217,7 +217,7 @@ class SiteTableRow(util.Dataclass):
     """
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class MutationTableRow(util.Dataclass):
     """
@@ -268,7 +268,7 @@ class MutationTableRow(util.Dataclass):
         )
 
 
-@metadata.lazy_decode
+@metadata.lazy_decode()
 @dataclass(**dataclass_options)
 class PopulationTableRow(util.Dataclass):
     """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4423,7 +4423,7 @@ class TreeSequence:
                 k -= 1
             yield EdgeDiff(Interval(left, right), edges_out, [])
 
-    def edge_diffs(self, include_terminal=False, *, direction=_tskit.FORWARD):
+    def edge_diffs(self, include_terminal=False, *, direction=tskit.FORWARD):
         """
         Returns an iterator over all the :ref:`edges <sec_edge_table_definition>` that
         are inserted and removed to build the trees as we move from left-to-right along
@@ -4442,6 +4442,10 @@ class TreeSequence:
         descending parent time, parent id, then child_id). This means that within
         each list, edges with the same parent appear consecutively.
 
+        The ``direction`` argument can be used to control whether diffs are produced
+        in the forward (left-to-right, increasing genome coordinate value)
+        or reverse (right-to-left, decreasing genome coordinate value) direction.
+
         :param bool include_terminal: If False (default), the iterator terminates
             after the final interval in the tree sequence (i.e., it does not
             report a final removal of all remaining edges), and the number
@@ -4449,7 +4453,9 @@ class TreeSequence:
             sequence. If True, an additional iteration takes place, with the last
             ``edges_out`` value reporting all the edges contained in the final
             tree (with both ``left`` and ``right`` equal to the sequence length).
-        :param int direction: FINISH ME
+        :param int direction: The direction of travel along the sequence for
+            diffs. Must be one of :data:`.FORWARD` or :data:`.REVERSE`.
+            (Default: :data:`.FORWARD`).
         :return: An iterator over the (interval, edges_out, edges_in) tuples. This
             is a named tuple, so the 3 values can be accessed by position
             (e.g. ``returned_tuple[0]``) or name (e.g. ``returned_tuple.interval``).


### PR DESCRIPTION
Adds a "direction" argument to edge_diffs to allow us to sequentially generate trees in reverse.

Moves the implementation to Python resulting in a roughly 2X perf regression. I doubt this will be significant in practise, because people will usually be *doing* something with the diffs, which will probably be more expensive. Nonetheless, it is a regression so we should be careful.

If we decide we don't mind about the perf loss for this operation, we can delete some of the Python-C interface boilderplate.

I also modernised the tests for this a bit, while I was in there.

cc @astheeggeggs

