### PR TITLE
individual convenience extractors

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -6687,6 +6687,172 @@ test_treeseq_row_access_errors(void)
 }
 
 static void
+test_treeseq_get_individuals_population_errors(void)
+{
+    int ret;
+    tsk_id_t ret_id;
+    tsk_table_collection_t tables;
+    tsk_treeseq_t ts;
+    tsk_id_t output[2];
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
+
+    ret_id = tsk_population_table_add_row(&tables.populations, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_individual_table_add_row(
+        &tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_individual_table_add_row(
+        &tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 1);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.25, 0, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.25, TSK_NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 1);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_TS_INIT_BUILD_INDEXES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret_id = tsk_treeseq_get_individuals_population(&ts, output);
+    CU_ASSERT_EQUAL_FATAL(ret_id, TSK_ERR_INDIVIDUAL_POPULATION_MISMATCH);
+
+    tsk_treeseq_free(&ts);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_treeseq_get_individuals_population(void)
+{
+    int ret;
+    tsk_id_t ret_id;
+    int j;
+    tsk_table_collection_t tables;
+    tsk_treeseq_t ts;
+    tsk_id_t output[4];
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
+
+    for (j = 0; j < 2; j++) {
+        ret_id = tsk_population_table_add_row(&tables.populations, NULL, 0);
+        CU_ASSERT_EQUAL_FATAL(ret_id, (tsk_id_t) j);
+    }
+    for (j = 0; j < 4; j++) {
+        ret_id = tsk_individual_table_add_row(
+            &tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+        CU_ASSERT_EQUAL_FATAL(ret_id, (tsk_id_t) j);
+    }
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.25, 0, 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 0.0, TSK_NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 1);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 3.0, 1, 3, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 2);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 0.0, TSK_NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 3);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.25, 0, 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 4);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_TS_INIT_BUILD_INDEXES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_treeseq_get_individuals_population(&ts, output);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    CU_ASSERT_EQUAL_FATAL(output[0], TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(output[1], 0);
+    CU_ASSERT_EQUAL_FATAL(output[2], TSK_NULL);
+    CU_ASSERT_EQUAL_FATAL(output[3], 1);
+
+    tsk_treeseq_free(&ts);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_treeseq_get_individuals_time_errors(void)
+{
+    int ret;
+    tsk_id_t ret_id;
+    tsk_table_collection_t tables;
+    tsk_treeseq_t ts;
+    double output[2];
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
+
+    ret_id = tsk_population_table_add_row(&tables.populations, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_individual_table_add_row(
+        &tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_individual_table_add_row(
+        &tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 1);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.2, 0, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 0.8, 0, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 1);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_TS_INIT_BUILD_INDEXES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_treeseq_get_individuals_time(&ts, output);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INDIVIDUAL_TIME_MISMATCH);
+
+    tsk_treeseq_free(&ts);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_treeseq_get_individuals_time(void)
+{
+    int ret;
+    tsk_id_t ret_id;
+    int j;
+    tsk_table_collection_t tables;
+    tsk_treeseq_t ts;
+    double output[4];
+
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    tables.sequence_length = 1;
+
+    for (j = 0; j < 2; j++) {
+        ret_id = tsk_population_table_add_row(&tables.populations, NULL, 0);
+        CU_ASSERT_EQUAL_FATAL(ret_id, j);
+    }
+    for (j = 0; j < 4; j++) {
+        ret_id = tsk_individual_table_add_row(
+            &tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
+        CU_ASSERT_EQUAL_FATAL(ret_id, j);
+    }
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.25, 0, 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 0);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 3.25, 0, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 1);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 3.0, 1, 3, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 2);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 3.25, 0, 0, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 3);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 1.25, 0, 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret_id, 4);
+    ret = tsk_treeseq_init(&ts, &tables, TSK_TS_INIT_BUILD_INDEXES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = tsk_treeseq_get_individuals_time(&ts, output);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    CU_ASSERT_EQUAL_FATAL(output[0], 3.25);
+    CU_ASSERT_EQUAL_FATAL(output[1], 1.25);
+    CU_ASSERT_FATAL(tsk_is_unknown_time(output[2]));
+    CU_ASSERT_EQUAL_FATAL(output[3], 3.0);
+
+    tsk_treeseq_free(&ts);
+    tsk_table_collection_free(&tables);
+}
+
+static void
 test_tree_copy_flags(void)
 {
     int iret, ret;
@@ -7637,6 +7803,13 @@ main(int argc, char **argv)
         /* Misc */
         { "test_tree_errors", test_tree_errors },
         { "test_treeseq_row_access_errors", test_treeseq_row_access_errors },
+        { "test_treeseq_get_individuals_population_errors",
+            test_treeseq_get_individuals_population_errors },
+        { "test_treeseq_get_individuals_population",
+            test_treeseq_get_individuals_population },
+        { "test_treeseq_get_individuals_time_errors",
+            test_treeseq_get_individuals_time_errors },
+        { "test_treeseq_get_individuals_time", test_treeseq_get_individuals_time },
         { "test_tree_copy_flags", test_tree_copy_flags },
         { "test_genealogical_nearest_neighbours_errors",
             test_genealogical_nearest_neighbours_errors },

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -571,6 +571,18 @@ tsk_strerror_internal(int err)
             ret = "Individuals cannot be their own ancestor. "
                   "(TSK_ERR_INDIVIDUAL_PARENT_CYCLE)";
             break;
+
+        case TSK_ERR_INDIVIDUAL_POPULATION_MISMATCH:
+            ret = "Individual populations cannot be returned "
+                  "if an individual has nodes from more than one population. "
+                  "(TSK_ERR_INDIVIDUAL_POPULATION_MISMATCH)";
+            break;
+
+        case TSK_ERR_INDIVIDUAL_TIME_MISMATCH:
+            ret = "Individual times cannot be returned "
+                  "if an individual has nodes from more than one time. "
+                  "(TSK_ERR_INDIVIDUAL_TIME_MISMATCH)";
+            break;
     }
     return ret;
 }

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -812,6 +812,16 @@ An individual was its own parent.
 An individual was its own ancestor in a cycle of references.
 */
 #define TSK_ERR_INDIVIDUAL_PARENT_CYCLE                            -1702
+/**
+An individual had nodes from more than one population
+(and only one was requested).
+*/
+#define TSK_ERR_INDIVIDUAL_POPULATION_MISMATCH                     -1703
+/**
+An individual had nodes from more than one time
+(and only one was requested).
+*/
+#define TSK_ERR_INDIVIDUAL_TIME_MISMATCH                           -1704
 /** @} */
 // clang-format on
 

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -697,7 +697,7 @@ Returns the location of each node in the list of samples or
 @endrst
 
 @param self A pointer to a tsk_treeseq_t object.
-@return Returns the pointer to the breakpoint array.
+@return Returns the pointer to the array of sample indexes.
 */
 const tsk_id_t *tsk_treeseq_get_sample_index_map(const tsk_treeseq_t *self);
 
@@ -889,6 +889,9 @@ int tsk_treeseq_split_edges(const tsk_treeseq_t *self, double time, tsk_flags_t 
     tsk_flags_t options, tsk_treeseq_t *output);
 
 bool tsk_treeseq_has_reference_sequence(const tsk_treeseq_t *self);
+
+int tsk_treeseq_get_individuals_population(const tsk_treeseq_t *self, tsk_id_t *output);
+int tsk_treeseq_get_individuals_time(const tsk_treeseq_t *self, double *output);
 
 int tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *other,
     double lambda_, double *result);

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -26,6 +26,10 @@
   edges at a specific time.
   (:user:`jeromekelleher`, :issue:`2276`, :pr:`2296`).
 
+- Add the ``TreeSequence.individuals_time`` and ``TreeSequence.individuals_population``
+  methods to return arrays of per-individual times and populations, respectively.
+  (:user:`petrelharp`, :issue:`1481`, :pr:`2298`).
+
 **Breaking Changes**
 
 - The JSON metadata codec now interprets the empty string as an empty object. This means

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -8309,6 +8309,69 @@ out:
 }
 
 static PyObject *
+TreeSequence_get_individuals_population(TreeSequence *self)
+{
+    PyObject *ret = NULL;
+    PyArrayObject *ret_array = NULL;
+    npy_intp dim;
+    int err;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+
+    dim = tsk_treeseq_get_num_individuals(self->tree_sequence);
+    ret_array = (PyArrayObject *) PyArray_SimpleNew(1, &dim, NPY_INT32);
+    if (ret_array == NULL) {
+        goto out;
+    }
+
+    err = tsk_treeseq_get_individuals_population(
+        self->tree_sequence, PyArray_DATA(ret_array));
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+
+    ret = (PyObject *) ret_array;
+    ret_array = NULL;
+out:
+    Py_XDECREF(ret_array);
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_individuals_time(TreeSequence *self)
+{
+    PyObject *ret = NULL;
+    PyArrayObject *ret_array = NULL;
+    npy_intp dim;
+    int err;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+
+    dim = tsk_treeseq_get_num_individuals(self->tree_sequence);
+    ret_array = (PyArrayObject *) PyArray_SimpleNew(1, &dim, NPY_FLOAT64);
+    if (ret_array == NULL) {
+        goto out;
+    }
+
+    err = tsk_treeseq_get_individuals_time(self->tree_sequence, PyArray_DATA(ret_array));
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+
+    ret = (PyObject *) ret_array;
+    ret_array = NULL;
+out:
+    Py_XDECREF(ret_array);
+    return ret;
+}
+
+static PyObject *
 TreeSequence_genealogical_nearest_neighbours(
     TreeSequence *self, PyObject *args, PyObject *kwds)
 {
@@ -9560,6 +9623,14 @@ static PyMethodDef TreeSequence_methods[] = {
         .ml_meth = (PyCFunction) TreeSequence_get_samples,
         .ml_flags = METH_NOARGS,
         .ml_doc = "Returns the samples." },
+    { .ml_name = "get_individuals_population",
+        .ml_meth = (PyCFunction) TreeSequence_get_individuals_population,
+        .ml_flags = METH_NOARGS,
+        .ml_doc = "Returns the vector of per-individual populations." },
+    { .ml_name = "get_individuals_time",
+        .ml_meth = (PyCFunction) TreeSequence_get_individuals_time,
+        .ml_flags = METH_NOARGS,
+        .ml_doc = "Returns the vector of per-individual times." },
     { .ml_name = "genealogical_nearest_neighbours",
         .ml_meth = (PyCFunction) TreeSequence_genealogical_nearest_neighbours,
         .ml_flags = METH_VARARGS | METH_KEYWORDS,

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2021 Tskit Developers
+# Copyright (c) 2018-2022 Tskit Developers
 # Copyright (c) 2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -358,7 +358,9 @@ class TestTskitConversionOutput(unittest.TestCase):
             record_migrations=True,
         )
         assert ts.num_migrations > 0
-        cls._tree_sequence = tsutil.insert_random_ploidy_individuals(ts)
+        cls._tree_sequence = tsutil.insert_random_ploidy_individuals(
+            ts, samples_only=True
+        )
         fd, cls._tree_sequence_file = tempfile.mkstemp(
             prefix="tsk_cli", suffix=".trees"
         )

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -4621,7 +4621,9 @@ class TestUnionTables(unittest.TestCase):
             random_seed=seed,
         )
         ts = tsutil.add_random_metadata(ts, seed)
-        ts = tsutil.insert_random_ploidy_individuals(ts, max_ploidy=1)
+        ts = tsutil.insert_random_ploidy_individuals(
+            ts, max_ploidy=1, samples_only=True
+        )
         return ts
 
     def get_wf_example(self, N, T, seed):
@@ -4631,7 +4633,9 @@ class TestUnionTables(unittest.TestCase):
         ts = ts.simplify()
         ts = tsutil.jukes_cantor(ts, 1, 10, seed=seed)
         ts = tsutil.add_random_metadata(ts, seed)
-        ts = tsutil.insert_random_ploidy_individuals(ts, max_ploidy=2)
+        ts = tsutil.insert_random_ploidy_individuals(
+            ts, max_ploidy=2, samples_only=True
+        )
         return ts
 
     def split_example(self, ts, T):

--- a/python/tests/test_vcf.py
+++ b/python/tests/test_vcf.py
@@ -200,7 +200,9 @@ class ExamplesMixin:
 
     def test_simple_infinite_sites_random_ploidy(self):
         ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
-        ts = tsutil.insert_random_ploidy_individuals(ts, min_ploidy=1)
+        ts = tsutil.insert_random_ploidy_individuals(
+            ts, min_ploidy=1, samples_only=True
+        )
         assert ts.num_sites > 2
         self.verify(ts)
 
@@ -227,7 +229,9 @@ class ExamplesMixin:
     def test_simple_jukes_cantor_random_ploidy(self):
         ts = msprime.simulate(10, random_seed=2)
         ts = tsutil.jukes_cantor(ts, num_sites=10, mu=1, seed=2)
-        ts = tsutil.insert_random_ploidy_individuals(ts, min_ploidy=1)
+        ts = tsutil.insert_random_ploidy_individuals(
+            ts, min_ploidy=1, samples_only=True
+        )
         self.verify(ts)
 
     def test_single_tree_multichar_mutations(self):

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -212,30 +212,74 @@ def insert_multichar_mutations(ts, seed=1, max_len=10):
 
 
 def insert_random_ploidy_individuals(
-    ts, min_ploidy=0, max_ploidy=5, max_dimension=3, seed=1
+    ts, min_ploidy=0, max_ploidy=5, max_dimension=3, samples_only=False, seed=1
 ):
     """
-    Takes random contiguous subsets of the samples an assigns them to individuals.
+    Takes random contiguous subsets of the samples and assigns them to individuals.
     Also creates random locations in variable dimensions in the unit interval,
-    and assigns random parents (including NULL parents).
+    and assigns random parents (including NULL parents). Note that resulting
+    individuals will often have nodes with inconsistent populations and/or time.
     """
     rng = random.Random(seed)
-    samples = np.array(ts.samples(), dtype=int)
+    if samples_only:
+        node_ids = np.array(ts.samples(), dtype="int")
+    else:
+        node_ids = np.arange(ts.num_nodes)
     j = 0
     tables = ts.dump_tables()
     tables.individuals.clear()
     individual = tables.nodes.individual[:]
     individual[:] = tskit.NULL
     ind_id = -1
-    while j < len(samples):
+    while j < len(node_ids):
         ploidy = rng.randint(min_ploidy, max_ploidy)
-        nodes = samples[j : min(j + ploidy, len(samples))]
+        nodes = node_ids[j : min(j + ploidy, len(node_ids))]
         dimension = rng.randint(0, max_dimension)
         location = [rng.random() for _ in range(dimension)]
         parents = rng.sample(range(-1, 1 + ind_id), min(1 + ind_id, rng.randint(0, 3)))
         ind_id = tables.individuals.add_row(location=location, parents=parents)
         individual[nodes] = ind_id
         j += ploidy
+        j += rng.randint(0, 5)  # skip a random number
+    tables.nodes.individual = individual
+    return tables.tree_sequence()
+
+
+def insert_random_consistent_individuals(
+    ts, min_ploidy=0, max_ploidy=5, min_dimension=0, max_dimension=3, seed=1
+):
+    """
+    Takes random subsets of nodes having the same time and population and
+    assigns them to individuals.  Also creates random locations in variable
+    dimensions in the unit interval, and assigns random parents (including NULL
+    parents).
+    """
+    rng = random.Random(seed)
+    tables = ts.dump_tables()
+    tables.individuals.clear()
+    individual = tables.nodes.individual[:]
+    individual[:] = tskit.NULL
+    ind_id = -1
+    pops = np.arange(ts.num_populations)
+    for pop in pops:
+        n = tables.nodes.population == pop
+        times = np.unique(tables.nodes.time[n])
+        for t in times:
+            nn = np.where(np.logical_and(n, tables.nodes.time == t))[0]
+            rng.shuffle(nn)
+            j = 0
+            while j < len(nn):
+                ploidy = rng.randint(min_ploidy, max_ploidy)
+                nodes = nn[j : min(j + ploidy, len(nn))]
+                dimension = rng.randint(min_dimension, max_dimension)
+                location = [rng.random() for _ in range(dimension)]
+                parents = rng.sample(
+                    range(-1, 1 + ind_id), min(1 + ind_id, rng.randint(0, 3))
+                )
+                ind_id = tables.individuals.add_row(location=location, parents=parents)
+                individual[nodes] = ind_id
+                j += ploidy
+                j += rng.randint(0, 2)  # skip a random number
     tables.nodes.individual = individual
     return tables.tree_sequence()
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2195,8 +2195,8 @@ class Tree:
 
     def preorder(self, u=NULL):
         """
-        Returns a numpy array of node ids in preorder
-        <https://en.wikipedia.org/wiki/Tree_traversal#Pre-order_(NLR)>. If the node u
+        Returns a numpy array of node ids in `preorder
+        <https://en.wikipedia.org/wiki/Tree_traversal#Pre-order_(NLR)>`_. If the node u
         is specified the traversal is rooted at this node (and it will be the first
         element in the returned array). Otherwise, all nodes reachable from the tree
         roots will be returned. See :ref:`tutorials:sec_analysing_trees_traversals` for
@@ -2211,8 +2211,8 @@ class Tree:
 
     def postorder(self, u=NULL):
         """
-        Returns a numpy array of node ids in postorder
-        <https://en.wikipedia.org/wiki/Tree_traversal##Post-order_(LRN)>. If the node u
+        Returns a numpy array of node ids in `postorder
+        <https://en.wikipedia.org/wiki/Tree_traversal##Post-order_(LRN)>`_. If the node u
         is specified the traversal is rooted at this node (and it will be the last
         element in the returned array). Otherwise, all nodes reachable from the tree
         roots will be returned. See :ref:`tutorials:sec_analysing_trees_traversals` for


### PR DESCRIPTION
Ok, here I'm adding `ts.individual_locations`, `ts.individual_times`, and `ts.individual_nodes`. These are all cached properties... which I *think* does what we want? To be clear, what (I think) we want is to (a) have them only be computed once, and (b) not be returning new copies of them every time they are accessed.  Hm - if this is working, I should make them read-only (how to do this?), so people don't think they can modify the tree sequence by modifying these.

The main decision I made that I'm not sure about is the case when some of an individuals' nodes have `population=-1` and some have a legit population. I made the decision - honestly, for convenience - to treat `-1` as "missing data", and so an individual with node populations `-1` and `1` would then be reported as having population `1`, with no contradiction. (i.e., the unique non-null population) This seems nice but I haven't thought through other implications of this sort of thing.

I also said I'd add `time` and `population` properties to the `Individual` class. However, I'm not sure what to put in for these properties in the case where these are not well-defined (ie the values are not consistent across nodes). Perhaps I should *not* do this and instruct people to use, e.g., `ts.individual_times[ind.id]` instead.

*Note:* I also made one of the generic "make up examples" methods in `tsutil` a bit more general (it was only adding individuals to samples); hopefully this does not break anything (if it does, that will likely be a bug).