### PR TITLE
link_ancestors stops after all relevant edges have been processed

### DIFF
--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -6613,7 +6613,7 @@ test_link_ancestors_samples_and_ancestors_overlap(void)
     tsk_table_collection_t tables;
     tsk_edge_table_t result;
     tsk_id_t samples[] = { 0, 1, 2, 4 };
-    tsk_id_t ancestors[] = { 4 };
+    tsk_id_t ancestors[] = { 2 };
 
     tsk_treeseq_from_text(&ts, 1, single_tree_ex_nodes, single_tree_ex_edges, NULL, NULL,
         NULL, NULL, NULL, 0);

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -9,6 +9,13 @@
    list or None (for a 1-way stat), OR indexes is None or a single list of 
    length k (instead of a list of length-k lists).
    (:user:`gtsambos`, :pr:`2417`, :issue:`2308`)
+
+**Performance improvements**
+
+ - TreeSequence.link_ancestors no longer continues to process edges once all
+   of the sample and ancestral nodes have been accounted for, improving memory 
+   overhead and overall performance
+   (:user:`gtsambos`, :pr:`2456`, :issue:`2442`)
    
 --------------------
 [0.5.2] - 2022-07-29

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2021 Tskit Developers
+# Copyright (c) 2022 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -582,12 +582,17 @@ class AncestorMap:
         for sample_id in sample:
             self.add_ancestry(0, self.sequence_length, sample_id, sample_id)
         self.edge_buffer = {}
+        self.oldest_ancestor_time = max(ts.tables.nodes.time[u] for u in ancestors)
+        self.oldest_sample_time = max(ts.tables.nodes.time[u] for u in sample)
+        self.oldest_node_time = max(self.oldest_ancestor_time, self.oldest_sample_time)
 
     def link_ancestors(self):
         if self.ts.num_edges > 0:
             all_edges = list(self.ts.edges())
             edges = all_edges[:1]
             for e in all_edges[1:]:
+                if self.ts.tables.nodes.time[e.parent] > self.oldest_node_time:
+                    break
                 if e.parent != edges[0].parent:
                     self.process_parent_edges(edges)
                     edges = []

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Tskit Developers
+# Copyright (c) 2019-2022 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -582,8 +582,8 @@ class AncestorMap:
         for sample_id in sample:
             self.add_ancestry(0, self.sequence_length, sample_id, sample_id)
         self.edge_buffer = {}
-        self.oldest_ancestor_time = max(ts.tables.nodes.time[u] for u in ancestors)
-        self.oldest_sample_time = max(ts.tables.nodes.time[u] for u in sample)
+        self.oldest_ancestor_time = max(ts.nodes_time[u] for u in ancestors)
+        self.oldest_sample_time = max(ts.nodes_time[u] for u in sample)
         self.oldest_node_time = max(self.oldest_ancestor_time, self.oldest_sample_time)
 
     def link_ancestors(self):


### PR DESCRIPTION
Not finished yet, but shows one way of addressing the efficiency problems mentioned in #2442. Currently assumes that the nodes IDs are in the (canonical) backwards-time order, which is why I changed one of the tests. Otherwise nothing breaks!

Fixes #2442
