### PR TITLE
Change error messages for Python 3.11

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -2725,9 +2725,9 @@ class TestTreeSequence(HighLevelTestCase):
         ts = ts_fixture
         a = getattr(ts, array)
         assert isinstance(a, np.ndarray)
-        with pytest.raises(AttributeError, match="set attribute"):
+        with pytest.raises(AttributeError):
             setattr(ts, array, None)
-        with pytest.raises(AttributeError, match="delete attribute"):
+        with pytest.raises(AttributeError):
             delattr(ts, array)
         with pytest.raises(ValueError, match="read-only"):
             a[:] = 1

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -931,7 +931,7 @@ class MetadataTestsMixin:
         table.metadata_schema = self.metadata_schema
         assert repr(table.metadata_schema) == repr(self.metadata_schema)
         # Del should fail
-        with pytest.raises(AttributeError, match="can't delete attribute"):
+        with pytest.raises(AttributeError):
             del table.metadata_schema
         # None should fail
         with pytest.raises(


### PR DESCRIPTION
Part of #2248 
Our test suite passes with Python 3.11 if these small changes are applied.
However, we can't yet add it to CI as one of our test dependencies (`lshmm`) depends on `numba` which doesn't yet have 3.11 support. (see https://github.com/numba/numba/issues/8304)