### PR TITLE
Table array access in TreeSequence

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -58,6 +58,54 @@ sequences.
   TreeSequence.reference_sequence
 ```
 
+#### Efficient table column access
+
+The {class}`.TreeSequence` class provides access to underlying numerical
+data defined in the {ref}`data model<sec_data_model>` in two ways:
+
+1. Via the {attr}`.TreeSequence.tables` property and the
+    {ref}`Tables API<sec_tables_api_accessing_table_data>`
+2. Via a set of properties on the ``TreeSequence`` class that provide
+   direct and efficient access to the underlying memory.
+
+:::{warning}
+Accessing table data via {attr}`.TreeSequence.tables` can be very inefficient
+at the moment because accessing the `.tables` property incurs a **full copy**
+of the data model. While we intend to implement this as a read-only view
+in the future, the engineering involved is nontrivial, and so we recommend
+using the properties listed here like ``ts.nodes_time`` in favour of
+``ts.tables.nodes.time``.
+Please see [issue #760](https://github.com/tskit-dev/tskit/issues/760)
+for more information.
+:::
+
+
+```{eval-rst}
+.. autosummary::
+  TreeSequence.individuals_flags
+  TreeSequence.nodes_time
+  TreeSequence.nodes_flags
+  TreeSequence.nodes_population
+  TreeSequence.nodes_individual
+  TreeSequence.edges_left
+  TreeSequence.edges_right
+  TreeSequence.edges_parent
+  TreeSequence.edges_child
+  TreeSequence.sites_position
+  TreeSequence.mutations_site
+  TreeSequence.mutations_node
+  TreeSequence.mutations_parent
+  TreeSequence.mutations_time
+  TreeSequence.migrations_left
+  TreeSequence.migrations_right
+  TreeSequence.migrations_right
+  TreeSequence.migrations_node
+  TreeSequence.migrations_source
+  TreeSequence.migrations_dest
+  TreeSequence.migrations_time
+  TreeSequence.indexes_edge_insertion_order
+  TreeSequence.indexes_edge_removal_order
+```
 
 (sec_python_api_tree_sequences_loading_and_saving)=
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -2,15 +2,34 @@
 [0.5.2] - 2022-XX-XX
 --------------------
 
+**Fixes**
+
+- Various memory leaks fixed (:user:`jeromekelleher`, :pr:`2424`, :issue:`2423`,
+  :issue:`2427`).
+
+**Performance improvements**
+
+- TreeSequence.site position search performance greatly improved, with much lower
+  memory overhead (:user:`jeromekelleher`, :pr:`2424`).
+
+- TreeSequence.samples time/population search performance greatly improved, with
+  much lower memory overhead (:user:`jeromekelleher`, :pr:`2424`, :issue:`1916`).
+
+- The ``timeasc`` and ``timedesc`` orders for ``Tree.nodes`` have much
+  improved performance and lower memory overhead
+  (:user:`jeromekelleher`, :pr:`2424`, :issue:`2423`).
+
 **Features**
 
 - Variant objects now have a ``.num_missing`` attribute and ``.counts()`` and
   ``.frequencies`` methods (:user:`hyanwong`, :issue:`2390` :pr:`2393`)
 
-**Changes**
 
 - Add the `Tree.num_lineages(t)` method to return the number of lineages present
   at time t in the tree (:user:`jeromekelleher`, :issue:`386`, :pr:`2422`)
+
+- Efficient array access to table data now provided via attributes like
+  `TreeSequence.nodes_time`, etc (:user:`jeromekelleher`, :pr:`2424`).
 
 --------------------
 [0.5.1] - 2022-07-14

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9532,6 +9532,376 @@ out:
     return ret;
 }
 
+/* Make a new array that is owned by the specified object. */
+static PyObject *
+make_owned_array(PyObject *self, tsk_size_t size, int dtype, void *data)
+{
+    PyObject *ret = NULL;
+    PyArrayObject *array = NULL;
+    npy_intp dims = (npy_intp) size;
+
+    array = (PyArrayObject *) PyArray_SimpleNewFromData(1, &dims, dtype, data);
+    if (array == NULL) {
+        goto out;
+    }
+    PyArray_CLEARFLAGS(array, NPY_ARRAY_WRITEABLE);
+    if (PyArray_SetBaseObject(array, (PyObject *) self) != 0) {
+        goto out;
+    }
+    /* PyArray_SetBaseObject steals a reference, so we have to incref this
+     * object. This makes sure that the instance will stay alive if there
+     * are any arrays that refer to its memory. */
+    Py_INCREF(self);
+    ret = (PyObject *) array;
+    array = NULL;
+out:
+    Py_XDECREF(array);
+    return ret;
+}
+
+static PyObject *
+TreeSequence_make_array(TreeSequence *self, tsk_size_t size, int dtype, void *data)
+{
+    return make_owned_array((PyObject *) self, size, dtype, data);
+}
+
+static PyObject *
+TreeSequence_get_individuals_flags(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_individual_table_t individuals;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    individuals = self->tree_sequence->tables->individuals;
+    ret = TreeSequence_make_array(
+        self, individuals.num_rows, NPY_UINT32, individuals.flags);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_nodes_time(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_node_table_t nodes;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    nodes = self->tree_sequence->tables->nodes;
+    ret = TreeSequence_make_array(self, nodes.num_rows, NPY_FLOAT64, nodes.time);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_nodes_flags(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_node_table_t nodes;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    nodes = self->tree_sequence->tables->nodes;
+    ret = TreeSequence_make_array(self, nodes.num_rows, NPY_UINT32, nodes.flags);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_nodes_population(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_node_table_t nodes;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    nodes = self->tree_sequence->tables->nodes;
+    ret = TreeSequence_make_array(self, nodes.num_rows, NPY_INT32, nodes.population);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_nodes_individual(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_node_table_t nodes;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    nodes = self->tree_sequence->tables->nodes;
+    ret = TreeSequence_make_array(self, nodes.num_rows, NPY_INT32, nodes.individual);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_edges_left(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_edge_table_t edges;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    edges = self->tree_sequence->tables->edges;
+    ret = TreeSequence_make_array(self, edges.num_rows, NPY_FLOAT64, edges.left);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_edges_right(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_edge_table_t edges;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    edges = self->tree_sequence->tables->edges;
+    ret = TreeSequence_make_array(self, edges.num_rows, NPY_FLOAT64, edges.right);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_edges_parent(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_edge_table_t edges;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    edges = self->tree_sequence->tables->edges;
+    ret = TreeSequence_make_array(self, edges.num_rows, NPY_INT32, edges.parent);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_edges_child(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_edge_table_t edges;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    edges = self->tree_sequence->tables->edges;
+    ret = TreeSequence_make_array(self, edges.num_rows, NPY_INT32, edges.child);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_sites_position(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_site_table_t sites;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    sites = self->tree_sequence->tables->sites;
+    ret = TreeSequence_make_array(self, sites.num_rows, NPY_FLOAT64, sites.position);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_mutations_site(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_mutation_table_t mutations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    mutations = self->tree_sequence->tables->mutations;
+    ret = TreeSequence_make_array(self, mutations.num_rows, NPY_INT32, mutations.site);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_mutations_node(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_mutation_table_t mutations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    mutations = self->tree_sequence->tables->mutations;
+    ret = TreeSequence_make_array(self, mutations.num_rows, NPY_INT32, mutations.node);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_mutations_parent(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_mutation_table_t mutations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    mutations = self->tree_sequence->tables->mutations;
+    ret = TreeSequence_make_array(self, mutations.num_rows, NPY_INT32, mutations.parent);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_mutations_time(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_mutation_table_t mutations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    mutations = self->tree_sequence->tables->mutations;
+    ret = TreeSequence_make_array(self, mutations.num_rows, NPY_FLOAT64, mutations.time);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_migrations_left(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_migration_table_t migrations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    migrations = self->tree_sequence->tables->migrations;
+    ret = TreeSequence_make_array(
+        self, migrations.num_rows, NPY_FLOAT64, migrations.left);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_migrations_right(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_migration_table_t migrations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    migrations = self->tree_sequence->tables->migrations;
+    ret = TreeSequence_make_array(
+        self, migrations.num_rows, NPY_FLOAT64, migrations.right);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_migrations_node(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_migration_table_t migrations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    migrations = self->tree_sequence->tables->migrations;
+    ret = TreeSequence_make_array(self, migrations.num_rows, NPY_INT32, migrations.node);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_migrations_source(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_migration_table_t migrations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    migrations = self->tree_sequence->tables->migrations;
+    ret = TreeSequence_make_array(
+        self, migrations.num_rows, NPY_INT32, migrations.source);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_migrations_dest(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_migration_table_t migrations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    migrations = self->tree_sequence->tables->migrations;
+    ret = TreeSequence_make_array(self, migrations.num_rows, NPY_INT32, migrations.dest);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_migrations_time(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_migration_table_t migrations;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    migrations = self->tree_sequence->tables->migrations;
+    ret = TreeSequence_make_array(
+        self, migrations.num_rows, NPY_FLOAT64, migrations.time);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_indexes_edge_insertion_order(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_table_collection_t *tables;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    tables = self->tree_sequence->tables;
+    ret = TreeSequence_make_array(
+        self, tables->edges.num_rows, NPY_INT32, tables->indexes.edge_insertion_order);
+out:
+    return ret;
+}
+
+static PyObject *
+TreeSequence_get_indexes_edge_removal_order(TreeSequence *self, void *closure)
+{
+    PyObject *ret = NULL;
+    tsk_table_collection_t *tables;
+
+    if (TreeSequence_check_state(self) != 0) {
+        goto out;
+    }
+    tables = self->tree_sequence->tables;
+    ret = TreeSequence_make_array(
+        self, tables->edges.num_rows, NPY_INT32, tables->indexes.edge_removal_order);
+out:
+    return ret;
+}
+
 static PyMethodDef TreeSequence_methods[] = {
     { .ml_name = "dump",
         .ml_meth = (PyCFunction) TreeSequence_dump,
@@ -9760,6 +10130,72 @@ static PyGetSetDef TreeSequence_getsetters[] = {
     { .name = "reference_sequence",
         .get = (getter) TreeSequence_get_reference_sequence,
         .doc = "The reference sequence." },
+    { .name = "individuals_flags",
+        .get = (getter) TreeSequence_get_individuals_flags,
+        .doc = "The individual flags array" },
+    { .name = "nodes_time",
+        .get = (getter) TreeSequence_get_nodes_time,
+        .doc = "The node time array" },
+    { .name = "nodes_flags",
+        .get = (getter) TreeSequence_get_nodes_flags,
+        .doc = "The node flags array" },
+    { .name = "nodes_population",
+        .get = (getter) TreeSequence_get_nodes_population,
+        .doc = "The node population array" },
+    { .name = "nodes_individual",
+        .get = (getter) TreeSequence_get_nodes_individual,
+        .doc = "The node individual array" },
+    { .name = "edges_left",
+        .get = (getter) TreeSequence_get_edges_left,
+        .doc = "The edge left array" },
+    { .name = "edges_right",
+        .get = (getter) TreeSequence_get_edges_right,
+        .doc = "The edge right array" },
+    { .name = "edges_parent",
+        .get = (getter) TreeSequence_get_edges_parent,
+        .doc = "The edge parent array" },
+    { .name = "edges_child",
+        .get = (getter) TreeSequence_get_edges_child,
+        .doc = "The edge child array" },
+    { .name = "sites_position",
+        .get = (getter) TreeSequence_get_sites_position,
+        .doc = "The site position array" },
+    { .name = "mutations_site",
+        .get = (getter) TreeSequence_get_mutations_site,
+        .doc = "The mutation site array" },
+    { .name = "mutations_node",
+        .get = (getter) TreeSequence_get_mutations_node,
+        .doc = "The mutation node array" },
+    { .name = "mutations_parent",
+        .get = (getter) TreeSequence_get_mutations_parent,
+        .doc = "The mutation parent array" },
+    { .name = "mutations_time",
+        .get = (getter) TreeSequence_get_mutations_time,
+        .doc = "The mutation time array" },
+    { .name = "migrations_left",
+        .get = (getter) TreeSequence_get_migrations_left,
+        .doc = "The migration left array" },
+    { .name = "migrations_right",
+        .get = (getter) TreeSequence_get_migrations_right,
+        .doc = "The migration right array" },
+    { .name = "migrations_node",
+        .get = (getter) TreeSequence_get_migrations_node,
+        .doc = "The migration node array" },
+    { .name = "migrations_source",
+        .get = (getter) TreeSequence_get_migrations_source,
+        .doc = "The migration source array" },
+    { .name = "migrations_dest",
+        .get = (getter) TreeSequence_get_migrations_dest,
+        .doc = "The migration dest array" },
+    { .name = "migrations_time",
+        .get = (getter) TreeSequence_get_migrations_time,
+        .doc = "The migration time array" },
+    { .name = "indexes_edge_insertion_order",
+        .get = (getter) TreeSequence_get_indexes_edge_insertion_order,
+        .doc = "The edge insertion order array" },
+    { .name = "indexes_edge_removal_order",
+        .get = (getter) TreeSequence_get_indexes_edge_removal_order,
+        .doc = "The edge removal order array" },
     { NULL } /* Sentinel */
 };
 
@@ -10991,27 +11427,7 @@ Tree_get_postorder(Tree *self, PyObject *args)
 static PyObject *
 Tree_make_array(Tree *self, int dtype, void *data)
 {
-    PyObject *ret = NULL;
-    PyArrayObject *array = NULL;
-    npy_intp dims = self->tree->num_nodes + 1;
-
-    array = (PyArrayObject *) PyArray_SimpleNewFromData(1, &dims, dtype, data);
-    if (array == NULL) {
-        goto out;
-    }
-    PyArray_CLEARFLAGS(array, NPY_ARRAY_WRITEABLE);
-    if (PyArray_SetBaseObject(array, (PyObject *) self) != 0) {
-        goto out;
-    }
-    /* PyArray_SetBaseObject steals a reference, so we have to incref the tree
-     * object. This makes sure that the Tree instance will stay alive if there
-     * are any arrays that refer to its memory. */
-    Py_INCREF(self);
-    ret = (PyObject *) array;
-    array = NULL;
-out:
-    Py_XDECREF(array);
-    return ret;
+    return make_owned_array((PyObject *) self, self->tree->num_nodes + 1, dtype, data);
 }
 
 static PyObject *

--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -27,7 +27,7 @@ pytest-cov
 pytest-xdist
 sphinx==4.5
 sphinx-argparse
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints>=1.18.3
 sphinx-issues
 sphinx-jupyterbook-latex
 sphinxcontrib-prettyspecialmethods

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -49,6 +49,7 @@ import msprime
 import networkx as nx
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 import _tskit
 import tests as tests
@@ -2591,6 +2592,81 @@ class TestTreeSequence(HighLevelTestCase):
         assert ts.num_individuals > 10
         self.verify_individual_properties(ts)
 
+    @pytest.mark.parametrize(
+        "array",
+        [
+            "individuals_flags",
+            "nodes_time",
+            "nodes_flags",
+            "nodes_population",
+            "nodes_individual",
+            "edges_left",
+            "edges_right",
+            "edges_parent",
+            "edges_child",
+            "sites_position",
+            "mutations_site",
+            "mutations_node",
+            "mutations_parent",
+            "mutations_time",
+            "migrations_left",
+            "migrations_right",
+            "migrations_node",
+            "migrations_source",
+            "migrations_dest",
+            "migrations_time",
+            "indexes_edge_insertion_order",
+            "indexes_edge_removal_order",
+        ],
+    )
+    def test_array_attr_properties(self, ts_fixture, array):
+        ts = ts_fixture
+        a = getattr(ts, array)
+        assert isinstance(a, np.ndarray)
+        with pytest.raises(AttributeError, match="set attribute"):
+            setattr(ts, array, None)
+        with pytest.raises(AttributeError, match="delete attribute"):
+            delattr(ts, array)
+        with pytest.raises(ValueError, match="read-only"):
+            a[:] = 1
+
+    def test_arrays_equal_to_tables(self, ts_fixture):
+        ts = ts_fixture
+        tables = ts.tables
+
+        assert_array_equal(ts.individuals_flags, tables.individuals.flags)
+
+        assert_array_equal(ts.nodes_flags, tables.nodes.flags)
+        assert_array_equal(ts.nodes_population, tables.nodes.population)
+        assert_array_equal(ts.nodes_time, tables.nodes.time)
+        assert_array_equal(ts.nodes_individual, tables.nodes.individual)
+
+        assert_array_equal(ts.edges_left, tables.edges.left)
+        assert_array_equal(ts.edges_right, tables.edges.right)
+        assert_array_equal(ts.edges_parent, tables.edges.parent)
+        assert_array_equal(ts.edges_child, tables.edges.child)
+
+        assert_array_equal(ts.sites_position, tables.sites.position)
+
+        assert_array_equal(ts.mutations_site, tables.mutations.site)
+        assert_array_equal(ts.mutations_node, tables.mutations.node)
+        assert_array_equal(ts.mutations_parent, tables.mutations.parent)
+        assert_array_equal(ts.mutations_time, tables.mutations.time)
+
+        assert_array_equal(ts.migrations_left, tables.migrations.left)
+        assert_array_equal(ts.migrations_right, tables.migrations.right)
+        assert_array_equal(ts.migrations_node, tables.migrations.node)
+        assert_array_equal(ts.migrations_source, tables.migrations.source)
+        assert_array_equal(ts.migrations_dest, tables.migrations.dest)
+        assert_array_equal(ts.migrations_time, tables.migrations.time)
+
+        assert_array_equal(
+            ts.indexes_edge_insertion_order, tables.indexes.edge_insertion_order
+        )
+        assert_array_equal(
+            ts.indexes_edge_removal_order, tables.indexes.edge_removal_order
+        )
+
 
 class TestSiteAlleles:
     def test_no_mutations(self):
@@ -2625,7 +2701,7 @@ class TestEdgeDiffs:
                 parent[edge.child] = tskit.NULL
             for edge in edge_diff.edges_in:
                 parent[edge.child] = edge.parent
-            np.testing.assert_array_equal(parent, tree.parent_array)
+            assert_array_equal(parent, tree.parent_array)
 
     @pytest.mark.parametrize("ts", get_example_tree_sequences())
     def test_correct_trees_reverse(self, ts):
@@ -2639,7 +2715,7 @@ class TestEdgeDiffs:
                 parent[edge.child] = tskit.NULL
             for edge in edge_diff.edges_in:
                 parent[edge.child] = edge.parent
-            np.testing.assert_array_equal(parent, tree.parent_array)
+            assert_array_equal(parent, tree.parent_array)
 
     def test_elements_are_like_named_tuple(self, simple_degree2_ts_fixture):
         for val in simple_degree2_ts_fixture.edge_diffs():


### PR DESCRIPTION
Add array access to TreeSequence and solve some performance issues/memory leaks. See below for more details.
