### PR TITLE
Adding path function and tests

### DIFF
--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2781,6 +2781,43 @@ class Tree:
             return math.inf
         return self.depth(u) + self.depth(v) - 2 * self.depth(mrca)
 
+    def path(self, u, v=None):
+        """
+        Returns the path between two nodes u and v, such that
+        ``len(tree.path(u, v)) == tree.path_length(u, v)``.
+        If the second node ``v`` is not specified, return the path from u to root.
+
+        :param int u: The starting node of the path.
+        :param int v: The last node of the path.
+        :return: The list of nodes from u to v (including v).
+        :rtype: list of int
+        """
+        if v is not None:
+            if u == v:
+                return []
+            mrca = self.mrca(u, v)
+            if mrca == -1:
+                return math.inf
+            path_u = []
+            while u != mrca and self.parent(u) != tskit.NULL:
+                u = self.parent(u)
+                path_u.append(u)
+            path_v = [] if v == mrca and v is not self.virtual_root else [v]
+            v2 = self.parent(v)
+            while mrca not in [v, v2] and v2 != tskit.NULL:
+                path_v.append(v2)
+                v2 = self.parent(v2)
+            return path_u + path_v[::-1]
+        else:
+            if self.has_multiple_roots:
+                return math.inf
+            path_u = []
+            u = self.parent(u)
+            while u != tskit.NULL:
+                path_u.append(u)
+                u = self.parent(u)
+            return path_u
+
     def b1_index(self):
         """
         Returns the B1 balance index for this tree.


### PR DESCRIPTION
This PR is for adding the `path` function which outputs the path between nodes u and v. It is needed for the B2 index https://github.com/tskit-dev/tskit/pull/2327 (issue https://github.com/tskit-dev/tskit/pull/2252).

By the way, the `path_length` function (https://github.com/tskit-dev/tskit/issues/2249 https://github.com/tskit-dev/tskit/pull/2259) is maybe a little too constrained: if the tree has more than one root, the outputs is always `inf`. However, in non-rooted trees the paths between nodes that have the same root appear to be defined. For the moment, I defined the `path` function with this same constrain as in the `path_length` function, so both functions remain consistent.

cc @jeromekelleher 