### PR TITLE
Allow haplotypes and alignments to have left, right, samples params

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -14,6 +14,10 @@
 
 - New ``Site.alleles()`` method (:user:`hyanwong`, :issue:`2380`, :pr:`2385`)
 
+- The ``variants()``, ``haplotypes()`` and ``alignments()`` methods can now
+  take a list of sample ids and a left and right position, to restrict the
+  size of the output (:user:`hyanwong`, :issue:`2092`, :pr:`2397`)
+
 
 --------------------
 [0.5.0] - 2022-06-22


### PR DESCRIPTION
## Description

Adds "samples", "start", and "stop" parameters to `ts.haplotypes()` and `ts.alignments()`. This (partially) fixes #2092. I was worried that calling `var.decode(site_id)` by simply iterating over the site ids would be slow, but that's how the `sites()` method does it anyway.

Is this the right approach? I haven't written any new tests until it's deemed sensible.

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
