### PR TITLE
Li Stephens backwards and tests

### DIFF
--- a/python/tests/fb_diploid_samples_variants.py
+++ b/python/tests/fb_diploid_samples_variants.py
@@ -1,0 +1,467 @@
+"""Collection of functions to run forwards and backwards algorithms on diploid genotype data, where the data is structured as samples x variants."""
+import numpy as np
+
+EQUAL_BOTH_HOM = 4
+UNEQUAL_BOTH_HOM = 0
+BOTH_HET = 7
+REF_HOM_OBS_HET = 1
+REF_HET_OBS_HOM = 2
+
+# https://github.com/numba/numba/issues/1269
+def np_apply_along_axis(func1d, axis, arr):
+    """Create numpy-like functions for max, sum etc."""
+    assert arr.ndim == 2
+    assert axis in [0, 1]
+    if axis == 0:
+        result = np.empty(arr.shape[1])
+        for i in range(len(result)):
+            result[i] = func1d(arr[:, i])
+    else:
+        result = np.empty(arr.shape[0])
+        for i in range(len(result)):
+            result[i] = func1d(arr[i, :])
+    return result
+
+
+def np_amax(array, axis):
+    """Numba implementation of numpy vectorised maximum."""
+    return np_apply_along_axis(np.amax, axis, array)
+
+
+def np_sum(array, axis):
+    """Numba implementation of numpy vectorised sum."""
+    return np_apply_along_axis(np.sum, axis, array)
+
+  
+def np_argmax(array, axis):
+    """Numba implementation of numpy vectorised argmax."""
+    return np_apply_along_axis(np.argmax, axis, array)
+
+
+def forwards_ls_dip(n, m, G, s, e, r, norm=True):
+    """Matrix based diploid LS forward algorithm using numpy vectorisation."""
+    # Initialise the forward tensor
+    F = np.zeros((n, n, m))
+    F[:, :, 0] = 1 / (n ** 2)
+    index = 4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64) + 2 * (
+        G[:, :, 0] == 1
+    ).astype(np.int64)
+    if s[0, 0] == 1:
+        index += 1
+    F[:, :, 0] *= e[index.ravel(), 0].reshape(n, n)
+    c = np.ones(m)
+    r_n = r / n
+
+    if norm:
+        c[0] = np.sum(F[:, :, 0])
+        F[:, :, 0] *= 1 / c[0]
+
+        # Forwards
+        for l in range(1, m):
+
+            index = 4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64) + 2 * (
+                G[:, :, l] == 1
+            ).astype(np.int64)
+
+            if s[0, l] == 1:
+                index += 1
+
+            # No change in both
+            F[:, :, l] = (1 - r[l]) ** 2 * F[:, :, l - 1]
+
+            # Both change
+            F[:, :, l] += (r_n[l]) ** 2
+
+            # One changes
+            sum_j = np_sum(F[:, :, l - 1], 0).repeat(n).reshape((-1, n))
+            F[:, :, l] += ((1 - r[l]) * r_n[l]) * (sum_j + sum_j.T)
+
+            # Emission
+            F[:, :, l] *= e[index.ravel(), l].reshape(n, n)
+            c[l] = np.sum(F[:, :, l])
+            F[:, :, l] *= 1 / c[l]
+
+        ll = np.sum(np.log10(c))
+    else:
+        # Forwards
+        for l in range(1, m):
+
+            index = 4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64) + 2 * (
+                G[:, :, l] == 1
+            ).astype(np.int64)
+
+            if s[0, l] == 1:
+                index += 1
+
+            # No change in both
+            F[:, :, l] = (1 - r[l]) ** 2 * F[:, :, l - 1]
+
+            # Both change
+            F[:, :, l] += (r_n[l]) ** 2 * np.sum(F[:, :, l - 1])
+
+            # One changes
+            sum_j = np_sum(F[:, :, l - 1], 0).repeat(n).reshape((-1, n)).T
+            F[:, :, l] += ((1 - r[l]) * r_n[l]) * (sum_j + sum_j.T)
+
+            # Emission
+            F[:, :, l] *= e[index.ravel(), l].reshape(n, n)
+
+        ll = np.log10(np.sum(F[:, :, l]))
+
+    return F, c, ll
+
+
+def backwards_ls_dip(n, m, G, s, e, c, r):
+    """Matrix based diploid LS backward algorithm using numpy vectorisation."""
+    # Initialise the backward tensor
+    B = np.zeros((n, n, m))
+
+    # Initialise
+    B[:, :, m - 1] = 1
+    r_n = r / n
+
+    # Backwards
+    for l in range(m - 2, -1, -1):
+
+        index = (
+            4 * np.equal(G[:, :, l + 1], s[0, l + 1]).astype(np.int64)
+            + 2 * (G[:, :, l + 1] == 1).astype(np.int64)
+            + np.int64(s[0, l + 1] == 1)
+        ).ravel()
+
+        # Both change
+        B[:, :, l] = r_n[l + 1] ** 2 * np.sum(
+            e[index, l + 1].reshape(n, n) * B[:, :, l + 1]
+        )
+
+        # No change in both
+        B[:, :, l] += (
+            (1 - r[l + 1]) ** 2 * B[:, :, l + 1] * e[index, l + 1].reshape(n, n)
+        )
+
+        sum_j = (
+            np_sum(B[:, :, l + 1] * e[index, l + 1].reshape(n, n), 0)
+            .repeat(n)
+            .reshape((-1, n))
+        )
+        B[:, :, l] += ((1 - r[l + 1]) * r_n[l + 1]) * (sum_j + sum_j.T)
+        B[:, :, l] *= 1 / c[l + 1]
+
+    return B
+
+
+def forward_ls_dip_starting_point(n, m, G, s, e, r):
+    """Naive implementation of LS diploid forwards algorithm."""
+    # Initialise the forward tensor
+    F = np.zeros((n, n, m))
+    F[:, :, 0] = 1 / (n ** 2)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    F[:, :, 0] *= e[index.ravel(), 0].reshape(n, n)
+    r_n = r / n
+
+    for l in range(1, m):
+
+        # Determine the various components
+        F_no_change = np.zeros((n, n))
+        F_j1_change = np.zeros(n)
+        F_j2_change = np.zeros(n)
+        F_both_change = 0
+
+        for j1 in range(n):
+            for j2 in range(n):
+                F_no_change[j1, j2] = (1 - r[l]) ** 2 * F[j1, j2, l - 1]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                F_both_change += r_n[l] ** 2 * F[j1, j2, l - 1]
+
+        for j1 in range(n):
+            for j2 in range(n):  # This is the variable to sum over - it changes
+                F_j2_change[j1] += (1 - r[l]) * r_n[l] * F[j1, j2, l - 1]
+
+        for j2 in range(n):
+            for j1 in range(n):  # This is the variable to sum over - it changes
+                F_j1_change[j2] += (1 - r[l]) * r_n[l] * F[j1, j2, l - 1]
+
+        F[:, :, l] = F_both_change
+
+        for j1 in range(n):
+            F[j1, :, l] += F_j2_change
+
+        for j2 in range(n):
+            F[:, j2, l] += F_j1_change
+
+        for j1 in range(n):
+            for j2 in range(n):
+                F[j1, j2, l] += F_no_change[j1, j2]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                # What is the emission?
+                if s[0, l] == 1:
+                    # OBS is het
+                    if G[j1, j2, l] == 1:  # REF is het
+                        F[j1, j2, l] *= e[BOTH_HET, l]
+                    else:  # REF is hom
+                        F[j1, j2, l] *= e[REF_HOM_OBS_HET, l]
+                else:
+                    # OBS is hom
+                    if G[j1, j2, l] == 1:  # REF is het
+                        F[j1, j2, l] *= e[REF_HET_OBS_HOM, l]
+                    else:  # REF is hom
+                        if G[j1, j2, l] == s[0, l]:  # Equal
+                            F[j1, j2, l] *= e[EQUAL_BOTH_HOM, l]
+                        else:  # Unequal
+                            F[j1, j2, l] *= e[UNEQUAL_BOTH_HOM, l]
+
+    ll = np.log10(np.sum(F[:, :, l]))
+    return F, ll
+
+
+def backward_ls_dip_starting_point(n, m, G, s, e, r):
+    """Naive implementation of LS diploid backwards algorithm."""
+    # Backwards
+    B = np.zeros((n, n, m))
+
+    # Initialise
+    B[:, :, m - 1] = 1
+    r_n = r / n
+
+    for l in range(m - 2, -1, -1):
+
+        # Determine the various components
+        B_no_change = np.zeros((n, n))
+        B_j1_change = np.zeros(n)
+        B_j2_change = np.zeros(n)
+        B_both_change = 0
+
+        # Evaluate the emission matrix at this site, for all pairs
+        e_tmp = np.zeros((n, n))
+        for j1 in range(n):
+            for j2 in range(n):
+                # What is the emission?
+                if s[0, l + 1] == 1:
+                    # OBS is het
+                    if G[j1, j2, l + 1] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[BOTH_HET, l + 1]
+                    else:  # REF is hom
+                        e_tmp[j1, j2] = e[REF_HOM_OBS_HET, l + 1]
+                else:
+                    # OBS is hom
+                    if G[j1, j2, l + 1] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[REF_HET_OBS_HOM, l + 1]
+                    else:  # REF is hom
+                        if G[j1, j2, l + 1] == s[0, l + 1]:  # Equal
+                            e_tmp[j1, j2] = e[EQUAL_BOTH_HOM, l + 1]
+                        else:  # Unequal
+                            e_tmp[j1, j2] = e[UNEQUAL_BOTH_HOM, l + 1]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B_no_change[j1, j2] = (
+                    (1 - r[l + 1]) ** 2 * B[j1, j2, l + 1] * e_tmp[j1, j2]
+                )
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B_both_change += r_n[l + 1] ** 2 * e_tmp[j1, j2] * B[j1, j2, l + 1]
+
+        for j1 in range(n):
+            for j2 in range(n):  # This is the variable to sum over - it changes
+                B_j2_change[j1] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[j1, j2, l + 1] * e_tmp[j1, j2]
+                )
+
+        for j2 in range(n):
+            for j1 in range(n):  # This is the variable to sum over - it changes
+                B_j1_change[j2] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[j1, j2, l + 1] * e_tmp[j1, j2]
+                )
+
+        B[:, :, l] = B_both_change
+
+        for j1 in range(n):
+            B[j1, :, l] += B_j2_change
+
+        for j2 in range(n):
+            B[:, j2, l] += B_j1_change
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B[j1, j2, l] += B_no_change[j1, j2]
+
+    return B
+
+
+def forward_ls_dip_loop(n, m, G, s, e, r, norm=True):
+    """LS diploid forwards algoritm without vectorisation."""
+    # Initialise the forward tensor
+    F = np.zeros((n, n, m))
+    F[:, :, 0] = 1 / (n ** 2)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    F[:, :, 0] *= e[index.ravel(), 0].reshape(n, n)
+    r_n = r / n
+    c = np.ones(m)
+
+    if norm:
+
+        c[0] = np.sum(F[:, :, 0])
+        F[:, :, 0] *= 1 / c[0]
+
+        for l in range(1, m):
+
+            # Determine the various components
+            F_no_change = np.zeros((n, n))
+            F_j_change = np.zeros(n)
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    F_no_change[j1, j2] = (1 - r[l]) ** 2 * F[j1, j2, l - 1]
+                    F_j_change[j1] += (1 - r[l]) * r_n[l] * F[j2, j1, l - 1]
+
+            F[:, :, l] = r_n[l] ** 2
+
+            for j1 in range(n):
+                F[j1, :, l] += F_j_change
+                F[:, j1, l] += F_j_change
+                for j2 in range(n):
+                    F[j1, j2, l] += F_no_change[j1, j2]
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    # What is the emission?
+                    if s[0, l] == 1:
+                        # OBS is het
+                        if G[j1, j2, l] == 1:  # REF is het
+                            F[j1, j2, l] *= e[BOTH_HET, l]
+                        else:  # REF is hom
+                            F[j1, j2, l] *= e[REF_HOM_OBS_HET, l]
+                    else:
+                        # OBS is hom
+                        if G[j1, j2, l] == 1:  # REF is het
+                            F[j1, j2, l] *= e[REF_HET_OBS_HOM, l]
+                        else:  # REF is hom
+                            if G[j1, j2, l] == s[0, l]:  # Equal
+                                F[j1, j2, l] *= e[EQUAL_BOTH_HOM, l]
+                            else:  # Unequal
+                                F[j1, j2, l] *= e[UNEQUAL_BOTH_HOM, l]
+
+            c[l] = np.sum(F[:, :, l])
+            F[:, :, l] *= 1 / c[l]
+
+        ll = np.sum(np.log10(c))
+
+    else:
+
+        for l in range(1, m):
+
+            # Determine the various components
+            F_no_change = np.zeros((n, n))
+            F_j1_change = np.zeros(n)
+            F_j2_change = np.zeros(n)
+            F_both_change = 0
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    F_no_change[j1, j2] = (1 - r[l]) ** 2 * F[j1, j2, l - 1]
+                    F_j1_change[j1] += (1 - r[l]) * r_n[l] * F[j2, j1, l - 1]
+                    F_j2_change[j1] += (1 - r[l]) * r_n[l] * F[j1, j2, l - 1]
+                    F_both_change += r_n[l] ** 2 * F[j1, j2, l - 1]
+
+            F[:, :, l] = F_both_change
+
+            for j1 in range(n):
+                F[j1, :, l] += F_j2_change
+                F[:, j1, l] += F_j1_change
+                for j2 in range(n):
+                    F[j1, j2, l] += F_no_change[j1, j2]
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    # What is the emission?
+                    if s[0, l] == 1:
+                        # OBS is het
+                        if G[j1, j2, l] == 1:  # REF is het
+                            F[j1, j2, l] *= e[BOTH_HET, l]
+                        else:  # REF is hom
+                            F[j1, j2, l] *= e[REF_HOM_OBS_HET, l]
+                    else:
+                        # OBS is hom
+                        if G[j1, j2, l] == 1:  # REF is het
+                            F[j1, j2, l] *= e[REF_HET_OBS_HOM, l]
+                        else:  # REF is hom
+                            if G[j1, j2, l] == s[0, l]:  # Equal
+                                F[j1, j2, l] *= e[EQUAL_BOTH_HOM, l]
+                            else:  # Unequal
+                                F[j1, j2, l] *= e[UNEQUAL_BOTH_HOM, l]
+
+        ll = np.log10(np.sum(F[:, :, l]))
+
+    return F, c, ll
+
+
+def backward_ls_dip_loop(n, m, G, s, e, c, r):
+    """LS diploid backwards algoritm without vectorisation."""
+    # Initialise the backward tensor
+    B = np.zeros((n, n, m))
+    B[:, :, m - 1] = 1
+    r_n = r / n
+
+    for l in range(m - 2, -1, -1):
+
+        # Determine the various components
+        B_no_change = np.zeros((n, n))
+        B_j_change = np.zeros(n)
+        B_both_change = 0
+
+        # Evaluate the emission matrix at this site, for all pairs
+        e_tmp = np.zeros((n, n))
+        for j1 in range(n):
+            for j2 in range(n):
+                # What is the emission?
+                if s[0, l + 1] == 1:
+                    # OBS is het
+                    if G[j1, j2, l + 1] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[BOTH_HET, l + 1]
+                    else:  # REF is hom
+                        e_tmp[j1, j2] = e[REF_HOM_OBS_HET, l + 1]
+                else:
+                    # OBS is hom
+                    if G[j1, j2, l + 1] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[REF_HET_OBS_HOM, l + 1]
+                    else:  # REF is hom
+                        if G[j1, j2, l + 1] == s[0, l + 1]:  # Equal
+                            e_tmp[j1, j2] = e[EQUAL_BOTH_HOM, l + 1]
+                        else:  # Unequal
+                            e_tmp[j1, j2] = e[UNEQUAL_BOTH_HOM, l + 1]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B_no_change[j1, j2] = (
+                    (1 - r[l + 1]) ** 2 * B[j1, j2, l + 1] * e_tmp[j1, j2]
+                )
+                B_j_change[j1] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[j1, j2, l + 1] * e_tmp[j1, j2]
+                )
+                B_both_change += r_n[l + 1] ** 2 * e_tmp[j1, j2] * B[j1, j2, l + 1]
+
+        B[:, :, l] = B_both_change
+
+        for j1 in range(n):
+            B[:, j1, l] += B_j_change
+            B[j1, :, l] += B_j_change
+
+            for j2 in range(n):
+                B[j1, j2, l] += B_no_change[j1, j2]
+
+        B[:, :, l] *= 1 / c[l + 1]
+
+    return B

--- a/python/tests/fb_diploid_variants_samples.py
+++ b/python/tests/fb_diploid_variants_samples.py
@@ -1,0 +1,479 @@
+"""Collection of functions to run forwards and backwards algorithms on haploid genotype data, where the data is structured as variants x samples."""
+import numpy as np
+
+EQUAL_BOTH_HOM = 4
+UNEQUAL_BOTH_HOM = 0
+BOTH_HET = 7
+REF_HOM_OBS_HET = 1
+REF_HET_OBS_HOM = 2
+
+# https://github.com/numba/numba/issues/1269
+def np_apply_along_axis(func1d, axis, arr):
+    """Create numpy-like functions for max, sum etc."""
+    assert arr.ndim == 2
+    assert axis in [0, 1]
+    if axis == 0:
+        result = np.empty(arr.shape[1])
+        for i in range(len(result)):
+            result[i] = func1d(arr[:, i])
+    else:
+        result = np.empty(arr.shape[0])
+        for i in range(len(result)):
+            result[i] = func1d(arr[i, :])
+    return result
+
+
+def np_amax(array, axis):
+    """Numba implementation of numpy vectorised maximum."""
+    return np_apply_along_axis(np.amax, axis, array)
+
+
+def np_sum(array, axis):
+    """Numba implementation of numpy vectorised sum."""
+    return np_apply_along_axis(np.sum, axis, array)
+
+
+def np_argmax(array, axis):
+    """Numba implementation of numpy vectorised argmax."""
+    return np_apply_along_axis(np.argmax, axis, array)
+
+
+def forwards_ls_dip(n, m, G, s, e, r, norm=True):
+    """Matrix based diploid LS forward algorithm using numpy vectorisation."""
+    # Initialise the forward tensor
+    F = np.zeros((m, n, n))
+    F[0, :, :] = 1 / (n ** 2)
+    index = 4 * np.equal(G[0, :, :], s[0, 0]).astype(np.int64) + 2 * (
+        G[0, :, :] == 1
+    ).astype(np.int64)
+
+    if s[0, 0] == 1:
+        index += 1
+    F[0, :, :] *= e[0, index]
+    c = np.ones(m)
+    r_n = r / n
+
+    if norm:
+        c[0] = np.sum(F[0, :, :])
+        F[0, :, :] *= 1 / c[0]
+
+        # Forwards
+        for l in range(1, m):
+
+            index = 4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64) + 2 * (
+                G[l, :, :] == 1
+            ).astype(np.int64)
+
+            if s[0, l] == 1:
+                index += 1
+
+            # No change in both
+            F[l, :, :] = (1 - r[l]) ** 2 * F[l - 1, :, :]
+
+            # Both change
+            F[l, :, :] += (r_n[l]) ** 2
+
+            # One changes
+            sum_j = np_sum(F[l - 1, :, :], 0).repeat(n).reshape((-1, n)).T
+            # sum_j2 = np_sum(F[l - 1, :, :], 1).repeat(n).reshape((-1, n))
+            F[l, :, :] += ((1 - r[l]) * r_n[l]) * (sum_j + sum_j.T)
+
+            # Emission
+            F[l, :, :] *= e[l, index]
+            c[l] = np.sum(F[l, :, :])
+            F[l, :, :] *= 1 / c[l]
+
+        ll = np.sum(np.log10(c))
+    else:
+        # Forwards
+        for l in range(1, m):
+
+            index = 4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64) + 2 * (
+                G[l, :, :] == 1
+            ).astype(np.int64)
+
+            if s[0, l] == 1:
+                index += 1
+
+            # No change in both
+            F[l, :, :] = (1 - r[l]) ** 2 * F[l - 1, :, :]
+
+            # Both change
+            F[l, :, :] += (r_n[l]) ** 2 * np.sum(F[l - 1, :, :])
+
+            # One changes
+            sum_j = np_sum(F[l - 1, :, :], 0).repeat(n).reshape((-1, n)).T
+            # sum_j2 = np_sum(F[l - 1, :, :], 1).repeat(n).reshape((-1, n))
+            F[l, :, :] += ((1 - r[l]) * r_n[l]) * (sum_j + sum_j.T)
+
+            # Emission
+            F[l, :, :] *= e[l, index]
+
+        ll = np.log10(np.sum(F[l, :, :]))
+
+    return F, c, ll
+
+
+def backwards_ls_dip(n, m, G, s, e, c, r):
+    """Matrix based diploid LS backward algorithm using numpy vectorisation."""
+    # Initialise the backward tensor
+    B = np.zeros((m, n, n))
+
+    # Initialise
+    B[m - 1, :, :] = 1
+    r_n = r / n
+
+    # Backwards
+    for l in range(m - 2, -1, -1):
+
+        index = (
+            4 * np.equal(G[l + 1, :, :], s[0, l + 1]).astype(np.int64)
+            + 2 * (G[l + 1, :, :] == 1).astype(np.int64)
+            + np.int64(s[0, l + 1] == 1)
+        )
+
+        # No change in both
+        B[l, :, :] = r_n[l + 1] ** 2 * np.sum(
+            e[l + 1, index.reshape((n, n))] * B[l + 1, :, :]
+        )
+
+        # Both change
+        B[l, :, :] += (
+            (1 - r[l + 1]) ** 2 * B[l + 1, :, :] * e[l + 1, index.reshape((n, n))]
+        )
+
+        # One changes
+        # sum_j1 = np.tile(np.sum(B[l+1,:,:] * e[l+1, index], 0, keepdims=True), (n,1))
+        # sum_j1 = np_sum(B[l + 1, :, :], 0).repeat(n).reshape((-1, n)).T
+        # sum_j2 = np.tile(np.sum(B[l+1,:,:] * e[l+1, index], 1, keepdims=True), (1,n))
+        # sum_j2 = np_sum(B[l + 1, :, :], 1).repeat(n).reshape((-1, n))
+        sum_j = np_sum(B[l + 1, :, :] * e[l + 1, index], 0).repeat(n).reshape((-1, n))
+        B[l, :, :] += ((1 - r[l + 1]) * r_n[l + 1]) * (sum_j + sum_j.T)
+        B[l, :, :] *= 1 / c[l + 1]
+
+    return B
+
+
+def forward_ls_dip_starting_point(n, m, G, s, e, r):
+    """Naive implementation of LS diploid forwards algorithm."""
+    # Initialise the forward tensor
+    F = np.zeros((m, n, n))
+    r_n = r / n
+    for j1 in range(n):
+        for j2 in range(n):
+            F[0, j1, j2] = 1 / (n ** 2)
+            index_tmp = (
+                4 * np.int64(np.equal(G[0, j1, j2], s[0, 0]))
+                + 2 * np.int64((G[0, j1, j2] == 1))
+                + np.int64(s[0, 0] == 1)
+            )
+            F[0, j1, j2] *= e[0, index_tmp]
+
+    for l in range(1, m):
+
+        # Determine the various components
+        F_no_change = np.zeros((n, n))
+        F_j1_change = np.zeros(n)
+        F_j2_change = np.zeros(n)
+        F_both_change = 0
+
+        for j1 in range(n):
+            for j2 in range(n):
+                F_no_change[j1, j2] = (1 - r[l]) ** 2 * F[l - 1, j1, j2]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                F_both_change += r_n[l] ** 2 * F[l - 1, j1, j2]
+
+        for j1 in range(n):
+            for j2 in range(n):  # This is the variable to sum over - it changes
+                F_j2_change[j1] += (1 - r[l]) * r_n[l] * F[l - 1, j1, j2]
+
+        for j2 in range(n):
+            for j1 in range(n):  # This is the variable to sum over - it changes
+                F_j1_change[j2] += (1 - r[l]) * r_n[l] * F[l - 1, j1, j2]
+
+        F[l, :, :] = F_both_change
+
+        for j1 in range(n):
+            F[l, j1, :] += F_j2_change
+
+        for j2 in range(n):
+            F[l, :, j2] += F_j1_change
+
+        for j1 in range(n):
+            for j2 in range(n):
+                F[l, j1, j2] += F_no_change[j1, j2]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                # What is the emission?
+                if s[0, l] == 1:
+                    # OBS is het
+                    if G[l, j1, j2] == 1:  # REF is het
+                        F[l, j1, j2] *= e[l, BOTH_HET]
+                    else:  # REF is hom
+                        F[l, j1, j2] *= e[l, REF_HOM_OBS_HET]
+                else:
+                    # OBS is hom
+                    if G[l, j1, j2] == 1:  # REF is het
+                        F[l, j1, j2] *= e[l, REF_HET_OBS_HOM]
+                    else:  # REF is hom
+                        if G[l, j1, j2] == s[0, l]:  # Equal
+                            F[l, j1, j2] *= e[l, EQUAL_BOTH_HOM]
+                        else:  # Unequal
+                            F[l, j1, j2] *= e[l, UNEQUAL_BOTH_HOM]
+
+    ll = np.log10(np.sum(F[l, :, :]))
+
+    return F, ll
+
+
+def backward_ls_dip_starting_point(n, m, G, s, e, r):
+    """Naive implementation of LS diploid backwards algorithm."""
+    # Backwards
+    B = np.zeros((m, n, n))
+
+    # Initialise
+    B[m - 1, :, :] = 1
+    r_n = r / n
+
+    for l in range(m - 2, -1, -1):
+
+        # Determine the various components
+        B_no_change = np.zeros((n, n))
+        B_j1_change = np.zeros(n)
+        B_j2_change = np.zeros(n)
+        B_both_change = 0
+
+        # Evaluate the emission matrix at this site, for all pairs
+        e_tmp = np.zeros((n, n))
+        for j1 in range(n):
+            for j2 in range(n):
+                # What is the emission?
+                if s[0, l + 1] == 1:
+                    # OBS is het
+                    if G[l + 1, j1, j2] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[l + 1, BOTH_HET]
+                    else:  # REF is hom
+                        e_tmp[j1, j2] = e[l + 1, REF_HOM_OBS_HET]
+                else:
+                    # OBS is hom
+                    if G[l + 1, j1, j2] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[l + 1, REF_HET_OBS_HOM]
+                    else:  # REF is hom
+                        if G[l + 1, j1, j2] == s[0, l + 1]:  # Equal
+                            e_tmp[j1, j2] = e[l + 1, EQUAL_BOTH_HOM]
+                        else:  # Unequal
+                            e_tmp[j1, j2] = e[l + 1, UNEQUAL_BOTH_HOM]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B_no_change[j1, j2] = (
+                    (1 - r[l + 1]) ** 2 * B[l + 1, j1, j2] * e_tmp[j1, j2]
+                )
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B_both_change += r_n[l + 1] ** 2 * e_tmp[j1, j2] * B[l + 1, j1, j2]
+
+        for j1 in range(n):
+            for j2 in range(n):  # This is the variable to sum over - it changes
+                B_j2_change[j1] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[l + 1, j1, j2] * e_tmp[j1, j2]
+                )
+
+        for j2 in range(n):
+            for j1 in range(n):  # This is the variable to sum over - it changes
+                B_j1_change[j2] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[l + 1, j1, j2] * e_tmp[j1, j2]
+                )
+
+        B[l, :, :] = B_both_change
+
+        for j1 in range(n):
+            B[l, j1, :] += B_j2_change
+
+        for j2 in range(n):
+            B[l, :, j2] += B_j1_change
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B[l, j1, j2] += B_no_change[j1, j2]
+
+    return B
+
+
+def forward_ls_dip_loop(n, m, G, s, e, r, norm=True):
+    """LS diploid forwards algoritm without vectorisation."""
+    # Initialise the forward tensor
+    F = np.zeros((m, n, n))
+    for j1 in range(n):
+        for j2 in range(n):
+            F[0, j1, j2] = 1 / (n ** 2)
+            index_tmp = (
+                4 * np.int64(np.equal(G[0, j1, j2], s[0, 0]))
+                + 2 * np.int64((G[0, j1, j2] == 1))
+                + np.int64(s[0, 0] == 1)
+            )
+            F[0, j1, j2] *= e[0, index_tmp]
+    r_n = r / n
+    c = np.ones(m)
+
+    if norm:
+
+        c[0] = np.sum(F[0, :, :])
+        F[0, :, :] *= 1 / c[0]
+
+        for l in range(1, m):
+
+            # Determine the various components
+            F_no_change = np.zeros((n, n))
+            F_j_change = np.zeros(n)
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    F_no_change[j1, j2] = (1 - r[l]) ** 2 * F[l - 1, j1, j2]
+                    F_j_change[j1] += (1 - r[l]) * r_n[l] * F[l - 1, j2, j1]
+
+            F[l, :, :] = r_n[l] ** 2
+
+            for j1 in range(n):
+                F[l, j1, :] += F_j_change
+                F[l, :, j1] += F_j_change
+                for j2 in range(n):
+                    F[l, j1, j2] += F_no_change[j1, j2]
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    # What is the emission?
+                    if s[0, l] == 1:
+                        # OBS is het
+                        if G[l, j1, j2] == 1:  # REF is het
+                            F[l, j1, j2] *= e[l, BOTH_HET]
+                        else:  # REF is hom
+                            F[l, j1, j2] *= e[l, REF_HOM_OBS_HET]
+                    else:
+                        # OBS is hom
+                        if G[l, j1, j2] == 1:  # REF is het
+                            F[l, j1, j2] *= e[l, REF_HET_OBS_HOM]
+                        else:  # REF is hom
+                            if G[l, j1, j2] == s[0, l]:  # Equal
+                                F[l, j1, j2] *= e[l, EQUAL_BOTH_HOM]
+                            else:  # Unequal
+                                F[l, j1, j2] *= e[l, UNEQUAL_BOTH_HOM]
+
+            c[l] = np.sum(F[l, :, :])
+            F[l, :, :] *= 1 / c[l]
+
+        ll = np.sum(np.log10(c))
+
+    else:
+
+        for l in range(1, m):
+
+            # Determine the various components
+            F_no_change = np.zeros((n, n))
+            F_j1_change = np.zeros(n)
+            F_j2_change = np.zeros(n)
+            F_both_change = 0
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    F_no_change[j1, j2] = (1 - r[l]) ** 2 * F[l - 1, j1, j2]
+                    F_j1_change[j1] += (1 - r[l]) * r_n[l] * F[l - 1, j2, j1]
+                    F_j2_change[j1] += (1 - r[l]) * r_n[l] * F[l - 1, j1, j2]
+                    F_both_change += r_n[l] ** 2 * F[l - 1, j1, j2]
+
+            F[l, :, :] = F_both_change
+
+            for j1 in range(n):
+                F[l, j1, :] += F_j2_change
+                F[l, :, j1] += F_j1_change
+                for j2 in range(n):
+                    F[l, j1, j2] += F_no_change[j1, j2]
+
+            for j1 in range(n):
+                for j2 in range(n):
+                    # What is the emission?
+                    if s[0, l] == 1:
+                        # OBS is het
+                        if G[l, j1, j2] == 1:  # REF is het
+                            F[l, j1, j2] *= e[l, BOTH_HET]
+                        else:  # REF is hom
+                            F[l, j1, j2] *= e[l, REF_HOM_OBS_HET]
+                    else:
+                        # OBS is hom
+                        if G[l, j1, j2] == 1:  # REF is het
+                            F[l, j1, j2] *= e[l, REF_HET_OBS_HOM]
+                        else:  # REF is hom
+                            if G[l, j1, j2] == s[0, l]:  # Equal
+                                F[l, j1, j2] *= e[l, EQUAL_BOTH_HOM]
+                            else:  # Unequal
+                                F[l, j1, j2] *= e[l, UNEQUAL_BOTH_HOM]
+
+            ll = np.log10(np.sum(F[l, :, :]))
+
+    return F, c, ll
+
+
+def backward_ls_dip_loop(n, m, G, s, e, c, r):
+    """LS diploid backwards algoritm without vectorisation."""
+    # Initialise the backward tensor
+    B = np.zeros((m, n, n))
+    B[m - 1, :, :] = 1
+    r_n = r / n
+
+    for l in range(m - 2, -1, -1):
+
+        # Determine the various components
+        B_no_change = np.zeros((n, n))
+        B_j1_change = np.zeros(n)
+        B_j2_change = np.zeros(n)
+        B_both_change = 0
+
+        # Evaluate the emission matrix at this site, for all pairs
+        e_tmp = np.zeros((n, n))
+        for j1 in range(n):
+            for j2 in range(n):
+                # What is the emission?
+                if s[0, l + 1] == 1:
+                    # OBS is het
+                    if G[l + 1, j1, j2] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[l + 1, BOTH_HET]
+                    else:  # REF is hom
+                        e_tmp[j1, j2] = e[l + 1, REF_HOM_OBS_HET]
+                else:
+                    # OBS is hom
+                    if G[l + 1, j1, j2] == 1:  # REF is het
+                        e_tmp[j1, j2] = e[l + 1, REF_HET_OBS_HOM]
+                    else:  # REF is hom
+                        if G[l + 1, j1, j2] == s[0, l + 1]:  # Equal
+                            e_tmp[j1, j2] = e[l + 1, EQUAL_BOTH_HOM]
+                        else:  # Unequal
+                            e_tmp[j1, j2] = e[l + 1, UNEQUAL_BOTH_HOM]
+
+        for j1 in range(n):
+            for j2 in range(n):
+                B_no_change[j1, j2] = (
+                    (1 - r[l + 1]) ** 2 * B[l + 1, j1, j2] * e_tmp[j1, j2]
+                )
+                B_j2_change[j1] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[l + 1, j1, j2] * e_tmp[j1, j2]
+                )
+                B_j1_change[j1] += (
+                    (1 - r[l + 1]) * r_n[l + 1] * B[l + 1, j2, j1] * e_tmp[j2, j1]
+                )
+                B_both_change += r_n[l + 1] ** 2 * e_tmp[j1, j2] * B[l + 1, j1, j2]
+
+        B[l, :, :] = B_both_change
+
+        for j1 in range(n):
+            B[l, j1, :] += B_j2_change
+            B[l, :, j1] += B_j1_change
+            for j2 in range(n):
+                B[l, j1, j2] += B_no_change[j1, j2]
+
+        B[l, :, :] *= 1 / c[l + 1]
+
+    return B

--- a/python/tests/fb_haploid_samples_variants.py
+++ b/python/tests/fb_haploid_samples_variants.py
@@ -1,0 +1,55 @@
+"""Collection of functions to run forwards and backwards algorithms on haploid genotype data, where the data is structured as samples x variants."""
+import numpy as np
+
+
+def forwards_ls_hap(n, m, H, s, e, r, norm=True):
+    """Matrix based haploid LS forward algorithm using numpy vectorisation."""
+    # Initialise
+    F = np.zeros((n, m))
+    c = np.ones(m)
+    F[:, 0] = 1 / n * e[np.equal(H[:, 0], s[0, 0]).astype(np.int64), 0]
+    r_n = r / n
+
+    if norm:
+
+        c[0] = np.sum(F[:, 0])
+        F[:, 0] *= 1 / c[0]
+
+        # Forwards pass
+        for l in range(1, m):
+            F[:, l] = (
+                F[:, l - 1] * (1 - r[l]) + r_n[l]
+            )  # Don't need to multiply by F[:,l-1] as we've normalised.
+            F[:, l] *= e[np.equal(H[:, l], s[0, l]).astype(np.int64), l]
+            c[l] = np.sum(F[:, l])
+            F[:, l] *= 1 / c[l]
+
+        ll = np.sum(np.log10(c))
+
+    else:
+        # Forwards pass
+        for l in range(1, m):
+            F[:, l] = F[:, l - 1] * (1 - r[l]) + np.sum(F[:, l - 1]) * r_n[l]
+            F[:, l] *= e[np.equal(H[:, l], s[0, l]).astype(np.int64), l]
+
+        ll = np.log10(np.sum(F[:, m - 1]))
+
+    return F, c, ll
+
+
+def backwards_ls_hap(n, m, H, s, e, c, r):
+    """Matrix based haploid LS backward algorithm using numpy vectorisation."""
+    # Initialise
+    B = np.zeros((n, m))
+    B[:, m - 1] = 1
+    r_n = r / n
+
+    # Backwards pass
+    for l in range(m - 2, -1, -1):
+        B_tmp = (
+            e[np.equal(H[:, l + 1], s[0, l + 1]).astype(np.int64), l + 1] * B[:, l + 1]
+        )
+        B[:, l] = r_n[l + 1] * np.sum(B_tmp) + (1 - r[l + 1]) * B_tmp
+        B[:, l] *= 1 / c[l + 1]
+
+    return B

--- a/python/tests/fb_haploid_variants_samples.py
+++ b/python/tests/fb_haploid_variants_samples.py
@@ -1,0 +1,72 @@
+"""Collection of functions to run forwards and backwards algorithms on haploid genotype data, where the data is structured as variants x samples."""
+import numpy as np
+
+def forwards_ls_hap(n, m, H, s, e, r, norm=True):
+    """Matrix based haploid LS forward algorithm using numpy vectorisation."""
+    # Initialise
+    F = np.zeros((m, n))
+    r_n = r / n
+
+    if norm:
+
+        c = np.zeros(m)
+        for i in range(n):
+            F[0, i] = 1 / n * e[0, np.int64(np.equal(H[0, i], s[0, 0]))]
+            c[0] += F[0, i]
+
+        for i in range(n):
+            F[0, i] *= 1 / c[0]
+
+        # Forwards pass
+        for l in range(1, m):
+            for i in range(n):
+                F[l, i] = F[l - 1, i] * (1 - r[l]) + r_n[l]
+                F[l, i] *= e[l, np.int64(np.equal(H[l, i], s[0, l]))]
+                c[l] += F[l, i]
+
+            for i in range(n):
+                F[l, i] *= 1 / c[l]
+
+        ll = np.sum(np.log10(c))
+
+    else:
+
+        c = np.ones(m)
+
+        for i in range(n):
+            F[0, i] = 1 / n * e[0, np.int64(np.equal(H[0, i], s[0, 0]))]
+
+        # Forwards pass
+        for l in range(1, m):
+            for i in range(n):
+                F[l, i] = F[l - 1, i] * (1 - r[l]) + np.sum(F[l - 1, :]) * r_n[l]
+                F[l, i] *= e[l, np.int64(np.equal(H[l, i], s[0, l]))]
+
+        ll = np.log10(np.sum(F[m - 1, :]))
+
+    return F, c, ll
+
+  
+def backwards_ls_hap(n, m, H, s, e, c, r):
+    """Matrix based haploid LS backward algorithm using numpy vectorisation."""
+    # Initialise
+    B = np.zeros((m, n))
+    for i in range(n):
+        B[m - 1, i] = 1
+    r_n = r / n
+
+    # Backwards pass
+    for l in range(m - 2, -1, -1):
+        tmp_B = np.zeros(n)
+        tmp_B_sum = 0
+        for i in range(n):
+            tmp_B[i] = (
+                e[l + 1, np.int64(np.equal(H[l + 1, i], s[0, l + 1]))] * B[l + 1, i]
+            )
+            tmp_B_sum += tmp_B[i]
+        for i in range(n):
+            B[l, i] = r_n[l + 1] * tmp_B_sum
+            B[l, i] += (1 - r[l + 1]) * tmp_B[i]
+            B[l, i] *= 1 / c[l + 1]
+
+    return B

--- a/python/tests/fb_haploid_variants_samples_tree.py
+++ b/python/tests/fb_haploid_variants_samples_tree.py
@@ -1,0 +1,439 @@
+import numpy as np
+import tskit
+
+def mirror_coordinates(ts):
+    """
+    Returns a copy of the specified tree sequence in which all
+    coordinates x are transformed into L - x.
+    """
+    L = ts.sequence_length
+    tables = ts.dump_tables()
+    left = tables.edges.left
+    right = tables.edges.right
+    tables.edges.left = L - right
+    tables.edges.right = L - left
+    tables.sites.position = L - tables.sites.position# + 1
+    # TODO migrations.
+    tables.sort()
+    return tables.tree_sequence()
+
+class ValueTransition:
+    """Simple struct holding value transition values."""
+
+    def __init__(self, tree_node=-1, value=-1, value_index=-1):
+        self.tree_node = tree_node
+        self.value = value
+        self.value_index = value_index
+
+    def copy(self):
+        return ValueTransition(self.tree_node, self.value, self.value_index)
+
+    def __repr__(self):
+        return repr(self.__dict__)
+
+    def __str__(self):
+        return repr(self)
+
+
+class LsHmmAlgorithm:
+    """
+    Abstract superclass of Li and Stephens HMM algorithm.
+    """
+
+    def __init__(self, ts, rho, mu, precision=10):
+        self.ts = ts
+        self.mu = mu
+        self.rho = rho
+        self.precision = precision
+        # The array of ValueTransitions.
+        self.T = []
+        # indexes in to the T array for each node.
+        self.T_index = np.zeros(ts.num_nodes, dtype=int) - 1
+        # The number of nodes underneath each element in the T array.
+        self.N = np.zeros(ts.num_nodes, dtype=int)
+        # Efficiently compute the allelic state at a site
+        self.allelic_state = np.zeros(ts.num_nodes, dtype=int) - 1
+        # Diffs so we can can update T and T_index between trees.
+        self.edge_diffs = self.ts.edge_diffs()
+        self.parent = np.zeros(self.ts.num_nodes, dtype=int) - 1
+        self.tree = tskit.Tree(self.ts)
+        self.output = None
+
+    def check_integrity(self):
+        M = [st.tree_node for st in self.T if st.tree_node != -1]
+        assert np.all(self.T_index[M] >= 0)
+        index = np.ones_like(self.T_index, dtype=bool)
+        index[M] = 0
+        assert np.all(self.T_index[index] == -1)
+        for j, st in enumerate(self.T):
+            if st.tree_node != -1:
+                assert j == self.T_index[st.tree_node]
+
+    def compress(self):
+        tree = self.tree
+        T = self.T
+        T_index = self.T_index
+
+        values = np.unique(list(st.value if st.tree_node != -1 else 1e200 for st in T))
+        for st in T:
+            if st.tree_node != -1:
+                st.value_index = np.searchsorted(values, st.value)
+
+        child = np.zeros(len(values), dtype=int)
+        num_values = len(values)
+        value_count = np.zeros(num_values, dtype=int)
+
+        def compute(u, parent_state):
+            value_count[:] = 0
+            for v in tree.children(u):
+                child[:] = optimal_set[v]
+                # If the set for a given child is empty, then we know it inherits
+                # directly from the parent state and must be a singleton set.
+                if np.sum(child) == 0:
+                    child[parent_state] = 1
+                for j in range(num_values):
+                    value_count[j] += child[j]
+            max_value_count = np.max(value_count)
+            optimal_set[u, :] = 0
+            optimal_set[u, value_count == max_value_count] = 1
+
+        optimal_set = np.zeros((tree.tree_sequence.num_nodes, len(values)), dtype=int)
+        t_node_time = [
+            -1 if st.tree_node == -1 else tree.time(st.tree_node) for st in T
+        ]
+        order = np.argsort(t_node_time)
+        for j in order:
+            st = T[j]
+            u = st.tree_node
+            if u != -1:
+                # Compute the value at this node
+                state = st.value_index
+                if tree.is_internal(u):
+                    compute(u, state)
+                else:
+                    # A[u, state] = 1
+                    optimal_set[u, state] = 1
+                # Find parent state
+                v = tree.parent(u)
+                if v != -1:
+                    while T_index[v] == -1:
+                        v = tree.parent(v)
+                    parent_state = T[T_index[v]].value_index
+                    v = tree.parent(u)
+                    while T_index[v] == -1:
+                        compute(v, parent_state)
+                        v = tree.parent(v)
+
+        T_old = [st.copy() for st in T]
+        T.clear()
+        T_parent = []
+
+        old_state = T_old[T_index[tree.root]].value_index
+        new_state = np.argmax(optimal_set[tree.root])
+
+        T.append(ValueTransition(tree_node=tree.root, value=values[new_state]))
+        T_parent.append(-1)
+        stack = [(tree.root, old_state, new_state, 0)]
+        while len(stack) > 0:
+            u, old_state, new_state, t_parent = stack.pop()
+            for v in tree.children(u):
+                old_child_state = old_state
+                if T_index[v] != -1:
+                    old_child_state = T_old[T_index[v]].value_index
+                if np.sum(optimal_set[v]) > 0:
+                    new_child_state = new_state
+                    child_t_parent = t_parent
+
+                    if optimal_set[v, new_state] == 0:
+                        new_child_state = np.argmax(optimal_set[v])
+                        child_t_parent = len(T)
+                        T_parent.append(t_parent)
+                        T.append(
+                            ValueTransition(tree_node=v, value=values[new_child_state])
+                        )
+                    stack.append((v, old_child_state, new_child_state, child_t_parent))
+                else:
+                    if old_child_state != new_state:
+                        T_parent.append(t_parent)
+                        T.append(
+                            ValueTransition(tree_node=v, value=values[old_child_state])
+                        )
+
+        for st in T_old:
+            if st.tree_node != -1:
+                T_index[st.tree_node] = -1
+        for j, st in enumerate(T):
+            T_index[st.tree_node] = j
+            self.N[j] = tree.num_samples(st.tree_node)
+        for j in range(len(T)):
+            if T_parent[j] != -1:
+                self.N[T_parent[j]] -= self.N[j]
+
+    def update_tree(self):
+        """
+        Update the internal data structures to move on to the next tree.
+        """
+        parent = self.parent
+        T_index = self.T_index
+        T = self.T
+        _, edges_out, edges_in = next(self.edge_diffs)
+
+        for edge in edges_out:
+            u = edge.child
+            if T_index[u] == -1:
+                # Make sure the subtree we're detaching has an T_index-value at the root.
+                while T_index[u] == -1:
+                    u = parent[u]
+                    assert u != -1
+                T_index[edge.child] = len(T)
+                T.append(
+                    ValueTransition(tree_node=edge.child, value=T[T_index[u]].value)
+                )
+            parent[edge.child] = -1
+
+        for edge in edges_in:
+            parent[edge.child] = edge.parent
+            u = edge.parent
+            if parent[edge.parent] == -1:
+                # Grafting onto a new root.
+                if T_index[edge.parent] == -1:
+                    T_index[edge.parent] = len(T)
+                    T.append(
+                        ValueTransition(
+                            tree_node=edge.parent, value=T[T_index[edge.child]].value
+                        )
+                    )
+            else:
+                # Grafting into an existing subtree.
+                while T_index[u] == -1:
+                    u = parent[u]
+                    assert u != -1
+            assert T_index[u] != -1 and T_index[edge.child] != -1
+            if T[T_index[u]].value == T[T_index[edge.child]].value:
+                st = T[T_index[edge.child]]
+                # Mark the lower ValueTransition as unused.
+                st.value = -1
+                st.tree_node = -1
+                T_index[edge.child] = -1
+
+        # We can have values left over still pointing to old roots. Remove
+        for root in self.tree.roots:
+            if T_index[root] != -1:
+                # Use a special marker here to designate the real roots.
+                T[T_index[root]].value_index = -2
+        for vt in T:
+            if vt.tree_node != -1:
+                if parent[vt.tree_node] == -1 and vt.value_index != -2:
+                    T_index[vt.tree_node] = -1
+                    vt.tree_node = -1
+                vt.value_index = -1
+
+    def update_probabilities(self, site, haplotype_state):
+        tree = self.tree
+        T_index = self.T_index
+        T = self.T
+        alleles = ["0", "1"]
+        allelic_state = self.allelic_state
+        # Set the allelic_state for this site.
+        allelic_state[tree.root] = alleles.index(site.ancestral_state)
+
+        for mutation in site.mutations:
+            u = mutation.node
+            allelic_state[u] = alleles.index(mutation.derived_state)
+            if T_index[u] == -1:
+                while T_index[u] == tskit.NULL:
+                    u = tree.parent(u)
+                T_index[mutation.node] = len(T)
+                T.append(
+                    ValueTransition(tree_node=mutation.node, value=T[T_index[u]].value)
+                )
+
+        for st in T:
+            u = st.tree_node
+            if u != -1:
+                # Get the allelic_state at u. TODO we can cache these states to
+                # avoid some upward traversals.
+                v = u
+                while allelic_state[v] == -1:
+                    v = tree.parent(v)
+                    assert v != -1
+                match = (
+                    haplotype_state == tskit.MISSING_DATA
+                    or haplotype_state == allelic_state[v]
+                )
+                st.value = self.compute_next_probability(site.id, st.value, match)
+
+        # Unset the states
+        allelic_state[tree.root] = -1
+        for mutation in site.mutations:
+            allelic_state[mutation.node] = -1
+
+    def process_site(self, site, haplotype_state, forwards=True):
+        if forwards:
+            # Forwards algorithm
+            self.update_probabilities(site, haplotype_state)
+            self.compress()
+            s = self.compute_normalisation_factor()
+            for st in self.T:
+                if st.tree_node != tskit.NULL:
+                    st.value /= s
+                    st.value = round(st.value, self.precision)
+            self.output.store_site(site.id, s, [(st.tree_node, st.value) for st in self.T])
+        else:
+            # Backwards algorithm
+            self.output.store_site(site.id, self.output.normalisation_factor[site.id], [(st.tree_node, st.value) for st in self.T])
+            self.update_probabilities(site, haplotype_state)
+            self.compress()
+            b_last_sum = self.compute_normalisation_factor()
+            s = self.output.normalisation_factor[site.id]
+            for st in self.T:
+                if st.tree_node != tskit.NULL:
+                    st.value = (self.rho[site.id]/self.ts.num_samples) * b_last_sum + (1 - self.rho[site.id]) * st.value
+                    st.value /= s
+                    st.value = round(st.value, self.precision)
+
+    def run_forward(self, h):
+        n = self.ts.num_samples
+        self.tree.clear()
+        for u in self.ts.samples():
+            self.T_index[u] = len(self.T)
+            self.T.append(ValueTransition(tree_node=u, value=1/n))
+        while self.tree.next():
+            self.update_tree()
+            for site in self.tree.sites():
+                self.process_site(site, h[site.id])
+        return self.output
+
+    def run_backward(self, h):
+        n = self.ts.num_samples
+        self.tree.clear()
+        for u in self.ts.samples():
+            self.T_index[u] = len(self.T)
+            self.T.append(ValueTransition(tree_node=u, value=1))
+        while self.tree.next():
+            self.update_tree()
+            for site in self.tree.sites():
+                self.process_site(site, h[site.id], forwards=False)
+    
+        return self.output
+
+    def compute_normalisation_factor(self):
+        raise NotImplementedError()
+
+    def compute_next_probability(self, site_id, p_last, is_match):
+        raise NotImplementedError()
+
+
+class CompressedMatrix:
+    """
+    Class representing a num_samples x num_sites matrix compressed by a
+    tree sequence. Each site is represented by a set of (node, value)
+    pairs, which act as "mutations", i.e., any sample that descends
+    from a particular node will inherit that value (unless any other
+    values are on the path).
+    """
+
+    def __init__(self, ts, normalisation_factor=None):
+        self.ts = ts
+        self.num_sites = ts.num_sites
+        self.num_samples = ts.num_samples
+        self.value_transitions = [None for _ in range(self.num_sites)]
+        if normalisation_factor is None:
+            self.normalisation_factor = np.zeros(self.num_sites)
+        else:
+            self.normalisation_factor = normalisation_factor
+            assert len(self.normalisation_factor) == self.num_sites
+
+    def store_site(self, site, normalisation_factor, value_transitions):
+        self.normalisation_factor[site] = normalisation_factor
+        self.value_transitions[site] = value_transitions
+
+    # Expose the same API as the low-level classes
+
+    @property
+    def num_transitions(self):
+        a = [len(self.value_transitions[j]) for j in range(self.num_sites)]
+        return np.array(a, dtype=np.int32)
+
+    def get_site(self, site):
+        return self.value_transitions[site]
+
+    def decode(self):
+        """
+        Decodes the tree encoding of the values into an explicit
+        matrix.
+        """
+        A = np.zeros((self.num_sites, self.num_samples))
+        for tree in self.ts.trees():
+            for site in tree.sites():
+                f = dict(self.value_transitions[site.id])
+                for j, u in enumerate(self.ts.samples()):
+                    while u not in f:
+                        u = tree.parent(u)
+                    A[site.id, j] = f[u]
+        return A
+
+
+class ForwardMatrix(CompressedMatrix):
+    """Class representing a compressed forward matrix."""
+
+class BackwardMatrix(CompressedMatrix):
+    """Class representing a compressed backward matrix."""
+
+class ForwardAlgorithm(LsHmmAlgorithm):
+    """Runs the Li and Stephens forward algorithm."""
+
+    def __init__(self, ts, rho, mu, precision=10):
+        super().__init__(ts, rho, mu, precision)
+        self.output = ForwardMatrix(ts)
+
+    def compute_normalisation_factor(self):
+        s = 0
+        for j, st in enumerate(self.T):
+            assert st.tree_node != tskit.NULL
+            assert self.N[j] > 0
+            s += self.N[j] * st.value
+        return s
+
+    def compute_next_probability(self, site_id, p_last, is_match):
+        rho = self.rho[site_id]
+        mu = self.mu[site_id]
+        n = self.ts.num_samples
+
+        p_t = p_last * (1 - rho) + rho / n
+        p_e = mu
+        if is_match:
+            p_e = 1 - mu
+        return p_t * p_e
+
+class BackwardAlgorithm(LsHmmAlgorithm):
+    """Runs the Li and Stephens forward algorithm."""
+
+    def __init__(self, ts, rho, mu, normalisation_factor, precision=10):
+        super().__init__(ts, rho, mu, precision)
+        self.output = BackwardMatrix(ts, normalisation_factor)
+
+    def compute_normalisation_factor(self):
+        s = 0
+        for j, st in enumerate(self.T):
+            assert st.tree_node != tskit.NULL
+            assert self.N[j] > 0
+            s += self.N[j] * st.value
+        return s
+
+    def compute_next_probability(self, site_id, p_next, is_match):
+        mu = self.mu[site_id]
+        e = mu
+        if is_match:
+            e = 1 - mu
+        return p_next * e
+
+def ls_forward_tree(h, ts, rho, mu, precision=30):
+    """Forward matrix computation based on a tree sequence."""
+    fa = ForwardAlgorithm(ts, rho, mu, precision=precision)
+    return fa.run_forward(h)
+
+def ls_backward_tree(h, ts_mirror, rho, mu, normalisation_factor, precision=30):
+    """Backward matrix computation based on a tree sequence."""
+    ba = BackwardAlgorithm(ts_mirror, rho, mu, normalisation_factor, precision=precision)
+    return ba.run_backward(h)

--- a/python/tests/test_haplotype_and_genotype_matching.py
+++ b/python/tests/test_haplotype_and_genotype_matching.py
@@ -1,0 +1,762 @@
+# Simulation
+import itertools
+
+# Python libraries
+import msprime
+import numpy as np
+import pytest
+
+import fb_diploid_samples_variants as fbd_sv
+import fb_diploid_variants_samples as fbd_vs
+import fb_haploid_samples_variants as fbh_sv
+import fb_haploid_variants_samples as fbh_vs
+
+import vit_diploid_samples_variants as vd_sv
+import diploid_variants_samples as vd_vs
+import vit_haploid_samples_variants as vh_sv
+import vit_haploid_variants_samples as vh_vs
+
+import fb_haploid_variants_samples_tree as fbh_vst
+
+EQUAL_BOTH_HOM = 4
+UNEQUAL_BOTH_HOM = 0
+BOTH_HET = 7
+REF_HOM_OBS_HET = 1
+REF_HET_OBS_HOM = 2
+
+import tskit
+
+def ls_forward_matrix(h, G, r, mu):
+    """
+    Simple matrix based method for LS forward algorithm using numpy vectorisation.
+    """
+    assert r[0] == 0
+    m, n = G.shape
+    F = np.zeros((m, n))
+    S = np.zeros(m)
+    f = np.zeros(n) + 1 / n
+    p_e = np.zeros(n)
+
+    for el in range(0, m):
+        p_t = f * (1 - r[el]) + r[el] / n
+        eq = G[el] == h[0, el]
+        # if h[el] == tskit.MISSING_DATA:
+        #     # Missing data is equal to everything
+        #     eq[:] = True
+        p_e[:] = mu[el]
+        p_e[eq] = 1 - mu[el]
+        f = p_t * p_e
+        S[el] = np.sum(f)
+        # TODO need to handle the 0 case.
+        assert S[el] > 0
+        f /= S[el]
+        F[el] = f
+    return F, S
+
+
+class LSBase:
+    """Superclass of Li and Stephens tests."""
+
+    def example_haplotypes(self, ts):
+
+        H = ts.genotype_matrix()
+        s = H[:, 0].reshape(1, H.shape[0])
+        H = H[:, 1:]
+
+        return H, s
+
+    def haplotype_emission(self, mu, m):
+        # Define the emission probability matrix
+        e = np.zeros((m, 2))
+        e[:, 0] = mu
+        e[:, 1] = 1 - mu
+
+        return e
+
+    def genotype_emission(self, mu, m):
+        # Define the emission probability matrix
+        e = np.zeros((m, 8))
+        e[:, EQUAL_BOTH_HOM] = (1 - mu) ** 2
+        e[:, UNEQUAL_BOTH_HOM] = mu ** 2
+        e[:, BOTH_HET] = 1 - mu
+        e[:, REF_HOM_OBS_HET] = 2 * mu * (1 - mu)
+        e[:, REF_HET_OBS_HOM] = mu * (1 - mu)
+
+        return e
+
+    def example_parameters_haplotypes(self, ts, seed=42):
+        """Returns an iterator over combinations of haplotype, recombination and mutation rates."""
+        np.random.seed(seed)
+        H, s = self.example_haplotypes(ts)
+        n = H.shape[1]
+        m = ts.get_num_sites()
+
+        # Here we have equal mutation and recombination
+        r = np.zeros(m) + 0.01
+        mu = np.zeros(m) + 0.01
+        r[0] = 0
+
+        e = self.haplotype_emission(mu, m)
+
+        yield n, m, H, s, e, r
+
+        # Mixture of random and extremes
+        rs = [np.zeros(m) + 0.999, np.zeros(m) + 1e-6, np.random.rand(m)]
+
+        mus = [np.zeros(m) + 0.33, np.zeros(m) + 1e-6, np.random.rand(m) * 0.33]
+
+        e = self.haplotype_emission(mu, m)
+
+        for r, mu in itertools.product(rs, mus):
+            r[0] = 0
+            yield n, m, H, s, e, r
+
+    def example_parameters_haplotypes_larger(
+        self, ts, seed=42, mean_r=1e-5, mean_mu=1e-5
+    ):
+
+        np.random.seed(seed)
+        H, s = self.example_haplotypes(ts)
+        n = H.shape[1]
+        m = ts.get_num_sites()
+
+        r = mean_r * np.ones(m) * ((np.random.rand(m) + 0.5) / 2)
+        r[0] = 0
+
+        # Error probability
+        mu = mean_mu * np.ones(m) * ((np.random.rand(m) + 0.5) / 2)
+
+        # Define the emission probability matrix
+        e = self.haplotype_emission(mu, m)
+
+        return n, m, H, s, e, r
+
+    def example_genotypes(self, ts):
+
+        H = ts.genotype_matrix()
+        s = H[:, 0].reshape(1, H.shape[0]) + H[:, 1].reshape(1, H.shape[0])
+        H = H[:, 2:]
+
+        m = ts.get_num_sites()
+        n = H.shape[1]
+
+        G = np.zeros((m, n, n))
+        for i in range(m):
+            G[i, :, :] = np.add.outer(H[i, :], H[i, :])
+
+        return H, G, s
+
+    def example_parameters_genotypes(self, ts, seed=42):
+        np.random.seed(seed)
+        H, G, s = self.example_genotypes(ts)
+        n = H.shape[1]
+        m = ts.get_num_sites()
+
+        # Here we have equal mutation and recombination
+        r = np.zeros(m) + 0.01
+        mu = np.zeros(m) + 0.01
+        r[0] = 0
+
+        e = self.genotype_emission(mu, m)
+
+        yield n, m, G, s, e, r
+
+        # Mixture of random and extremes
+        rs = [np.zeros(m) + 0.999, np.zeros(m) + 1e-6, np.random.rand(m)]
+
+        mus = [np.zeros(m) + 0.33, np.zeros(m) + 1e-6, np.random.rand(m) * 0.33]
+
+        e = self.genotype_emission(mu, m)
+
+        for r, mu in itertools.product(rs, mus):
+            r[0] = 0
+            yield n, m, G, s, e, r
+
+    def example_parameters_genotypes_larger(
+        self, ts, seed=42, mean_r=1e-5, mean_mu=1e-5
+    ):
+
+        np.random.seed(seed)
+        H, G, s = self.example_genotypes(ts)
+
+        m = ts.get_num_sites()
+        n = H.shape[1]
+
+        r = mean_r * np.ones(m) * ((np.random.rand(m) + 0.5) / 2)
+        r[0] = 0
+
+        # Error probability
+        mu = mean_mu * np.ones(m) * ((np.random.rand(m) + 0.5) / 2)
+
+        # Define the emission probability matrix
+        e = self.genotype_emission(mu, m)
+
+        return n, m, G, s, e, r
+
+    def assertAllClose(self, A, B):
+        """Assert that all entries of two matrices are 'close'"""
+        assert np.allclose(A, B, rtol=1e-9, atol=0.0)
+
+    # Define a bunch of very small tree-sequences for testing a collection of parameters on
+    def test_simple_n_10_no_recombination(self):
+        ts = msprime.simulate(
+            10, recombination_rate=0, mutation_rate=0.5, random_seed=42
+        )
+        assert ts.num_sites > 3
+        self.verify(ts)
+
+    def test_simple_n_6(self):
+        ts = msprime.simulate(6, recombination_rate=2, mutation_rate=7, random_seed=42)
+        assert ts.num_sites > 5
+        self.verify(ts)
+
+    def test_simple_n_8(self):
+        ts = msprime.simulate(8, recombination_rate=2, mutation_rate=5, random_seed=42)
+        assert ts.num_sites > 5
+        self.verify(ts)
+
+    def test_simple_n_8_high_recombination(self):
+        ts = msprime.simulate(8, recombination_rate=20, mutation_rate=5, random_seed=42)
+        assert ts.num_trees > 15
+        assert ts.num_sites > 5
+        self.verify(ts)
+
+    def test_simple_n_16(self):
+        ts = msprime.simulate(16, recombination_rate=2, mutation_rate=5, random_seed=42)
+        assert ts.num_sites > 5
+        self.verify(ts)
+
+    # Test a bigger one.
+    def test_large(self, n=50, length=100000, mean_r=1e-5, mean_mu=1e-5, seed=42):
+        ts = msprime.simulate(
+            n + 1,
+            length=length,
+            mutation_rate=mean_mu,
+            recombination_rate=mean_r,
+            random_seed=seed,
+        )
+        self.verify_larger(ts)
+
+    def verify(self, ts):
+        raise NotImplementedError()
+
+    def verify_larger(self, ts):
+        pass
+
+class FBAlgorithmBase(LSBase):
+    """Base for forwards backwards algorithm tests."""
+
+@pytest.mark.skip(reason="DEV: skip for time being")
+class TestNonTreeMethodsHap(FBAlgorithmBase):
+    """Test that we compute the sample likelihoods across all implementations."""
+    def verify(self, ts):
+        for n, m, H_vs, s, e_vs, r in self.example_parameters_haplotypes(ts):
+            e_sv = e_vs.T
+            H_sv = H_vs.T
+
+            # variants x samples
+            F_vs, c_vs, ll_vs = fbh_vs.forwards_ls_hap(
+                n, m, H_vs, s, e_vs, r, norm=False
+            )
+            B_vs = fbh_vs.backwards_ls_hap(n, m, H_vs, s, e_vs, c_vs, r)
+            self.assertAllClose(np.log10(np.sum(F_vs * B_vs, 1)), ll_vs * np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbh_vs.forwards_ls_hap(
+                n, m, H_vs, s, e_vs, r, norm=True
+            )
+            B_tmp = fbh_vs.backwards_ls_hap(n, m, H_vs, s, e_vs, c_tmp, r)
+            self.assertAllClose(ll_vs, ll_tmp)
+            self.assertAllClose(np.sum(F_tmp * B_tmp, 1), np.ones(m))
+
+            # samples x variants
+            F_sv, c_sv, ll_sv = fbh_sv.forwards_ls_hap(
+                n, m, H_sv, s, e_sv, r, norm=False
+            )
+            B_sv = fbh_sv.backwards_ls_hap(n, m, H_sv, s, e_sv, c_sv, r)
+            self.assertAllClose(np.log10(np.sum(F_sv * B_sv, 0)), ll_sv * np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbh_sv.forwards_ls_hap(
+                n, m, H_sv, s, e_sv, r, norm=True
+            )
+            B_tmp = fbh_sv.backwards_ls_hap(n, m, H_sv, s, e_sv, c_tmp, r)
+            self.assertAllClose(ll_sv, ll_tmp)
+            self.assertAllClose(np.sum(F_tmp * B_tmp, 0), np.ones(m))
+
+            # samples x variants agrees with variants x samples
+            self.assertAllClose(ll_vs, ll_sv)
+
+    def verify_larger(self, ts):
+        # variants x samples
+        n, m, H_vs, s, e_vs, r = self.example_parameters_haplotypes_larger(ts)
+
+        e_sv = e_vs.T
+        H_sv = H_vs.T
+
+        F_vs, c_vs, ll_vs = fbh_vs.forwards_ls_hap(n, m, H_vs, s, e_vs, r, norm=False)
+        B_vs = fbh_vs.backwards_ls_hap(n, m, H_vs, s, e_vs, c_vs, r)
+        self.assertAllClose(np.log10(np.sum(F_vs * B_vs, 1)), ll_vs * np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbh_vs.forwards_ls_hap(n, m, H_vs, s, e_vs, r, norm=True)
+        B_tmp = fbh_vs.backwards_ls_hap(n, m, H_vs, s, e_vs, c_tmp, r)
+        self.assertAllClose(ll_vs, ll_tmp)
+        self.assertAllClose(np.sum(F_tmp * B_tmp, 1), np.ones(m))
+
+        # samples x variants
+        F_sv, c_sv, ll_sv = fbh_sv.forwards_ls_hap(n, m, H_sv, s, e_sv, r, norm=False)
+        B_sv = fbh_sv.backwards_ls_hap(n, m, H_sv, s, e_sv, c_sv, r)
+        self.assertAllClose(np.log10(np.sum(F_sv * B_sv, 0)), ll_sv * np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbh_sv.forwards_ls_hap(n, m, H_sv, s, e_sv, r, norm=True)
+        B_tmp = fbh_sv.backwards_ls_hap(n, m, H_sv, s, e_sv, c_tmp, r)
+        self.assertAllClose(ll_sv, ll_tmp)
+        self.assertAllClose(np.sum(F_tmp * B_tmp, 0), np.ones(m))
+
+        # samples x variants agrees with variants x samples
+        self.assertAllClose(ll_vs, ll_sv)
+
+class TestNonTreeMethodsDip(FBAlgorithmBase):
+    """Test that we compute the sample likelihoods across all implementations."""
+    def verify(self, ts):
+        for n, m, G_vs, s, e_vs, r in self.example_parameters_genotypes(ts):
+            e_sv = e_vs.T
+            G_sv = G_vs.T
+
+            # variants x samples
+            F_vs, c_vs, ll_vs = fbd_vs.forwards_ls_dip(n, m, G_vs, s, e_vs, r, norm=True)
+            B_vs = fbd_vs.backwards_ls_dip(n, m, G_vs, s, e_vs, c_vs, r)
+            self.assertAllClose(np.sum(F_vs * B_vs, (1, 2)), np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbd_vs.forwards_ls_dip(n, m, G_vs, s, e_vs, r, norm=False)
+            B_tmp = fbd_vs.backwards_ls_dip(n, m, G_vs, s, e_vs, c_tmp, r)
+            self.assertAllClose(ll_vs, ll_tmp)
+            self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (1, 2))), ll_tmp * np.ones(m))
+
+            F_tmp, ll_tmp = fbd_vs.forward_ls_dip_starting_point(n, m, G_vs, s, e_vs, r)
+            B_tmp = fbd_vs.backward_ls_dip_starting_point(n, m, G_vs, s, e_vs, r)
+            self.assertAllClose(ll_vs, ll_tmp)
+            self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (1, 2))), ll_tmp * np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbd_vs.forward_ls_dip_loop(n, m, G_vs, s, e_vs, r, norm=False)
+            B_tmp = fbd_vs.backward_ls_dip_loop(n, m, G_vs, s, e_vs, c_tmp, r)
+            self.assertAllClose(ll_vs, ll_tmp)
+            self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (1, 2))), ll_tmp * np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbd_vs.forward_ls_dip_loop(n, m, G_vs, s, e_vs, r, norm=True)
+            B_tmp = fbd_vs.backward_ls_dip_loop(n, m, G_vs, s, e_vs, c_tmp, r)
+            self.assertAllClose(ll_vs, ll_tmp)
+            self.assertAllClose(np.sum(F_tmp * B_tmp, (1, 2)), np.ones(m))
+
+            # samples x variants
+
+            F_sv, c_sv, ll_sv = fbd_sv.forwards_ls_dip(n, m, G_sv, s, e_sv, r, norm=True)
+            B_sv = fbd_sv.backwards_ls_dip(n, m, G_sv, s, e_sv, c_sv, r)
+            self.assertAllClose(np.sum(F_sv * B_sv, (0, 1)), np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbd_sv.forwards_ls_dip(n, m, G_sv, s, e_sv, r, norm=False)
+            B_tmp = fbd_sv.backwards_ls_dip(n, m, G_sv, s, e_sv, c_tmp, r)
+            self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (0, 1))), ll_tmp * np.ones(m))
+            self.assertAllClose(ll_sv, ll_tmp)
+
+            F_tmp, ll_tmp = fbd_sv.forward_ls_dip_starting_point(n, m, G_sv, s, e_sv, r)
+            B_tmp = fbd_sv.backward_ls_dip_starting_point(n, m, G_sv, s, e_sv, r)
+            self.assertAllClose(ll_sv, ll_tmp)
+            self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (0, 1))), ll_tmp * np.ones(m))
+
+            F_tmp, c_tmp, ll_tmp = fbd_sv.forward_ls_dip_loop(n, m, G_sv, s, e_sv, r, norm=True)
+            B_tmp = fbd_sv.backward_ls_dip_loop(n, m, G_sv, s, e_sv, c_tmp, r)
+            self.assertAllClose(ll_sv, ll_tmp)
+            self.assertAllClose(np.sum(F_tmp * B_tmp, (0, 1)), np.ones(m))
+            F_tmp, c_tmp, ll_tmp = fbd_sv.forward_ls_dip_loop(n, m, G_sv, s, e_sv, r, norm=False)
+            B_tmp = fbd_sv.backward_ls_dip_loop(n, m, G_sv, s, e_sv, c_tmp, r)
+            self.assertAllClose(ll_sv, ll_tmp)
+            self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (0, 1))), ll_tmp * np.ones(m))
+
+            # compare sample x variants to variants x samples
+            self.assertAllClose(ll_vs, ll_sv)
+
+    def verify_larger(self, ts):
+        # variants x samples
+        n, m, G_vs, s, e_vs, r = self.example_parameters_genotypes_larger(ts)
+        
+        e_sv = e_vs.T
+        G_sv = G_vs.T
+
+        # variants x samples
+        F_vs, c_vs, ll_vs = fbd_vs.forwards_ls_dip(n, m, G_vs, s, e_vs, r, norm=True)
+        B_vs = fbd_vs.backwards_ls_dip(n, m, G_vs, s, e_vs, c_vs, r)
+        self.assertAllClose(np.sum(F_vs * B_vs, (1, 2)), np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbd_vs.forwards_ls_dip(n, m, G_vs, s, e_vs, r, norm=False)
+        B_tmp = fbd_vs.backwards_ls_dip(n, m, G_vs, s, e_vs, c_tmp, r)
+        self.assertAllClose(ll_vs, ll_tmp)
+        self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (1, 2))), ll_tmp * np.ones(m))
+
+        F_tmp, ll_tmp = fbd_vs.forward_ls_dip_starting_point(n, m, G_vs, s, e_vs, r)
+        B_tmp = fbd_vs.backward_ls_dip_starting_point(n, m, G_vs, s, e_vs, r)
+        self.assertAllClose(ll_vs, ll_tmp)
+        self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (1, 2))), ll_tmp * np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbd_vs.forward_ls_dip_loop(n, m, G_vs, s, e_vs, r, norm=False)
+        B_tmp = fbd_vs.backward_ls_dip_loop(n, m, G_vs, s, e_vs, c_tmp, r)
+        self.assertAllClose(ll_vs, ll_tmp)
+        self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (1, 2))), ll_tmp * np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbd_vs.forward_ls_dip_loop(n, m, G_vs, s, e_vs, r, norm=True)
+        B_tmp = fbd_vs.backward_ls_dip_loop(n, m, G_vs, s, e_vs, c_tmp, r)
+        self.assertAllClose(ll_vs, ll_tmp)
+        self.assertAllClose(np.sum(F_tmp * B_tmp, (1, 2)), np.ones(m))
+
+        # samples x variants
+
+        F_sv, c_sv, ll_sv = fbd_sv.forwards_ls_dip(n, m, G_sv, s, e_sv, r, norm=True)
+        B_sv = fbd_sv.backwards_ls_dip(n, m, G_sv, s, e_sv, c_sv, r)
+        self.assertAllClose(np.sum(F_sv * B_sv, (0, 1)), np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbd_sv.forwards_ls_dip(n, m, G_sv, s, e_sv, r, norm=False)
+        B_tmp = fbd_sv.backwards_ls_dip(n, m, G_sv, s, e_sv, c_tmp, r)
+        self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (0, 1))), ll_tmp * np.ones(m))
+        self.assertAllClose(ll_sv, ll_tmp)
+
+        F_tmp, ll_tmp = fbd_sv.forward_ls_dip_starting_point(n, m, G_sv, s, e_sv, r)
+        B_tmp = fbd_sv.backward_ls_dip_starting_point(n, m, G_sv, s, e_sv, r)
+        self.assertAllClose(ll_sv, ll_tmp)
+        self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (0, 1))), ll_tmp * np.ones(m))
+
+        F_tmp, c_tmp, ll_tmp = fbd_sv.forward_ls_dip_loop(n, m, G_sv, s, e_sv, r, norm=True)
+        B_tmp = fbd_sv.backward_ls_dip_loop(n, m, G_sv, s, e_sv, c_tmp, r)
+        self.assertAllClose(ll_sv, ll_tmp)
+        self.assertAllClose(np.sum(F_tmp * B_tmp, (0, 1)), np.ones(m))
+        F_tmp, c_tmp, ll_tmp = fbd_sv.forward_ls_dip_loop(n, m, G_sv, s, e_sv, r, norm=False)
+        B_tmp = fbd_sv.backward_ls_dip_loop(n, m, G_sv, s, e_sv, c_tmp, r)
+        self.assertAllClose(ll_sv, ll_tmp)
+        self.assertAllClose(np.log10(np.sum(F_tmp * B_tmp, (0, 1))), ll_tmp * np.ones(m))
+
+        # compare sample x variants to variants x samples
+        self.assertAllClose(ll_vs, ll_sv)
+
+
+class VitAlgorithmBase(LSBase):
+    """Base for viterbi algoritm tests."""
+
+class TestNonTreeViterbiHap(VitAlgorithmBase):
+    """Test that we have the same log-likelihood across all implementations"""
+
+    def verify(self, ts):
+        for n, m, H_vs, s, e_vs, r in self.example_parameters_haplotypes(ts):
+            e_sv = e_vs.T
+            H_sv = H_vs.T
+
+            # variants x samples
+            V_vs, P_vs, ll_vs = vh_vs.forwards_viterbi_hap_naive(n, m, H_vs, s, e_vs, r)
+            path_vs = vh_vs.backwards_viterbi_hap(m, V_vs[m-1, :], P_vs)
+            ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_vs, s, e_vs, r)
+            self.assertAllClose(ll_vs, ll_check)
+            V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_naive_vec(n, m, H_vs, s, e_vs, r)
+            path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp[m-1, :], P_tmp)
+            ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_vs, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_naive_low_mem(n, m, H_vs, s, e_vs, r)
+            path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_vs, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_naive_low_mem_rescaling(n, m, H_vs, s, e_vs, r)
+            path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_vs, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_low_mem_rescaling(n, m, H_vs, s, e_vs, r)
+            path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_vs, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_lower_mem_rescaling(n, m, H_vs, s, e_vs, r)
+            path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_vs, ll_tmp)
+
+            # samples x variants
+            V_sv, P_sv, ll_sv = vh_sv.forwards_viterbi_hap_naive(n, m, H_sv, s, e_sv, r)
+            path_tmp = vh_sv.backwards_viterbi_hap(m, V_sv[:, m-1], P_sv)
+            ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_sv, ll_check)
+            V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_naive_vec(n, m, H_sv, s, e_sv, r)
+            path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp[:, m-1], P_tmp)
+            ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_sv, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_naive_low_mem(n, m, H_sv, s, e_sv, r)
+            path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_sv, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_naive_low_mem_rescaling(n, m, H_sv, s, e_sv, r)
+            path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_sv, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_low_mem_rescaling(n, m, H_sv, s, e_sv, r)
+            path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_sv, ll_tmp)
+            V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_lower_mem_rescaling(n, m, H_sv, s, e_sv, r)
+            path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+            ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, ll_check)
+            self.assertAllClose(ll_vs, ll_tmp)
+
+            # samples x variants agrees with variants x samples
+            self.assertAllClose(ll_vs, ll_sv)
+
+    def verify_larger(self, ts):
+        n, m, H_vs, s, e_vs, r = self.example_parameters_haplotypes_larger(ts)
+        e_sv = e_vs.T
+        H_sv = H_vs.T
+
+        # variants x samples
+        V_vs, P_vs, ll_vs = vh_vs.forwards_viterbi_hap_naive(n, m, H_vs, s, e_vs, r)
+        path_vs = vh_vs.backwards_viterbi_hap(m, V_vs[m-1, :], P_vs)
+        ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_vs, s, e_vs, r)
+        self.assertAllClose(ll_vs, ll_check)
+        V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_naive_vec(n, m, H_vs, s, e_vs, r)
+        path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp[m-1, :], P_tmp)
+        ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_vs, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_naive_low_mem(n, m, H_vs, s, e_vs, r)
+        path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_vs, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_naive_low_mem_rescaling(n, m, H_vs, s, e_vs, r)
+        path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_vs, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_low_mem_rescaling(n, m, H_vs, s, e_vs, r)
+        path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_vs, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_vs.forwards_viterbi_hap_lower_mem_rescaling(n, m, H_vs, s, e_vs, r)
+        path_tmp = vh_vs.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_vs.path_ll_hap(n, m, H_vs, path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_vs, ll_tmp)
+
+        # samples x variants
+        V_sv, P_sv, ll_sv = vh_sv.forwards_viterbi_hap_naive(n, m, H_sv, s, e_sv, r)
+        path_tmp = vh_sv.backwards_viterbi_hap(m, V_sv[:, m-1], P_sv)
+        ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_sv, ll_check)
+        V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_naive_vec(n, m, H_sv, s, e_sv, r)
+        path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp[:, m-1], P_tmp)
+        ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_sv, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_naive_low_mem(n, m, H_sv, s, e_sv, r)
+        path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_sv, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_naive_low_mem_rescaling(n, m, H_sv, s, e_sv, r)
+        path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_sv, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_low_mem_rescaling(n, m, H_sv, s, e_sv, r)
+        path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_sv, ll_tmp)
+        V_tmp, P_tmp, ll_tmp = vh_sv.forwards_viterbi_hap_lower_mem_rescaling(n, m, H_sv, s, e_sv, r)
+        path_tmp = vh_sv.backwards_viterbi_hap(m, V_tmp, P_tmp)
+        ll_check = vh_sv.path_ll_hap(n, m, H_sv, path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, ll_check)
+        self.assertAllClose(ll_vs, ll_tmp)
+
+        # samples x variants agrees with variants x samples
+        self.assertAllClose(ll_vs, ll_sv)
+
+class TestNonTreeViterbiDip(VitAlgorithmBase):
+    """Test that we have the same log-likelihood across all implementations"""
+
+    def verify(self, ts):
+        for n, m, G_vs, s, e_vs, r in self.example_parameters_genotypes(ts):
+            e_sv = e_vs.T
+            G_sv = G_vs.T
+
+            # variants x samples
+            V_vs, P_vs, ll_vs = vd_vs.forwards_viterbi_dip_naive(n, m, G_vs, s, e_vs, r)
+            path_vs = vd_vs.backwards_viterbi_dip(m, V_vs[m-1, :, :], P_vs)
+            phased_path_vs = vd_vs.get_phased_path(n, path_vs)
+            path_ll_vs = vd_vs.path_ll_dip(n, m, G_vs, phased_path_vs, s, e_vs, r)
+            self.assertAllClose(ll_vs, path_ll_vs)
+
+            V_tmp, P_tmp, ll_tmp = vd_vs.forwards_viterbi_dip_naive_low_mem(n, m, G_vs, s, e_vs, r)
+            path_tmp = vd_vs.backwards_viterbi_dip(m, V_tmp, P_tmp)
+            phased_path_tmp = vd_vs.get_phased_path(n, path_tmp)
+            path_ll_tmp = vd_vs.path_ll_dip(n, m, G_vs, phased_path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, path_ll_tmp)
+            self.assertAllClose(ll_vs, ll_tmp)
+
+            V_tmp, P_tmp, ll_tmp = vd_vs.forwards_viterbi_dip_low_mem(n, m, G_vs, s, e_vs, r)
+            path_tmp = vd_vs.backwards_viterbi_dip(m, V_tmp, P_tmp)
+            phased_path_tmp = vd_vs.get_phased_path(n, path_tmp)
+            path_ll_tmp = vd_vs.path_ll_dip(n, m, G_vs, phased_path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, path_ll_tmp)
+            self.assertAllClose(ll_vs, ll_tmp)
+
+            V_tmp, P_tmp, ll_tmp = vd_vs.forwards_viterbi_dip_naive_vec(n, m, G_vs, s, e_vs, r)
+            path_tmp = vd_vs.backwards_viterbi_dip(m, V_tmp[m-1, :, :], P_tmp)
+            phased_path_tmp = vd_vs.get_phased_path(n, path_tmp)
+            path_ll_tmp = vd_vs.path_ll_dip(n, m, G_vs, phased_path_tmp, s, e_vs, r)
+            self.assertAllClose(ll_tmp, path_ll_tmp)
+            self.assertAllClose(ll_vs, ll_tmp)
+
+            # samples x variants
+            V_sv, P_sv, ll_sv = vd_sv.forwards_viterbi_dip_naive(n, m, G_sv, s, e_sv, r)
+            path_sv = vd_sv.backwards_viterbi_dip(m, V_sv[:, :, m-1], P_sv)
+            phased_path_sv = vd_sv.get_phased_path(n, path_sv)
+            path_ll_sv = vd_sv.path_ll_dip(n, m, G_sv, phased_path_sv, s, e_sv, r)
+            self.assertAllClose(ll_sv, path_ll_sv)
+
+            V_tmp, P_tmp, ll_tmp = vd_sv.forwards_viterbi_dip_naive_low_mem(n, m, G_sv, s, e_sv, r)
+            path_tmp = vd_sv.backwards_viterbi_dip(m, V_tmp, P_tmp)
+            phased_path_tmp = vd_sv.get_phased_path(n, path_tmp)
+            path_ll_tmp = vd_sv.path_ll_dip(n, m, G_sv, phased_path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, path_ll_tmp)
+            self.assertAllClose(ll_sv, ll_tmp)
+
+            V_tmp, P_tmp, ll_tmp = vd_sv.forwards_viterbi_dip_low_mem(n, m, G_sv, s, e_sv, r)
+            path_tmp = vd_sv.backwards_viterbi_dip(m, V_tmp, P_tmp)
+            phased_path_tmp = vd_sv.get_phased_path(n, path_tmp)
+            path_ll_tmp = vd_sv.path_ll_dip(n, m, G_sv, phased_path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, path_ll_tmp)
+            self.assertAllClose(ll_sv, ll_tmp)
+
+            V_tmp, P_tmp, ll_tmp = vd_sv.forwards_viterbi_dip_naive_vec(n, m, G_sv, s, e_sv, r)
+            path_tmp = vd_sv.backwards_viterbi_dip(m, V_tmp[:, :, m-1], P_tmp)
+            phased_path_tmp = vd_sv.get_phased_path(n, path_tmp)
+            path_ll_tmp = vd_sv.path_ll_dip(n, m, G_sv, phased_path_tmp, s, e_sv, r)
+            self.assertAllClose(ll_tmp, path_ll_tmp)
+            self.assertAllClose(ll_sv, ll_tmp)
+
+            # samples x variants agrees with variants x samples
+            self.assertAllClose(ll_vs, ll_sv)
+
+    def verify_larger(self, ts):
+        n, m, G_vs, s, e_vs, r = self.example_parameters_genotypes_larger(ts)
+        e_sv = e_vs.T
+        G_sv = G_vs.T
+
+        # variants x samples
+        V_vs, P_vs, ll_vs = vd_vs.forwards_viterbi_dip_naive(n, m, G_vs, s, e_vs, r)
+        path_vs = vd_vs.backwards_viterbi_dip(m, V_vs[m-1, :, :], P_vs)
+        phased_path_vs = vd_vs.get_phased_path(n, path_vs)
+        path_ll_vs = vd_vs.path_ll_dip(n, m, G_vs, phased_path_vs, s, e_vs, r)
+        self.assertAllClose(ll_vs, path_ll_vs)
+
+        V_tmp, P_tmp, ll_tmp = vd_vs.forwards_viterbi_dip_naive_low_mem(n, m, G_vs, s, e_vs, r)
+        path_tmp = vd_vs.backwards_viterbi_dip(m, V_tmp, P_tmp)
+        phased_path_tmp = vd_vs.get_phased_path(n, path_tmp)
+        path_ll_tmp = vd_vs.path_ll_dip(n, m, G_vs, phased_path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, path_ll_tmp)
+        self.assertAllClose(ll_vs, ll_tmp)
+
+        V_tmp, P_tmp, ll_tmp = vd_vs.forwards_viterbi_dip_low_mem(n, m, G_vs, s, e_vs, r)
+        path_tmp = vd_vs.backwards_viterbi_dip(m, V_tmp, P_tmp)
+        phased_path_tmp = vd_vs.get_phased_path(n, path_tmp)
+        path_ll_tmp = vd_vs.path_ll_dip(n, m, G_vs, phased_path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, path_ll_tmp)
+        self.assertAllClose(ll_vs, ll_tmp)
+
+        V_tmp, P_tmp, ll_tmp = vd_vs.forwards_viterbi_dip_naive_vec(n, m, G_vs, s, e_vs, r)
+        path_tmp = vd_vs.backwards_viterbi_dip(m, V_tmp[m-1, :, :], P_tmp)
+        phased_path_tmp = vd_vs.get_phased_path(n, path_tmp)
+        path_ll_tmp = vd_vs.path_ll_dip(n, m, G_vs, phased_path_tmp, s, e_vs, r)
+        self.assertAllClose(ll_tmp, path_ll_tmp)
+        self.assertAllClose(ll_vs, ll_tmp)
+
+        # samples x variants
+        V_sv, P_sv, ll_sv = vd_sv.forwards_viterbi_dip_naive(n, m, G_sv, s, e_sv, r)
+        path_sv = vd_sv.backwards_viterbi_dip(m, V_sv[:, :, m-1], P_sv)
+        phased_path_sv = vd_sv.get_phased_path(n, path_sv)
+        path_ll_sv = vd_sv.path_ll_dip(n, m, G_sv, phased_path_sv, s, e_sv, r)
+        self.assertAllClose(ll_sv, path_ll_sv)
+
+        V_tmp, P_tmp, ll_tmp = vd_sv.forwards_viterbi_dip_naive_low_mem(n, m, G_sv, s, e_sv, r)
+        path_tmp = vd_sv.backwards_viterbi_dip(m, V_tmp, P_tmp)
+        phased_path_tmp = vd_sv.get_phased_path(n, path_tmp)
+        path_ll_tmp = vd_sv.path_ll_dip(n, m, G_sv, phased_path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, path_ll_tmp)
+        self.assertAllClose(ll_sv, ll_tmp)
+
+        V_tmp, P_tmp, ll_tmp = vd_sv.forwards_viterbi_dip_low_mem(n, m, G_sv, s, e_sv, r)
+        path_tmp = vd_sv.backwards_viterbi_dip(m, V_tmp, P_tmp)
+        phased_path_tmp = vd_sv.get_phased_path(n, path_tmp)
+        path_ll_tmp = vd_sv.path_ll_dip(n, m, G_sv, phased_path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, path_ll_tmp)
+        self.assertAllClose(ll_sv, ll_tmp)
+
+        V_tmp, P_tmp, ll_tmp = vd_sv.forwards_viterbi_dip_naive_vec(n, m, G_sv, s, e_sv, r)
+        path_tmp = vd_sv.backwards_viterbi_dip(m, V_tmp[:, :, m-1], P_tmp)
+        phased_path_tmp = vd_sv.get_phased_path(n, path_tmp)
+        path_ll_tmp = vd_sv.path_ll_dip(n, m, G_sv, phased_path_tmp, s, e_sv, r)
+        self.assertAllClose(ll_tmp, path_ll_tmp)
+        self.assertAllClose(ll_sv, ll_tmp)
+
+        # samples x variants agrees with variants x samples
+        self.assertAllClose(ll_vs, ll_sv)
+
+
+class TestForwardTree(FBAlgorithmBase):
+    """Tests that the tree algorithm computes the same forward matrix as the simple method."""
+
+    def verify(self, ts):
+        for n, m, H_vs, s, e_vs, r in self.example_parameters_haplotypes(ts):
+            mu = e_vs[:,0]
+            F_vs, c_vs, ll_vs = fbh_vs.forwards_ls_hap(n, m, H_vs, s, e_vs, r, norm=True)
+            # Note, need to remove the first sample from the ts, and ensure that invariant sites aren't removed.
+            ts_check = ts.simplify(range(1,n+1), filter_sites=False)
+            cm = fbh_vst.ls_forward_tree(s[0,:], ts_check, r, mu)
+            ll_tree = np.sum(np.log10(cm.normalisation_factor))
+            self.assertAllClose(ll_vs, ll_tree)
+
+class TestMirroring(FBAlgorithmBase):
+    """Tests that mirroring the tree sequence and running forwards and backwards algorithms gives
+    the same log-likelihood of observing the data."""
+
+    def verify(self, ts):
+        for n, m, H_vs, s, e_vs, r in self.example_parameters_haplotypes(ts):
+            mu = e_vs[:,0]
+            F_vs, c_vs, ll_vs = fbh_vs.forwards_ls_hap(n, m, H_vs, s, e_vs, r, norm=True)
+            ts_check = ts.simplify(range(1,n+1), filter_sites=False)
+            cm = fbh_vst.ls_forward_tree(s[0,:], ts_check, r, mu)
+            ll_tree = np.sum(np.log10(cm.normalisation_factor))
+            ts_check_mirror = fbh_vst.mirror_coordinates(ts_check)
+            r_flip = np.insert(np.flip(r)[:-1], 0, 0)
+            cm = fbh_vst.ls_forward_tree(np.flip(s[0,:]), ts_check_mirror, r_flip, np.flip(mu))
+            ll_mirror_tree = np.sum(np.log10(cm.normalisation_factor))
+
+            self.assertAllClose(ll_tree, ll_mirror_tree)
+
+            # Ensure that the decoded matrices are the same
+            F_vs_mirror_matrix, c_vs, ll_vs = fbh_vs.forwards_ls_hap(
+                n, m, np.flip(H_vs, axis=0), np.flip(s, axis=1), np.flip(e_vs, axis=0), r_flip, norm=True)
+            F_vs_mirror = cm.decode()
+
+            self.assertAllClose(F_vs_mirror_matrix, F_vs_mirror)
+
+
+class TestForwardBackwardTree(FBAlgorithmBase):
+    """Tests that the tree algorithm computes the same forward matrix as the simple method."""
+
+    def verify(self, ts):
+        for n, m, H_vs, s, e_vs, r in self.example_parameters_haplotypes(ts):
+            mu = e_vs[:,0]
+            F_vs, c_vs, ll_vs = fbh_vs.forwards_ls_hap(n, m, H_vs, s, e_vs, r, norm=True)
+            B_vs = fbh_vs.backwards_ls_hap(n, m, H_vs, s, e_vs, c_vs, r)
+
+            # Note, need to remove the first sample from the ts, and ensure that invariant sites aren't removed.
+            ts_check = ts.simplify(range(1,n+1), filter_sites=False)
+            cm = fbh_vst.ls_forward_tree(s[0,:], ts_check, r, mu)
+            ll_tree = np.sum(np.log10(cm.normalisation_factor))
+            
+            ts_check_mirror = fbh_vst.mirror_coordinates(ts_check)
+            r_flip = np.flip(r)
+            cm = fbh_vst.ls_backward_tree(np.flip(s[0,:]), ts_check_mirror, r_flip, np.flip(mu), np.flip(cm.normalisation_factor))
+            B_vs_tree = np.flip(cm.decode(), axis=0)
+
+            self.assertAllClose(B_vs, B_vs_tree)

--- a/python/tests/vib_diploid_variants_samples.py
+++ b/python/tests/vib_diploid_variants_samples.py
@@ -1,0 +1,352 @@
+"""Collection of functions to run Viterbi algorithms on dipoid genotype data, where the data is structured as variants x samples."""
+import numpy as np
+
+
+# https://github.com/numba/numba/issues/1269
+def np_apply_along_axis(func1d, axis, arr):
+    """Create numpy-like functions for max, sum etc."""
+    assert arr.ndim == 2
+    assert axis in [0, 1]
+    if axis == 0:
+        result = np.empty(arr.shape[1])
+        for i in range(len(result)):
+            result[i] = func1d(arr[:, i])
+    else:
+        result = np.empty(arr.shape[0])
+        for i in range(len(result)):
+            result[i] = func1d(arr[i, :])
+    return result
+
+
+def np_amax(array, axis):
+    """Numba implementation of numpy vectorised maximum."""
+    return np_apply_along_axis(np.amax, axis, array)
+
+
+def np_sum(array, axis):
+    """Numba implementation of numpy vectorised sum."""
+    return np_apply_along_axis(np.sum, axis, array)
+
+
+def np_argmax(array, axis):
+    """Numba implementation of numpy vectorised argmax."""
+    return np_apply_along_axis(np.argmax, axis, array)
+
+
+def forwards_viterbi_dip_naive(n, m, G, s, e, r):
+    """Naive implementation of LS diploid Viterbi algorithm."""
+    # Initialise
+    V = np.zeros((m, n, n))
+    P = np.zeros((m, n, n)).astype(np.int64)
+    c = np.ones(m)
+    r_n = r / n
+
+    for j1 in range(n):
+        for j2 in range(n):
+            index_tmp = (
+                4 * np.int64(np.equal(G[0, j1, j2], s[0, 0]))
+                + 2 * np.int64((G[0, j1, j2] == 1))
+                + np.int64(s[0, 0] == 1)
+            )
+            V[0, j1, j2] = 1 / (n ** 2) * e[0, index_tmp]
+
+    for l in range(1, m):
+        index = (
+            4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64)
+            + 2 * (G[l, :, :] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+        for j1 in range(n):
+            for j2 in range(n):
+                # Get the vector to maximise over
+                v = np.zeros((n, n))
+                for k1 in range(n):
+                    for k2 in range(n):
+                        v[k1, k2] = V[l - 1, k1, k2]
+                        if (k1 == j1) and (k2 == j2):
+                            v[k1, k2] *= (
+                                (1 - r[l]) ** 2 + 2 * (1 - r[l]) * r_n[l] + r_n[l] ** 2
+                            )
+                        elif (k1 == j1) or (k2 == j2):
+                            v[k1, k2] *= r_n[l] * (1 - r[l]) + r_n[l] ** 2
+                        else:
+                            v[k1, k2] *= r_n[l] ** 2
+                V[l, j1, j2] = np.amax(v) * e[l, index[j1, j2]]
+                P[l, j1, j2] = np.argmax(v)
+        c[l] = np.amax(V[l, :, :])
+        V[l, :, :] *= 1 / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_naive_low_mem(n, m, G, s, e, r):
+    """Naive implementation of LS diploid Viterbi algorithm, with reduced memory."""
+    # Initialise
+    V = np.zeros((n, n))
+    V_previous = np.zeros((n, n))
+    P = np.zeros((m, n, n)).astype(np.int64)
+    c = np.ones(m)
+    r_n = r / n
+
+    for j1 in range(n):
+        for j2 in range(n):
+            index_tmp = (
+                4 * np.int64(np.equal(G[0, j1, j2], s[0, 0]))
+                + 2 * np.int64((G[0, j1, j2] == 1))
+                + np.int64(s[0, 0] == 1)
+            )
+            V_previous[j1, j2] = 1 / (n ** 2) * e[0, index_tmp]
+
+    # Take a look at Haploid Viterbi implementation in Jeromes code and see if we can pinch some ideas.
+    # Diploid Viterbi, with smaller memory footprint.
+    for l in range(1, m):
+        index = (
+            4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64)
+            + 2 * (G[l, :, :] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+        for j1 in range(n):
+            for j2 in range(n):
+                # Get the vector to maximise over
+                v = np.zeros((n, n))
+                for k1 in range(n):
+                    for k2 in range(n):
+                        v[k1, k2] = V_previous[k1, k2]
+                        if (k1 == j1) and (k2 == j2):
+                            v[k1, k2] *= (
+                                (1 - r[l]) ** 2 + 2 * (1 - r[l]) * r_n[l] + r_n[l] ** 2
+                            )
+                        elif (k1 == j1) or (k2 == j2):
+                            v[k1, k2] *= r_n[l] * (1 - r[l]) + r_n[l] ** 2
+                        else:
+                            v[k1, k2] *= r_n[l] ** 2
+                V[j1, j2] = np.amax(v) * e[l, index[j1, j2]]
+                P[l, j1, j2] = np.argmax(v)
+        c[l] = np.amax(V)
+        V_previous = np.copy(V) / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_low_mem(n, m, G, s, e, r):
+    """LS diploid Viterbi algorithm, with reduced memory."""
+    # Initialise
+    V = np.zeros((n, n))
+    V_previous = np.zeros((n, n))
+    P = np.zeros((m, n, n)).astype(np.int64)
+    c = np.ones(m)
+    r_n = r / n
+
+    for j1 in range(n):
+        for j2 in range(n):
+            index_tmp = (
+                4 * np.int64(np.equal(G[0, j1, j2], s[0, 0]))
+                + 2 * np.int64((G[0, j1, j2] == 1))
+                + np.int64(s[0, 0] == 1)
+            )
+            V_previous[j1, j2] = 1 / (n ** 2) * e[0, index_tmp]
+
+    # Diploid Viterbi, with smaller memory footprint, rescaling, and using the structure of the HMM.
+    for l in range(1, m):
+
+        index = (
+            4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64)
+            + 2 * (G[l, :, :] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+
+        c[l] = np.amax(V_previous)
+        argmax = np.argmax(V_previous)
+
+        V_previous *= 1 / c[l]
+        V_rowcol_max = np_amax(V_previous, 0)
+        arg_rowcol_max = np_argmax(V_previous, 0)
+
+        no_switch = (1 - r[l]) ** 2 + 2 * (r_n[l] * (1 - r[l])) + r_n[l] ** 2
+        single_switch = r_n[l] * (1 - r[l]) + r_n[l] ** 2
+        double_switch = r_n[l] ** 2
+
+        j1_j2 = 0
+
+        for j1 in range(n):
+            for j2 in range(n):
+
+                V_single_switch = max(V_rowcol_max[j1], V_rowcol_max[j2])
+                P_single_switch = np.argmax(
+                    np.array([V_rowcol_max[j1], V_rowcol_max[j2]])
+                )
+
+                if P_single_switch == 0:
+                    template_single_switch = j1 * n + arg_rowcol_max[j1]
+                else:
+                    template_single_switch = arg_rowcol_max[j2] * n + j2
+
+                V[j1, j2] = V_previous[j1, j2] * no_switch  # No switch in either
+                P[l, j1, j2] = j1_j2
+
+                # Single or double switch?
+                single_switch_tmp = single_switch * V_single_switch
+                if single_switch_tmp > double_switch:
+                    # Then single switch is the alternative
+                    if V[j1, j2] < single_switch * V_single_switch:
+                        V[j1, j2] = single_switch * V_single_switch
+                        P[l, j1, j2] = template_single_switch
+                else:
+                    # Double switch is the alternative
+                    if V[j1, j2] < double_switch:
+                        V[j1, j2] = double_switch
+                        P[l, j1, j2] = argmax
+
+                V[j1, j2] *= e[l, index[j1, j2]]
+                j1_j2 += 1
+        V_previous = np.copy(V)
+
+    ll = np.sum(np.log10(c)) + np.log10(np.amax(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_naive_vec(n, m, G, s, e, r):
+    """Vectorised LS diploid Viterbi algorithm using numpy."""
+    # Initialise
+    V = np.zeros((m, n, n))
+    P = np.zeros((m, n, n)).astype(np.int64)
+    c = np.ones(m)
+    r_n = r / n
+
+    for j1 in range(n):
+        for j2 in range(n):
+            index_tmp = (
+                4 * np.int64(np.equal(G[0, j1, j2], s[0, 0]))
+                + 2 * np.int64((G[0, j1, j2] == 1))
+                + np.int64(s[0, 0] == 1)
+            )
+            V[0, j1, j2] = 1 / (n ** 2) * e[0, index_tmp]
+
+    # Jumped the gun - vectorising.
+    for l in range(1, m):
+
+        index = (
+            4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64)
+            + 2 * (G[l, :, :] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+
+        for j1 in range(n):
+            for j2 in range(n):
+                v = (r_n[l] ** 2) * np.ones((n, n))
+                v[j1, j2] += (1 - r[l]) ** 2
+                v[j1, :] += r_n[l] * (1 - r[l])
+                v[:, j2] += r_n[l] * (1 - r[l])
+                v *= V[l - 1, :, :]
+                V[l, j1, j2] = np.amax(v) * e[l, index[j1, j2]]
+                P[l, j1, j2] = np.argmax(v)
+
+        c[l] = np.amax(V[l, :, :])
+        V[l, :, :] *= 1 / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_naive_full_vec(n, m, G, s, e, r):
+    """Fully vectorised naive LS diploid Viterbi algorithm using numpy."""
+    char_both = np.eye(n * n).ravel().reshape((n, n, n, n))
+    char_col = np.tile(np.sum(np.eye(n * n).reshape((n, n, n, n)), 3), (n, 1, 1, 1))
+    char_row = np.copy(char_col).T
+    rows, cols = np.ogrid[:n, :n]
+
+    # Initialise
+    V = np.zeros((m, n, n))
+    P = np.zeros((m, n, n)).astype(np.int64)
+    c = np.ones(m)
+    index = (
+        4 * np.equal(G[0, :, :], s[0, 0]).astype(np.int64)
+        + 2 * (G[0, :, :] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    V[0, :, :] = 1 / (n ** 2) * e[0, index]
+    r_n = r / n
+
+    for l in range(1, m):
+        index = (
+            4 * np.equal(G[l, :, :], s[0, l]).astype(np.int64)
+            + 2 * (G[l, :, :] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+        v = (
+            (r_n[l] ** 2)
+            + (1 - r[l]) ** 2 * char_both
+            + (r_n[l] * (1 - r[l])) * (char_col + char_row)
+        )
+        v *= V[l - 1, :, :]
+        P[l, :, :] = np.argmax(v.reshape(n, n, -1), 2)  # Have to flatten to use argmax
+        V[l, :, :] = v.reshape(n, n, -1)[rows, cols, P[l, :, :]] * e[l, index]
+        c[l] = np.amax(V[l, :, :])
+        V[l, :, :] *= 1 / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def backwards_viterbi_dip(m, V_last, P):
+    """Run a backwards pass to determine the most likely path."""
+    assert V_last.ndim == 2
+    assert V_last.shape[0] == V_last.shape[1]
+    # Initialisation
+    path = np.zeros(m).astype(np.int64)
+    path[m - 1] = np.argmax(V_last)
+
+    # Backtrace
+    for j in range(m - 2, -1, -1):
+        path[j] = P[j + 1, :, :].ravel()[path[j + 1]]
+
+    return path
+
+
+def get_phased_path(n, path):
+    """Obtain the phased path."""
+    return np.unravel_index(path, (n, n))
+
+
+def path_ll_dip(n, m, G, phased_path, s, e, r):
+    """Evaluate log-likelihood path through a reference panel which results in sequence s."""
+    index = (
+        4 * np.int64(np.equal(G[0, phased_path[0][0], phased_path[1][0]], s[0, 0]))
+        + 2 * np.int64(G[0, phased_path[0][0], phased_path[1][0]] == 1)
+        + np.int64(s[0, 0] == 1)
+    )
+    log_prob_path = np.log10(1 / (n ** 2) * e[0, index])
+    old_phase = np.array([phased_path[0][0], phased_path[1][0]])
+    r_n = r / n
+
+    for l in range(1, m):
+
+        index = (
+            4 * np.int64(np.equal(G[l, phased_path[0][l], phased_path[1][l]], s[0, l]))
+            + 2 * np.int64(G[l, phased_path[0][l], phased_path[1][l]] == 1)
+            + np.int64(s[0, l] == 1)
+        )
+
+        current_phase = np.array([phased_path[0][l], phased_path[1][l]])
+        phase_diff = np.sum(~np.equal(current_phase, old_phase))
+
+        if phase_diff == 0:
+            log_prob_path += np.log10(
+                (1 - r[l]) ** 2 + 2 * (r_n[l] * (1 - r[l])) + r_n[l] ** 2
+            )
+        elif phase_diff == 1:
+            log_prob_path += np.log10(r_n[l] * (1 - r[l]) + r_n[l] ** 2)
+        else:
+            log_prob_path += np.log10(r_n[l] ** 2)
+
+        log_prob_path += np.log10(e[l, index])
+        old_phase = current_phase
+
+    return log_prob_path

--- a/python/tests/vit_diploid_samples_variants.py
+++ b/python/tests/vit_diploid_samples_variants.py
@@ -1,0 +1,336 @@
+"""Collection of functions to run Viterbi algorithms on dipoid genotype data, where the data is structured as samples x variants."""
+import numpy as np
+
+def np_apply_along_axis(func1d, axis, arr):
+    """Create numpy-like functions for max, sum etc."""
+    assert arr.ndim == 2
+    assert axis in [0, 1]
+    if axis == 0:
+        result = np.empty(arr.shape[1])
+        for i in range(len(result)):
+            result[i] = func1d(arr[:, i])
+    else:
+        result = np.empty(arr.shape[0])
+        for i in range(len(result)):
+            result[i] = func1d(arr[i, :])
+    return result
+
+
+def np_amax(array, axis):
+    """Numba implementation of numpy vectorised maximum."""
+    return np_apply_along_axis(np.amax, axis, array)
+
+
+def np_sum(array, axis):
+    """Numba implementation of numpy vectorised sum."""
+    return np_apply_along_axis(np.sum, axis, array)
+
+
+def np_argmax(array, axis):
+    """Numba implementation of numpy vectorised argmax."""
+    return np_apply_along_axis(np.argmax, axis, array)
+
+
+def forwards_viterbi_dip_naive(n, m, G, s, e, r):
+    """Naive implementation of LS diploid Viterbi algorithm."""
+    # Initialise
+    V = np.zeros((n, n, m))
+    P = np.zeros((n, n, m)).astype(np.int64)
+    c = np.ones(m)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    V[:, :, 0] = 1 / (n ** 2) * e[index.ravel(), 0].reshape(n, n)
+    r_n = r / n
+
+    for l in range(1, m):
+        index = (
+            4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64)
+            + 2 * (G[:, :, l] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+        for j1 in range(n):
+            for j2 in range(n):
+                # Get the vector to maximise over
+                v = np.zeros((n, n))
+                for k1 in range(n):
+                    for k2 in range(n):
+                        v[k1, k2] = V[k1, k2, l - 1]
+                        if (k1 == j1) and (k2 == j2):
+                            v[k1, k2] *= (
+                                (1 - r[l]) ** 2 + 2 * (1 - r[l]) * r_n[l] + r_n[l] ** 2
+                            )
+                        elif (k1 == j1) or (k2 == j2):
+                            v[k1, k2] *= r_n[l] * (1 - r[l]) + r_n[l] ** 2
+                        else:
+                            v[k1, k2] *= r_n[l] ** 2
+                V[j1, j2, l] = np.amax(v) * e[index[j1, j2], l]
+                P[j1, j2, l] = np.argmax(v)
+        c[l] = np.amax(V[:, :, l])
+        V[:, :, l] *= 1 / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_naive_low_mem(n, m, G, s, e, r):
+    """Naive implementation of LS diploid Viterbi algorithm, with reduced memory."""
+    # Initialise
+    V = np.zeros((n, n))
+    P = np.zeros((n, n, m)).astype(np.int64)
+    c = np.ones(m)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    V_previous = 1 / (n ** 2) * e[index.ravel(), 0].reshape(n, n)
+    r_n = r / n
+
+    # Take a look at Haploid Viterbi implementation in Jeromes code and see if we can pinch some ideas.
+    # Diploid Viterbi, with smaller memory footprint.
+    for l in range(1, m):
+        index = (
+            4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64)
+            + 2 * (G[:, :, l] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+        for j1 in range(n):
+            for j2 in range(n):
+                # Get the vector to maximise over
+                v = np.zeros((n, n))
+                for k1 in range(n):
+                    for k2 in range(n):
+                        v[k1, k2] = V_previous[k1, k2]
+                        if (k1 == j1) and (k2 == j2):
+                            v[k1, k2] *= (
+                                (1 - r[l]) ** 2 + 2 * (1 - r[l]) * r_n[l] + r_n[l] ** 2
+                            )
+                        elif (k1 == j1) or (k2 == j2):
+                            v[k1, k2] *= r_n[l] * (1 - r[l]) + r_n[l] ** 2
+                        else:
+                            v[k1, k2] *= r_n[l] ** 2
+                V[j1, j2] = np.amax(v) * e[index[j1, j2], l]
+                P[j1, j2, l] = np.argmax(v)
+        c[l] = np.amax(V)
+        V_previous = np.copy(V) / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_low_mem(n, m, G, s, e, r):
+    """LS diploid Viterbi algorithm, with reduced memory."""
+    # Initialise
+    V = np.zeros((n, n))
+    P = np.zeros((n, n, m)).astype(np.int64)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    V_previous = 1 / (n ** 2) * e[index.ravel(), 0].reshape(n, n)
+    c = np.ones(m)
+    r_n = r / n
+
+    # Diploid Viterbi, with smaller memory footprint, rescaling, and using the structure of the HMM.
+    for l in range(1, m):
+
+        index = (
+            4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64)
+            + 2 * (G[:, :, l] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+
+        c[l] = np.amax(V_previous)
+        argmax = np.argmax(V_previous)
+
+        V_previous *= 1 / c[l]
+        V_rowcol_max = np_amax(V_previous, axis=0)
+        arg_rowcol_max = np_argmax(V_previous, axis=0)
+
+        no_switch = (1 - r[l]) ** 2 + 2 * (r_n[l] * (1 - r[l])) + r_n[l] ** 2
+        single_switch = r_n[l] * (1 - r[l]) + r_n[l] ** 2
+        double_switch = r_n[l] ** 2
+
+        j1_j2 = 0
+
+        for j1 in range(n):
+            for j2 in range(n):
+
+                V_single_switch = max(V_rowcol_max[j1], V_rowcol_max[j2])
+                P_single_switch = np.argmax(
+                    np.array([V_rowcol_max[j1], V_rowcol_max[j2]])
+                )
+
+                if P_single_switch == 0:
+                    template_single_switch = j1 * n + arg_rowcol_max[j1]
+                else:
+                    template_single_switch = arg_rowcol_max[j2] * n + j2
+
+                V[j1, j2] = V_previous[j1, j2] * no_switch  # No switch in either
+                P[j1, j2, l] = j1_j2
+
+                # Single or double switch?
+                single_switch_tmp = single_switch * V_single_switch
+                if single_switch_tmp > double_switch:
+                    # Then single switch is the alternative
+                    if V[j1, j2] < single_switch * V_single_switch:
+                        V[j1, j2] = single_switch * V_single_switch
+                        P[j1, j2, l] = template_single_switch
+                else:
+                    # Double switch is the alternative
+                    if V[j1, j2] < double_switch:
+                        V[j1, j2] = double_switch
+                        P[j1, j2, l] = argmax
+
+                V[j1, j2] *= e[index[j1, j2], l]
+                j1_j2 += 1
+        V_previous = np.copy(V)
+
+    ll = np.sum(np.log10(c)) + np.log10(np.amax(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_naive_vec(n, m, G, s, e, r):
+    """Vectorised LS diploid Viterbi algorithm using numpy."""
+    # Initialise
+    V = np.zeros((n, n, m))
+    P = np.zeros((n, n, m)).astype(np.int64)
+    c = np.ones(m)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    V[:, :, 0] = 1 / (n ** 2) * e[index.ravel(), 0].reshape(n, n)
+    r_n = r / n
+
+    # Jumped the gun - vectorising.
+    for l in range(1, m):
+
+        index = (
+            4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64)
+            + 2 * (G[:, :, l] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+
+        for j1 in range(n):
+            for j2 in range(n):
+                v = (r_n[l] ** 2) * np.ones((n, n))
+                v[j1, j2] += (1 - r[l]) ** 2
+                v[j1, :] += r_n[l] * (1 - r[l])
+                v[:, j2] += r_n[l] * (1 - r[l])
+                v *= V[:, :, l - 1]
+                V[j1, j2, l] = np.amax(v) * e[index[j1, j2], l]
+                P[j1, j2, l] = np.argmax(v)
+
+        c[l] = np.amax(V[:, :, l])
+        V[:, :, l] *= 1 / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def forwards_viterbi_dip_naive_full_vec(n, m, G, s, e, r):
+    """Fully vectorised naive LS diploid Viterbi algorithm using numpy."""
+    char_both = np.eye(n * n).ravel().reshape((n, n, n, n))
+    char_col = np.tile(np.sum(np.eye(n * n).reshape((n, n, n, n)), 3), (n, 1, 1, 1))
+    char_row = np.copy(char_col.T)
+    rows, cols = np.ogrid[:n, :n]
+
+    # Initialise
+    V = np.zeros((n, n, m))
+    P = np.zeros((n, n, m)).astype(np.int64)
+    c = np.ones(m)
+    index = (
+        4 * np.equal(G[:, :, 0], s[0, 0]).astype(np.int64)
+        + 2 * (G[:, :, 0] == 1).astype(np.int64)
+        + np.int64(s[0, 0] == 1)
+    )
+    V[:, :, 0] = 1 / (n ** 2) * e[index, 0]
+    r_n = r / n
+
+    for l in range(1, m):
+        index = (
+            4 * np.equal(G[:, :, l], s[0, l]).astype(np.int64)
+            + 2 * (G[:, :, l] == 1).astype(np.int64)
+            + np.int64(s[0, l] == 1)
+        )
+        v = (
+            (r_n[l] ** 2)
+            + (1 - r[l]) ** 2 * char_both
+            + (r_n[l] * (1 - r[l])) * (char_col + char_row)
+        )
+        v *= V[:, :, l - 1]
+        P[:, :, l] = np.argmax(v.reshape(n, n, -1), 2)  # Have to flatten to use argmax
+        V[:, :, l] = v.reshape(n, n, -1)[rows, cols, P[:, :, l]] * e[index, l]
+        c[l] = np.amax(V[:, :, l])
+        V[:, :, l] *= 1 / c[l]
+
+    ll = np.sum(np.log10(c))
+
+    return V, P, ll
+
+
+def backwards_viterbi_dip(m, V_last, P):
+    """Run a backwards pass to determine the most likely path."""
+    assert V_last.ndim == 2
+    assert V_last.shape[0] == V_last.shape[1]
+    # Initialisation
+    path = np.zeros(m).astype(np.int64)
+    path[m - 1] = np.argmax(V_last)
+
+    # Backtrace
+    for j in range(m - 2, -1, -1):
+        path[j] = P[:, :, j + 1].ravel()[path[j + 1]]
+
+    return path
+
+
+def get_phased_path(n, path):
+    """Obtain the phased path."""
+    return np.unravel_index(path, (n, n))
+
+
+def path_ll_dip(n, m, G, phased_path, s, e, r):
+    """Evaluate log-likelihood path through a reference panel which results in sequence s."""
+    index = (
+        4 * np.int64(np.equal(G[phased_path[0][0], phased_path[1][0], 0], s[0, 0]))
+        + 2 * np.int64(G[phased_path[0][0], phased_path[1][0], 0] == 1)
+        + np.int64(s[0, 0] == 1)
+    )
+    log_prob_path = np.log10(1 / (n ** 2) * e[index, 0])
+    old_phase = np.array([phased_path[0][0], phased_path[1][0]])
+    r_n = r / n
+
+    for l in range(1, m):
+
+        index = (
+            4 * np.int64(np.equal(G[phased_path[0][l], phased_path[1][l], l], s[0, l]))
+            + 2 * np.int64(G[phased_path[0][l], phased_path[1][l], l] == 1)
+            + np.int64(s[0, l] == 1)
+        )
+
+        current_phase = np.array([phased_path[0][l], phased_path[1][l]])
+        phase_diff = np.sum(~np.equal(current_phase, old_phase))
+
+        if phase_diff == 0:
+            log_prob_path += np.log10(
+                (1 - r[l]) ** 2 + 2 * (r_n[l] * (1 - r[l])) + r_n[l] ** 2
+            )
+        elif phase_diff == 1:
+            log_prob_path += np.log10(r_n[l] * (1 - r[l]) + r_n[l] ** 2)
+        else:
+            log_prob_path += np.log10(r_n[l] ** 2)
+
+        log_prob_path += np.log10(e[index, l])
+        old_phase = current_phase
+
+    return log_prob_path

--- a/python/tests/vit_haploid_samples_variants.py
+++ b/python/tests/vit_haploid_samples_variants.py
@@ -1,0 +1,222 @@
+"""Collection of functions to run Viterbi algorithms on haploid genotype data, where the data is structured as samples x variants."""
+import numpy as np
+
+
+def viterbi_naive_init(n, m, H, s, e, r):
+    """Initialise naive implementation of LS viterbi."""
+    V = np.zeros((n, m))
+    P = np.zeros((n, m)).astype(np.int64)
+    V[:, 0] = 1 / n * e[np.equal(H[:, 0], s[0, 0]).astype(np.int64), 0]
+    P[:, 0] = 0  # Reminder
+    r_n = r / n
+
+    return V, P, r_n
+
+
+def viterbi_init(n, m, H, s, e, r):
+    """Initialise naive, but more space memory efficient implementation of LS viterbi."""
+    V_previous = 1 / n * e[np.equal(H[:, 0], s[0, 0]).astype(np.int64), 0]
+    V = np.zeros(n)
+    P = np.zeros((n, m)).astype(np.int64)
+    P[:, 0] = 0  # Reminder
+    r_n = r / n
+
+    return V, V_previous, P, r_n
+
+
+def forwards_viterbi_hap_naive(n, m, H, s, e, r):
+    """Naive implementation of LS haploid Viterbi algorithm."""
+    # Initialise
+    V, P, r_n = viterbi_naive_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        for i in range(n):
+            # Get the vector to maximise over
+            v = np.zeros(n)
+            for k in range(n):
+                v[k] = e[np.int64(np.equal(H[i, j], s[0, j])), j] * V[k, j - 1]
+                if k == i:
+                    v[k] *= 1 - r[j] + r_n[j]
+                else:
+                    v[k] *= r_n[j]
+            P[i, j] = np.argmax(v)
+            V[i, j] = v[P[i, j]]
+
+    ll = np.log10(np.amax(V[:, m - 1]))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_vec(n, m, H, s, e, r):
+    """Naive matrix based implementation of LS haploid forward Viterbi algorithm using numpy."""
+    # Initialise
+    V, P, r_n = viterbi_naive_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        v_tmp = V[:, j - 1] * r_n[j]
+        for i in range(n):
+            v = np.copy(v_tmp)
+            v[i] += V[i, j - 1] * (1 - r[j])
+            v *= e[np.int64(np.equal(H[i, j], s[0, j])), j]
+            P[i, j] = np.argmax(v)
+            V[i, j] = v[P[i, j]]
+
+    ll = np.log10(np.amax(V[:, m - 1]))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_full_vec(n, m, H, s, e, r):
+    """Fully vectorised naive implementation of LS haploid forward Viterbi algorithm using numpy."""
+    # Initialise
+    V, P, r_n = viterbi_naive_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        v = np.tile(V[:, j - 1] * r_n[j], (n, 1)) + np.diag(V[:, j - 1] * (1 - r[j]))
+        P[:, j] = np.argmax(v, 1)
+        V[:, j] = (
+            v[range(n), P[:, j]] * e[np.equal(H[:, j], s[0, j]).astype(np.int64), j]
+        )
+
+    ll = np.log10(np.amax(V[:, m - 1]))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_low_mem(n, m, H, s, e, r):
+    """Naive implementation of LS haploid Viterbi algorithm, with reduced memory."""
+    # Initialise
+    V, V_previous, P, r_n = viterbi_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        for i in range(n):
+            # Get the vector to maximise over
+            v = np.zeros(n)
+            for k in range(n):
+                v[k] = e[np.int64(np.equal(H[i, j], s[0, j])), j] * V_previous[k]
+                if k == i:
+                    v[k] *= (1 - r[j]) + r_n[j]
+                else:
+                    v[k] *= r_n[j]
+            P[i, j] = np.argmax(v)
+            V[i] = v[P[i, j]]
+        V_previous = np.copy(V)
+
+    ll = np.log10(np.amax(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_low_mem_rescaling(n, m, H, s, e, r):
+    """Naive implementation of LS haploid Viterbi algorithm, with reduced memory and rescaling."""
+    # Initialise
+    V, V_previous, P, r_n = viterbi_init(n, m, H, s, e, r)
+    c = np.ones(m)
+
+    for j in range(1, m):
+        c[j] = np.amax(V_previous)
+        V_previous *= 1 / c[j]
+        for i in range(n):
+            # Get the vector to maximise over
+            v = np.zeros(n)
+            for k in range(n):
+                v[k] = e[np.int64(np.equal(H[i, j], s[0, j])), j] * V_previous[k]
+                if k == i:
+                    v[k] *= (1 - r[j]) + r_n[j]
+                else:
+                    v[k] *= r_n[j]
+            P[i, j] = np.argmax(v)
+            V[i] = v[P[i, j]]
+
+        V_previous = np.copy(V)
+
+    ll = np.sum(np.log10(c)) + np.log10(np.amax(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_low_mem_rescaling(n, m, H, s, e, r):
+    """LS haploid Viterbi algorithm, with reduced memory and exploits the Markov process structure."""
+    # Initialise
+    V, V_previous, P, r_n = viterbi_init(n, m, H, s, e, r)
+    c = np.ones(m)
+
+    for j in range(1, m):
+        argmax = np.argmax(V_previous)
+        c[j] = V_previous[argmax]
+        V_previous *= 1 / c[j]
+        V = np.zeros(n)
+        for i in range(n):
+            V[i] = V_previous[i] * (1 - r[j] + r_n[j])
+            P[i, j] = i
+            if V[i] < r_n[j]:
+                V[i] = r_n[j]
+                P[i, j] = argmax
+            V[i] *= e[np.int64(np.equal(H[i, j], s[0, j])), j]
+        V_previous = np.copy(V)
+
+    ll = np.sum(np.log10(c)) + np.log10(np.max(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_lower_mem_rescaling(n, m, H, s, e, r):
+    """LS haploid Viterbi algorithm with even smaller memory footprint and exploits the Markov process structure."""
+    # Initialise
+    V = 1 / n * e[np.equal(H[:, 0], s[0, 0]).astype(np.int64), 0]
+    P = np.zeros((n, m)).astype(np.int64)
+    P[:, 0] = 0
+    r_n = r / n
+    c = np.ones(m)
+
+    for j in range(1, m):
+        argmax = np.argmax(V)
+        c[j] = V[argmax]
+        V *= 1 / c[j]
+        for i in range(n):
+            V[i] = V[i] * (1 - r[j] + r_n[j])
+            P[i, j] = i
+            if V[i] < r_n[j]:
+                V[i] = r_n[j]
+                P[i, j] = argmax
+            V[i] *= e[np.int64(np.equal(H[i, j], s[0, j])), j]
+
+    ll = np.sum(np.log10(c)) + np.log10(np.max(V))
+
+    return V, P, ll
+
+
+def backwards_viterbi_hap(m, V_last, P):
+    """Run a backwards pass to determine the most likely path."""
+    # Initialise
+    assert len(V_last.shape) == 1
+    path = np.zeros(m).astype(np.int64)
+    path[m - 1] = np.argmax(V_last)
+
+    for j in range(m - 2, -1, -1):
+        path[j] = P[path[j + 1], j + 1]
+
+    return path
+
+
+def path_ll_hap(n, m, H, path, s, e, r):
+    """Evaluate log-likelihood path through a reference panel which results in sequence s."""
+    index = np.int64(np.equal(H[path[0], 0], s[0, 0]))
+    log_prob_path = np.log10((1 / n) * e[index, 0])
+    old = path[0]
+    r_n = r / n
+
+    for l in range(1, m):
+        index = np.int64(np.equal(H[path[l], l], s[0, l]))
+        current = path[l]
+        same = old == current
+
+        if same:
+            log_prob_path += np.log10((1 - r[l]) + r_n[l])
+        else:
+            log_prob_path += np.log10(r_n[l])
+
+        log_prob_path += np.log10(e[index, l])
+        old = current
+
+    return log_prob_path

--- a/python/tests/vit_haploid_variants_samples.py
+++ b/python/tests/vit_haploid_variants_samples.py
@@ -1,0 +1,210 @@
+"""Collection of functions to run Viterbi algorithms on haploid genotype data, where the data is structured as variants x samples."""
+import numpy as np
+
+
+def viterbi_naive_init(n, m, H, s, e, r):
+    """Initialise naive implementation of LS viterbi."""
+    V = np.zeros((m, n))
+    P = np.zeros((m, n)).astype(np.int64)
+    r_n = r / n
+    for i in range(n):
+        V[0, i] = 1 / n * e[0, np.int64(np.equal(H[0, i], s[0, 0]))]
+
+    return V, P, r_n
+
+
+def viterbi_init(n, m, H, s, e, r):
+    """Initialise naive, but more space memory efficient implementation of LS viterbi."""
+    V_previous = np.zeros(n)
+    V = np.zeros(n)
+    P = np.zeros((m, n)).astype(np.int64)
+    r_n = r / n
+
+    for i in range(n):
+        V_previous[i] = 1 / n * e[0, np.int64(np.equal(H[0, i], s[0, 0]))]
+
+    return V, V_previous, P, r_n
+
+
+def forwards_viterbi_hap_naive(n, m, H, s, e, r):
+    """Naive implementation of LS haploid Viterbi algorithm."""
+    # Initialise
+    V, P, r_n = viterbi_naive_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        for i in range(n):
+            # Get the vector to maximise over
+            v = np.zeros(n)
+            for k in range(n):
+                # v[k] = e[j,np.equal(H[j,i], s[0,j]).astype(np.int64)] * V[j-1,k]
+                v[k] = e[j, np.int64(np.equal(H[j, i], s[0, j]))] * V[j - 1, k]
+                if k == i:
+                    v[k] *= 1 - r[j] + r_n[j]
+                else:
+                    v[k] *= r_n[j]
+            P[j, i] = np.argmax(v)
+            V[j, i] = v[P[j, i]]
+
+    ll = np.log10(np.amax(V[m - 1, :]))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_vec(n, m, H, s, e, r):
+    """Naive matrix based implementation of LS haploid forward Viterbi algorithm using numpy."""
+    # Initialise
+    V, P, r_n = viterbi_naive_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        v_tmp = V[j - 1, :] * r_n[j]
+        for i in range(n):
+            v = np.copy(v_tmp)
+            v[i] += V[j - 1, i] * (1 - r[j])
+            v *= e[j, np.int64(np.equal(H[j, i], s[0, j]))]
+            P[j, i] = np.argmax(v)
+            V[j, i] = v[P[j, i]]
+
+    ll = np.log10(np.amax(V[m - 1, :]))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_low_mem(n, m, H, s, e, r):
+    """Naive implementation of LS haploid Viterbi algorithm, with reduced memory."""
+    # Initialise
+    V, V_previous, P, r_n = viterbi_init(n, m, H, s, e, r)
+
+    for j in range(1, m):
+        for i in range(n):
+            # Get the vector to maximise over
+            v = np.zeros(n)
+            for k in range(n):
+                v[k] = e[j, np.int64(np.equal(H[j, i], s[0, j]))] * V_previous[k]
+                if k == i:
+                    v[k] *= 1 - r[j] + r_n[j]
+                else:
+                    v[k] *= r_n[j]
+            P[j, i] = np.argmax(v)
+            V[i] = v[P[j, i]]
+        V_previous = np.copy(V)
+
+    ll = np.log10(np.amax(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_naive_low_mem_rescaling(n, m, H, s, e, r):
+    """Naive implementation of LS haploid Viterbi algorithm, with reduced memory and rescaling."""
+    # Initialise
+    V, V_previous, P, r_n = viterbi_init(n, m, H, s, e, r)
+    c = np.ones(m)
+
+    for j in range(1, m):
+        c[j] = np.amax(V_previous)
+        V_previous *= 1 / c[j]
+        for i in range(n):
+            # Get the vector to maximise over
+            v = np.zeros(n)
+            for k in range(n):
+                v[k] = e[j, np.int64(np.equal(H[j, i], s[0, j]))] * V_previous[k]
+                if k == i:
+                    v[k] *= 1 - r[j] + r_n[j]
+                else:
+                    v[k] *= r_n[j]
+            P[j, i] = np.argmax(v)
+            V[i] = v[P[j, i]]
+
+        V_previous = np.copy(V)
+
+    ll = np.sum(np.log10(c)) + np.log10(np.amax(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_low_mem_rescaling(n, m, H, s, e, r):
+    """LS haploid Viterbi algorithm, with reduced memory and exploits the Markov process structure."""
+    # Initialise
+    V, V_previous, P, r_n = viterbi_init(n, m, H, s, e, r)
+    c = np.ones(m)
+
+    for j in range(1, m):
+        argmax = np.argmax(V_previous)
+        c[j] = V_previous[argmax]
+        V_previous *= 1 / c[j]
+        V = np.zeros(n)
+        for i in range(n):
+            V[i] = V_previous[i] * (1 - r[j] + r_n[j])
+            P[j, i] = i
+            if V[i] < r_n[j]:
+                V[i] = r_n[j]
+                P[j, i] = argmax
+            V[i] *= e[j, np.int64(np.equal(H[j, i], s[0, j]))]
+        V_previous = np.copy(V)
+
+    ll = np.sum(np.log10(c)) + np.log10(np.max(V))
+
+    return V, P, ll
+
+
+def forwards_viterbi_hap_lower_mem_rescaling(n, m, H, s, e, r):
+    """LS haploid Viterbi algorithm with even smaller memory footprint and exploits the Markov process structure."""
+    # Initialise
+    V = np.zeros(n)
+    for i in range(n):
+        V[i] = 1 / n * e[0, np.int64(np.equal(H[0, i], s[0, 0]))]
+    P = np.zeros((m, n)).astype(np.int64)
+    r_n = r / n
+    c = np.ones(m)
+
+    for j in range(1, m):
+        argmax = np.argmax(V)
+        c[j] = V[argmax]
+        V *= 1 / c[j]
+        for i in range(n):
+            V[i] = V[i] * (1 - r[j] + r_n[j])
+            P[j, i] = i
+            if V[i] < r_n[j]:
+                V[i] = r_n[j]
+                P[j, i] = argmax
+            V[i] *= e[j, np.int64(np.equal(H[j, i], s[0, j]))]
+
+    ll = np.sum(np.log10(c)) + np.log10(np.max(V))
+
+    return V, P, ll
+
+
+# Speedier version, variants x samples
+def backwards_viterbi_hap(m, V_last, P):
+    """Run a backwards pass to determine the most likely path."""
+    # Initialise
+    assert len(V_last.shape) == 1
+    path = np.zeros(m).astype(np.int64)
+    path[m - 1] = np.argmax(V_last)
+
+    for j in range(m - 2, -1, -1):
+        path[j] = P[j + 1, path[j + 1]]
+
+    return path
+
+
+def path_ll_hap(n, m, H, path, s, e, r):
+    """Evaluate log-likelihood path through a reference panel which results in sequence s."""
+    index = np.int64(np.equal(H[0, path[0]], s[0, 0]))
+    log_prob_path = np.log10((1 / n) * e[0, index])
+    old = path[0]
+    r_n = r / n
+
+    for l in range(1, m):
+        index = np.int64(np.equal(H[l, path[l]], s[0, l]))
+        current = path[l]
+        same = old == current
+
+        if same:
+            log_prob_path += np.log10((1 - r[l]) + r_n[l])
+        else:
+            log_prob_path += np.log10(r_n[l])
+
+        log_prob_path += np.log10(e[l, index])
+        old = current
+
+    return log_prob_path


### PR DESCRIPTION
## Description

This PR adds a collection of tests to check haploid and diploid Li and Stephens for forwards, backwards, and viterbi by testing a set of implementations against each other. For the backwards algorithm we also include a tree based implementation in python which uses existing tskit python functions.

All tests: test_haplotype_and_genotype_matching.py, based on testing in test_haplotype_matching.py.
All matrix based and tree based LiS python functions are included in separate python files:

**Matrix based:**
_Forwards backwards_
fb_haploid_samples_variants.py
fb_haploid_variants_samples.py
fb_diploid_samples_variants.py
fb_diploid_variants_samples.py
_Viterbi_
fb_haploid_samples_variants.py
fb_haploid_variants_samples.py
fb_diploid_samples_variants.py
fb_diploid_variants_samples.py

**Tree based:**
_Forwards backwards_
fb_haploid_variants_samples_tree.py