### PR TITLE
Move generic flags to core.h

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -16,6 +16,8 @@
 - Rename all flags to ``simplify`` for example ``TSK_KEEP_INPUT_ROOTS`` becomes ``TSK_SIMPLIFY_KEEP_INPUT_ROOTS``
   (:user:`benjeffery`, :issue:`1720`, :pr:`2226`))
 
+- ``TSK_DEBUG``, ``TSK_NO_INIT``, ``TSK_NO_CHECK_INTEGRITY`` and ``TSK_TAKE_OWNERSHIP`` have moved to ``core.h``
+  (:user:`benjeffery`, :issue:`2218`, :pr:`2230`))
 
 **Features**
 

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -181,6 +181,31 @@ to the API or ABI are introduced, i.e., internal refactors of bugfixes.
 #define TSK_FILE_FORMAT_VERSION_MINOR 7
 
 /**
+@defgroup GENERIC_FUNCTION_OPTIONS General options flags used in some functions.
+@{
+*/
+
+/* Place the commmon options at the top of the space; this way we can start
+ * options for individual functions at the bottom without worrying about
+ * clashing with the common options */
+
+/** @brief Turn on debugging output. Not supported by all functions. */
+#define TSK_DEBUG (1u << 31)
+
+/** @brief Do not initialise the parameter object. */
+#define TSK_NO_INIT (1u << 30)
+
+/** @brief Do not run integrity checks before performing an operation. */
+#define TSK_NO_CHECK_INTEGRITY (1u << 29)
+
+/** @brief Instead of taking a copy of input data, take ownership of it
+ *  and its lifecycle */
+#define TSK_TAKE_OWNERSHIP (1u << 28)
+
+/** @} */
+
+
+/**
 @defgroup GENERAL_ERROR_GROUP General errors.
 @{
 */

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -671,30 +671,6 @@ typedef struct {
 /* Common function options */
 /****************************************************************************/
 
-/**
-@defgroup TABLES_API_FUNCTION_OPTIONS Common function options in tables API
-@{
-*/
-
-/* Start the commmon options at the top of the space; this way we can start
- * options for individual functions at the bottom without worrying about
- * clashing with the common options */
-
-/** @brief Turn on debugging output. Not supported by all functions. */
-#define TSK_DEBUG (1u << 31)
-
-/** @brief Do not initialise the parameter object. */
-#define TSK_NO_INIT (1u << 30)
-
-/** @brief Do not run integrity checks before performing an operation. */
-#define TSK_NO_CHECK_INTEGRITY (1u << 29)
-
-/** @brief Instead of taking a copy of input data, take ownership of it
- *  and its lifecycle */
-#define TSK_TAKE_OWNERSHIP (1 << 28)
-
-/**@} */
-
 /* Flags for simplify() */
 #define TSK_SIMPLIFY_FILTER_SITES (1 << 0)
 #define TSK_SIMPLIFY_FILTER_POPULATIONS (1 << 1)
@@ -726,8 +702,8 @@ typedef struct {
 
 /* Flags for dump tables */
 /* We may not want to document this flag, but it's useful for testing
- * so we put it high up in the bit space */
-#define TSK_DUMP_FORCE_OFFSET_64 (1 << 30)
+ * so we put it high up in the bit space, below the common options */
+#define TSK_DUMP_FORCE_OFFSET_64 (1 << 27)
 
 /* Flags for table collection init/copy */
 /* TODO: need to careful about what flags get passed to init, from other

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -203,7 +203,7 @@ Basic Types
 Common options
 **************
 
-.. doxygengroup:: TABLES_API_FUNCTION_OPTIONS
+.. doxygengroup:: GENERIC_FUNCTION_OPTIONS
    :content-only:
 
 .. _sec_c_api_tables_api:


### PR DESCRIPTION
Fixes #2218 
Instead of moving to trees.h it seemed to make more sense to move all the generic flags to `core.h` then all flags in other files should be namespaced to a function.