### PR TITLE
Change schema code to work with new and old jsonschema versions

### DIFF
--- a/python/requirements/CI-complete/requirements.txt
+++ b/python/requirements/CI-complete/requirements.txt
@@ -4,7 +4,7 @@ coverage==6.3.2
 dendropy==4.5.2
 flake8==4.0.1
 h5py==3.6.0
-jsonschema==4.9.0
+jsonschema==4.16.0
 kastore==0.3.1
 lshmm==0.0.2
 msgpack==1.0.3

--- a/python/requirements/CI-tests-conda/requirements.txt
+++ b/python/requirements/CI-tests-conda/requirements.txt
@@ -1,3 +1,3 @@
 msprime==1.2.0
 kastore==0.3.1
-jsonschema==4.9.0
+jsonschema==4.16.0

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -48,7 +48,7 @@ packages = tskit
 python_requires = >=3.7
 include_package_data = True
 install_requires =
-    jsonschema>=3.0.0,<4.10.0
+    jsonschema>=3.0.0
     numpy>=1.7
     svgwrite>=1.1.10
 setup_requires =


### PR DESCRIPTION
Fixes #2509 
Tested with `jsonschema==3.0.0` and the lastest `4.16.0`.