### PR TITLE
Refactor python vargen

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,5 +1,5 @@
 ----------------------
-[0.4.2] - 2022-0X-XX
+[0.5.0] - 2022-0X-XX
 ----------------------
 
 **Changes**
@@ -10,14 +10,25 @@
 - Make dumping of tables and tree seqences to disk a zero-copy operation.
   (:user:`benjeffery`, :issue:`2111`, :pr:`2124`)
 
+- Add ``return_variant_copies`` argument to ``TreeSequence.variants`` which if False reuses the
+  returned ``Variant`` object for improved performance. Defaults to True.
+  (:user:`benjeffery`, :issue:`605`, :pr:`2172`)
+
+- ``tree.mrca`` now takes 2 or more arguments and gives the common ancestor of them all.
+  (:user:`savitakartik`, :issue:`1340`, :pr:`2121`)
+
 **Breaking Changes**
 
 - The JSON metadata codec now interprets the empty string as an empty object. This means
   that applying a schema to an existing table will no longer necessitate modifying the
   existing rows. (:user:`benjeffery`, :issue:`2064`, :pr:`2104`)
-- ``tree.mrca`` now takes 2 or more arguments.
-  (:user:`savitakartik`, :issue:`1340`, :pr:`2121`)
 
+- Remove the previously deprecated ``as_bytes`` argument to ``TreeSequence.variants``.
+  If you need genotypes in byte form this can be done following the code in the
+  ``to_macs`` method on line ``5573`` of ``trees.py``.
+  This argument was initially deprecated more than 3 years ago when the code was part of
+  ``msprime``.
+  (:user:`benjeffery`, :issue:`605`, :pr:`2172`)
 
 ----------------------
 [0.4.1] - 2022-01-11

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -11402,18 +11402,16 @@ out:
 }
 
 static PyObject *
-Variant_decode(Variant *self, PyObject *args, PyObject *kwds)
+Variant_decode(Variant *self, PyObject *args)
 {
     int err;
     PyObject *ret = NULL;
     tsk_id_t site_id;
-    static char *kwlist[] = { "site", NULL };
 
     if (Variant_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "O&", kwlist, &tsk_id_converter, &site_id)) {
+    if (!PyArg_ParseTuple(args, "O&", &tsk_id_converter, &site_id)) {
         goto out;
     }
     err = tsk_variant_decode(self->variant, site_id, 0);
@@ -11534,7 +11532,7 @@ static PyGetSetDef Variant_getsetters[]
 static PyMethodDef Variant_methods[] = {
     { .ml_name = "decode",
         .ml_meth = (PyCFunction) Variant_decode,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_VARARGS,
         .ml_doc = "Sets the variant's genotypes to those of a given tree and site" },
     { .ml_name = "restricted_copy",
         .ml_meth = (PyCFunction) Variant_restricted_copy,

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -191,29 +191,6 @@ class TestVariantGenerator:
         assert ts.get_num_mutations() > 10
         return ts
 
-    def test_as_bytes(self):
-        ts = self.get_tree_sequence()
-        n = ts.get_sample_size()
-        m = ts.get_num_mutations()
-        A = np.zeros((m, n), dtype="u1")
-        B = np.zeros((m, n), dtype="u1")
-        for variant in ts.variants():
-            A[variant.index] = variant.genotypes
-        for variant in ts.variants(as_bytes=True):
-            assert isinstance(variant.genotypes, bytes)
-            B[variant.index] = np.frombuffer(variant.genotypes, np.uint8) - ord("0")
-        assert np.all(A == B)
-        bytes_variants = list(ts.variants(as_bytes=True))
-        for j, variant in enumerate(bytes_variants):
-            assert j == variant.index
-            row = np.frombuffer(variant.genotypes, np.uint8) - ord("0")
-            assert np.all(A[j] == row)
-
-    def test_as_bytes_fails(self):
-        ts = tsutil.insert_multichar_mutations(self.get_tree_sequence())
-        with pytest.raises(ValueError):
-            list(ts.variants(as_bytes=True))
-
     def test_dtype(self):
         ts = self.get_tree_sequence()
         for var in ts.variants():
@@ -913,7 +890,7 @@ class TestUserAlleles:
         ):
             assert v2.alleles == alleles
             assert v1.site == v2.site
-            g = v1.genotypes
+            g = np.array(v1.genotypes)
             index = np.where(g == 1)
             g[index] = 2
             assert np.array_equal(g, v2.genotypes)

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -4196,18 +4196,6 @@ class TestEdgesetContainer(SimpleContainersMixin):
         return [tskit.Edgeset(left=j, right=j, parent=j, children=j) for j in range(n)]
 
 
-class TestVariantContainer(SimpleContainersMixin):
-    def get_instances(self, n):
-        return [
-            tskit.Variant(
-                site=TestSiteContainer().get_instances(1)[0],
-                alleles=["A" * j, "T"],
-                genotypes=np.zeros(j, dtype=np.int8),
-            )
-            for j in range(n)
-        ]
-
-
 class TestContainersAppend:
     def test_containers_append(self, ts_fixture):
         """
@@ -4262,3 +4250,14 @@ class TestTskitConversionOutput(unittest.TestCase):
             assert len(col) == n
             for j in range(n):
                 assert col[j] == haplotypes[j][site_id]
+
+    def test_macs_error(self):
+        tables = tskit.TableCollection(1)
+        tables.sites.add_row(position=0.5, ancestral_state="A")
+        tables.nodes.add_row(time=1, flags=tskit.NODE_IS_SAMPLE)
+        tables.mutations.add_row(node=0, site=0, derived_state="FOO")
+        ts = tables.tree_sequence()
+        with pytest.raises(
+            ValueError, match="macs output only supports single letter alleles"
+        ):
+            ts.to_macs()


### PR DESCRIPTION
Stacked on #2169 

A proposal for how `TreeSequence.variants` and the Variants class will look. No docs or any changes to tests yet. Note that the `as_bytes` option has been removed for now - we can easily reinstate it. The other breaking change is that the genotype array on `Variant` is now read-only. I think this makes sense, it technically could be writeable though. 