### PR TITLE
 VCF masking

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -34,6 +34,11 @@
   methods to return arrays of per-individual times and populations, respectively.
   (:user:`petrelharp`, :issue:`1481`, :pr:`2298`).
 
+- Add the ``sample_mask`` and ``site_mask`` to ``write_vcf`` to allow parts
+  of an output VCF to be omitted or marked as missing data. Also add the
+  ``as_vcf`` convenience function, to return VCF as a string.
+  (:user:`jeromekelleher`, :pr:`2300`).
+
 **Breaking Changes**
 
 - The JSON metadata codec now interprets the empty string as an empty object. This means


### PR DESCRIPTION
After discussing things with @szhan and the bottlenecks he's experiencing, this is a proposal we came up with for how we can provide a flexible interface for masking out sites and samples in the VCF output. Usage:
```python
ts = msprime.sim_ancestry(5, random_seed=1, sequence_length=100)
ts = msprime.sim_mutations(ts, rate=0.1, random_seed=1234)
site_mask = np.zeros(ts.num_sites, dtype=int)
site_mask[::4] = 1
sample_mask = np.zeros(ts.num_samples, dtype=int)
sample_mask[0] = 1
sample_mask[1] = 1

def sample_mask(variant):
    sample_mask = np.zeros(ts.num_samples, dtype=int)
    sample_mask[variant.site.id % ts.num_samples] = 1
    return sample_mask

ts.write_vcf(sys.stdout, site_mask=site_mask, sample_mask=sample_mask)
```

Here, in this contrived example, we're masking out every 4th site, and have a sample mask that depends on the site. This is done by having ``sample_mask`` optionally be a callable, which takes the variant as input and returns the relevant mask.

Output:
```
##fileformat=VCFv4.2
##source=tskit 0.4.1
##FILTER=<ID=PASS,Description="All filters passed">
##contig=<ID=1,length=100>
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  tsk_0   tsk_1   tsk_2   tsk_3   tsk_4
1       0       0       A       C       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       1       1       A       T,C     .       PASS    .       GT      0|.     0|0     0|0     0|1     0|0
1       2       2       T       G       .       PASS    .       GT      1|0     .|1     1|1     1|0     1|1
1       4       3       G       A,T     .       PASS    .       GT      2|0     0|.     0|1     1|0     2|1
1       7       4       T       C       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       11      5       A       T       .       PASS    .       GT      0|1     1|0     0|.     0|0     0|0
1       13      6       A       T       .       PASS    .       GT      1|0     1|1     1|1     .|0     1|1
1       15      7       A       C       .       PASS    .       GT      0|1     0|0     0|0     0|.     0|0
1       16      8       G       A       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       17      9       A       T       .       PASS    .       GT      1|0     1|1     1|1     1|0     1|.
1       26      10      T       G,A     .       PASS    .       GT      .|0     2|1     1|2     2|0     1|2
1       27      11      A       C       .       PASS    .       GT      0|.     0|0     0|0     0|0     1|0
1       28      12      G       C       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       37      13      C       T       .       PASS    .       GT      0|0     0|.     0|0     0|1     0|0
1       39      14      T       G       .       PASS    .       GT      0|0     1|0     .|0     0|0     0|0
1       41      15      G       A       .       PASS    .       GT      1|0     1|1     1|.     1|0     1|1
1       45      16      G       C       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       46      17      G       A       .       PASS    .       GT      0|0     1|0     0|0     0|.     0|0
1       47      18      G       T       .       PASS    .       GT      0|0     0|0     1|0     0|0     .|0
1       50      19      A       T       .       PASS    .       GT      0|0     0|0     0|1     0|0     0|.
1       53      20      T       G       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       54      21      T       C       .       PASS    .       GT      0|.     0|0     0|1     1|0     0|1
1       56      22      T       A       .       PASS    .       GT      1|0     .|1     1|1     1|0     1|1
1       58      23      G       C       .       PASS    .       GT      0|1     0|.     0|0     0|1     0|0
1       61      24      C       T,A     .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       62      25      C       G       .       PASS    .       GT      0|0     0|0     1|.     0|0     0|0
1       64      26      A       G       .       PASS    .       GT      1|0     0|1     0|0     .|0     1|0
1       68      27      G       A       .       PASS    .       GT      1|0     0|1     0|0     0|.     1|0
1       69      28      G       A       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       71      29      C       G       .       PASS    .       GT      0|0     0|0     0|0     0|1     0|.
1       73      30      G       A       .       PASS    .       GT      .|1     0|0     0|0     0|1     0|0
1       77      31      T       C       .       PASS    .       GT      0|.     0|0     0|0     0|0     1|0
1       78      32      C       G,A,T   .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       79      33      A       T       .       PASS    .       GT      0|0     1|.     0|0     0|0     0|0
1       80      34      A       C       .       PASS    .       GT      1|0     0|1     .|0     0|0     0|0
1       88      35      C       A       .       PASS    .       GT      0|0     0|0     0|.     0|0     0|1
1       91      36      G       A       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       92      37      C       T       .       PASS    .       GT      1|0     0|1     0|0     0|.     1|0
1       93      38      G       T       .       PASS    .       GT      0|1     0|0     0|0     0|1     .|0
1       94      39      G       C       .       PASS    .       GT      0|1     0|0     0|0     0|1     0|.
1       95      40      G       A       .       PASS    .       GT      .|.     .|.     .|.     .|.     .|.
1       96      41      G       A       .       PASS    .       GT      0|.     0|0     0|1     1|0     0|1
1       97      42      C       T       .       PASS    .       GT      1|1     .|1     0|0     0|1     1|0
1       99      43      A       C,G,T   .       PASS    .       GT      3|1     0|.     2|0     0|1     3|0
```

We haven't tested this for perf at all yet, so it could be a significant regression and need a little refactoring to make sure the common case is still fast.

Thoughts?