### PR TITLE
Document tree traversals in C

### DIFF
--- a/c/examples/tree_traversal.c
+++ b/c/examples/tree_traversal.c
@@ -9,9 +9,8 @@
         errx(EXIT_FAILURE, "line %d: %s", __LINE__, tsk_strerror(val));                 \
     }
 
-
 static void
-traverse_standard(tsk_tree_t *tree)
+traverse_standard(const tsk_tree_t *tree)
 {
     int ret;
     tsk_size_t num_nodes, j;
@@ -20,14 +19,13 @@ traverse_standard(tsk_tree_t *tree)
     if (nodes == NULL) {
         errx(EXIT_FAILURE, "Out of memory");
     }
-
-    ret = tsk_tree_preorder(tree, -1, nodes, &num_nodes);
+    ret = tsk_tree_preorder(tree, nodes, &num_nodes);
     check_tsk_error(ret);
     for (j = 0; j < num_nodes; j++) {
         printf("Visit preorder %lld\n", (long long) nodes[j]);
     }
 
-    ret = tsk_tree_postorder(tree, -1, nodes, &num_nodes);
+    ret = tsk_tree_postorder(tree, nodes, &num_nodes);
     check_tsk_error(ret);
     for (j = 0; j < num_nodes; j++) {
         printf("Visit postorder %lld\n", (long long) nodes[j]);
@@ -36,9 +34,8 @@ traverse_standard(tsk_tree_t *tree)
     free(nodes);
 }
 
-
 static void
-_traverse(tsk_tree_t *tree, tsk_id_t u, int depth)
+_traverse(const tsk_tree_t *tree, tsk_id_t u, int depth)
 {
     tsk_id_t v;
     int j;
@@ -53,13 +50,13 @@ _traverse(tsk_tree_t *tree, tsk_id_t u, int depth)
 }
 
 static void
-traverse_recursive(tsk_tree_t *tree)
+traverse_recursive(const tsk_tree_t *tree)
 {
     _traverse(tree, tree->virtual_root, -1);
 }
 
 static void
-traverse_stack(tsk_tree_t *tree)
+traverse_stack(const tsk_tree_t *tree)
 {
     int stack_top;
     tsk_id_t u, v;
@@ -84,7 +81,7 @@ traverse_stack(tsk_tree_t *tree)
 }
 
 static void
-traverse_upwards(tsk_tree_t *tree)
+traverse_upwards(const tsk_tree_t *tree)
 {
     const tsk_id_t *samples = tsk_treeseq_get_samples(tree->tree_sequence);
     tsk_size_t num_samples = tsk_treeseq_get_num_samples(tree->tree_sequence);

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -632,7 +632,7 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
     CU_ASSERT_EQUAL(ret, 0);
 
     for (ret = tsk_tree_first(&tree); ret == TSK_TREE_OK; ret = tsk_tree_next(&tree)) {
-        ret = tsk_tree_preorder(&tree, -1, nodes, &num_nodes);
+        ret = tsk_tree_preorder(&tree, nodes, &num_nodes);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
 
         s = 0;

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -5402,18 +5402,16 @@ test_no_sample_count_semantics(void)
 
     CU_ASSERT_EQUAL(tsk_tree_get_num_roots(&t), 0);
     CU_ASSERT_EQUAL(tsk_tree_get_left_root(&t), TSK_NULL);
-    CU_ASSERT_EQUAL(
-        tsk_tree_preorder(&t, -1, &nodes, &n), TSK_ERR_UNSUPPORTED_OPERATION);
-    CU_ASSERT_EQUAL(
-        tsk_tree_postorder(&t, -1, &nodes, &n), TSK_ERR_UNSUPPORTED_OPERATION);
-    CU_ASSERT_EQUAL(
-        tsk_tree_preorder_samples(&t, -1, &nodes, &n), TSK_ERR_UNSUPPORTED_OPERATION);
+    CU_ASSERT_EQUAL(tsk_tree_preorder(&t, &nodes, &n), TSK_ERR_UNSUPPORTED_OPERATION);
+    CU_ASSERT_EQUAL(tsk_tree_postorder(&t, &nodes, &n), TSK_ERR_UNSUPPORTED_OPERATION);
+    CU_ASSERT_EQUAL(tsk_tree_preorder_samples_from(&t, -1, &nodes, &n),
+        TSK_ERR_UNSUPPORTED_OPERATION);
 
-    CU_ASSERT_EQUAL(tsk_tree_preorder(&t, t.virtual_root, &nodes, &n),
+    CU_ASSERT_EQUAL(tsk_tree_preorder_from(&t, t.virtual_root, &nodes, &n),
         TSK_ERR_UNSUPPORTED_OPERATION);
-    CU_ASSERT_EQUAL(tsk_tree_postorder(&t, t.virtual_root, &nodes, &n),
+    CU_ASSERT_EQUAL(tsk_tree_postorder_from(&t, t.virtual_root, &nodes, &n),
         TSK_ERR_UNSUPPORTED_OPERATION);
-    CU_ASSERT_EQUAL(tsk_tree_preorder_samples(&t, t.virtual_root, &nodes, &n),
+    CU_ASSERT_EQUAL(tsk_tree_preorder_samples_from(&t, t.virtual_root, &nodes, &n),
         TSK_ERR_UNSUPPORTED_OPERATION);
 
     tsk_tree_free(&t);
@@ -5458,65 +5456,75 @@ test_single_tree_traversal(void)
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_TREE_OK);
 
-    ret = tsk_tree_preorder(&t, -1, nodes, &n);
+    ret = tsk_tree_preorder(&t, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, num_nodes);
     verify_node_lists(n, nodes, preorder);
 
-    ret = tsk_tree_preorder(&t, t.virtual_root, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, -1, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, num_nodes);
+    verify_node_lists(n, nodes, preorder);
+
+    ret = tsk_tree_preorder_from(&t, t.virtual_root, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, num_nodes + 1);
     verify_node_lists(n, nodes, preorder_vr);
 
-    ret = tsk_tree_preorder_samples(&t, -1, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, -1, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 4);
     verify_node_lists(n, nodes, preorder_samples);
 
-    ret = tsk_tree_preorder_samples(&t, t.virtual_root, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, t.virtual_root, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 4);
     verify_node_lists(n, nodes, preorder_samples);
 
-    ret = tsk_tree_preorder(&t, 5, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, 5, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, preorder + 4);
 
-    ret = tsk_tree_preorder_samples(&t, 5, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, 5, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 2);
     verify_node_lists(n, nodes, preorder_samples + 2);
 
-    ret = tsk_tree_postorder(&t, -1, nodes, &n);
+    ret = tsk_tree_postorder(&t, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, num_nodes);
     verify_node_lists(n, nodes, postorder);
 
-    ret = tsk_tree_postorder(&t, t.virtual_root, nodes, &n);
+    ret = tsk_tree_postorder_from(&t, -1, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, num_nodes);
+    verify_node_lists(n, nodes, postorder);
+
+    ret = tsk_tree_postorder_from(&t, t.virtual_root, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, num_nodes + 1);
     verify_node_lists(n, nodes, postorder_vr);
 
-    ret = tsk_tree_postorder(&t, 4, nodes, &n);
+    ret = tsk_tree_postorder_from(&t, 4, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, postorder);
 
     /* Check errors */
-    ret = tsk_tree_preorder(&t, -2, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, -2, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
-    ret = tsk_tree_preorder(&t, 8, nodes, &n);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
-
-    ret = tsk_tree_preorder_samples(&t, -2, nodes, &n);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
-    ret = tsk_tree_preorder_samples(&t, 8, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, 8, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
-    ret = tsk_tree_postorder(&t, -2, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, -2, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
-    ret = tsk_tree_postorder(&t, 8, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, 8, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+
+    ret = tsk_tree_postorder_from(&t, -2, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    ret = tsk_tree_postorder_from(&t, 8, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     tsk_tree_free(&t);
@@ -5563,52 +5571,62 @@ test_multiroot_tree_traversal(void)
     ret = tsk_tree_first(&t);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_TREE_OK);
 
-    ret = tsk_tree_preorder(&t, -1, nodes, &n);
+    ret = tsk_tree_preorder(&t, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 9);
     verify_node_lists(n, nodes, preorder);
 
-    ret = tsk_tree_preorder(&t, t.virtual_root, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, -1, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 9);
+    verify_node_lists(n, nodes, preorder);
+
+    ret = tsk_tree_preorder_from(&t, t.virtual_root, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 10);
     verify_node_lists(n, nodes, preorder_vr);
 
-    ret = tsk_tree_preorder(&t, 10, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, 10, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, preorder + 6);
 
-    ret = tsk_tree_preorder_samples(&t, -1, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, -1, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 6);
     verify_node_lists(n, nodes, preorder_samples);
 
-    ret = tsk_tree_preorder_samples(&t, t.virtual_root, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, t.virtual_root, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 6);
     verify_node_lists(n, nodes, preorder_samples);
 
-    ret = tsk_tree_preorder_samples(&t, 5, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, 5, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 1);
     verify_node_lists(n, nodes, preorder_samples);
 
-    ret = tsk_tree_preorder_samples(&t, 10, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, 10, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 2);
     verify_node_lists(n, nodes, preorder_samples + 4);
 
-    ret = tsk_tree_postorder(&t, -1, nodes, &n);
+    ret = tsk_tree_postorder(&t, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 9);
     verify_node_lists(n, nodes, postorder);
 
-    ret = tsk_tree_postorder(&t, t.virtual_root, nodes, &n);
+    ret = tsk_tree_postorder_from(&t, -1, nodes, &n);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(n, 9);
+    verify_node_lists(n, nodes, postorder);
+
+    ret = tsk_tree_postorder_from(&t, t.virtual_root, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 10);
     verify_node_lists(n, nodes, postorder_vr);
 
-    ret = tsk_tree_postorder(&t, 10, nodes, &n);
+    ret = tsk_tree_postorder_from(&t, 10, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 3);
     verify_node_lists(n, nodes, postorder + 6);
@@ -5616,17 +5634,17 @@ test_multiroot_tree_traversal(void)
     /* Nodes that aren't "in" the tree have singleton traversal lists and
      * connect to no samples */
 
-    ret = tsk_tree_preorder(&t, 11, nodes, &n);
+    ret = tsk_tree_preorder_from(&t, 11, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 1);
     CU_ASSERT_EQUAL_FATAL(nodes[0], 11);
 
-    ret = tsk_tree_postorder(&t, 11, nodes, &n);
+    ret = tsk_tree_postorder_from(&t, 11, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 1);
     CU_ASSERT_EQUAL_FATAL(nodes[0], 11);
 
-    ret = tsk_tree_preorder_samples(&t, 11, nodes, &n);
+    ret = tsk_tree_preorder_samples_from(&t, 11, nodes, &n);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(n, 0);
 

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3410,7 +3410,7 @@ tsk_tree_track_descendant_samples(tsk_tree_t *self, tsk_id_t node)
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
-    ret = tsk_tree_postorder(self, node, nodes, &num_nodes);
+    ret = tsk_tree_postorder_from(self, node, nodes, &num_nodes);
     if (ret != 0) {
         goto out;
     }
@@ -3592,7 +3592,7 @@ tsk_tree_get_num_samples_by_traversal(
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
-    ret = tsk_tree_preorder(self, u, nodes, &num_nodes);
+    ret = tsk_tree_preorder_from(self, u, nodes, &num_nodes);
     if (ret != 0) {
         goto out;
     }
@@ -3749,7 +3749,7 @@ tsk_tree_get_total_branch_length(const tsk_tree_t *self, tsk_id_t node, double *
         ret = TSK_ERR_NO_MEMORY;
         goto out;
     }
-    ret = tsk_tree_preorder(self, node, nodes, &num_nodes);
+    ret = tsk_tree_preorder_from(self, node, nodes, &num_nodes);
     if (ret != 0) {
         goto out;
     }
@@ -4455,7 +4455,13 @@ tsk_tree_alloc_node_stack(const tsk_tree_t *self)
 }
 
 int
-tsk_tree_preorder(
+tsk_tree_preorder(const tsk_tree_t *self, tsk_id_t *nodes, tsk_size_t *num_nodes_ret)
+{
+    return tsk_tree_preorder_from(self, -1, nodes, num_nodes_ret);
+}
+
+int
+tsk_tree_preorder_from(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes_ret)
 {
     int ret = 0;
@@ -4512,7 +4518,7 @@ out:
  * of mallocing the intermediate node list (which will be bigger than
  * the number of samples). */
 int
-tsk_tree_preorder_samples(
+tsk_tree_preorder_samples_from(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes_ret)
 {
     int ret = 0;
@@ -4571,7 +4577,12 @@ out:
 }
 
 int
-tsk_tree_postorder(
+tsk_tree_postorder(const tsk_tree_t *self, tsk_id_t *nodes, tsk_size_t *num_nodes_ret)
+{
+    return tsk_tree_postorder_from(self, -1, nodes, num_nodes_ret);
+}
+int
+tsk_tree_postorder_from(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes_ret)
 {
     int ret = 0;
@@ -4753,7 +4764,7 @@ tsk_tree_map_mutations(tsk_tree_t *self, int32_t *genotypes,
         }
     }
 
-    ret = tsk_tree_postorder(self, self->virtual_root, nodes, &num_nodes);
+    ret = tsk_tree_postorder_from(self, self->virtual_root, nodes, &num_nodes);
     if (ret != 0) {
         goto out;
     }

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1289,8 +1289,9 @@ int tsk_tree_get_sites(
 This function provides an upper bound on the number of nodes that
 can be reached in tree traversals, and is intended to be used
 for memory allocation purposes. If ``num_nodes`` is the number
-of nodes visited in a tree traversal from the virtual root
-(e.g., ``tsk_tree_preorder(tree, tree->virtual_root, nodes,
+of nodes visited in a tree traversal from the
+:ref:`virtual root<sec_data_model_tree_roots>`
+(e.g., ``tsk_tree_preorder_from(tree, tree->virtual_root, nodes,
 &num_nodes)``), the bound ``N`` returned here is guaranteed to
 be greater than or equal to ``num_nodes``.
 
@@ -1360,10 +1361,9 @@ for example:
         tsk_id_t *nodes = malloc(tsk_tree_get_size_bound(tree) * sizeof(*nodes));
 
         if (nodes == NULL) {
-
             errx(EXIT_FAILURE, "Out of memory");
         }
-        ret = tsk_tree_preorder(tree, -1, nodes, &num_nodes);
+        ret = tsk_tree_preorder(tree, nodes, &num_nodes);
         check_tsk_error(ret);
         for (j = 0; j < num_nodes; j++) {
             printf("time = %f\n", node_time[nodes[j]]);
@@ -1421,8 +1421,9 @@ int tsk_tree_get_branch_length(
 
 @rst
 Return the total branch length in a particular subtree or of the
-entire tree. If the specified node is TSK_NULL (or the virtual
-root) the sum of the lengths of all branches reachable from roots
+entire tree. If the specified node is TSK_NULL (or the
+:ref:`virtual root<sec_data_model_tree_roots>`)
+the sum of the lengths of all branches reachable from roots
 is returned. Branch length is defined as difference between the time
 of a node and its parent. The branch length of a root is zero.
 
@@ -1499,16 +1500,151 @@ bool tsk_tree_is_descendant(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v);
 @{
 */
 
-int tsk_tree_preorder(
+/**
+@brief Fill an array with the nodes of this tree in preorder.
+
+@rst
+Populate an array with the nodes in this tree in preorder. The array
+must be pre-allocated and be sufficiently large to hold the array
+of nodes visited. The recommended approach is to use the
+:c:func:`tsk_tree_get_size_bound` function, as in the following example:
+
+.. code-block:: c
+
+    static void
+    print_preorder(tsk_tree_t *tree)
+    {
+        int ret;
+        tsk_size_t num_nodes, j;
+        tsk_id_t *nodes = malloc(tsk_tree_get_size_bound(tree) * sizeof(*nodes));
+
+        if (nodes == NULL) {
+            errx(EXIT_FAILURE, "Out of memory");
+        }
+        ret = tsk_tree_preorder(tree, nodes, &num_nodes);
+        check_tsk_error(ret);
+        for (j = 0; j < num_nodes; j++) {
+            printf("Visit preorder %lld\n", (long long) nodes[j]);
+        }
+        free(nodes);
+    }
+
+.. seealso::
+    See the :ref:`sec_c_api_examples_tree_traversals` section for
+    more examples.
+
+@endrst
+
+@param self A pointer to a tsk_tree_t object.
+@param nodes The tsk_id_t array to store nodes in. See notes above for
+    details.
+@param num_nodes A pointer to a tsk_size_t value where we store the number
+    of nodes in the traversal.
+@return 0 on success or a negative value on failure.
+*/
+int tsk_tree_preorder(const tsk_tree_t *self, tsk_id_t *nodes, tsk_size_t *num_nodes);
+
+/**
+@brief Fill an array with the nodes of this tree starting from a particular node.
+
+@rst
+As for :c:func:`tsk_tree_preorder` but starting the traversal at a particular node
+(which will be the first node in the traversal list). The
+:ref:`virtual root<sec_data_model_tree_roots>` is a valid input for this function
+and will be treated like any other tree node. The value ``-1`` is a special case,
+in which we visit all nodes reachable from the roots, and equivalent to
+calling :c:func:`tsk_tree_preorder`.
+
+See :c:func:`tsk_tree_preorder` for details the requirements for the ``nodes``
+array.
+@endrst
+
+@param self A pointer to a tsk_tree_t object.
+@param root The root of the subtree to traverse, or -1 to visit all nodes.
+@param nodes The tsk_id_t array to store nodes in.
+@param num_nodes A pointer to a tsk_size_t value where we store the number
+    of nodes in the traversal.
+@return 0 on success or a negative value on failure.
+*/
+int tsk_tree_preorder_from(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
-int tsk_tree_postorder(
-    const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
-int tsk_tree_preorder_samples(
+
+/**
+@brief Fill an array with the nodes of this tree in postorder.
+
+@rst
+Populate an array with the nodes in this tree in postorder. The array
+must be pre-allocated and be sufficiently large to hold the array
+of nodes visited. The recommended approach is to use the
+:c:func:`tsk_tree_get_size_bound` function, as in the following example:
+
+.. code-block:: c
+
+    static void
+    print_postorder(tsk_tree_t *tree)
+    {
+        int ret;
+        tsk_size_t num_nodes, j;
+        tsk_id_t *nodes = malloc(tsk_tree_get_size_bound(tree) * sizeof(*nodes));
+
+        if (nodes == NULL) {
+            errx(EXIT_FAILURE, "Out of memory");
+        }
+        ret = tsk_tree_postorder(tree, nodes, &num_nodes);
+        check_tsk_error(ret);
+        for (j = 0; j < num_nodes; j++) {
+            printf("Visit postorder %lld\n", (long long) nodes[j]);
+        }
+        free(nodes);
+    }
+
+.. seealso::
+    See the :ref:`sec_c_api_examples_tree_traversals` section for
+    more examples.
+
+@endrst
+
+@param self A pointer to a tsk_tree_t object.
+@param nodes The tsk_id_t array to store nodes in. See notes above for
+    details.
+@param num_nodes A pointer to a tsk_size_t value where we store the number
+    of nodes in the traversal.
+@return 0 on success or a negative value on failure.
+*/
+int tsk_tree_postorder(const tsk_tree_t *self, tsk_id_t *nodes, tsk_size_t *num_nodes);
+
+/**
+@brief Fill an array with the nodes of this tree starting from a particular node.
+
+@rst
+As for :c:func:`tsk_tree_postorder` but starting the traversal at a particular node
+(which will be the last node in the traversal list). The
+:ref:`virtual root<sec_data_model_tree_roots>` is a valid input for this function
+and will be treated like any other tree node. The value ``-1`` is a special case,
+in which we visit all nodes reachable from the roots, and equivalent to
+calling :c:func:`tsk_tree_postorder`.
+
+See :c:func:`tsk_tree_postorder` for details the requirements for the ``nodes``
+array.
+@endrst
+
+@param self A pointer to a tsk_tree_t object.
+@param root The root of the subtree to traverse, or -1 to visit all nodes.
+@param nodes The tsk_id_t array to store nodes in. See
+    :c:func:`tsk_tree_postorder` for more details.
+@param num_nodes A pointer to a tsk_size_t value where we store the number
+    of nodes in the traversal.
+@return 0 on success or a negative value on failure.
+*/
+int tsk_tree_postorder_from(
     const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
 
 /** @} */
 
 /* Undocumented for now */
+
+int tsk_tree_preorder_samples_from(
+    const tsk_tree_t *self, tsk_id_t root, tsk_id_t *nodes, tsk_size_t *num_nodes);
 
 int tsk_tree_set_root_threshold(tsk_tree_t *self, tsk_size_t root_threshold);
 tsk_size_t tsk_tree_get_root_threshold(const tsk_tree_t *self);

--- a/docs/c-api.rst
+++ b/docs/c-api.rst
@@ -678,25 +678,26 @@ Tree traversals
 ---------------
 
 In this example we load a tree sequence file, and then traverse the first
-tree in three different ways:
+tree in four different ways:
 
-1. We first traverse the tree in preorder using recursion. This is a very
-   common way of navigating around trees and can be very convenient for
+1. We first traverse the tree in preorder and postorder using the
+   :c:func:`tsk_tree_preorder`
+   :c:func:`tsk_tree_postorder` functions to fill an array of
+   nodes in the appropriate orders. This is the recommended approach
+   and will be convenient and efficient for most purposes.
+
+2. As an example of how we might build our own traveral algorithms, we
+   then traverse the tree in preorder using recursion. This is a very
+   common way of navigating around trees and can be convenient for
    some applications. For example, here we compute the depth of each node
    (i.e., it's distance from the root) and use this when printing out the
    nodes as we visit them.
 
-2. Then we traverse the tree in preorder using an iterative approach. This
+3. Then we traverse the tree in preorder using an iterative approach. This
    is a little more efficient than using recursion, and is sometimes
-   more convenient than structuring the calculation recursively. Note that
-   we allocate a stack here with space to hold the total number of nodes
-   in the tree sequence. This is safe, but it likely to be a massive
-   over estimate. However, this makes very little difference in practise
-   even for tree sequences with millions of nodes since it's likely
-   only the first page (usually 4K) will be written to and the
-   rest of the stack will never therefore be mapped to physical memory.
+   more convenient than structuring the calculation recursively.
 
-3. In the third example we iterate upwards from the samples rather than
+4. In the third example we iterate upwards from the samples rather than
    downwards from the root.
 
 .. literalinclude:: ../c/examples/tree_traversal.c

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -10660,13 +10660,13 @@ out:
 static PyObject *
 Tree_get_preorder(Tree *self, PyObject *args)
 {
-    return Tree_get_traversal_array(self, args, tsk_tree_preorder);
+    return Tree_get_traversal_array(self, args, tsk_tree_preorder_from);
 }
 
 static PyObject *
 Tree_get_postorder(Tree *self, PyObject *args)
 {
-    return Tree_get_traversal_array(self, args, tsk_tree_postorder);
+    return Tree_get_traversal_array(self, args, tsk_tree_postorder_from);
 }
 
 /* The x_array properties are the high-performance zero-copy interface to the


### PR DESCRIPTION
I think this the last piece of the puzzle for documenting the 1.0 tree API. I ended up adding two new functions, but I think traversing all nodes is a common enough use-case that we should give it its own function and not make people remember that -1 is the magic value you need to use.