### PR TITLE
Mock-up of ibd-segments trash collection method.

### DIFF
--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -5875,6 +5875,8 @@ class TestMapToAncestors:
         ancestor_table = s.link_ancestors()
         if compare_lib:
             lib_result = ts.tables.link_ancestors(samples, ancestors)
+            print(lib_result)
+            print(ancestor_table)
             assert ancestor_table == lib_result
         return ancestor_table
 


### PR DESCRIPTION
## Description

This is a Python mockup of some functions that might help to keep the internal memory requirements of `ibd_segments` in check. Would work similarly for `link_ancestors` (and perhaps also for `simplify`, but with smaller gains). See #2461 for more details. I'm aware that I'm really pumping out these PRs and issues at the moment 😅 -- this one is more of a long-term project and not urgent for anyone to look at

Before taking this any further, there are a few things we'll need to figure out:
1. (under what conditions) does this actually improve memory usage? I need to do some profiling of these functions.
2. what are the costs to runtime? I suspect this will really depend on how frequently we run these methods -- I've included a `trash_interval` parameter here that controls this.
3. will this implementation translate well into C code? (I might need @jeromekelleher's insight here sometime in the future)

Fixes #2461 

### PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
