### PR TITLE
Add `states()` method to return actual genotype states as characters

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -42,6 +42,10 @@
 - Edges now have an ``.interval`` attribute returning a ``tskit.Interval`` object.
   (:user:`hyanwong`, :pr:`2531`)
 
+- Variants now have a `states()` method that returns the genotypes as an
+   (inefficient) array of strings, rather than integer indexes, to
+   aid comparison of genetic variation (:user:`hyanwong`, :pr:`2617`)
+
 - Added ``distance_between`` that calculates the total distance between two nodes in a tree.
   (:user:`Billyzhang1229`, :pr:`2771`)
 
@@ -95,6 +99,7 @@
 
 - Add ``Tree.rf_distance`` method to calculate the unweighted Robinson-Foulds distance
   between two trees. (:user:`Billyzhang1229`, :issue:`995`, :pr:`2643`, :pr:`3032`)
+
 
 --------------------
 [0.5.8] - 2024-06-27
@@ -216,7 +221,6 @@
    parameters to simplify previously defaulted to ``True`` but now default
    to ``None``, which is treated as ``True``. Previously, passing ``None``
    would result in an error. (:user:`hyanwong`, :pr:`2609`, :issue:`2608`)
-
 
 --------------------
 [0.5.3] - 2022-10-03

--- a/python/tskit/genotypes.py
+++ b/python/tskit/genotypes.py
@@ -245,6 +245,35 @@ class Variant:
         variant_copy._ll_variant = self._ll_variant.restricted_copy()
         return variant_copy
 
+    def states(self, missing_data_string=None) -> np.ndarray:
+        """
+        Returns the allelic states at this site as an array of strings.
+
+        .. warning::
+            Using this method is inefficient compared to working with the
+            underlying integer representation of genotypes as returned by
+            the :attr:`~Variant.genotypes` property.
+
+        :param str missing_data_string: A string that will be used to represent missing
+            data. If any normal allele contains this character, an error is raised.
+            Default: `None`, treated as `'N'`.
+        :return: An numpy array of strings of length ``num_sites``.
+        """
+        if missing_data_string is None:
+            missing_data_string = "N"
+        elif not isinstance(missing_data_string, str):
+            # Must explicitly test here, otherwise we output a numpy object array
+            raise ValueError("Missing data string is not a string")
+        alleles = self.alleles
+        if alleles[-1] is None:
+            if missing_data_string in alleles:
+                raise ValueError(
+                    "An existing allele is equal to the "
+                    f"missing data string '{missing_data_string}'"
+                )
+            alleles = alleles[:-1] + (missing_data_string,)
+        return np.array(alleles)[self.genotypes]
+
     def counts(self) -> typing.Counter[str | None]:
         """
         Returns a :class:`python:collections.Counter` object providing counts for each


### PR DESCRIPTION
## Description

Adds `variant.genotype_values()`. See https://github.com/tskit-dev/tsinfer/issues/739

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
