### PR TITLE
Pin sub-dependencies due to new PIP resolver

### DIFF
--- a/python/requirements/CI-docs/requirements.txt
+++ b/python/requirements/CI-docs/requirements.txt
@@ -12,3 +12,6 @@ sphinx-autodoc-typehints==1.18.3
 sphinx-issues==3.0.1
 sphinxcontrib-prettyspecialmethods==0.1.0
 svgwrite==1.4.2
+# These are added for the new pip stricter resolver until packages fix their dep specifications
+Jinja2==3.0.3
+ipywidgets==7.7.2


### PR DESCRIPTION
Gah.
The new `pip` resolver is strict in the sense that it requires that all dependencies' sub-dependency version specifications are satisfied. To do this it tries out many versions, one of which (`jinga`) has a broken version that fails install. It also takes ages to do this. The proximal fix is to pin some sub-dependancy versions as I've done here. Long term it requires python packages to be far more careful about specifying versions of dependancies.