### PR TITLE
Document treeseq struct members

### DIFF
--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -88,7 +88,9 @@ typedef struct {
     tsk_mutation_t *site_mutations_mem;
     tsk_mutation_t **site_mutations;
     tsk_size_t *site_mutations_length;
-    /* The underlying tables */
+    /** @brief  The table collection underlying this tree sequence, This table
+     *  collection must be treated as read-only, and any changes to it will
+     *  lead to undefined behaviour. */
     tsk_table_collection_t *tables;
 } tsk_treeseq_t;
 


### PR DESCRIPTION
Part of #2139

I've been very liberal here documenting most of the struct, but happy to remove any we don't want to commit to. I do see most of these as being useful to users of the class though and unlikely to change.