### PR TITLE
filter_nodes for simplify

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -10,6 +10,13 @@
   ``tsk_treeseq_get_min_time`` and ``tsk_treeseq_get_max_time``, respectively.
   (:user:`szhan`, :pr:`2612`, :issue:`2271`)
 
+- Add the `TSK_SIMPLIFY_NO_FILTER_NODES` option to simplify to allow unreferenced
+  nodes be kept in the output (:user:`jeromekelleher`, :user:`hyanwong`,
+  :issue:`2606`, :pr:`2619`).
+
+- Guarantee that unfiltered tables are not written to unnecessarily
+  during simplify (:user:`jeromekelleher` :pr:`2619`).
+
 --------------------
 [1.1.1] - 2022-07-29
 --------------------

--- a/c/tests/test_tables.c
+++ b/c/tests/test_tables.c
@@ -345,9 +345,31 @@ test_table_collection_simplify_errors(void)
     tsk_id_t samples[] = { 0, 1 };
     tsk_id_t ret_id;
     const char *individuals = "1      0.25     -2\n";
+
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
+
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 0, TSK_NULL, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret_id >= 0);
+    ret_id = tsk_node_table_add_row(&tables.nodes, 0, 0, TSK_NULL, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret_id >= 0);
+
+    /* Bad samples */
+    samples[0] = -1;
+    ret = tsk_table_collection_simplify(&tables, samples, 2, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    samples[0] = 10;
+    ret = tsk_table_collection_simplify(&tables, samples, 2, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    samples[0] = 0;
+
+    /* Duplicate samples */
+    samples[0] = 0;
+    samples[1] = 0;
+    ret = tsk_table_collection_simplify(&tables, samples, 2, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
+    samples[0] = 0;
 
     ret_id = tsk_site_table_add_row(&tables.sites, 0, "A", 1, NULL, 0);
     CU_ASSERT_FATAL(ret_id >= 0);

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -715,6 +715,10 @@ flag). It keeps unary nodes, but only if the unary node is referenced from an in
 @endrst
 */
 #define TSK_SIMPLIFY_KEEP_UNARY_IN_INDIVIDUALS (1 << 6)
+/** Retain nodes in the output even if no edges reference them. This is negated
+compared to the other TSK_SIMPLIFY_FILTER_XXX flags to preserve previous behaviour.
+*/
+#define TSK_SIMPLIFY_NO_FILTER_NODES (1 << 7)
 /** @} */
 
 /**
@@ -3928,6 +3932,7 @@ flags:
 - :c:macro:`TSK_SIMPLIFY_KEEP_UNARY`
 - :c:macro:`TSK_SIMPLIFY_KEEP_INPUT_ROOTS`
 - :c:macro:`TSK_SIMPLIFY_KEEP_UNARY_IN_INDIVIDUALS`
+- :c:macro:`TSK_SIMPLIFY_NO_FILTER_NODES`
 @endrst
 
 @param self A pointer to a tsk_table_collection_t object.

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -6585,22 +6585,23 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     npy_intp *shape, dims;
     tsk_size_t num_samples;
     tsk_flags_t options = 0;
-    int filter_sites = true;
+    int filter_sites = false;
     int filter_individuals = false;
     int filter_populations = false;
+    int filter_nodes = true;
     int keep_unary = false;
     int keep_unary_in_individuals = false;
     int keep_input_roots = false;
     int reduce_to_site_topology = false;
     static char *kwlist[] = { "samples", "filter_sites", "filter_populations",
-        "filter_individuals", "reduce_to_site_topology", "keep_unary",
+        "filter_individuals", "filter_nodes", "reduce_to_site_topology", "keep_unary",
         "keep_unary_in_individuals", "keep_input_roots", NULL };
 
     if (TableCollection_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiiiii", kwlist, &samples,
-            &filter_sites, &filter_populations, &filter_individuals,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiiiiii", kwlist, &samples,
+            &filter_sites, &filter_populations, &filter_individuals, &filter_nodes,
             &reduce_to_site_topology, &keep_unary, &keep_unary_in_individuals,
             &keep_input_roots)) {
         goto out;
@@ -6620,6 +6621,9 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     if (filter_populations) {
         options |= TSK_SIMPLIFY_FILTER_POPULATIONS;
+    }
+    if (!filter_nodes) {
+        options |= TSK_SIMPLIFY_NO_FILTER_NODES;
     }
     if (reduce_to_site_topology) {
         options |= TSK_SIMPLIFY_REDUCE_TO_SITE_TOPOLOGY;

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -112,6 +112,14 @@ def ts_fixture():
 
 
 @fixture(scope="session")
+def ts_fixture_for_simplify():
+    """
+    A tree sequence with data in all fields execpt edge metadata and migrations
+    """
+    return tsutil.all_fields_ts(edge_metadata=False, migrations=False)
+
+
+@fixture(scope="session")
 def replicate_ts_fixture():
     """
     A list of tree sequences

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -347,8 +347,28 @@ class TestTableCollection(LowLevelTestCase):
             tc.simplify([0, 1], keep_input_roots="sdf")
         with pytest.raises(TypeError):
             tc.simplify([0, 1], filter_populations="x")
+        with pytest.raises(TypeError):
+            tc.simplify([0, 1], filter_nodes="x")
         with pytest.raises(_tskit.LibraryError):
             tc.simplify([0, -1])
+
+    @pytest.mark.parametrize("value", [True, False])
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "filter_sites",
+            "filter_populations",
+            "filter_individuals",
+            "filter_nodes",
+            "reduce_to_site_topology",
+            "keep_unary",
+            "keep_unary_in_individuals",
+            "keep_input_roots",
+        ],
+    )
+    def test_simplify_flags(self, flag, value):
+        tables = _tskit.TableCollection(1)
+        tables.simplify([], **{flag: value})
 
     def test_link_ancestors_bad_args(self):
         ts = msprime.simulate(10, random_seed=1)

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -3029,8 +3029,8 @@ class TestSimplifyTables:
     def test_bad_samples(self):
         n = 10
         ts = msprime.simulate(n, random_seed=self.random_seed)
-        tables = ts.dump_tables()
-        for bad_node in [-1, n, n + 1, ts.num_nodes - 1, ts.num_nodes, 2**31 - 1]:
+        for bad_node in [-1, ts.num_nodes, 2**31 - 1]:
+            tables = ts.dump_tables()
             with pytest.raises(_tskit.LibraryError):
                 tables.simplify(samples=[0, bad_node])
 

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3348,6 +3348,7 @@ class TableCollection(metadata.MetadataProvider):
         filter_populations=None,
         filter_individuals=None,
         filter_sites=None,
+        filter_nodes=None,
         keep_unary=False,
         keep_unary_in_individuals=None,
         keep_input_roots=False,
@@ -3357,9 +3358,9 @@ class TableCollection(metadata.MetadataProvider):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
-        This will change the ID of the nodes, so that the node
-        ``samples[k]`` will have ID ``k`` in the result. The resulting
-        NodeTable will have only the first ``len(samples)`` nodes marked
+        If ``filter_nodes`` is True, this can change the ID of the nodes, so
+        that the node ``samples[k]`` will have ID ``k`` in the result, resulting
+        in a NodeTable where only the first ``len(samples)`` nodes are marked
         as samples. The mapping from node IDs in the current set of tables to
         their equivalent values in the simplified tables is also returned as a
         numpy array. If an array ``a`` is returned by this function and ``u``
@@ -3399,6 +3400,11 @@ class TableCollection(metadata.MetadataProvider):
             not referenced by mutations after simplification; new site IDs are
             allocated sequentially from zero. If False, the site table will not
             be altered in any way. (Default: None, treated as True)
+        :param bool filter_nodes: If True, remove any nodes that are
+            not referenced by edges after simplification. If False, the only
+            potential change to the node table may be to change the node flags
+            (if ``samples`` is specified and different from the existing samples).
+            (Default: None, treated as True)
         :param bool keep_unary: If True, preserve unary nodes (i.e. nodes with
             exactly one child) that exist on the path from samples to root.
             (Default: False)
@@ -3440,6 +3446,8 @@ class TableCollection(metadata.MetadataProvider):
             filter_individuals = True
         if filter_sites is None:
             filter_sites = True
+        if filter_nodes is None:
+            filter_nodes = True
         if keep_unary_in_individuals is None:
             keep_unary_in_individuals = False
 
@@ -3448,6 +3456,7 @@ class TableCollection(metadata.MetadataProvider):
             filter_sites=filter_sites,
             filter_individuals=filter_individuals,
             filter_populations=filter_populations,
+            filter_nodes=filter_nodes,
             reduce_to_site_topology=reduce_to_site_topology,
             keep_unary=keep_unary,
             keep_unary_in_individuals=keep_unary_in_individuals,

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3358,15 +3358,26 @@ class TableCollection(metadata.MetadataProvider):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
-        If ``filter_nodes`` is True, this can change the ID of the nodes, so
-        that the node ``samples[k]`` will have ID ``k`` in the result, resulting
-        in a NodeTable where only the first ``len(samples)`` nodes are marked
-        as samples. The mapping from node IDs in the current set of tables to
-        their equivalent values in the simplified tables is also returned as a
-        numpy array. If an array ``a`` is returned by this function and ``u``
-        is the ID of a node in the input table, then ``a[u]`` is the ID of this
-        node in the output table. For any node ``u`` that is not mapped into
-        the output tables, this mapping will equal ``-1``.
+        If ``filter_nodes`` is True (the default), this can change the ID of
+        the nodes, so that the node ``samples[k]`` will have ID ``k`` in the
+        result, resulting in a NodeTable where only the first ``len(samples)``
+        nodes are marked as samples. The mapping from node IDs in the current
+        set of tables to their equivalent values in the simplified tables is
+        also returned as a numpy array. If an array ``a`` is returned by this
+        function and ``u`` is the ID of a node in the input table, then
+        ``a[u]`` is the ID of this node in the output table. For any node ``u``
+        that is not mapped into the output tables, this mapping will equal
+        ``-1``.
+
+        If ``filter_nodes`` is False, then the output node table will be
+        unchanged except for updating the sample status of nodes. Nodes that
+        are in the specified list of ``samples`` will be marked as samples
+        in the output, and nodes that are currently marked as samples in
+        the node table but **not** in the specified list of ``samples``
+        will have their sample flag cleared. Note also that the order of
+        the ``samples`` list is not meaningful when ``filter_nodes`` is False.
+        The returned node mapping is always the identity mapping, such that
+        ``a[u] == u`` for all nodes.
 
         Tables operated on by this function must: be sorted (see
         :meth:`TableCollection.sort`), have children be born strictly after their

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6491,6 +6491,7 @@ class TreeSequence:
         filter_populations=None,
         filter_individuals=None,
         filter_sites=None,
+        filter_nodes=None,
         keep_unary=False,
         keep_unary_in_individuals=None,
         keep_input_roots=False,
@@ -6505,11 +6506,14 @@ class TreeSequence:
         original tree sequence, or :data:`tskit.NULL` (-1) if ``u`` is no longer
         present in the simplified tree sequence.
 
-        In the returned tree sequence, the node with ID ``0`` corresponds to
-        ``samples[0]``, node ``1`` corresponds to ``samples[1]`` etc., and all
-        the passed-in nodes are flagged as samples. The remaining node IDs in
-        the returned tree sequence are allocated sequentially in time order
-        and are not flagged as samples.
+        In the returned tree sequence the only nodes flagged as samples are those
+        passed as ``samples``: all others are not flagged as samples.
+        If ``filter_nodes`` is not False, nodes in the returned tree sequence are
+        also reordered such that the node with ID ``0`` corresponds to ``samples[0]``,
+        node ``1`` corresponds to ``samples[1]`` etc., and the remaining node IDs
+        are allocated sequentially in time order. Alternatively, if ``filter_nodes``
+        is False, the node order is not changed, and the order of IDs passed to
+        ``samples`` is irrelevant.
 
         If you wish to simplify a set of tables that do not satisfy all
         requirements for building a TreeSequence, then use
@@ -6525,12 +6529,12 @@ class TreeSequence:
         (up to node ID remapping) to the topology of the corresponding tree
         in the input tree sequence.
 
-        If ``filter_populations``, ``filter_individuals`` or ``filter_sites`` is
-        True, any of the corresponding objects that are not referenced elsewhere
-        are filtered out. As this is the default behaviour, it is important to
-        realise IDs for these objects may change through simplification. By setting
-        these parameters to False, however, the corresponding tables can be preserved
-        without changes.
+        If ``filter_populations``, ``filter_individuals``, ``filter_sites``, or
+        ``filter_nodes`` is True, any of the corresponding objects that are not
+        referenced elsewhere are filtered out. As this is the default behaviour,
+        it is important to realise IDs for these objects may change through
+        simplification. By setting these parameters to False, however, the
+        corresponding tables can be preserved without changes.
 
         :param list[int] samples: A list of node IDs to retain as samples. They
             need not be nodes marked as samples in the original tree sequence, but
@@ -6556,6 +6560,11 @@ class TreeSequence:
             not referenced by mutations after simplification; new site IDs are
             allocated sequentially from zero. If False, the site table will not
             be altered in any way. (Default: None, treated as True)
+        :param bool filter_nodes: If True, remove any nodes that are
+            not referenced by edges after simplification. If False, the only
+            potential change to the node table may be to change the node flags
+            (if ``samples`` is specified and different from the existing samples).
+            (Default: None, treated as True)
         :param bool keep_unary: If True, preserve unary nodes (i.e., nodes with
             exactly one child) that exist on the path from samples to root.
             (Default: False)
@@ -6587,6 +6596,7 @@ class TreeSequence:
             filter_populations=filter_populations,
             filter_individuals=filter_individuals,
             filter_sites=filter_sites,
+            filter_nodes=filter_nodes,
             keep_unary=keep_unary,
             keep_unary_in_individuals=keep_unary_in_individuals,
             keep_input_roots=keep_input_roots,

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6506,14 +6506,14 @@ class TreeSequence:
         original tree sequence, or :data:`tskit.NULL` (-1) if ``u`` is no longer
         present in the simplified tree sequence.
 
-        In the returned tree sequence the only nodes flagged as samples are those
-        passed as ``samples``: all others are not flagged as samples.
-        If ``filter_nodes`` is not False, nodes in the returned tree sequence are
-        also reordered such that the node with ID ``0`` corresponds to ``samples[0]``,
-        node ``1`` corresponds to ``samples[1]`` etc., and the remaining node IDs
-        are allocated sequentially in time order. Alternatively, if ``filter_nodes``
-        is False, the node order is not changed, and the order of IDs passed to
-        ``samples`` is irrelevant.
+        In the returned tree sequence the only nodes flagged as samples are
+        those passed as ``samples``: all others are not flagged as samples. If
+        ``filter_nodes`` is True (the default), nodes in the returned tree
+        sequence are also reordered such that the node with ID ``0``
+        corresponds to ``samples[0]``, node ``1`` corresponds to ``samples[1]``
+        etc., and the remaining node IDs are allocated sequentially in time
+        order. Alternatively, if ``filter_nodes`` is False, the node order is
+        not changed, and the order of IDs passed to ``samples`` is irrelevant.
 
         If you wish to simplify a set of tables that do not satisfy all
         requirements for building a TreeSequence, then use


### PR DESCRIPTION
## Description

A follow up to https://github.com/tskit-dev/tskit/pull/2606 with tests added. Currently intentionally failing until we decide whether to allow the passed-in `samples` to be anything other than `ts.samples()`. Will also need to implement this in the C version of simplify, and switch `compare_lib=True`

Fixes #2605.

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
