### PR TITLE
update returned dtype in genotype_matrix doc

### DIFF
--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -5301,7 +5301,7 @@ class TreeSequence:
             Will be removed in a future version*
 
         :return: The full matrix of genotypes.
-        :rtype: numpy.ndarray (dtype=np.int8)
+        :rtype: numpy.ndarray (dtype=np.int32)
         """
         if impute_missing_data is not None:
             warnings.warn(


### PR DESCRIPTION
Small documentation change for the type returned by the genotype_matrix() method.
Issue  #2596
