### PR TITLE
Remove description of individual table sort order

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -411,10 +411,10 @@ Individuals are a basic type in a tree sequence and are not defined with
 respect to any other tables. Individuals can have a reference to their parent
 individuals, if present these references must be valid or null (-1).
 
-Individuals must be sorted such that parents are before children.
-Sorting a set of tables using {meth}`TableCollection.sort` will ensure that
-this requirement is fulfilled.
-
+A valid tree sequence does not require individuals to be sorted in any
+particular order, and sorting a set of tables using {meth}`TableCollection.sort`
+has no effect on individuals. However, individuals can be optionally sorted
+using {meth}`TableCollection.sort_individuals`.
 
 (sec_node_requirements)=
 


### PR DESCRIPTION
We decided in https://github.com/tskit-dev/tskit/issues/1774 to remove the requirement, but the docs aren't all updated.
