### PR TITLE
Cache table refs

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -26,13 +26,22 @@
 **Features**
 
 - Variant objects now have a ``.num_missing`` attribute and ``.counts()`` and
-  ``.frequencies`` methods (:user:`hyanwong`, :issue:`2390` :pr:`2393`)
+  ``.frequencies`` methods (:user:`hyanwong`, :issue:`2390` :pr:`2393`).
 
 - Add the `Tree.num_lineages(t)` method to return the number of lineages present
   at time t in the tree (:user:`jeromekelleher`, :issue:`386`, :pr:`2422`)
 
 - Efficient array access to table data now provided via attributes like
   `TreeSequence.nodes_time`, etc (:user:`jeromekelleher`, :pr:`2424`).
+
+**Breaking Changes**
+
+- Previously, accessing (e.g.) ``tables.edges`` returned a different instance of
+  EdgeTable each time. This has been changed to return the same instance
+  for the lifetime of a given TableCollection instance. This is technically
+  a breaking change, although it's difficult to see how code would depend
+  on the property that (e.g.) ``tables.edges is not tables.edges``.
+  (:user:`jeromekelleher`, :pr:`2441`, :issue:`2080`).
 
 --------------------
 [0.5.1] - 2022-07-14

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4085,9 +4085,9 @@ class TreeSequence:
             the tree sequence.
         :rtype: TableCollection
         """
-        t = tables.TableCollection(sequence_length=self.sequence_length)
-        self._ll_tree_sequence.dump_tables(t._ll_tables)
-        return t
+        ll_tables = _tskit.TableCollection(self.sequence_length)
+        self._ll_tree_sequence.dump_tables(ll_tables)
+        return tables.TableCollection(ll_tables=ll_tables)
 
     def dump_text(
         self,


### PR DESCRIPTION
Stacked on #2439 

Closes #2080 

Rather than creating new references each time we access ``tables.edges``, this caches the objects in TableCollection. There were a few things that tripped me up along the way, but I think it does lead to simpler code and makes it fairly clear  now how we addess (part of, at least) making ``ts.tables`` return a view of the TableCollection data.

Benchmarks:
```python
import msprime
import sys
import time

before = time.perf_counter()
ts = msprime.sim_ancestry(
    100000,
    sequence_length=1000000,
    population_size=10_000,
    recombination_rate=1e-8,
    random_seed=1234,
)
ts = msprime.sim_mutations(ts, rate=1e-7, random_seed=1)
print(ts)
duration = time.perf_counter() - before
print(f"Simulation of {ts.num_trees} trees done after {duration:.2f} seconds")

tables = ts.tables
before = time.perf_counter()
for _ in range(10000):
    tables.nodes
    tables.edges
    tables.individuals
    tables.populations
    tables.mutations
    tables.sites
    tables.provenances
    tables.migrations
duration = time.perf_counter() - before
print(f"Pulled out tables in {duration:.2g} seconds")

before = time.perf_counter()
populations = tables.populations
for _ in range(10000):
    populations.metadata_schema
duration = time.perf_counter() - before
print(f"Pulled out metadata_schema in {duration:.2g} seconds")

before = time.perf_counter()
edges = tables.edges
for _ in range(10000):
    edges.left
duration = time.perf_counter() - before
print(f"Pulled out edges.left in {duration:.2g} seconds")

before = time.perf_counter()
for _ in range(1000):
    tables = ts.tables
    # tables.nodes
duration = time.perf_counter() - before
print(f"Pulled out ts.tables in {duration:.2g} seconds")

before = time.perf_counter()
for _ in range(1000):
    nodes = ts.tables.nodes
duration = time.perf_counter() - before
print(f"Pulled out ts.tables.nodes in {duration:.2g} seconds")
```
**NOTE: the last two run 10x fewer iterations as ``ts.tables`` is still slowwww.**

# Results

# Current upstream main
```
╔═══════════════════════════╗
║TreeSequence               ║
╠═══════════════╤═══════════╣
║Trees          │       4885║
╟───────────────┼───────────╢
║Sequence Length│    1000000║
╟───────────────┼───────────╢
║Time Units     │generations║
╟───────────────┼───────────╢
║Sample Nodes   │     200000║
╟───────────────┼───────────╢
║Total Size     │   32.5 MiB║
╚═══════════════╧═══════════╝
╔═══════════╤══════╤═════════╤════════════╗
║Table      │Rows  │Size     │Has Metadata║
╠═══════════╪══════╪═════════╪════════════╣
║Edges      │418790│ 12.8 MiB│          No║
╟───────────┼──────┼─────────┼────────────╢
║Individuals│100000│  2.7 MiB│          No║
╟───────────┼──────┼─────────┼────────────╢
║Migrations │     0│  8 Bytes│          No║
╟───────────┼──────┼─────────┼────────────╢
║Mutations  │ 51949│  1.8 MiB│          No║
╟───────────┼──────┼─────────┼────────────╢
║Nodes      │404076│ 10.8 MiB│          No║
╟───────────┼──────┼─────────┼────────────╢
║Populations│     1│224 Bytes│         Yes║
╟───────────┼──────┼─────────┼────────────╢
║Provenances│     2│  1.6 KiB│          No║
╟───────────┼──────┼─────────┼────────────╢
║Sites      │ 50650│  1.2 MiB│          No║
╚═══════════╧══════╧═════════╧════════════╝

Simulation of 4885 trees done after 1.26 seconds
Pulled out tables in 0.19 seconds
Pulled out metadata_schema in 0.0011 seconds
Pulled out edges.left in 0.99 seconds
Pulled out ts.tables in 3.4 seconds
Pulled out ts.tables.nodes in 4.5 seconds
```
![upsteam-main](https://user-images.githubusercontent.com/2664569/180824564-f018a05e-b135-44b9-92fb-3b92b0db65f5.png)

# This branch
```
Simulation of 4885 trees done after 1.30 seconds
Pulled out tables in 0.005 seconds
Pulled out metadata_schema in 0.0029 seconds
Pulled out edges.left in 1.1 seconds
Pulled out ts.tables in 3.5 seconds
Pulled out ts.tables.nodes in 7.4 seconds
```
![this-branch](https://user-images.githubusercontent.com/2664569/180825022-f188f1ef-18b6-44e3-a7b1-8ca19be6e41f.png)

