### PR TITLE
Add order argument to ts.nodes()

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -7,6 +7,11 @@
  - ``ts.subset()`` produces valid tree sequences even if nodes are shuffled
    out of time order (:user:`hyanwong`, :pr:`2479`, :issue:`2473`)
 
+**Features**
+
+ - The ``ts.nodes`` method now takes an ``order`` parameter so that nodes
+   can be visited in time order (:user:`hyanwong`, :pr:`2471`, :issue:`2370`)
+
 **Changes**
 
  - Single statistics computed with ``TreeSequence.general_stat`` are now


### PR DESCRIPTION
Fixes #2370

This uses a lambda function, which make it quite a neat and flexible change without affecting performance of the `SimpleContainerSequence.__getitem__` function. Is that OK?

It also means we can do things like:

```
ts = tskit.Tree.generate_balanced(10).tree_sequence
nodes_in_time_order = ts.nodes(order="timedesc")
nodes_in_time_order[0]  # returns node 18
```

But I think that's quite reasonable behaviour. If this seems like the right approach, I'll add some tests.