### PR TITLE
Simplify call sig uses `None` for filter_XX args

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,4 +1,16 @@
 --------------------
+[0.5.4] - 2022-XX-XX
+--------------------
+
+**Breaking Changes**
+
+ - the ``filter_populations``, ``filter_individuals``, and ``filter_sites``
+   parameters to simplify previously defaulted to ``True`` but now default
+   to ``None``, which is treated as ``True``. Previously, passing ``None``
+   would result in an error. (:user:`hyanwong`, :pr:`2609`, :issue:`2608`)
+
+
+--------------------
 [0.5.3] - 2022-10-03
 --------------------
 

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -3314,12 +3314,37 @@ class TestSimplifyTables:
     def test_unsorted_individuals_ok(self, simple_degree1_ts_fixture):
         tables = simple_degree1_ts_fixture.dump_tables()
         tables.individuals.clear()
-        tables.individuals.clear()
         tables.individuals.add_row(parents=[1])
         tables.individuals.add_row(parents=[-1])
         # we really just want to check that no error is thrown here
         tables.simplify()
         assert tables.individuals.num_rows == 0
+
+    def test_filter_none(self, simple_degree1_ts_fixture):
+        tables = simple_degree1_ts_fixture.simplify().dump_tables()
+        tables.populations.add_row()
+        tables.individuals.add_row()
+        tables.sites.add_row(
+            position=np.nextafter(tables.sequence_length, 0),
+            ancestral_state="XXX",
+        )
+        orig_num_populations = len(tables.populations)
+        orig_num_individuals = len(tables.individuals)
+        orig_num_sites = len(tables.sites)
+
+        tables.simplify(
+            filter_populations=False, filter_individuals=False, filter_sites=False
+        )
+        assert len(tables.populations) == orig_num_populations
+        assert len(tables.individuals) == orig_num_individuals
+        assert len(tables.sites) == orig_num_sites
+
+        tables.simplify(
+            filter_populations=None, filter_individuals=None, filter_sites=None
+        )
+        assert len(tables.populations) < orig_num_populations
+        assert len(tables.individuals) < orig_num_individuals
+        assert len(tables.sites) < orig_num_sites
 
 
 class TestTableCollection:

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3345,9 +3345,9 @@ class TableCollection(metadata.MetadataProvider):
         samples=None,
         *,
         reduce_to_site_topology=False,
-        filter_populations=True,
-        filter_individuals=True,
-        filter_sites=True,
+        filter_populations=None,
+        filter_individuals=None,
+        filter_sites=None,
         keep_unary=False,
         keep_unary_in_individuals=None,
         keep_input_roots=False,
@@ -3390,15 +3390,15 @@ class TableCollection(metadata.MetadataProvider):
         :param bool filter_populations: If True, remove any populations that are
             not referenced by nodes after simplification; new population IDs are
             allocated sequentially from zero. If False, the population table will
-            not be altered in any way. (Default: True)
+            not be altered in any way. (Default: None, treated as True)
         :param bool filter_individuals: If True, remove any individuals that are
             not referenced by nodes after simplification; new individual IDs are
             allocated sequentially from zero. If False, the individual table will
-            not be altered in any way. (Default: True)
+            not be altered in any way. (Default: None, treated as True)
         :param bool filter_sites: If True, remove any sites that are
             not referenced by mutations after simplification; new site IDs are
             allocated sequentially from zero. If False, the site table will not
-            be altered in any way. (Default: True)
+            be altered in any way. (Default: None, treated as True)
         :param bool keep_unary: If True, preserve unary nodes (i.e. nodes with
             exactly one child) that exist on the path from samples to root.
             (Default: False)
@@ -3434,6 +3434,12 @@ class TableCollection(metadata.MetadataProvider):
             ].astype(np.int32)
         else:
             samples = util.safe_np_int_cast(samples, np.int32)
+        if filter_populations is None:
+            filter_populations = True
+        if filter_individuals is None:
+            filter_individuals = True
+        if filter_sites is None:
+            filter_sites = True
         if keep_unary_in_individuals is None:
             keep_unary_in_individuals = False
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6444,9 +6444,9 @@ class TreeSequence:
         *,
         map_nodes=False,
         reduce_to_site_topology=False,
-        filter_populations=True,
-        filter_individuals=True,
-        filter_sites=True,
+        filter_populations=None,
+        filter_individuals=None,
+        filter_sites=None,
         keep_unary=False,
         keep_unary_in_individuals=None,
         keep_input_roots=False,
@@ -6503,15 +6503,15 @@ class TreeSequence:
         :param bool filter_populations: If True, remove any populations that are
             not referenced by nodes after simplification; new population IDs are
             allocated sequentially from zero. If False, the population table will
-            not be altered in any way. (Default: True)
+            not be altered in any way. (Default: None, treated as True)
         :param bool filter_individuals: If True, remove any individuals that are
             not referenced by nodes after simplification; new individual IDs are
             allocated sequentially from zero. If False, the individual table will
-            not be altered in any way. (Default: True)
+            not be altered in any way. (Default: None, treated as True)
         :param bool filter_sites: If True, remove any sites that are
             not referenced by mutations after simplification; new site IDs are
             allocated sequentially from zero. If False, the site table will not
-            be altered in any way. (Default: True)
+            be altered in any way. (Default: None, treated as True)
         :param bool keep_unary: If True, preserve unary nodes (i.e., nodes with
             exactly one child) that exist on the path from samples to root.
             (Default: False)


### PR DESCRIPTION
Fixes https://github.com/tskit-dev/tskit/issues/2608

I presume this doesn't need extra tests. Does it require an addition to the changelog?
