### PR TITLE
Fix segfault in tsk_variant_restricted_copy

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -1,8 +1,12 @@
 --------------------
-[1.2.0] - 2022-XX-XX
+[1.1.1] - 2022-XX-XX
 --------------------
 
+**Bug fixes**
 
+- Fix segfault in tsk_variant_restricted_copy in tree sequences with large
+  numbers of alleles or very long alleles
+  (:user:`jeromekelleher`, :pr:`2437`, :issue:`2429`).
 
 --------------------
 [1.1.0] - 2022-07-14

--- a/c/tskit/genotypes.c
+++ b/c/tskit/genotypes.c
@@ -463,7 +463,6 @@ tsk_variant_decode(
     tsk_id_t allele_index;
     tsk_size_t j, num_missing;
     int no_longer_missing;
-
     tsk_mutation_t mutation;
     bool impute_missing = !!(self->options & TSK_ISOLATED_NOT_MISSING);
     bool by_traversal = self->alt_samples != NULL;
@@ -582,11 +581,11 @@ tsk_variant_restricted_copy(const tsk_variant_t *self, tsk_variant_t *other)
     tsk_size_t total_len, offset, j;
 
     /* Copy everything */
-    tsk_memcpy(other, self, sizeof(tsk_variant_t));
+    tsk_memcpy(other, self, sizeof(*other));
     /* Tree sequence left as NULL and zero'd tree is a way of indicating this variant is
      * fixed and cannot be further decoded. */
     other->tree_sequence = NULL;
-    tsk_memset(&other->tree, sizeof(tsk_tree_t), 0);
+    tsk_memset(&other->tree, sizeof(other->tree), 0);
     other->traversal_stack = NULL;
     other->samples = NULL;
     other->sample_index_map = NULL;
@@ -598,9 +597,9 @@ tsk_variant_restricted_copy(const tsk_variant_t *self, tsk_variant_t *other)
     for (j = 0; j < self->num_alleles; j++) {
         total_len += self->allele_lengths[j];
     }
-    other->samples = tsk_malloc(other->num_samples * sizeof(tsk_id_t));
-    other->genotypes = tsk_malloc(other->num_samples * sizeof(int32_t));
-    other->user_alleles_mem = tsk_malloc(total_len * sizeof(char *));
+    other->samples = tsk_malloc(other->num_samples * sizeof(*other->samples));
+    other->genotypes = tsk_malloc(other->num_samples * sizeof(*other->genotypes));
+    other->user_alleles_mem = tsk_malloc(total_len * sizeof(*other->user_alleles_mem));
     other->allele_lengths
         = tsk_malloc(other->num_alleles * sizeof(*other->allele_lengths));
     other->alleles = tsk_malloc(other->num_alleles * sizeof(*other->alleles));
@@ -612,13 +611,14 @@ tsk_variant_restricted_copy(const tsk_variant_t *self, tsk_variant_t *other)
     }
     tsk_memcpy(
         other->samples, self->samples, other->num_samples * sizeof(*other->samples));
-    tsk_memcpy(other->genotypes, self->genotypes, other->num_samples * sizeof(int32_t));
+    tsk_memcpy(other->genotypes, self->genotypes,
+        other->num_samples * sizeof(*other->genotypes));
     tsk_memcpy(other->allele_lengths, self->allele_lengths,
         other->num_alleles * sizeof(*other->allele_lengths));
     offset = 0;
     for (j = 0; j < other->num_alleles; j++) {
         tsk_memcpy(other->user_alleles_mem + offset, self->alleles[j],
-            other->allele_lengths[j] * sizeof(char *));
+            other->allele_lengths[j] * sizeof(*other->user_alleles_mem));
         other->alleles[j] = other->user_alleles_mem + offset;
         offset += other->allele_lengths[j];
     }

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,10 @@
 
 **Fixes**
 
+- Iterating over ``ts.variants()`` could cause a segfault in tree sequences
+  with large numbers of alleles or very long alleles
+  (:user:`jeromekelleher`, :pr:`2437`, :issue:`2429`).
+
 - Various memory leaks fixed (:user:`jeromekelleher`, :pr:`2424`, :issue:`2423`,
   :issue:`2427`).
 
@@ -23,7 +27,6 @@
 
 - Variant objects now have a ``.num_missing`` attribute and ``.counts()`` and
   ``.frequencies`` methods (:user:`hyanwong`, :issue:`2390` :pr:`2393`)
-
 
 - Add the `Tree.num_lineages(t)` method to return the number of lineages present
   at time t in the tree (:user:`jeromekelleher`, :issue:`386`, :pr:`2422`)

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2502,7 +2502,6 @@ class TestVariant(LowLevelTestCase):
         variant2 = variant.restricted_copy()
         assert variant.site_id == variant2.site_id
         assert variant.alleles == variant2.alleles
-        print(variant.alleles)
         assert np.array_equal(variant.genotypes, variant2.genotypes)
         assert np.array_equal(variant.samples, variant2.samples)
         assert variant.isolated_as_missing == variant2.isolated_as_missing


### PR DESCRIPTION
Incorrect buffer size calculations caused segfault when long alleles are present.

Closes #2429
