### PR TITLE
Tree num lineages

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -4740,6 +4740,45 @@ test_single_tree_total_branch_length(void)
 }
 
 static void
+test_single_tree_num_lineages(void)
+{
+    int ret;
+    tsk_treeseq_t ts;
+    tsk_tree_t tree;
+    tsk_size_t num_lineages;
+
+    tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
+        NULL, NULL, NULL, 0);
+    ret = tsk_tree_init(&tree, &ts, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = tsk_tree_first(&tree);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_TREE_OK);
+
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, 0, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 4);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, -1, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 0);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, 1, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 3);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, 2, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 2);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, 2.999, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 2);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, 3, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 0);
+    CU_ASSERT_EQUAL_FATAL(tsk_tree_num_lineages(&tree, 300, &num_lineages), 0);
+    CU_ASSERT_EQUAL_FATAL(num_lineages, 0);
+
+    CU_ASSERT_EQUAL_FATAL(
+        tsk_tree_num_lineages(&tree, INFINITY, &num_lineages), TSK_ERR_TIME_NONFINITE);
+    CU_ASSERT_EQUAL_FATAL(
+        tsk_tree_num_lineages(&tree, NAN, &num_lineages), TSK_ERR_TIME_NONFINITE);
+
+    tsk_tree_free(&tree);
+    tsk_treeseq_free(&ts);
+}
+
+static void
 test_single_tree_map_mutations(void)
 {
     tsk_treeseq_t ts;
@@ -7924,6 +7963,7 @@ main(int argc, char **argv)
         { "test_single_tree_mutation_edges", test_single_tree_mutation_edges },
         { "test_single_tree_is_descendant", test_single_tree_is_descendant },
         { "test_single_tree_total_branch_length", test_single_tree_total_branch_length },
+        { "test_single_tree_num_lineages", test_single_tree_num_lineages },
         { "test_single_tree_map_mutations", test_single_tree_map_mutations },
         { "test_single_tree_map_mutations_internal_samples",
             test_single_tree_map_mutations_internal_samples },

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1702,6 +1702,8 @@ int tsk_tree_b1_index(const tsk_tree_t *self, double *result);
  * happen like a base 0 seems to return a finite value. */
 int tsk_tree_b2_index(const tsk_tree_t *self, double base, double *result);
 
+int tsk_tree_num_lineages(const tsk_tree_t *self, double t, tsk_size_t *result);
+
 /* Things to consider removing: */
 
 /* This is redundant, really */

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -7,6 +7,10 @@
 - Variant objects now have a ``.num_missing`` attribute and ``.counts()`` and
   ``.frequencies`` methods (:user:`hyanwong`, :issue:`2390` :pr:`2393`)
 
+**Changes**
+
+- Add the `Tree.num_lineages(t)` method to return the number of lineages present
+  at time t in the tree (:user:`jeromekelleher`, :issue:`386`, :pr:`2422`)
 
 --------------------
 [0.5.1] - 2022-07-14

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -10858,6 +10858,30 @@ out:
 }
 
 static PyObject *
+Tree_get_num_lineages(Tree *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    int err;
+    double t;
+    tsk_size_t result;
+
+    if (Tree_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "d", &t)) {
+        goto out;
+    }
+    err = tsk_tree_num_lineages(self->tree, t, &result);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("K", (unsigned long long) result);
+out:
+    return ret;
+}
+
+static PyObject *
 Tree_get_root_threshold(Tree *self)
 {
     PyObject *ret = NULL;
@@ -11304,6 +11328,10 @@ static PyMethodDef Tree_methods[] = {
         .ml_meth = (PyCFunction) Tree_get_b2_index,
         .ml_flags = METH_VARARGS,
         .ml_doc = "Returns the B2 index for this tree." },
+    { .ml_name = "get_num_lineages",
+        .ml_meth = (PyCFunction) Tree_get_num_lineages,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Returns number of lineages at time t." },
     { NULL } /* Sentinel */
 };
 

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -3234,6 +3234,29 @@ class TestTree(LowLevelTestCase):
         with pytest.raises(TypeError):
             t1.get_b2_index("asdf")
 
+    def test_b2(self):
+        ts1 = self.get_example_tree_sequence(10)
+        t1 = _tskit.Tree(ts1)
+        t1.first()
+        assert t1.get_b2_index(10) > 0
+
+    def test_num_lineages_errors(self):
+        ts1 = self.get_example_tree_sequence(10)
+        t1 = _tskit.Tree(ts1)
+        t1.first()
+        with pytest.raises(TypeError):
+            t1.get_num_lineages()
+        with pytest.raises(TypeError):
+            t1.get_num_lineages("asdf")
+        with pytest.raises(_tskit.LibraryError, match="TIME_NONFINITE"):
+            t1.get_num_lineages(np.inf)
+
+    def test_num_lineages(self):
+        ts1 = self.get_example_tree_sequence(10)
+        t1 = _tskit.Tree(ts1)
+        t1.first()
+        assert t1.get_num_lineages(0) == 10
+
     def test_kc_distance_errors(self):
         ts1 = self.get_example_tree_sequence(10)
         t1 = _tskit.Tree(ts1, options=_tskit.SAMPLE_LISTS)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2893,6 +2893,30 @@ class Tree:
         """
         return self._ll_tree.get_sackin_index()
 
+    def num_lineages(self, t):
+        """
+        Returns the number of lineages present in this tree at time ``t``. This
+        is defined as the number of branches in this tree (reachable from roots)
+        that intersect with ``t``, plus the number of roots with time ``>= t``.
+        Thus, ``tree.num_lineages(t)`` is equal to 1 for any ``t`` greater than
+        or equal to the time of the root in a singly-rooted tree.
+
+        :param int t: The time to count lineages at.
+        :return: The number of lineages in the tree at time t.
+        :rtype: int
+        """
+        lineages = 0
+        stack = [self.virtual_root]
+        while len(stack) > 0:
+            parent = stack.pop()
+            for child in self.children(parent):
+                child_time = self.time(child)
+                if child_time > t:
+                    stack.append(child)
+                elif child_time <= t:
+                    lineages += 1
+        return lineages
+
     def split_polytomies(
         self,
         *,

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -2896,26 +2896,20 @@ class Tree:
     def num_lineages(self, t):
         """
         Returns the number of lineages present in this tree at time ``t``. This
-        is defined as the number of branches in this tree (reachable from roots)
-        that intersect with ``t``, plus the number of roots with time ``>= t``.
-        Thus, ``tree.num_lineages(t)`` is equal to 1 for any ``t`` greater than
-        or equal to the time of the root in a singly-rooted tree.
+        is defined as the number of branches in this tree (reachable from the
+        samples) that intersect with ``t``. Thus, ``tree.num_lineages(t)``
+        is equal to 0 for any ``t`` greater than or equal to the time of
+        the root in a singly-rooted tree.
+
+        .. note:: Note that this definition means that if a (non root) node
+            with three children has time ``t``, then it will count as one lineage,
+            not three.
 
         :param int t: The time to count lineages at.
         :return: The number of lineages in the tree at time t.
         :rtype: int
         """
-        lineages = 0
-        stack = [self.virtual_root]
-        while len(stack) > 0:
-            parent = stack.pop()
-            for child in self.children(parent):
-                child_time = self.time(child)
-                if child_time > t:
-                    stack.append(child)
-                elif child_time <= t:
-                    lineages += 1
-        return lineages
+        return self._ll_tree.get_num_lineages(t)
 
     def split_polytomies(
         self,


### PR DESCRIPTION
Adds the ``Tree.num_lineages(t)`` method as discussed in #386 and elsewhere. 

The definition is slightly tricky because we're not just counting the edges that intersect with a given time/space coordinate, but we're also counting the number of roots. It seems logical that the number of lineages in a tree for any time greater than the root time should be 1 (assuming a single root) rather than 0.

I didn't bother adding the vector form (where t can be a sorted list of values) because it's a lot more work, and we can add it later if we want. This will be efficient enough for most purposes I think.

@savitakartik, @a-ignatieva - we should now be able to define the Relate statistic p-value easily in terms of this, right?