### PR TITLE
Fixed ibd.py CLI so that it works with the latest argument inputs

### DIFF
--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 Tskit Developers
+# Copyright (c) 2020-2022 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -293,8 +293,8 @@ if __name__ == "__main__":
     else:
         max_time = args.max_time[0]
 
-    s = IbdFinder(ts, samples=ts.samples(), min_span=min_span, max_time=max_time)
-    all_segs = s.find_ibd_segments()
+    s = IbdFinder(ts, min_span=min_span, max_time=max_time)
+    all_segs = s.run()
 
     if args.samples is None:
         print(all_segs)


### PR DESCRIPTION
This is a very small change that updates the simple CLI at the bottom of the ibd.py script so that it works again. Since there are now a number of PRs that require me to use this CLI for testing (#2460 , #2462), I thought I'd submit this change separately so that I only have to do it once, and to avoid possible merge conflicts further down the line.