### PR TITLE
Place result as the last arg in stats API

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -1,6 +1,6 @@
-----------------------
-[1.0.0b1] - 2022-05-11
-----------------------
+--------------------
+[1.0.0] - 2022-05-XX
+--------------------
 
 ##BETA RELEASE
 
@@ -31,6 +31,7 @@
   Remove ``TSK_ERR_NON_SINGLE_CHAR_MUTATION`` which was unused.
   (:user:`benjeffery`, :pr:`2260`)
 
+- Reorder stats API methods to place ``result`` as the last argument. (:user:`benjeffery`, :pr:`2292`, :issue:`2285`)
 
 **Features**
 

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -296,29 +296,29 @@ verify_window_errors(tsk_treeseq_t *ts, tsk_flags_t mode)
 
     /* Window errors */
     ret = tsk_treeseq_general_stat(
-        ts, 1, W, 1, general_stat_error, NULL, 0, windows, sigma, options);
+        ts, 1, W, 1, general_stat_error, NULL, 0, windows, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NUM_WINDOWS);
 
     ret = tsk_treeseq_general_stat(
-        ts, 1, W, 1, general_stat_error, NULL, 2, windows, sigma, options);
+        ts, 1, W, 1, general_stat_error, NULL, 2, windows, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 
     windows[0] = 10;
     ret = tsk_treeseq_general_stat(
-        ts, 1, W, 1, general_stat_error, NULL, 2, windows, sigma, options);
+        ts, 1, W, 1, general_stat_error, NULL, 2, windows, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 
     windows[0] = 0;
     windows[2] = tsk_treeseq_get_sequence_length(ts) + 1;
     ret = tsk_treeseq_general_stat(
-        ts, 1, W, 1, general_stat_error, NULL, 2, windows, sigma, options);
+        ts, 1, W, 1, general_stat_error, NULL, 2, windows, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 
     windows[0] = 0;
     windows[1] = -1;
     windows[2] = tsk_treeseq_get_sequence_length(ts);
     ret = tsk_treeseq_general_stat(
-        ts, 1, W, 1, general_stat_error, NULL, 2, windows, sigma, options);
+        ts, 1, W, 1, general_stat_error, NULL, 2, windows, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 
     free(W);
@@ -344,7 +344,7 @@ verify_summary_func_errors(tsk_treeseq_t *ts, tsk_flags_t mode)
         params.error_on = j;
         params.error_code = -j;
         ret = tsk_treeseq_general_stat(ts, 1, W, 1, general_stat_error, &params, 0, NULL,
-            sigma, TSK_STAT_POLARISED | mode);
+            TSK_STAT_POLARISED | mode, sigma);
         if (ret == 0) {
             break;
         }
@@ -359,7 +359,7 @@ verify_summary_func_errors(tsk_treeseq_t *ts, tsk_flags_t mode)
         params.error_on = j;
         params.error_code = -j;
         ret = tsk_treeseq_general_stat(
-            ts, 1, W, 1, general_stat_error, &params, 0, NULL, sigma, mode);
+            ts, 1, W, 1, general_stat_error, &params, 0, NULL, mode, sigma);
         if (ret == 0) {
             break;
         }
@@ -408,7 +408,7 @@ verify_one_way_weighted_func_errors(tsk_treeseq_t *ts, one_way_weighted_method *
         weights[j] = 1.0;
     }
 
-    ret = method(ts, 0, weights, 0, NULL, &result, 0);
+    ret = method(ts, 0, weights, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_STATE_DIMS);
 
     free(weights);
@@ -431,7 +431,7 @@ verify_one_way_weighted_covariate_func_errors(
         weights[j] = 1.0;
     }
 
-    ret = method(ts, 0, weights, 0, covariates, 0, NULL, &result, 0);
+    ret = method(ts, 0, weights, 0, covariates, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_STATE_DIMS);
 
     free(weights);
@@ -447,41 +447,41 @@ verify_one_way_stat_func_errors(tsk_treeseq_t *ts, one_way_sample_stat_method *m
     double windows[] = { 0, 0, 0 };
     double result;
 
-    ret = method(ts, 0, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 0, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
     samples[0] = TSK_NULL;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     samples[0] = -10;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     samples[0] = num_nodes;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
     samples[0] = num_nodes + 1;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
 
     samples[0] = num_nodes - 1;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLES);
 
     samples[0] = 1;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
 
     samples[0] = 0;
     sample_set_sizes = 0;
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EMPTY_SAMPLE_SET);
 
     sample_set_sizes = 4;
     /* Window errors */
-    ret = method(ts, 1, &sample_set_sizes, samples, 0, windows, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, windows, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NUM_WINDOWS);
 
-    ret = method(ts, 1, &sample_set_sizes, samples, 2, windows, &result, 0);
+    ret = method(ts, 1, &sample_set_sizes, samples, 2, windows, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 }
 
@@ -494,25 +494,25 @@ verify_two_way_stat_func_errors(tsk_treeseq_t *ts, general_sample_stat_method *m
     tsk_id_t set_indexes[] = { 0, 1 };
     double result;
 
-    ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
-    ret = method(ts, 2, sample_set_sizes, samples, 0, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 2, sample_set_sizes, samples, 0, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_INDEX_TUPLES);
 
     set_indexes[0] = -1;
-    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
     set_indexes[0] = 0;
     set_indexes[1] = 2;
-    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
 }
 
@@ -525,28 +525,28 @@ verify_three_way_stat_func_errors(tsk_treeseq_t *ts, general_sample_stat_method 
     tsk_id_t set_indexes[] = { 0, 1, 2 };
     double result;
 
-    ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
-    ret = method(ts, 3, sample_set_sizes, samples, 0, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 3, sample_set_sizes, samples, 0, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_INDEX_TUPLES);
 
     set_indexes[0] = -1;
-    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
     set_indexes[0] = 0;
     set_indexes[1] = 3;
-    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
 }
 
@@ -559,31 +559,31 @@ verify_four_way_stat_func_errors(tsk_treeseq_t *ts, general_sample_stat_method *
     tsk_id_t set_indexes[] = { 0, 1, 2, 3 };
     double result;
 
-    ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
-    ret = method(ts, 4, sample_set_sizes, samples, 0, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 4, sample_set_sizes, samples, 0, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_INDEX_TUPLES);
 
     set_indexes[0] = -1;
-    ret = method(ts, 4, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 4, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
     set_indexes[0] = 0;
     set_indexes[1] = 4;
-    ret = method(ts, 4, sample_set_sizes, samples, 1, set_indexes, 0, NULL, &result,
-        TSK_STAT_SITE);
+    ret = method(ts, 4, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
 }
 
@@ -624,8 +624,8 @@ verify_branch_general_stat_identity(tsk_treeseq_t *ts)
     }
 
     ret = tsk_treeseq_general_stat(ts, 1, W, 1, general_stat_identity, NULL,
-        tsk_treeseq_get_num_trees(ts), tsk_treeseq_get_breakpoints(ts), sigma,
-        TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE);
+        tsk_treeseq_get_num_trees(ts), tsk_treeseq_get_breakpoints(ts),
+        TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_tree_init(&tree, ts, 0);
@@ -688,7 +688,7 @@ verify_general_stat_dims(
         }
     }
     ret = tsk_treeseq_general_stat(
-        ts, K, W, M, general_stat_sum, NULL, 0, NULL, sigma, options);
+        ts, K, W, M, general_stat_sum, NULL, 0, NULL, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     free(W);
@@ -722,7 +722,7 @@ verify_general_stat_windows(
         windows[j] = ((double) j) * L / (double) num_windows;
     }
     ret = tsk_treeseq_general_stat(
-        ts, 1, W, M, general_stat_sum, NULL, num_windows, windows, sigma, options);
+        ts, 1, W, M, general_stat_sum, NULL, num_windows, windows, options, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     free(W);
@@ -748,11 +748,11 @@ verify_default_general_stat(tsk_treeseq_t *ts)
         }
     }
     ret = tsk_treeseq_general_stat(
-        ts, K, W, M, general_stat_sum, NULL, 0, NULL, &sigma1, TSK_STAT_SITE);
+        ts, K, W, M, general_stat_sum, NULL, 0, NULL, TSK_STAT_SITE, &sigma1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_general_stat(
-        ts, K, W, M, general_stat_sum, NULL, 0, NULL, &sigma2, 0);
+        ts, K, W, M, general_stat_sum, NULL, 0, NULL, 0, &sigma2);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(sigma1, sigma2);
     free(W);
@@ -796,23 +796,23 @@ verify_afs(tsk_treeseq_t *ts)
     sample_set_sizes[0] = n - 2;
     sample_set_sizes[1] = 2;
     ret = tsk_treeseq_allele_frequency_spectrum(
-        ts, 2, sample_set_sizes, samples, 0, NULL, result, 0);
+        ts, 2, sample_set_sizes, samples, 0, NULL, 0, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        ts, 2, sample_set_sizes, samples, 0, NULL, result, TSK_STAT_POLARISED);
+        ts, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_POLARISED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-        NULL, result, TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE);
+        NULL, TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-        NULL, result, TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE);
+        NULL, TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-        NULL, result, TSK_STAT_BRANCH | TSK_STAT_SPAN_NORMALISE);
+        NULL, TSK_STAT_BRANCH | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     free(result);
@@ -831,22 +831,22 @@ test_general_stat_input_errors(void)
 
     /* Bad input dimensions */
     ret = tsk_treeseq_general_stat(
-        &ts, 0, &W, 1, general_stat_sum, NULL, 0, NULL, &result, 0);
+        &ts, 0, &W, 1, general_stat_sum, NULL, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_STATE_DIMS);
 
     ret = tsk_treeseq_general_stat(
-        &ts, 1, &W, 0, general_stat_sum, NULL, 0, NULL, &result, 0);
+        &ts, 1, &W, 0, general_stat_sum, NULL, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_RESULT_DIMS);
 
     /* Multiple stats*/
     ret = tsk_treeseq_general_stat(&ts, 1, &W, 1, general_stat_sum, NULL, 0, NULL,
-        &result, TSK_STAT_SITE | TSK_STAT_BRANCH);
+        TSK_STAT_SITE | TSK_STAT_BRANCH, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_STAT_MODES);
     ret = tsk_treeseq_general_stat(&ts, 1, &W, 1, general_stat_sum, NULL, 0, NULL,
-        &result, TSK_STAT_SITE | TSK_STAT_NODE);
+        TSK_STAT_SITE | TSK_STAT_NODE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_STAT_MODES);
     ret = tsk_treeseq_general_stat(&ts, 1, &W, 1, general_stat_sum, NULL, 0, NULL,
-        &result, TSK_STAT_BRANCH | TSK_STAT_NODE);
+        TSK_STAT_BRANCH | TSK_STAT_NODE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_STAT_MODES);
 
     tsk_treeseq_free(&ts);
@@ -1078,14 +1078,14 @@ test_paper_ex_diversity(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_diversity(
-        &ts, 1, &sample_set_sizes, samples, 0, NULL, &pi, TSK_STAT_SITE);
+        &ts, 1, &sample_set_sizes, samples, 0, NULL, TSK_STAT_SITE, &pi);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(pi, 1.5, 1e-6);
 
     /* A sample set size of 1 leads to NaN */
     sample_set_sizes = 1;
     ret = tsk_treeseq_diversity(
-        &ts, 1, &sample_set_sizes, samples, 0, NULL, &pi, TSK_STAT_SITE);
+        &ts, 1, &sample_set_sizes, samples, 0, NULL, TSK_STAT_SITE, &pi);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(pi));
 
@@ -1118,7 +1118,7 @@ test_paper_ex_trait_covariance(void)
     weights[0] = weights[1] = 0.0;
     weights[2] = weights[3] = 1.0;
 
-    ret = tsk_treeseq_trait_covariance(&ts, 1, weights, 0, NULL, &result, TSK_STAT_SITE);
+    ret = tsk_treeseq_trait_covariance(&ts, 1, weights, 0, NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 1.0 / 12.0, 1e-6);
 
@@ -1126,7 +1126,7 @@ test_paper_ex_trait_covariance(void)
     for (j = 0; j < 4; j++) {
         weights[j] = 0.0;
     }
-    ret = tsk_treeseq_trait_covariance(&ts, 1, weights, 0, NULL, &result, TSK_STAT_SITE);
+    ret = tsk_treeseq_trait_covariance(&ts, 1, weights, 0, NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 0.0, 1e-6);
 
@@ -1160,7 +1160,7 @@ test_paper_ex_trait_correlation(void)
     weights[2] = weights[3] = 1.0;
 
     ret = tsk_treeseq_trait_correlation(
-        &ts, 1, weights, 0, NULL, &result, TSK_STAT_SITE);
+        &ts, 1, weights, 0, NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 1.0, 1e-6);
 
@@ -1200,7 +1200,7 @@ test_paper_ex_trait_linear_model(void)
     covariates[5] = covariates[7] = 1.0;
 
     ret = tsk_treeseq_trait_linear_model(
-        &ts, 1, weights, 2, covariates, 0, NULL, &result, TSK_STAT_SITE);
+        &ts, 1, weights, 2, covariates, 0, NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(result, 0.0, 1e-6);
 
@@ -1233,14 +1233,14 @@ test_paper_ex_segregating_sites(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_segregating_sites(
-        &ts, 1, &sample_set_sizes, samples, 0, NULL, &segsites, TSK_STAT_SITE);
+        &ts, 1, &sample_set_sizes, samples, 0, NULL, TSK_STAT_SITE, &segsites);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(segsites, 3.0, 1e-6);
 
     /* A sample set size of 1 leads to 0 */
     sample_set_sizes = 1;
     ret = tsk_treeseq_segregating_sites(
-        &ts, 1, &sample_set_sizes, samples, 0, NULL, &segsites, TSK_STAT_SITE);
+        &ts, 1, &sample_set_sizes, samples, 0, NULL, TSK_STAT_SITE, &segsites);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(segsites, 0.0, 1e-6);
 
@@ -1270,12 +1270,12 @@ test_paper_ex_Y1(void)
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
-    ret = tsk_treeseq_Y1(&ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = tsk_treeseq_Y1(&ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* A sample set size of < 2 leads to NaN */
     sample_set_sizes = 1;
-    ret = tsk_treeseq_Y1(&ts, 1, &sample_set_sizes, samples, 0, NULL, &result, 0);
+    ret = tsk_treeseq_Y1(&ts, 1, &sample_set_sizes, samples, 0, NULL, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(result));
 
@@ -1307,14 +1307,14 @@ test_paper_ex_divergence(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_divergence(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0,
-        NULL, &result, TSK_STAT_SITE);
+        NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* sample_set[0] size = 1 with indexes = (0, 0) leads to NaN */
     sample_set_sizes[0] = 1;
     set_indexes[1] = 0;
     ret = tsk_treeseq_divergence(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0,
-        NULL, &result, TSK_STAT_SITE);
+        NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(result));
 
@@ -1335,7 +1335,7 @@ test_paper_ex_genetic_relatedness(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_genetic_relatedness(&ts, 2, sample_set_sizes, samples, 1,
-        set_indexes, 0, NULL, &result, TSK_STAT_SITE);
+        set_indexes, 0, NULL, TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_treeseq_free(&ts);
 }
@@ -1376,13 +1376,13 @@ test_paper_ex_Y2(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_Y2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* sample_set_size of 1 leads to NaN */
     sample_set_sizes[1] = 1;
     ret = tsk_treeseq_Y2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(result));
 
@@ -1414,13 +1414,13 @@ test_paper_ex_f2(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_f2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* sample_set_size of 1 leads to NaN */
     sample_set_sizes[0] = 1;
     ret = tsk_treeseq_f2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(result));
 
@@ -1428,7 +1428,7 @@ test_paper_ex_f2(void)
     sample_set_sizes[0] = 2;
     sample_set_sizes[1] = 1;
     ret = tsk_treeseq_f2(&ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(result));
 
@@ -1460,7 +1460,7 @@ test_paper_ex_Y3(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_Y3(&ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tsk_treeseq_free(&ts);
@@ -1491,13 +1491,13 @@ test_paper_ex_f3(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_f3(&ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* sample_set_size of 1 leads to NaN */
     sample_set_sizes[0] = 1;
     ret = tsk_treeseq_f3(&ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT(tsk_isnan(result));
 
@@ -1529,7 +1529,7 @@ test_paper_ex_f4(void)
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
     ret = tsk_treeseq_f4(&ts, 4, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        &result, TSK_STAT_SITE);
+        TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_treeseq_free(&ts);
 }
@@ -1549,11 +1549,11 @@ test_paper_ex_afs_errors(void)
     verify_one_way_stat_func_errors(&ts, tsk_treeseq_allele_frequency_spectrum);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts, 2, sample_set_sizes, samples, 0, NULL, result, TSK_STAT_NODE);
+        &ts, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_NODE, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSUPPORTED_STAT_MODE);
 
     ret = tsk_treeseq_allele_frequency_spectrum(&ts, 2, sample_set_sizes, samples, 0,
-        NULL, result, TSK_STAT_BRANCH | TSK_STAT_SITE);
+        NULL, TSK_STAT_BRANCH | TSK_STAT_SITE, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_STAT_MODES);
 
     tsk_treeseq_free(&ts);
@@ -1573,14 +1573,14 @@ test_paper_ex_afs(void)
     /* we have two singletons and one tripleton */
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts, 1, sample_set_sizes, samples, 0, NULL, result, 0);
+        &ts, 1, sample_set_sizes, samples, 0, NULL, 0, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result[0], 0);
     CU_ASSERT_EQUAL_FATAL(result[1], 3.0);
     CU_ASSERT_EQUAL_FATAL(result[2], 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts, 1, sample_set_sizes, samples, 0, NULL, result, TSK_STAT_POLARISED);
+        &ts, 1, sample_set_sizes, samples, 0, NULL, TSK_STAT_POLARISED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result[0], 0);
     CU_ASSERT_EQUAL_FATAL(result[1], 2.0);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -7190,13 +7190,13 @@ test_time_uncalibrated(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts2, 2, sample_set_sizes, samples, 0, NULL, result, TSK_STAT_SITE);
+        &ts2, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_SITE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts2, 2, sample_set_sizes, samples, 0, NULL, result, TSK_STAT_BRANCH);
+        &ts2, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_BRANCH, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_UNCALIBRATED);
     ret = tsk_treeseq_allele_frequency_spectrum(&ts2, 2, sample_set_sizes, samples, 0,
-        NULL, result, TSK_STAT_BRANCH | TSK_STAT_ALLOW_TIME_UNCALIBRATED);
+        NULL, TSK_STAT_BRANCH | TSK_STAT_ALLOW_TIME_UNCALIBRATED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     sigma = tsk_calloc(tsk_treeseq_get_num_nodes(&ts2), sizeof(double));
@@ -7204,16 +7204,16 @@ test_time_uncalibrated(void)
     W = tsk_calloc(num_samples, sizeof(double));
 
     ret = tsk_treeseq_general_stat(&ts2, 1, W, 1, dummy_stat, NULL,
-        tsk_treeseq_get_num_trees(&ts2), tsk_treeseq_get_breakpoints(&ts2), sigma,
-        TSK_STAT_SITE);
+        tsk_treeseq_get_num_trees(&ts2), tsk_treeseq_get_breakpoints(&ts2),
+        TSK_STAT_SITE, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_general_stat(&ts2, 1, W, 1, dummy_stat, NULL,
-        tsk_treeseq_get_num_trees(&ts2), tsk_treeseq_get_breakpoints(&ts2), sigma,
-        TSK_STAT_BRANCH);
+        tsk_treeseq_get_num_trees(&ts2), tsk_treeseq_get_breakpoints(&ts2),
+        TSK_STAT_BRANCH, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_UNCALIBRATED);
     ret = tsk_treeseq_general_stat(&ts2, 1, W, 1, dummy_stat, NULL,
-        tsk_treeseq_get_num_trees(&ts2), tsk_treeseq_get_breakpoints(&ts2), sigma,
-        TSK_STAT_BRANCH | TSK_STAT_ALLOW_TIME_UNCALIBRATED);
+        tsk_treeseq_get_num_trees(&ts2), tsk_treeseq_get_breakpoints(&ts2),
+        TSK_STAT_BRANCH | TSK_STAT_ALLOW_TIME_UNCALIBRATED, sigma);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     tsk_safe_free(W);

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1169,8 +1169,8 @@ update_running_sum(tsk_id_t u, double sign, const double *restrict branch_length
 static int
 tsk_treeseq_branch_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     const double *sample_weights, tsk_size_t result_dim, general_stat_func_t *f,
-    void *f_params, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options)
+    void *f_params, tsk_size_t num_windows, const double *windows, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -1459,8 +1459,8 @@ out:
 static int
 tsk_treeseq_site_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     const double *sample_weights, tsk_size_t result_dim, general_stat_func_t *f,
-    void *f_params, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options)
+    void *f_params, tsk_size_t num_windows, const double *windows, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -1593,8 +1593,8 @@ increment_row(tsk_size_t length, double multiplier, double *source, double *dest
 static int
 tsk_treeseq_node_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     const double *sample_weights, tsk_size_t result_dim, general_stat_func_t *f,
-    void *f_params, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t TSK_UNUSED(options))
+    void *f_params, tsk_size_t num_windows, const double *windows,
+    tsk_flags_t TSK_UNUSED(options), double *result)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -1784,8 +1784,8 @@ out:
 static int
 tsk_polarisable_func_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     const double *sample_weights, tsk_size_t result_dim, general_stat_func_t *f,
-    void *f_params, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options)
+    void *f_params, tsk_size_t num_windows, const double *windows, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     bool stat_branch = !!(options & TSK_STAT_BRANCH);
@@ -1824,11 +1824,11 @@ tsk_polarisable_func_general_stat(const tsk_treeseq_t *self, tsk_size_t state_di
 
     if (stat_branch) {
         ret = tsk_treeseq_branch_general_stat(self, state_dim, sample_weights,
-            result_dim, wrapped_f, wrapped_f_params, num_windows, windows, result,
-            options);
+            result_dim, wrapped_f, wrapped_f_params, num_windows, windows, options,
+            result);
     } else {
         ret = tsk_treeseq_node_general_stat(self, state_dim, sample_weights, result_dim,
-            wrapped_f, wrapped_f_params, num_windows, windows, result, options);
+            wrapped_f, wrapped_f_params, num_windows, windows, options, result);
     }
 out:
     tsk_safe_free(upargs.total_weight);
@@ -1840,8 +1840,8 @@ out:
 int
 tsk_treeseq_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     const double *sample_weights, tsk_size_t result_dim, general_stat_func_t *f,
-    void *f_params, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options)
+    void *f_params, tsk_size_t num_windows, const double *windows, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     bool stat_site = !!(options & TSK_STAT_SITE);
@@ -1880,10 +1880,10 @@ tsk_treeseq_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
 
     if (stat_site) {
         ret = tsk_treeseq_site_general_stat(self, state_dim, sample_weights, result_dim,
-            f, f_params, num_windows, windows, result, options);
+            f, f_params, num_windows, windows, options, result);
     } else {
         ret = tsk_polarisable_func_general_stat(self, state_dim, sample_weights,
-            result_dim, f, f_params, num_windows, windows, result, options);
+            result_dim, f, f_params, num_windows, windows, options, result);
     }
 
     if (options & TSK_STAT_SPAN_NORMALISE) {
@@ -1973,7 +1973,7 @@ static int
 tsk_treeseq_sample_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t result_dim, const tsk_id_t *set_indexes, general_stat_func_t *f,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     const tsk_size_t num_samples = self->num_samples;
@@ -2011,7 +2011,7 @@ tsk_treeseq_sample_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sample_s
         }
     }
     ret = tsk_treeseq_general_stat(self, num_sample_sets, weights, result_dim, f, &args,
-        num_windows, windows, result, options);
+        num_windows, windows, options, result);
 out:
     tsk_safe_free(weights);
     return ret;
@@ -2053,8 +2053,8 @@ fold(tsk_size_t *restrict coordinate, const tsk_size_t *restrict dims,
 static int
 tsk_treeseq_update_site_afs(const tsk_treeseq_t *self, const tsk_site_t *site,
     const double *total_counts, const double *counts, tsk_size_t num_sample_sets,
-    tsk_size_t window_index, tsk_size_t *result_dims, double *result,
-    tsk_flags_t options)
+    tsk_size_t window_index, tsk_size_t *result_dims, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     tsk_size_t afs_size;
@@ -2103,7 +2103,7 @@ static int
 tsk_treeseq_site_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes, double *counts,
     tsk_size_t num_windows, const double *windows, tsk_size_t *result_dims,
-    double *result, tsk_flags_t options)
+    tsk_flags_t options, double *result)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -2183,7 +2183,7 @@ tsk_treeseq_site_allele_frequency_spectrum(const tsk_treeseq_t *self,
                 tsk_bug_assert(window_index < num_windows);
             }
             ret = tsk_treeseq_update_site_afs(self, site, total_counts, counts,
-                num_sample_sets, window_index, result_dims, result, options);
+                num_sample_sets, window_index, result_dims, options, result);
             if (ret != 0) {
                 goto out;
             }
@@ -2206,7 +2206,7 @@ static int TSK_WARN_UNUSED
 tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double right,
     const double *restrict branch_length, double *restrict last_update,
     const double *counts, tsk_size_t num_sample_sets, tsk_size_t window_index,
-    const tsk_size_t *result_dims, double *result, tsk_flags_t options)
+    const tsk_size_t *result_dims, tsk_flags_t options, double *result)
 {
     int ret = 0;
     tsk_size_t afs_size;
@@ -2246,8 +2246,8 @@ out:
 static int
 tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, double *counts, tsk_size_t num_windows,
-    const double *windows, const tsk_size_t *result_dims, double *result,
-    tsk_flags_t options)
+    const double *windows, const tsk_size_t *result_dims, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -2293,15 +2293,15 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             u = edge_child[h];
             v = edge_parent[h];
             ret = tsk_treeseq_update_branch_afs(self, u, t_left, branch_length,
-                last_update, counts, num_sample_sets, window_index, result_dims, result,
-                options);
+                last_update, counts, num_sample_sets, window_index, result_dims, options,
+                result);
             if (ret != 0) {
                 goto out;
             }
             while (v != TSK_NULL) {
                 ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
                     last_update, counts, num_sample_sets, window_index, result_dims,
-                    result, options);
+                    options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -2322,7 +2322,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             while (v != TSK_NULL) {
                 ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
                     last_update, counts, num_sample_sets, window_index, result_dims,
-                    result, options);
+                    options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -2346,7 +2346,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
                 tsk_bug_assert(last_update[u] < w_right);
                 ret = tsk_treeseq_update_branch_afs(self, u, w_right, branch_length,
                     last_update, counts, num_sample_sets, window_index, result_dims,
-                    result, options);
+                    options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -2374,7 +2374,7 @@ int
 tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
-    double *result, tsk_flags_t options)
+    tsk_flags_t options, double *result)
 {
     int ret = 0;
     bool stat_site = !!(options & TSK_STAT_SITE);
@@ -2452,11 +2452,11 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_memset(result, 0, num_windows * afs_size * sizeof(*result));
     if (stat_site) {
         ret = tsk_treeseq_site_allele_frequency_spectrum(self, num_sample_sets,
-            sample_set_sizes, counts, num_windows, windows, result_dims, result,
-            options);
+            sample_set_sizes, counts, num_windows, windows, result_dims, options,
+            result);
     } else {
         ret = tsk_treeseq_branch_allele_frequency_spectrum(self, num_sample_sets, counts,
-            num_windows, windows, result_dims, result, options);
+            num_windows, windows, result_dims, options, result);
     }
 
     if (options & TSK_STAT_SPAN_NORMALISE) {
@@ -2491,11 +2491,11 @@ diversity_summary_func(tsk_size_t state_dim, const double *state,
 int
 tsk_treeseq_diversity(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result)
 {
     return tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_sample_sets, NULL, diversity_summary_func, num_windows, windows,
-        result, options);
+        options, result);
 }
 
 static int
@@ -2515,8 +2515,8 @@ trait_covariance_summary_func(tsk_size_t state_dim, const double *state,
 
 int
 tsk_treeseq_trait_covariance(const tsk_treeseq_t *self, tsk_size_t num_weights,
-    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options)
+    const double *weights, tsk_size_t num_windows, const double *windows,
+    tsk_flags_t options, double *result)
 {
     tsk_size_t num_samples = self->num_samples;
     tsk_size_t j, k;
@@ -2551,7 +2551,7 @@ tsk_treeseq_trait_covariance(const tsk_treeseq_t *self, tsk_size_t num_weights,
     }
 
     ret = tsk_treeseq_general_stat(self, num_weights, new_weights, num_weights,
-        trait_covariance_summary_func, &args, num_windows, windows, result, options);
+        trait_covariance_summary_func, &args, num_windows, windows, options, result);
 
 out:
     tsk_safe_free(means);
@@ -2582,8 +2582,8 @@ trait_correlation_summary_func(tsk_size_t state_dim, const double *state,
 
 int
 tsk_treeseq_trait_correlation(const tsk_treeseq_t *self, tsk_size_t num_weights,
-    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options)
+    const double *weights, tsk_size_t num_windows, const double *windows,
+    tsk_flags_t options, double *result)
 {
     tsk_size_t num_samples = self->num_samples;
     tsk_size_t j, k;
@@ -2631,7 +2631,7 @@ tsk_treeseq_trait_correlation(const tsk_treeseq_t *self, tsk_size_t num_weights,
     }
 
     ret = tsk_treeseq_general_stat(self, num_weights + 1, new_weights, num_weights,
-        trait_correlation_summary_func, &args, num_windows, windows, result, options);
+        trait_correlation_summary_func, &args, num_windows, windows, options, result);
 
 out:
     tsk_safe_free(means);
@@ -2690,7 +2690,7 @@ trait_linear_model_summary_func(tsk_size_t state_dim, const double *state,
 int
 tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights,
     const double *weights, tsk_size_t num_covariates, const double *covariates,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result)
 {
     tsk_size_t num_samples = self->num_samples;
     tsk_size_t i, j, k;
@@ -2747,7 +2747,7 @@ tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights
 
     ret = tsk_treeseq_general_stat(self, num_weights + num_covariates + 1, new_weights,
         num_weights, trait_linear_model_summary_func, &args, num_windows, windows,
-        result, options);
+        options, result);
 
 out:
     tsk_safe_free(V);
@@ -2775,11 +2775,11 @@ segregating_sites_summary_func(tsk_size_t state_dim, const double *state,
 int
 tsk_treeseq_segregating_sites(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result)
 {
     return tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_sample_sets, NULL, segregating_sites_summary_func, num_windows,
-        windows, result, options);
+        windows, options, result);
 }
 
 static int
@@ -2803,11 +2803,11 @@ Y1_summary_func(tsk_size_t TSK_UNUSED(state_dim), const double *state,
 int
 tsk_treeseq_Y1(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result)
 {
     return tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_sample_sets, NULL, Y1_summary_func, num_windows, windows,
-        result, options);
+        options, result);
 }
 
 /***********************************
@@ -2862,7 +2862,7 @@ int
 tsk_treeseq_divergence(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
@@ -2871,7 +2871,7 @@ tsk_treeseq_divergence(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, divergence_summary_func,
-        num_windows, windows, result, options);
+        num_windows, windows, options, result);
 out:
     return ret;
 }
@@ -2908,7 +2908,7 @@ int
 tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
@@ -2917,7 +2917,7 @@ tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, genetic_relatedness_summary_func,
-        num_windows, windows, result, options);
+        num_windows, windows, options, result);
 out:
     return ret;
 }
@@ -2947,7 +2947,7 @@ int
 tsk_treeseq_Y2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
@@ -2956,7 +2956,7 @@ tsk_treeseq_Y2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, Y2_summary_func, num_windows,
-        windows, result, options);
+        windows, options, result);
 out:
     return ret;
 }
@@ -2988,7 +2988,7 @@ int
 tsk_treeseq_f2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
@@ -2997,7 +2997,7 @@ tsk_treeseq_f2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, f2_summary_func, num_windows,
-        windows, result, options);
+        windows, options, result);
 out:
     return ret;
 }
@@ -3034,7 +3034,7 @@ int
 tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 3, num_index_tuples, index_tuples);
@@ -3043,7 +3043,7 @@ tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, Y3_summary_func, num_windows,
-        windows, result, options);
+        windows, options, result);
 out:
     return ret;
 }
@@ -3077,7 +3077,7 @@ int
 tsk_treeseq_f3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 3, num_index_tuples, index_tuples);
@@ -3086,7 +3086,7 @@ tsk_treeseq_f3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, f3_summary_func, num_windows,
-        windows, result, options);
+        windows, options, result);
 out:
     return ret;
 }
@@ -3126,7 +3126,7 @@ int
 tsk_treeseq_f4(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options)
+    const double *windows, tsk_flags_t options, double *result)
 {
     int ret = 0;
     ret = check_sample_stat_inputs(num_sample_sets, 4, num_index_tuples, index_tuples);
@@ -3135,7 +3135,7 @@ tsk_treeseq_f4(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     }
     ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
         sample_sets, num_index_tuples, index_tuples, f4_summary_func, num_windows,
-        windows, result, options);
+        windows, options, result);
 out:
     return ret;
 }

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -900,90 +900,90 @@ typedef int general_stat_func_t(tsk_size_t state_dim, const double *state,
 
 int tsk_treeseq_general_stat(const tsk_treeseq_t *self, tsk_size_t K, const double *W,
     tsk_size_t M, general_stat_func_t *f, void *f_params, tsk_size_t num_windows,
-    const double *windows, double *sigma, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 
 /* One way weighted stats */
 
 typedef int one_way_weighted_method(const tsk_treeseq_t *self, tsk_size_t num_weights,
-    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options);
+    const double *weights, tsk_size_t num_windows, const double *windows,
+    tsk_flags_t options, double *result);
 
 int tsk_treeseq_trait_covariance(const tsk_treeseq_t *self, tsk_size_t num_weights,
-    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options);
+    const double *weights, tsk_size_t num_windows, const double *windows,
+    tsk_flags_t options, double *result);
 int tsk_treeseq_trait_correlation(const tsk_treeseq_t *self, tsk_size_t num_weights,
-    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
-    tsk_flags_t options);
+    const double *weights, tsk_size_t num_windows, const double *windows,
+    tsk_flags_t options, double *result);
 
 /* One way weighted stats with covariates */
 
 typedef int one_way_covariates_method(const tsk_treeseq_t *self, tsk_size_t num_weights,
     const double *weights, tsk_size_t num_covariates, const double *covariates,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result);
 
 int tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights,
     const double *weights, tsk_size_t num_covariates, const double *covariates,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result);
 
 /* One way sample set stats */
 
 typedef int one_way_sample_stat_method(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
-    double *result, tsk_flags_t options);
+    tsk_flags_t options, double *result);
 
 int tsk_treeseq_diversity(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_segregating_sites(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_Y1(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
-    double *result, tsk_flags_t options);
+    tsk_flags_t options, double *result);
 
 typedef int general_sample_stat_method(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_indexes, const tsk_id_t *indexes,
-    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+    tsk_size_t num_windows, const double *windows, tsk_flags_t options, double *result);
 
 int tsk_treeseq_divergence(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_Y2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_f2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_index_tuples,
     const tsk_id_t *index_tuples, tsk_size_t num_windows, const double *windows,
-    double *result, tsk_flags_t options);
+    tsk_flags_t options, double *result);
 
 /* Three way sample set stats */
 int tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 int tsk_treeseq_f3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 
 /* Four way sample set stats */
 int tsk_treeseq_f4(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
     tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
-    const double *windows, double *result, tsk_flags_t options);
+    const double *windows, tsk_flags_t options, double *result);
 
 /****************************************************************************/
 /* Tree */

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -8731,7 +8731,7 @@ TreeSequence_general_stat(TreeSequence *self, PyObject *args, PyObject *kwds)
 
     err = tsk_treeseq_general_stat(self->tree_sequence, w_shape[1],
         PyArray_DATA(weights_array), output_dim, general_stat_func, summary_func,
-        num_windows, PyArray_DATA(windows_array), PyArray_DATA(result_array), options);
+        num_windows, PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
     if (err == TSK_PYTHON_CALLBACK_ERROR) {
         goto out;
     } else if (err != 0) {
@@ -8805,7 +8805,7 @@ TreeSequence_one_way_weighted_method(
     }
 
     err = method(self->tree_sequence, w_shape[1], PyArray_DATA(weights_array),
-        num_windows, PyArray_DATA(windows_array), PyArray_DATA(result_array), options);
+        num_windows, PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
     if (err == TSK_PYTHON_CALLBACK_ERROR) {
         goto out;
     } else if (err != 0) {
@@ -8893,7 +8893,7 @@ TreeSequence_one_way_covariates_method(TreeSequence *self, PyObject *args,
 
     err = method(self->tree_sequence, w_shape[1], PyArray_DATA(weights_array),
         z_shape[1], PyArray_DATA(covariates_array), num_windows,
-        PyArray_DATA(windows_array), PyArray_DATA(result_array), options);
+        PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
     if (err == TSK_PYTHON_CALLBACK_ERROR) {
         goto out;
     } else if (err != 0) {
@@ -8963,7 +8963,7 @@ TreeSequence_one_way_stat_method(TreeSequence *self, PyObject *args, PyObject *k
     }
     err = method(self->tree_sequence, num_sample_sets,
         PyArray_DATA(sample_set_sizes_array), PyArray_DATA(sample_sets_array),
-        num_windows, PyArray_DATA(windows_array), PyArray_DATA(result_array), options);
+        num_windows, PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -9042,7 +9042,7 @@ TreeSequence_allele_frequency_spectrum(
     }
     err = tsk_treeseq_allele_frequency_spectrum(self->tree_sequence, num_sample_sets,
         PyArray_DATA(sample_set_sizes_array), PyArray_DATA(sample_sets_array),
-        num_windows, PyArray_DATA(windows_array), PyArray_DATA(result_array), options);
+        num_windows, PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -9168,7 +9168,7 @@ TreeSequence_k_way_stat_method(TreeSequence *self, PyObject *args, PyObject *kwd
     err = method(self->tree_sequence, num_sample_sets,
         PyArray_DATA(sample_set_sizes_array), PyArray_DATA(sample_sets_array),
         num_set_index_tuples, PyArray_DATA(indexes_array), num_windows,
-        PyArray_DATA(windows_array), PyArray_DATA(result_array), options);
+        PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
     if (err != 0) {
         handle_library_error(err);
         goto out;


### PR DESCRIPTION
Seemed to make sense to do this before 1.0 even though these are undocumented.
Fixes #2285 