### PR TITLE
Keep unary for coalescent nodes in simplify

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -1198,6 +1198,12 @@ test_simplest_records(void)
     CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables, 0));
     tsk_treeseq_free(&simplified);
 
+    ret = tsk_treeseq_simplify(
+        &ts, sample_ids, 2, TSK_SIMPLIFY_KEEP_UNARY_IF_COALESCENT, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables, 0));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
 }
 
@@ -1376,6 +1382,48 @@ test_simplest_unary_with_individuals(void)
     tsk_treeseq_free(&simplified);
 
     tsk_treeseq_free(&expected);
+    tsk_treeseq_free(&ts);
+}
+
+static void
+test_simplest_partially_unary(void)
+{
+    int ret;
+    const char *nodes = "1  0   0\n"
+                        "1  0   0\n"
+                        "0  1   0";
+    const char *edges = "0  2   2   0\n"
+                        "0  1   2   1\n";
+    tsk_treeseq_t ts, simplified;
+    tsk_id_t sample_ids[] = { 0, 1 };
+
+    tsk_treeseq_from_text(&ts, 2, nodes, edges, NULL, NULL, NULL, NULL, NULL, 0);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&ts), 2);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&ts), 2.0);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&ts), 3);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&ts), 2);
+
+    ret = tsk_treeseq_simplify(&ts, sample_ids, 2, 0, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_samples(&simplified), 2);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_sequence_length(&simplified), 2.0);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_nodes(&simplified), 3);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_edges(&simplified), 2);
+    CU_ASSERT_EQUAL(tsk_treeseq_get_num_trees(&simplified), 2);
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(
+        &ts, sample_ids, 2, TSK_SIMPLIFY_KEEP_UNARY, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables, 0));
+    tsk_treeseq_free(&simplified);
+
+    ret = tsk_treeseq_simplify(
+        &ts, sample_ids, 2, TSK_SIMPLIFY_KEEP_UNARY_IF_COALESCENT, &simplified, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(tsk_table_collection_equals(ts.tables, simplified.tables, 0));
+    tsk_treeseq_free(&simplified);
+
     tsk_treeseq_free(&ts);
 }
 
@@ -7840,6 +7888,7 @@ main(int argc, char **argv)
         { "test_simplest_nonbinary_records", test_simplest_nonbinary_records },
         { "test_simplest_unary_records", test_simplest_unary_records },
         { "test_simplest_unary_with_individuals", test_simplest_unary_with_individuals },
+        { "test_simplest_partially_unary", test_simplest_partially_unary },
         { "test_simplest_non_sample_leaf_records",
             test_simplest_non_sample_leaf_records },
         { "test_simplest_degenerate_multiple_root_records",

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -715,6 +715,13 @@ flag). It keeps unary nodes, but only if the unary node is referenced from an in
 @endrst
 */
 #define TSK_SIMPLIFY_KEEP_UNARY_IN_INDIVIDUALS (1 << 6)
+/**
+@rst
+DOCUMENT ME
+@endrst
+*/
+#define TSK_SIMPLIFY_KEEP_UNARY_IF_COALESCENT (1 << 7)
+
 /** @} */
 
 /**

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6590,19 +6590,21 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     int filter_populations = false;
     int keep_unary = false;
     int keep_unary_in_individuals = false;
+    int keep_unary_if_coalescent = false;
     int keep_input_roots = false;
     int reduce_to_site_topology = false;
-    static char *kwlist[] = { "samples", "filter_sites", "filter_populations",
-        "filter_individuals", "reduce_to_site_topology", "keep_unary",
-        "keep_unary_in_individuals", "keep_input_roots", NULL };
+    static char *kwlist[]
+        = { "samples", "filter_sites", "filter_populations", "filter_individuals",
+              "reduce_to_site_topology", "keep_unary", "keep_unary_in_individuals",
+              "keep_unary_if_coalescent", "keep_input_roots", NULL };
 
     if (TableCollection_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiiiii", kwlist, &samples,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiiiiii", kwlist, &samples,
             &filter_sites, &filter_populations, &filter_individuals,
             &reduce_to_site_topology, &keep_unary, &keep_unary_in_individuals,
-            &keep_input_roots)) {
+            &keep_unary_if_coalescent, &keep_input_roots)) {
         goto out;
     }
     samples_array = (PyArrayObject *) PyArray_FROMANY(
@@ -6629,6 +6631,9 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     if (keep_unary_in_individuals) {
         options |= TSK_SIMPLIFY_KEEP_UNARY_IN_INDIVIDUALS;
+    }
+    if (keep_unary_if_coalescent) {
+        options |= TSK_SIMPLIFY_KEEP_UNARY_IF_COALESCENT;
     }
     if (keep_input_roots) {
         options |= TSK_SIMPLIFY_KEEP_INPUT_ROOTS;

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -344,11 +344,32 @@ class TestTableCollection(LowLevelTestCase):
         with pytest.raises(TypeError):
             tc.simplify([0, 1], keep_unary_in_individuals="abc")
         with pytest.raises(TypeError):
+            tc.simplify([0, 1], keep_unary_if_coalescent="abc")
+        with pytest.raises(TypeError):
             tc.simplify([0, 1], keep_input_roots="sdf")
         with pytest.raises(TypeError):
             tc.simplify([0, 1], filter_populations="x")
         with pytest.raises(_tskit.LibraryError):
             tc.simplify([0, -1])
+
+    @pytest.mark.parametrize("value", [True, False])
+    @pytest.mark.parametrize(
+        "flag_option",
+        [
+            "keep_unary",
+            "keep_unary_in_individuals",
+            "keep_unary_if_coalescent",
+            "keep_input_roots",
+            "filter_sites",
+            "filter_populations",
+            "filter_individuals",
+            "reduce_to_site_topology",
+        ],
+    )
+    def test_simplify_flag_args(self, flag_option, value):
+        ts = msprime.simulate(10, random_seed=1)
+        tc = ts.tables._ll_tables
+        tc.simplify([0, 1], **{flag_option: value})
 
     def test_link_ancestors_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3361,6 +3361,7 @@ class TableCollection(metadata.MetadataProvider):
         filter_sites=True,
         keep_unary=False,
         keep_unary_in_individuals=None,
+        keep_unary_if_coalescent=None,
         keep_input_roots=False,
         record_provenance=True,
         filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
@@ -3447,6 +3448,8 @@ class TableCollection(metadata.MetadataProvider):
             samples = util.safe_np_int_cast(samples, np.int32)
         if keep_unary_in_individuals is None:
             keep_unary_in_individuals = False
+        if keep_unary_if_coalescent is None:
+            keep_unary_if_coalescent = False
 
         node_map = self._ll_tables.simplify(
             samples,
@@ -3456,6 +3459,7 @@ class TableCollection(metadata.MetadataProvider):
             reduce_to_site_topology=reduce_to_site_topology,
             keep_unary=keep_unary,
             keep_unary_in_individuals=keep_unary_in_individuals,
+            keep_unary_if_coalescent=keep_unary_if_coalescent,
             keep_input_roots=keep_input_roots,
         )
         if record_provenance:

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6150,6 +6150,7 @@ class TreeSequence:
         filter_sites=True,
         keep_unary=False,
         keep_unary_in_individuals=None,
+        keep_unary_if_coalescent=None,
         keep_input_roots=False,
         record_provenance=True,
         filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
@@ -6246,6 +6247,7 @@ class TreeSequence:
             filter_sites=filter_sites,
             keep_unary=keep_unary,
             keep_unary_in_individuals=keep_unary_in_individuals,
+            keep_unary_if_coalescent=keep_unary_if_coalescent,
             keep_input_roots=keep_input_roots,
             record_provenance=record_provenance,
             filter_zero_mutation_sites=filter_zero_mutation_sites,


### PR DESCRIPTION
See #2127. See also #1190 for when keep_unary_in_individuals was added.

This is a quick prototype to show how it can be done. Essentially we just need to make a second pass through the overlapping segments to see whether a node participates in any coalescences. The rest is refactoring.

Ideally we would like to use an enumeration like ``keep_unary="all" | "individuals" | "coalescent"``, but we need to be a bit careful about how this might interact with people using "truthy" inputs to ``keep_unary`` at the moment.

Here's an example:

```
When keep_unary = True:                                                                                               
3.86┊             24      ┊            24       ┊                     ┊ 
    ┊         ┏━━━━┻━━━━┓ ┊        ┏━━━━┻━━━━┓  ┊                     ┊ 
2.40┊        23         ┃ ┊       23         ┃  ┊            23       ┊ 
    ┊         ┃         ┃ ┊        ┃         ┃  ┊        ┏━━━━┻━━━━┓  ┊ 
1.32┊         ┃        21 ┊        ┃        21  ┊        ┃        22  ┊ 
    ┊         ┃         ┃ ┊        ┃         ┃  ┊        ┃         ┃  ┊ 
0.48┊        20         ┃ ┊       20         ┃  ┊       20         ┃  ┊ 
    ┊     ┏━━━┻━━━┓     ┃ ┊     ┏━━┻━━┓      ┃  ┊     ┏━━┻━━┓      ┃  ┊ 
0.38┊     ┃       ┃    19 ┊     ┃     ┃     19  ┊     ┃     ┃     19  ┊ 
    ┊     ┃       ┃     ┃ ┊     ┃     ┃     ┏┻┓ ┊     ┃     ┃     ┏┻┓ ┊ 
0.20┊    18       ┃     ┃ ┊    18     ┃     ┃ ┃ ┊    18     ┃     ┃ ┃ ┊ 
    ┊   ┏━┻━━┓    ┃     ┃ ┊   ┏━┻━┓   ┃     ┃ ┃ ┊   ┏━┻━┓   ┃     ┃ ┃ ┊ 
0.20┊  17    ┃    ┃     ┃ ┊  17   ┃   ┃     ┃ ┃ ┊  17   ┃   ┃     ┃ ┃ ┊ 
    ┊  ┏┻━┓  ┃    ┃     ┃ ┊  ┏┻━┓ ┃   ┃     ┃ ┃ ┊  ┏┻━┓ ┃   ┃     ┃ ┃ ┊ 
0.17┊  ┃  ┃ 16    ┃     ┃ ┊  ┃  ┃16   ┃     ┃ ┃ ┊  ┃  ┃16   ┃     ┃ ┃ ┊ 
    ┊  ┃  ┃ ┏┻┓   ┃     ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊ 
0.11┊ 15  ┃ ┃ ┃   ┃     ┃ ┊ 15  ┃ ┃   ┃     ┃ ┃ ┊ 15  ┃ ┃   ┃     ┃ ┃ ┊ 
    ┊ ┏┻┓ ┃ ┃ ┃   ┃     ┃ ┊ ┏┻┓ ┃ ┃   ┃     ┃ ┃ ┊ ┏┻┓ ┃ ┃   ┃     ┃ ┃ ┊ 
0.08┊ ┃ ┃ ┃ ┃ ┃  14     ┃ ┊ ┃ ┃ ┃ ┃  14     ┃ ┃ ┊ ┃ ┃ ┃ ┃  14     ┃ ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┊ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┃ ┊ 
0.07┊ ┃ ┃ ┃ ┃ ┃ ┃  13   ┃ ┊ ┃ ┃ ┃ ┃ ┃  13   ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃  13   ┃ ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┊ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┃ ┊ 
0.06┊ ┃ ┃ ┃ ┃ ┃ ┃ 12  ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ 12  ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ 12  ┃ ┃ ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┃ ┊ 
0.06┊ ┃ ┃ ┃10 ┃ ┃ ┃ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃11 ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃11 ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┊ 
0.00┊ 0 4 1 2 7 5 6 9 8 3 ┊ 0 4 1 7 5 6 9 8 2 3 ┊ 0 4 1 7 5 6 9 8 2 3 ┊ 
    0                     2                     4                    10 
                                                                                                                      
                                                                                                                      
When keep_unary_if_coalescent = True                                                                                  
3.86┊             20      ┊            20       ┊                     ┊ 
    ┊         ┏━━━━┻━━━━┓ ┊        ┏━━━━┻━━━━┓  ┊                     ┊ 
2.40┊        19         ┃ ┊       19         ┃  ┊            19       ┊ 
    ┊         ┃         ┃ ┊        ┃         ┃  ┊        ┏━━━━┻━━━━┓  ┊ 
0.48┊        18         ┃ ┊       18         ┃  ┊       18         ┃  ┊ 
    ┊     ┏━━━┻━━━┓     ┃ ┊     ┏━━┻━━┓      ┃  ┊     ┏━━┻━━┓      ┃  ┊ 
0.38┊     ┃       ┃    17 ┊     ┃     ┃     17  ┊     ┃     ┃     17  ┊ 
    ┊     ┃       ┃     ┃ ┊     ┃     ┃     ┏┻┓ ┊     ┃     ┃     ┏┻┓ ┊ 
0.20┊    16       ┃     ┃ ┊    16     ┃     ┃ ┃ ┊    16     ┃     ┃ ┃ ┊ 
    ┊   ┏━┻━━┓    ┃     ┃ ┊   ┏━┻━┓   ┃     ┃ ┃ ┊   ┏━┻━┓   ┃     ┃ ┃ ┊ 
0.20┊  15    ┃    ┃     ┃ ┊  15   ┃   ┃     ┃ ┃ ┊  15   ┃   ┃     ┃ ┃ ┊ 
    ┊  ┏┻━┓  ┃    ┃     ┃ ┊  ┏┻━┓ ┃   ┃     ┃ ┃ ┊  ┏┻━┓ ┃   ┃     ┃ ┃ ┊ 
0.17┊  ┃  ┃ 14    ┃     ┃ ┊  ┃  ┃14   ┃     ┃ ┃ ┊  ┃  ┃14   ┃     ┃ ┃ ┊ 
    ┊  ┃  ┃ ┏┻┓   ┃     ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊ 
0.11┊ 13  ┃ ┃ ┃   ┃     ┃ ┊ 13  ┃ ┃   ┃     ┃ ┃ ┊ 13  ┃ ┃   ┃     ┃ ┃ ┊ 
    ┊ ┏┻┓ ┃ ┃ ┃   ┃     ┃ ┊ ┏┻┓ ┃ ┃   ┃     ┃ ┃ ┊ ┏┻┓ ┃ ┃   ┃     ┃ ┃ ┊ 
0.08┊ ┃ ┃ ┃ ┃ ┃  12     ┃ ┊ ┃ ┃ ┃ ┃  12     ┃ ┃ ┊ ┃ ┃ ┃ ┃  12     ┃ ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┊ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┃ ┊ 
0.07┊ ┃ ┃ ┃ ┃ ┃ ┃  11   ┃ ┊ ┃ ┃ ┃ ┃ ┃  11   ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃  11   ┃ ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┊ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┃ ┊ 
0.06┊ ┃ ┃ ┃ ┃ ┃ ┃ 10  ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ 10  ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ 10  ┃ ┃ ┃ ┊ 
    ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┃ ┊ 
0.00┊ 0 4 1 2 7 5 6 9 8 3 ┊ 0 4 1 7 5 6 9 8 2 3 ┊ 0 4 1 7 5 6 9 8 2 3 ┊ 
    0                     2                     4                    10 


When keep_unary = False                                    
3.86┊             20      ┊            20       ┊                     ┊                                                
    ┊         ┏━━━━┻━━━━┓ ┊        ┏━━━━┻━━━━┓  ┊                     ┊                                                
2.40┊         ┃         ┃ ┊        ┃         ┃  ┊            19       ┊                                                
    ┊         ┃         ┃ ┊        ┃         ┃  ┊        ┏━━━━┻━━━━┓  ┊                                                
0.48┊        18         ┃ ┊       18         ┃  ┊       18         ┃  ┊                                                
    ┊     ┏━━━┻━━━┓     ┃ ┊     ┏━━┻━━┓      ┃  ┊     ┏━━┻━━┓      ┃  ┊                                                
0.38┊     ┃       ┃     ┃ ┊     ┃     ┃     17  ┊     ┃     ┃     17  ┊                                                
    ┊     ┃       ┃     ┃ ┊     ┃     ┃     ┏┻┓ ┊     ┃     ┃     ┏┻┓ ┊                                                
0.20┊    16       ┃     ┃ ┊    16     ┃     ┃ ┃ ┊    16     ┃     ┃ ┃ ┊                                                
    ┊   ┏━┻━━┓    ┃     ┃ ┊   ┏━┻━┓   ┃     ┃ ┃ ┊   ┏━┻━┓   ┃     ┃ ┃ ┊                                                
0.20┊  15    ┃    ┃     ┃ ┊  15   ┃   ┃     ┃ ┃ ┊  15   ┃   ┃     ┃ ┃ ┊                                                
    ┊  ┏┻━┓  ┃    ┃     ┃ ┊  ┏┻━┓ ┃   ┃     ┃ ┃ ┊  ┏┻━┓ ┃   ┃     ┃ ┃ ┊                                                
0.17┊  ┃  ┃ 14    ┃     ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊                                                
    ┊  ┃  ┃ ┏┻┓   ┃     ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊  ┃  ┃ ┃   ┃     ┃ ┃ ┊                                                
0.11┊ 13  ┃ ┃ ┃   ┃     ┃ ┊ 13  ┃ ┃   ┃     ┃ ┃ ┊ 13  ┃ ┃   ┃     ┃ ┃ ┊                                                
    ┊ ┏┻┓ ┃ ┃ ┃   ┃     ┃ ┊ ┏┻┓ ┃ ┃   ┃     ┃ ┃ ┊ ┏┻┓ ┃ ┃   ┃     ┃ ┃ ┊                                                
0.08┊ ┃ ┃ ┃ ┃ ┃  12     ┃ ┊ ┃ ┃ ┃ ┃  12     ┃ ┃ ┊ ┃ ┃ ┃ ┃  12     ┃ ┃ ┊                                                
    ┊ ┃ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┊ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┏━┻━┓   ┃ ┃ ┊                                                
0.07┊ ┃ ┃ ┃ ┃ ┃ ┃  11   ┃ ┊ ┃ ┃ ┃ ┃ ┃  11   ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃  11   ┃ ┃ ┊                                                
    ┊ ┃ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┊ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃  ┏┻━┓ ┃ ┃ ┊                                                
0.06┊ ┃ ┃ ┃ ┃ ┃ ┃ 10  ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ 10  ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ 10  ┃ ┃ ┃ ┊                                                
    ┊ ┃ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┃ ┃ ┏┻┓ ┃ ┃ ┃ ┊                                                
0.00┊ 0 4 1 2 7 5 6 9 8 3 ┊ 0 4 1 7 5 6 9 8 2 3 ┊ 0 4 1 7 5 6 9 8 2 3 ┊                                                
    0                     2                     4                    10                                                

```