### PR TITLE
Don't print empty byte strings for no metadata

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -85,6 +85,9 @@
 - Arguments after ``ploidy`` in ``write_vcf`` marked as keyword only
   (:user:`jeromekelleher`, :pr:`2329`, :issue:`2315`).
 
+- When metadata equal to ``b''`` is printed to text or HTML tables it will render as
+  an empty string rather than ``"b''"``. (:user:`hyanwong`, :issue:`2349`, :pr:`2351`)
+
 ----------------------
 [0.4.1] - 2022-01-11
 ----------------------

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -635,9 +635,13 @@ class CommonTestsMixin:
         input_data = self.make_input_data(41)
         table = self.table_class()
         table.set_columns(**input_data)
+        blank_meta_row = 39
+        if "metadata" in input_data:
+            table[blank_meta_row] = table[blank_meta_row].replace(metadata=b"")
         assert "1 rows skipped" in str(table)
         tskit.set_print_options(max_lines=None)
         assert "1 rows skipped" not in str(table)
+        assert "b''" not in str(table)
         tskit.set_print_options(max_lines=40)
         tskit.MAX_LINES = 40
 

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -410,9 +410,17 @@ def test_obj_to_collapsed_html(obj, expected):
 
 
 def test_truncate_string_end():
-    assert util.truncate_string_end("testing") == "testing"
+    assert util.truncate_string_end("testing", 40) == "testing"
     assert util.truncate_string_end("testing", 7) == "testing"
     assert util.truncate_string_end("testing", 5) == "te..."
+
+
+def test_render_metadata():
+    assert util.render_metadata({}) == "{}"
+    assert util.render_metadata("testing") == "testing"
+    assert util.render_metadata(b"testing") == "b'testing'"
+    assert util.render_metadata(b"testing", 6) == "b't..."
+    assert util.render_metadata(b"") == ""
 
 
 def test_unicode_table():

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -861,7 +861,7 @@ class IndividualTable(BaseTable, MetadataColumnMixin):
                         row.flags,
                         location_str,
                         parents_str,
-                        util.truncate_string_end(str(row.metadata)),
+                        util.render_metadata(row.metadata),
                     ).split("\t")
                 )
         return headers, rows
@@ -1111,7 +1111,7 @@ class NodeTable(BaseTable, MetadataColumnMixin):
                         row.population,
                         row.individual,
                         row.time,
-                        util.truncate_string_end(str(row.metadata)),
+                        util.render_metadata(row.metadata),
                     ).split("\t")
                 )
         return headers, rows
@@ -1309,7 +1309,7 @@ class EdgeTable(BaseTable, MetadataColumnMixin):
                         row.right,
                         row.parent,
                         row.child,
-                        util.truncate_string_end(str(row.metadata)),
+                        util.render_metadata(row.metadata),
                     ).split("\t")
                 )
         return headers, rows
@@ -1527,7 +1527,7 @@ class MigrationTable(BaseTable, MetadataColumnMixin):
                         row.source,
                         row.dest,
                         row.time,
-                        util.truncate_string_end(str(row.metadata)),
+                        util.render_metadata(row.metadata),
                     ).split("\t")
                 )
         return headers, rows
@@ -1729,7 +1729,6 @@ class SiteTable(BaseTable, MetadataColumnMixin):
                 range(self.num_rows - (limit - (limit // 2)), self.num_rows),
             )
         for j in indexes:
-
             if j == -1:
                 rows.append(f"__skipped__{self.num_rows-limit}")
             else:
@@ -1739,7 +1738,7 @@ class SiteTable(BaseTable, MetadataColumnMixin):
                         j,
                         row.position,
                         row.ancestral_state,
-                        util.truncate_string_end(str(row.metadata)),
+                        util.render_metadata(row.metadata),
                     ).split("\t")
                 )
         return headers, rows
@@ -1962,7 +1961,7 @@ class MutationTable(BaseTable, MetadataColumnMixin):
                         row.time,
                         row.derived_state,
                         row.parent,
-                        util.truncate_string_end(str(row.metadata)),
+                        util.render_metadata(row.metadata),
                     ).split("\t")
                 )
         return headers, rows
@@ -2210,12 +2209,7 @@ class PopulationTable(BaseTable, MetadataColumnMixin):
             if j == -1:
                 rows.append(f"__skipped__{self.num_rows-limit}")
             else:
-                rows.append(
-                    (
-                        str(j),
-                        util.truncate_string_end(str(self[j].metadata), length=70),
-                    )
-                )
+                rows.append((str(j), util.render_metadata(self[j].metadata, length=70)))
         return headers, rows
 
     def set_columns(self, metadata=None, metadata_offset=None, metadata_schema=None):

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -353,7 +353,7 @@ def obj_to_collapsed_html(d, name=None, open_depth=0):
         return f"{name} {d}"
 
 
-def truncate_string_end(string, length=40):
+def truncate_string_end(string, length):
     """
     If a string is longer than "length" then snip out the middle and replace with an
     ellipsis.
@@ -361,6 +361,12 @@ def truncate_string_end(string, length=40):
     if len(string) <= length:
         return string
     return f"{string[:length-3]}..."
+
+
+def render_metadata(md, length=40):
+    if md == b"":
+        return ""
+    return truncate_string_end(str(md), length)
 
 
 def unicode_table(rows, title=None, header=None, row_separator=True):


### PR DESCRIPTION
Fixes #2349 but no tests yet: I want to see if this is the right approach: i.e. should an empty metadata schema be treated as False when viewed as a bool? Thoughts @benjeffery ?