### PR TITLE
Use recursive updates for weights in ``CoalescenceTimeDistribution``

### DIFF
--- a/python/tests/test_coaltime_distribution.py
+++ b/python/tests/test_coaltime_distribution.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2022 Tskit Developers
+# Copyright (c) 2018-2023 Tskit Developers
 # Copyright (C) 2016 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,6 +25,7 @@ Test cases for coalescence time distribution objects in tskit.
 """
 import msprime
 import numpy as np
+import pytest
 
 import tests
 import tskit
@@ -181,7 +182,7 @@ class TestCoalescenceTimeDistribution:
     @tests.cached_example
     def ts_many_edge_diffs(self):
         ts = msprime.sim_ancestry(
-            samples=75,
+            samples=80,
             ploidy=1,
             sequence_length=4,
             recombination_rate=10,
@@ -216,31 +217,31 @@ class TestUnweightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         t = np.array([0, 1, 5, 8, 29])
         distr = self.coalescence_time_distribution()
         tt = distr.tables[0].time
-        assert np.allclose(t, tt)
+        np.testing.assert_allclose(t, tt)
 
     def test_block(self):
         b = np.array([0, 0, 0, 0, 0])
         distr = self.coalescence_time_distribution()
         tb = distr.tables[0].block
-        assert np.allclose(b, tb)
+        np.testing.assert_allclose(b, tb)
 
     def test_weights(self):
         w = np.array([[0, 1, 1, 1, 1]]).T
         distr = self.coalescence_time_distribution()
         tw = distr.tables[0].weights
-        assert np.allclose(w, tw)
+        np.testing.assert_allclose(w, tw)
 
     def test_cum_weights(self):
         c = np.array([[0, 1, 2, 3, 4]]).T
         distr = self.coalescence_time_distribution()
         tc = distr.tables[0].cum_weights
-        assert np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
 
     def test_quantile(self):
         q = np.array([[0, 0.25, 0.50, 0.75, 1]]).T
         distr = self.coalescence_time_distribution()
         tq = distr.tables[0].quantile
-        assert np.allclose(q, tq)
+        np.testing.assert_allclose(q, tq)
 
 
 class TestPairWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
@@ -277,13 +278,13 @@ class TestPairWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         t = np.array([0, 1, 5, 8, 29])
         distr = self.coalescence_time_distribution()
         tt = distr.tables[0].time
-        assert np.allclose(t, tt)
+        np.testing.assert_allclose(t, tt)
 
     def test_block(self):
         b = np.array([0, 0, 0, 0, 0])
         distr = self.coalescence_time_distribution()
         tb = distr.tables[0].block
-        assert np.allclose(b, tb)
+        np.testing.assert_allclose(b, tb)
 
     def test_weights(self):
         w = np.array(
@@ -297,7 +298,7 @@ class TestPairWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         )
         distr = self.coalescence_time_distribution()
         tw = distr.tables[0].weights
-        assert np.allclose(w, tw)
+        np.testing.assert_allclose(w, tw)
 
     def test_cum_weights(self):
         c = np.array(
@@ -311,7 +312,7 @@ class TestPairWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         )
         distr = self.coalescence_time_distribution()
         tc = distr.tables[0].cum_weights
-        assert np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
 
     def test_quantile(self):
         q = np.array(
@@ -325,7 +326,7 @@ class TestPairWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         )
         distr = self.coalescence_time_distribution()
         tq = distr.tables[0].quantile
-        assert np.allclose(q, tq)
+        np.testing.assert_allclose(q, tq)
 
 
 class TestTrioFirstWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
@@ -376,13 +377,13 @@ class TestTrioFirstWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution)
         t = np.array([0.0, 1.0, 2.0, 2.0, 6.0, 8.00])
         distr = self.coalescence_time_distribution()
         tt = distr.tables[0].time
-        assert np.allclose(t, tt)
+        np.testing.assert_allclose(t, tt)
 
     def test_block(self):
         b = np.array([0, 0, 0, 0, 0, 0])
         distr = self.coalescence_time_distribution()
         tb = distr.tables[0].block
-        assert np.allclose(b, tb)
+        np.testing.assert_allclose(b, tb)
 
     def test_weights(self):
         w = np.array(
@@ -397,7 +398,7 @@ class TestTrioFirstWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution)
         )
         distr = self.coalescence_time_distribution()
         tw = distr.tables[0].weights
-        assert np.allclose(w, tw)
+        np.testing.assert_allclose(w, tw)
 
     def test_cum_weights(self):
         c = np.array(
@@ -412,7 +413,7 @@ class TestTrioFirstWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution)
         )
         distr = self.coalescence_time_distribution()
         tc = distr.tables[0].cum_weights
-        assert np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
 
     def test_quantile(self):
         q = np.array(
@@ -429,7 +430,7 @@ class TestTrioFirstWeightedCoalescenceTimeTable(TestCoalescenceTimeDistribution)
         q /= q[-1, :]
         distr = self.coalescence_time_distribution()
         tq = distr.tables[0].quantile
-        assert np.allclose(q, tq[:, :-1]) and np.all(np.isnan(tq[:, -1]))
+        np.testing.assert_allclose(q, tq[:, :-1]) and np.all(np.isnan(tq[:, -1]))
 
 
 class TestSingleBlockCoalescenceTimeTable(TestCoalescenceTimeDistribution):
@@ -461,31 +462,32 @@ class TestSingleBlockCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         t = np.array([0.0, 0.54, 0.59, 0.73, 1.74])
         distr = self.coalescence_time_distribution()
         tt = distr.tables[0].time
-        assert np.allclose(t, tt)
+        np.testing.assert_allclose(t, tt)
 
     def test_block(self):
         b = np.array([0, 0, 0, 0, 0])
         distr = self.coalescence_time_distribution()
         tb = distr.tables[0].block
-        assert np.allclose(b, tb)
+        np.testing.assert_allclose(b, tb)
 
     def test_weights(self):
         w = np.array([[0, 1, 2, 1, 2]]).T
         distr = self.coalescence_time_distribution()
         tw = distr.tables[0].weights
-        assert np.allclose(w, tw)
+        np.testing.assert_allclose(w, tw)
 
     def test_cum_weights(self):
         c = np.array([[0, 1, 3, 4, 6]]).T
         distr = self.coalescence_time_distribution()
         tc = distr.tables[0].cum_weights
-        assert np.allclose(c, tc) and np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
 
     def test_quantile(self):
         q = np.array([[0.0, 1 / 6, 3 / 6, 4 / 6, 1.0]]).T
         distr = self.coalescence_time_distribution()
         tq = distr.tables[0].quantile
-        assert np.allclose(q, tq)
+        np.testing.assert_allclose(q, tq)
 
 
 class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
@@ -523,7 +525,8 @@ class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         distr = self.coalescence_time_distribution()
         tt1 = distr.tables[0].time
         tt2 = distr.tables[1].time
-        assert np.allclose(t1, tt1) and np.allclose(t2, tt2)
+        np.testing.assert_allclose(t1, tt1)
+        np.testing.assert_allclose(t2, tt2)
 
     def test_block(self):
         b1 = np.array([0, 0, 0, 0])
@@ -531,7 +534,8 @@ class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         distr = self.coalescence_time_distribution()
         tb1 = distr.tables[0].block
         tb2 = distr.tables[1].block
-        assert np.allclose(b1, tb1) and np.allclose(b2, tb2)
+        np.testing.assert_allclose(b1, tb1)
+        np.testing.assert_allclose(b2, tb2)
 
     def test_weights(self):
         w1 = np.array([[0, 1, 1, 1]]).T
@@ -539,7 +543,8 @@ class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         distr = self.coalescence_time_distribution()
         tw1 = distr.tables[0].weights
         tw2 = distr.tables[1].weights
-        assert np.allclose(w1, tw1) and np.allclose(w2, tw2)
+        np.testing.assert_allclose(w1, tw1)
+        np.testing.assert_allclose(w2, tw2)
 
     def test_cum_weights(self):
         c1 = np.array([[0, 1, 2, 3]]).T
@@ -547,7 +552,8 @@ class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         distr = self.coalescence_time_distribution()
         tc1 = distr.tables[0].cum_weights
         tc2 = distr.tables[1].cum_weights
-        assert np.allclose(c1, tc1) and np.allclose(c2, tc2)
+        np.testing.assert_allclose(c1, tc1)
+        np.testing.assert_allclose(c2, tc2)
 
     def test_quantile(self):
         e1 = np.array([[0.0, 1 / 3, 2 / 3, 1.0]]).T
@@ -555,7 +561,8 @@ class TestWindowedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
         distr = self.coalescence_time_distribution()
         te1 = distr.tables[0].quantile
         te2 = distr.tables[1].quantile
-        assert np.allclose(e1, te1) and np.allclose(e2, te2)
+        np.testing.assert_allclose(e1, te1)
+        np.testing.assert_allclose(e2, te2)
 
 
 class TestCoalescenceTimeDistributionPointMethods(TestCoalescenceTimeDistribution):
@@ -595,7 +602,7 @@ class TestCoalescenceTimeDistributionPointMethods(TestCoalescenceTimeDistributio
             [0.0, 0.25, et[1], 0.57, et[2], 0.65, et[3], 1.00, et[4], 2.00],
         )
         te = distr.ecdf(t)
-        assert np.allclose(e, te)
+        np.testing.assert_allclose(e, te)
 
     def test_num_coalesced(self):
         c = np.array([0, 0, 1, 1, 3, 3, 4, 4, 6, 6]).reshape(1, 10, 1)
@@ -605,7 +612,7 @@ class TestCoalescenceTimeDistributionPointMethods(TestCoalescenceTimeDistributio
             [0.0, 0.25, et[1], 0.57, et[2], 0.65, et[3], 1.00, et[4], 2.00],
         )
         tc = distr.num_coalesced(t)
-        assert np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
 
     def test_num_uncoalesced(self):
         u = np.array([6, 6, 5, 5, 3, 3, 2, 2, 0, 0]).reshape(1, 10, 1)
@@ -615,7 +622,28 @@ class TestCoalescenceTimeDistributionPointMethods(TestCoalescenceTimeDistributio
             [0.0, 0.25, et[1], 0.57, et[2], 0.65, et[3], 1.00, et[4], 2.00],
         )
         tu = distr.num_uncoalesced(t)
-        assert np.allclose(u, tu)
+        np.testing.assert_allclose(u, tu)
+
+    def test_interpolated_quantile(self):
+        x = np.array(
+            [
+                0.54,
+                0.558,
+                0.576,
+                0.5993,
+                0.6413,
+                0.6833,
+                0.7253,
+                0.9609,
+                1.2206,
+                1.4803,
+                1.74,
+            ]
+        ).reshape(1, 11, 1)
+        distr = self.coalescence_time_distribution()
+        q = np.linspace(0, 1, 11)
+        qx = distr.quantile(q).round(4)
+        np.testing.assert_allclose(x, qx)
 
 
 class TestCoalescenceTimeDistributionIntervalMethods(TestCoalescenceTimeDistribution):
@@ -667,7 +695,7 @@ class TestCoalescenceTimeDistributionIntervalMethods(TestCoalescenceTimeDistribu
         et = distr.tables[0].time
         t = np.array([0.00, 0.55, et[3], 2.00])
         tp = distr.coalescence_probability_in_intervals(t)
-        assert np.allclose(p, tp)
+        np.testing.assert_allclose(p, tp)
 
     def test_coalescence_probability_in_intervals_oor(self):
         distr = self.coalescence_time_distribution()
@@ -681,7 +709,7 @@ class TestCoalescenceTimeDistributionIntervalMethods(TestCoalescenceTimeDistribu
         et = distr.tables[0].time
         t = np.array([0.00, 0.55, et[3], 2.00])
         tc = distr.coalescence_rate_in_intervals(t)
-        assert np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc, atol=1e-6)
 
     def test_coalescence_rate_in_intervals_oor(self):
         distr = self.coalescence_time_distribution()
@@ -694,7 +722,7 @@ class TestCoalescenceTimeDistributionIntervalMethods(TestCoalescenceTimeDistribu
         distr = self.coalescence_time_distribution()
         et = distr.tables[0].time
         tm = distr.mean(et[2])
-        assert np.allclose(m, tm)
+        np.testing.assert_allclose(m, tm)
 
     def test_mean_oor(self):
         distr = self.coalescence_time_distribution()
@@ -754,7 +782,8 @@ class TestCoalescenceTimeDistributionBootstrap(TestCoalescenceTimeDistribution):
         boot_distr = self.coalescence_time_distribution_boot()
         tw1 = boot_distr.tables[0].cum_weights
         tw2 = boot_distr.tables[1].cum_weights
-        assert np.allclose(w1, tw1) and np.allclose(w2, tw2)
+        np.testing.assert_allclose(w1, tw1)
+        np.testing.assert_allclose(w2, tw2)
 
     def test_ecdf(self):
         e = np.array(
@@ -766,20 +795,20 @@ class TestCoalescenceTimeDistributionBootstrap(TestCoalescenceTimeDistribution):
         boot_distr = self.coalescence_time_distribution_boot()
         t = np.array([0.54, 0.55, 0.59, 0.60, 0.73, 0.74, 1.74])
         te = boot_distr.ecdf(t)
-        assert np.allclose(e, te)
+        np.testing.assert_allclose(e, te)
 
     def test_mean(self):
         m = np.array([[1.02, 0.9566667]])
         boot_distr = self.coalescence_time_distribution_boot()
         tm = boot_distr.mean()
-        assert np.allclose(m, tm)
+        np.testing.assert_allclose(m, tm)
 
     def test_boot_of_boot_equivalence(self):
         boot_distr = self.coalescence_time_distribution_boot()
         reboot_distr = next(boot_distr.block_bootstrap(1, 3))
         cw1 = boot_distr.tables[1].cum_weights
         cw2 = reboot_distr.tables[1].cum_weights
-        assert np.allclose(cw1, cw2)
+        np.testing.assert_allclose(cw1, cw2)
 
 
 class TestCoalescenceTimeDistributionEmpty(TestCoalescenceTimeDistribution):
@@ -790,11 +819,16 @@ class TestCoalescenceTimeDistributionEmpty(TestCoalescenceTimeDistribution):
     def coalescence_time_distribution(self):
         ts = self.ts_two_trees_four_leaves()
 
-        def null_weight(node, tree, sample_sets):
-            return np.array([0, 0])
+        def null_weight_init(node, sample_sets):
+            blank = np.array([[0, 0]], dtype=np.float64)
+            return (blank,)
+
+        def null_weight_update(blank):
+            blank = np.array([[0, 0]], dtype=np.float64)
+            return blank, (blank,)
 
         distr = ts.coalescence_time_distribution(
-            weight_func=null_weight,
+            weight_func=(null_weight_init, null_weight_update),
             span_normalise=False,
         )
         return distr
@@ -834,6 +868,18 @@ class TestCoalescenceTimeDistributionEmpty(TestCoalescenceTimeDistribution):
         tc = distr.coalescence_rate_in_intervals(t)
         assert np.all(np.isnan(tc))
 
+    def test_quantile(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tq = distr.quantile(t)
+        assert np.all(np.isnan(tq))
+
+    def test_resample(self):
+        distr = self.coalescence_time_distribution()
+        boot_distr = next(distr.block_bootstrap(1, 3))
+        assert np.all(boot_distr.tables[0].cum_weights == 0)
+        assert np.all(np.isnan(boot_distr.tables[0].quantile))
+
 
 class TestCoalescenceTimeDistributionNullWeight(TestCoalescenceTimeDistribution):
     """
@@ -844,11 +890,16 @@ class TestCoalescenceTimeDistributionNullWeight(TestCoalescenceTimeDistribution)
     def coalescence_time_distribution(self):
         ts = self.ts_two_trees_four_leaves()
 
-        def half_empty(node, tree, sample_sets):
-            return np.array([1, 0])
+        def half_empty_init(node, sample_sets):
+            blank = np.array([[1, 0]], dtype=np.float64)
+            return (blank,)
+
+        def half_empty_update(blank):
+            blank = np.array([[1, 0]], dtype=np.float64)
+            return blank, (blank,)
 
         distr = ts.coalescence_time_distribution(
-            weight_func=half_empty,
+            weight_func=(half_empty_init, half_empty_update),
             span_normalise=False,
         )
         return distr
@@ -888,6 +939,20 @@ class TestCoalescenceTimeDistributionNullWeight(TestCoalescenceTimeDistribution)
         tr = distr.coalescence_rate_in_intervals(t)
         assert np.all(np.isnan(tr[1, :])) and np.all(~np.isnan(tr[0, :]))
 
+    def test_quantile(self):
+        distr = self.coalescence_time_distribution()
+        t = np.array([0.0, 0.5, 1.0])
+        tq = distr.quantile(t)
+        assert np.all(np.isnan(tq[1, :])) and np.all(~np.isnan(tq[0, :]))
+
+    def test_resample(self):
+        distr = self.coalescence_time_distribution()
+        boot_distr = next(distr.block_bootstrap(1, 3))
+        assert np.all(boot_distr.tables[0].cum_weights[:, 1] == 0)
+        assert np.all(np.isnan(boot_distr.tables[0].quantile[:, 1]))
+        assert np.any(boot_distr.tables[0].cum_weights[:, 0] > 0)
+        assert np.all(~np.isnan(boot_distr.tables[0].quantile[:, 0]))
+
 
 class TestCoalescenceTimeDistributionTableResize(TestCoalescenceTimeDistribution):
     """
@@ -921,12 +986,18 @@ class TestCoalescenceTimeDistributionBlocking(TestCoalescenceTimeDistribution):
         ts = self.ts_eight_trees_two_leaves()
         bk = [t.interval.left for t in ts.trees()][::4] + [ts.sequence_length]
 
-        def count_root(node, tree, sample_sets):
-            weight = int(node == tree.get_root())
-            return np.array([weight])
+        def count_root_init(node, sample_sets):
+            all_samples = [i for s in sample_sets for i in s]
+            state = np.array([[node == i for i in all_samples]], dtype=np.float64)
+            return (state,)
+
+        def count_root_update(child_state):
+            state = np.sum(child_state, axis=0, keepdims=True)
+            is_root = np.array([[np.all(state > 0)]], dtype=np.float64)
+            return is_root, (state,)
 
         distr = ts.coalescence_time_distribution(
-            weight_func=count_root,
+            weight_func=(count_root_init, count_root_update),
             window_breaks=np.array(bk),
             blocks_per_window=2,
             span_normalise=False,
@@ -936,12 +1007,12 @@ class TestCoalescenceTimeDistributionBlocking(TestCoalescenceTimeDistribution):
     def test_blocks_per_window(self):
         distr = self.coalescence_time_distribution()
         bpw = np.array([i.num_blocks for i in distr.tables])
-        assert np.allclose(bpw, 2)
+        np.testing.assert_allclose(bpw, 2)
 
     def test_trees_per_window(self):
         distr = self.coalescence_time_distribution()
         tpw = np.array([np.sum(distr.tables[i].weights) for i in range(2)])
-        assert np.allclose(tpw, 4)
+        np.testing.assert_allclose(tpw, 4)
 
     def test_trees_per_block(self):
         distr = self.coalescence_time_distribution()
@@ -949,7 +1020,80 @@ class TestCoalescenceTimeDistributionBlocking(TestCoalescenceTimeDistribution):
         for table in distr.tables:
             for block in range(2):
                 tpb += [np.sum(table.weights[table.block == block])]
-        assert np.allclose(tpb, 2)
+        np.testing.assert_allclose(tpb, 2)
+
+
+class TestCoalescenceTimeDistributionBlockedVsUnblocked(
+    TestCoalescenceTimeDistribution
+):
+    """
+    Test that methods give the same result regardless of how trees are blocked.
+    """
+
+    def coalescence_time_distribution(self, num_blocks=1):
+        ts = self.ts_many_edge_diffs()
+        sample_sets = [list(range(10)), list(range(20, 40)), list(range(70, 80))]
+        distr = ts.coalescence_time_distribution(
+            sample_sets=sample_sets,
+            weight_func="pair_coalescence_events",
+            blocks_per_window=num_blocks,
+            span_normalise=True,
+        )
+        return distr
+
+    def test_ecdf(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        t = np.linspace(0, distr_noblock.tables[0].time[-1] + 1, 5)
+        np.testing.assert_allclose(distr_noblock.ecdf(t), distr_block.ecdf(t))
+
+    def test_num_coalesced(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        t = np.linspace(0, distr_noblock.tables[0].time[-1] + 1, 5)
+        np.testing.assert_allclose(
+            distr_noblock.num_coalesced(t), distr_block.num_coalesced(t)
+        )
+
+    def test_num_uncoalesced(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        t = np.linspace(0, distr_noblock.tables[0].time[-1] + 1, 5)
+        np.testing.assert_allclose(
+            distr_noblock.num_uncoalesced(t), distr_block.num_uncoalesced(t)
+        )
+
+    def test_quantile(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        q = np.linspace(0, 1, 11)
+        np.testing.assert_allclose(distr_noblock.quantile(q), distr_block.quantile(q))
+
+    def test_mean(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        t = distr_noblock.tables[0].time[-1] / 2
+        np.testing.assert_allclose(
+            distr_noblock.mean(since=t), distr_block.mean(since=t)
+        )
+
+    def test_coalescence_rate_in_intervals(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        t = np.linspace(0, distr_noblock.tables[0].time[-1] + 1, 5)
+        np.testing.assert_allclose(
+            distr_noblock.coalescence_rate_in_intervals(t),
+            distr_block.coalescence_rate_in_intervals(t),
+        )
+
+    def test_coalescence_probability_in_intervals(self):
+        distr_noblock = self.coalescence_time_distribution(num_blocks=1)
+        distr_block = self.coalescence_time_distribution(num_blocks=10)
+        t = np.linspace(0, distr_noblock.tables[0].time[-1] + 1, 5)
+        np.testing.assert_allclose(
+            distr_noblock.coalescence_probability_in_intervals(t),
+            distr_block.coalescence_probability_in_intervals(t),
+        )
 
 
 class TestCoalescenceTimeDistributionRunningUpdate(TestCoalescenceTimeDistribution):
@@ -957,23 +1101,23 @@ class TestCoalescenceTimeDistributionRunningUpdate(TestCoalescenceTimeDistributi
     When traversing trees, weights are updated for nodes whose descendant subtree
     has changed. This is done by taking the parents of added edges, and tracing
     ancestors down to the root. This class tests that this "running update"
-    scheme produces the same results as calculating weights separately for each
-    tree.
+    scheme produces the correct result.
     """
 
-    # TODO: when missing data handling is implemented, test here
-
-    def coalescence_time_distribution(self, ts):
-        brk = np.array([t.interval.left for t in ts.trees()] + [ts.sequence_length])
-        smp_set = np.arange(0, ts.num_samples)
-        smp_set = np.floor_divide((len(brk) - 1) * smp_set, ts.num_samples)
-        smp_set = [np.where(smp_set == i)[0].tolist() for i in range(len(brk) - 1)]
+    def coalescence_time_distribution_running(self, ts, brk, sets=2):
+        n = ts.num_samples // sets
+        smp_set = [list(range(i, i + n)) for i in range(0, ts.num_samples, n)]
         distr = ts.coalescence_time_distribution(
             sample_sets=smp_set,
             window_breaks=brk,
             weight_func="trio_first_coalescence_events",
             span_normalise=False,
         )
+        return distr
+
+    def coalescence_time_distribution_split(self, ts, brk, sets=2):
+        n = ts.num_samples // sets
+        smp_set = [list(range(i, i + n)) for i in range(0, ts.num_samples, n)]
         distr_by_win = []
         for left, right in zip(brk[:-1], brk[1:]):
             ts_trim = ts.keep_intervals([[left, right]]).trim()
@@ -981,20 +1125,65 @@ class TestCoalescenceTimeDistributionRunningUpdate(TestCoalescenceTimeDistributi
                 ts_trim.coalescence_time_distribution(
                     sample_sets=smp_set,
                     weight_func="trio_first_coalescence_events",
+                    span_normalise=False,
                 )
             ]
-        return distr, distr_by_win
+        return distr_by_win
 
     def test_many_edge_diffs(self):
+        """
+        Test that ts windowed by tree gives same result as set of single trees.
+        """
         ts = self.ts_many_edge_diffs()
-        distr, distr_win = self.coalescence_time_distribution(ts)
+        brk = np.array([t.interval.left for t in ts.trees()] + [ts.sequence_length])
+        distr = self.coalescence_time_distribution_running(ts, brk)
+        distr_win = self.coalescence_time_distribution_split(ts, brk)
         time_breaks = np.array([np.inf])
         updt = distr.num_coalesced(time_breaks)
         sepr = np.zeros(updt.shape)
         for i, d in enumerate(distr_win):
             c = d.num_coalesced(time_breaks)
             sepr[:, :, i] = c.reshape((c.shape[0], 1))
-        assert np.allclose(sepr, updt)
+        np.testing.assert_allclose(sepr, updt)
+
+    def test_missing_trees(self):
+        """
+        Test that ts with half of each tree masked gives same result as unmasked ts.
+        """
+        ts = self.ts_many_edge_diffs()
+        brk = np.array([t.interval.left for t in ts.trees()] + [ts.sequence_length])
+        mask = np.array(
+            [
+                [tr.interval.left, (tr.interval.right + tr.interval.left) / 2]
+                for tr in ts.trees()
+            ]
+        )
+        ts_mask = ts.delete_intervals(mask)
+        distr = self.coalescence_time_distribution_running(ts, brk)
+        distr_mask = self.coalescence_time_distribution_running(ts_mask, brk)
+        time_breaks = np.array([np.inf])
+        updt = distr.num_coalesced(time_breaks)
+        updt_mask = distr_mask.num_coalesced(time_breaks)
+        np.testing.assert_allclose(updt, updt_mask)
+
+    def test_unary_nodes(self):
+        """
+        Test that ts with unary nodes gives same result as ts with unary nodes removed.
+        """
+        ts = self.ts_many_edge_diffs()
+        ts_unary = ts.simplify(
+            samples=list(range(ts.num_samples // 2)), keep_unary=True
+        )
+        ts_nounary = ts.simplify(
+            samples=list(range(ts.num_samples // 2)), keep_unary=False
+        )
+        brk = np.array([t.interval.left for t in ts.trees()] + [ts.sequence_length])
+        distr_unary = self.coalescence_time_distribution_running(ts_unary, brk)
+        distr_nounary = self.coalescence_time_distribution_running(ts_nounary, brk)
+        time_breaks = np.array([np.inf])
+        updt_unary = distr_unary.num_coalesced(time_breaks)
+        updt_nounary = distr_nounary.num_coalesced(time_breaks)
+        np.testing.assert_allclose(updt_unary, updt_nounary)
 
 
 class TestSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
@@ -1016,24 +1205,39 @@ class TestSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
     Uniform weights on nodes summed over trees, weighted by tree span
     """
 
-    def coalescence_time_distribution(self):
+    def coalescence_time_distribution(self, mask_half_of_each_tree=False):
+        """
+        Methods should give the same result if half of each tree is masked,
+        because "span weights" are normalised using the accessible (nonmissing)
+        portion of the tree sequence.
+        """
         ts = self.ts_two_trees_four_leaves()
+        if mask_half_of_each_tree:
+            mask = np.array(
+                [
+                    [t.interval.left, (t.interval.right + t.interval.left) / 2]
+                    for t in ts.trees()
+                ]
+            )
+            ts = ts.delete_intervals(mask)
         distr = ts.coalescence_time_distribution(
             span_normalise=True,
         )
         return distr
 
-    def test_weights(self):
+    @pytest.mark.parametrize("with_missing_data", [True, False])
+    def test_weights(self, with_missing_data):
         w = np.array([[0, 0.12, 1.0, 0.88, 1.0]]).T
-        distr = self.coalescence_time_distribution()
+        distr = self.coalescence_time_distribution(with_missing_data)
         tw = distr.tables[0].weights
-        assert np.allclose(w, tw)
+        np.testing.assert_allclose(w, tw)
 
-    def test_cum_weights(self):
+    @pytest.mark.parametrize("with_missing_data", [True, False])
+    def test_cum_weights(self, with_missing_data):
         c = np.array([[0, 0.12, 1.12, 2.00, 3.00]]).T
-        distr = self.coalescence_time_distribution()
+        distr = self.coalescence_time_distribution(with_missing_data)
         tc = distr.tables[0].cum_weights
-        assert np.allclose(c, tc) and np.allclose(c, tc)
+        np.testing.assert_allclose(c, tc)
 
 
 class TestWindowedSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribution):
@@ -1058,9 +1262,19 @@ class TestWindowedSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribu
     """
 
     @tests.cached_example
-    def coalescence_time_distribution(self):
+    def coalescence_time_distribution(self, mask_half_of_each_tree=False):
+        """
+        Methods should give the same result if half of each tree is masked,
+        because "span weights" are normalised using the accessible (nonmissing)
+        portion of the tree sequence.
+        """
         ts = self.ts_two_trees_four_leaves()
         gen_breaks = np.array([0.0, 0.5, 1.0])
+        if mask_half_of_each_tree:
+            breaks = [i for i in ts.breakpoints()]
+            breaks = np.unique(np.concatenate([breaks, gen_breaks]))
+            mask = np.array([[a, (a + b) / 2] for a, b in zip(breaks[:-1], breaks[1:])])
+            ts = ts.keep_intervals(mask)
         distr = ts.coalescence_time_distribution(
             window_breaks=gen_breaks,
             blocks_per_window=2,
@@ -1068,26 +1282,32 @@ class TestWindowedSpanNormalisedCoalescenceTimeTable(TestCoalescenceTimeDistribu
         )
         return distr
 
-    def test_time(self):
+    @pytest.mark.parametrize("with_missing_data", [True, False])
+    def test_time(self, with_missing_data):
         t1 = np.array([0.0, 0.59, 0.73, 1.74])
         t2 = np.array([0.0, 0.54, 0.59, 0.59, 0.73, 1.74, 1.74])
-        distr = self.coalescence_time_distribution()
+        distr = self.coalescence_time_distribution(with_missing_data)
         tt1 = distr.tables[0].time
         tt2 = distr.tables[1].time
-        assert np.allclose(t1, tt1) and np.allclose(t2, tt2)
+        np.testing.assert_allclose(t1, tt1)
+        np.testing.assert_allclose(t2, tt2)
 
-    def test_block(self):
+    @pytest.mark.parametrize("with_missing_data", [True, False])
+    def test_block(self, with_missing_data):
         b1 = np.array([0, 0, 0, 0])
         b2 = np.array([0, 1, 0, 1, 0, 0, 1])
-        distr = self.coalescence_time_distribution()
+        distr = self.coalescence_time_distribution(with_missing_data)
         tb1 = distr.tables[0].block
         tb2 = distr.tables[1].block
-        assert np.allclose(b1, tb1) and np.allclose(b2, tb2)
+        np.testing.assert_allclose(b1, tb1)
+        np.testing.assert_allclose(b2, tb2)
 
-    def test_weights(self):
+    @pytest.mark.parametrize("with_missing_data", [True, False])
+    def test_weights(self, with_missing_data):
         w1 = np.array([[0, 1.0, 1.0, 1.0]]).T
         w2 = np.array([[0, 0.24, 0.76, 0.24, 0.76, 0.76, 0.24]]).T
-        distr = self.coalescence_time_distribution()
+        distr = self.coalescence_time_distribution(with_missing_data)
         tw1 = distr.tables[0].weights
         tw2 = distr.tables[1].weights
-        assert np.allclose(w1, tw1) and np.allclose(w2, tw2)
+        np.testing.assert_allclose(w1, tw1)
+        np.testing.assert_allclose(w2, tw2)

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -215,24 +215,49 @@ class CoalescenceTimeTable:
             )
             if self.cum_weights[-1, i] > 0:
                 self.quantile[:, i] = self.cum_weights[:, i] / self.cum_weights[-1, i]
+            else:
+                self.quantile[:, i] = np.nan
 
 
 class CoalescenceTimeDistribution:
     """
     Class to precompute a table of sorted/weighted node times, from which to calculate
     the empirical distribution function and estimate coalescence rates in time windows.
+
+    To compute weights efficiently requires an update operation of the form:
+
+        ``output[parent], state[parent] = update(state[children])``
+
+    where ``output`` are the weights associated with the node, and ``state``
+    are values that are needed to compute ``output`` that are recursively
+    calculated along the tree. The value of ``state`` on the leaves is
+    initialized via,
+
+        ``state[sample] = initialize(sample, sample_sets)``
     """
 
     @staticmethod
-    def _count_coalescence_events(node, tree, sample_sets):
-        # TODO this will count unary nodes: should it count nodes
-        # with >1 child instead?
-        return np.array([1], dtype=np.int32)
+    def _count_coalescence_events():
+        """
+        Count the number of samples that coalesce in ``node``, within each
+        set of samples in ``sample_sets``.
+        """
+
+        def initialize(node, sample_sets):
+            singles = np.array([[node in s for s in sample_sets]], dtype=np.float64)
+            return (singles,)
+
+        def update(singles_per_child):
+            singles = np.sum(singles_per_child, axis=0, keepdims=True)
+            is_ancestor = (singles > 0).astype(np.float64)
+            return is_ancestor, (singles,)
+
+        return (initialize, update)
 
     @staticmethod
-    def _count_pair_coalescence_events(node, tree, sample_sets):
+    def _count_pair_coalescence_events():
         """
-        Count the number of pairs that coalesce in node, within and between the
+        Count the number of pairs that coalesce in ``node``, within and between the
         sets of samples in ``sample_sets``. The count of pairs with members that
         belong to sets :math:`a` and :math:`b` is:
 
@@ -246,30 +271,29 @@ class CoalescenceTimeDistribution:
         correspond to counts of pairs with set labels ``[(0,0), (0,1), (1,1)]``.
         """
 
-        # TODO needs to be optimized, use np.intersect1d
-        children = tree.children(node)
-        samples_per_child = [set(list(tree.samples(c))) for c in children]
-        sample_counts = np.zeros((len(sample_sets), len(children)), dtype=np.int32)
-        for i, s1 in enumerate(samples_per_child):
-            for a, s2 in enumerate([set(s) for s in sample_sets]):
-                sample_counts[a, i] = len(s1 & s2)
+        def initialize(node, sample_sets):
+            singles = np.array([[node in s for s in sample_sets]], dtype=np.float64)
+            return (singles,)
 
-        pair_counts = []
-        for a, b in itertools.combinations_with_replacement(
-            range(sample_counts.shape[0]), 2
-        ):
-            count = 0
-            for i, j in itertools.combinations(range(sample_counts.shape[1]), 2):
-                count += (
-                    sample_counts[a, i] * sample_counts[b, j]
-                    + sample_counts[a, j] * sample_counts[b, i]
-                ) / (1 + int(a == b))
-            pair_counts.append(count)
+        def update(singles_per_child):
+            C = singles_per_child.shape[0]  # number of children
+            S = singles_per_child.shape[1]  # number of sample sets
+            singles = np.sum(singles_per_child, axis=0, keepdims=True)
+            pairs = np.zeros((1, int(S * (S + 1) / 2)), dtype=np.float64)
+            for a, b in itertools.combinations(range(C), 2):
+                for i, (j, k) in enumerate(
+                    itertools.combinations_with_replacement(range(S), 2)
+                ):
+                    pairs[0, i] += (
+                        singles_per_child[a, j] * singles_per_child[b, k]
+                        + singles_per_child[a, k] * singles_per_child[b, j]
+                    ) / (1 + int(j == k))
+            return pairs, (singles,)
 
-        return np.array(pair_counts, dtype=np.int32)
+        return (initialize, update)
 
     @staticmethod
-    def _count_trio_first_coalescence_events(node, tree, sample_sets):
+    def _count_trio_first_coalescence_events():
         """
         Count the number of pairs that coalesce in node with an outgroup,
         within and between the sets of samples in ``sample_sets``. In other
@@ -290,88 +314,160 @@ class CoalescenceTimeDistribution:
         correspond to counts of pairs with set labels,
         ``[((0,0),0), ((0,0),1), ..., ((0,1),0), ((0,1),1), ...]``.
         """
-        samples = list(tree.samples(node))
-        outg_counts = [len(s) - len(np.intersect1d(samples, s)) for s in sample_sets]
-        pair_counts = CoalescenceTimeDistribution._count_pair_coalescence_events(
-            node, tree, sample_sets
-        )
-        trio_counts = []
-        for i in pair_counts:
-            for j in outg_counts:
-                trio_counts.append(i * j)
-        return np.array(trio_counts, dtype=np.int32)
 
-    def _update_weights_by_edge_diff(self, tree, edge_diff, running_weights):
+        def initialize(node, sample_sets):
+            S = len(sample_sets)
+            totals = np.array([[len(s) for s in sample_sets]], dtype=np.float64)
+            singles = np.array([[node in s for s in sample_sets]], dtype=np.float64)
+            pairs = np.zeros((1, int(S * (S + 1) / 2)), dtype=np.float64)
+            return (
+                totals,
+                singles,
+                pairs,
+            )
+
+        def update(totals_per_child, singles_per_child, pairs_per_child):
+            C = totals_per_child.shape[0]  # number of children
+            S = totals_per_child.shape[1]  # number of sample sets
+            totals = np.mean(totals_per_child, axis=0, keepdims=True)
+            singles = np.sum(singles_per_child, axis=0, keepdims=True)
+            pairs = np.zeros((1, int(S * (S + 1) / 2)), dtype=np.float64)
+            for a, b in itertools.combinations(range(C), 2):
+                pair_iterator = itertools.combinations_with_replacement(range(S), 2)
+                for i, (j, k) in enumerate(pair_iterator):
+                    pairs[0, i] += (
+                        singles_per_child[a, j] * singles_per_child[b, k]
+                        + singles_per_child[a, k] * singles_per_child[b, j]
+                    ) / (1 + int(j == k))
+            outgr = totals - singles
+            trios = np.zeros((1, pairs.size * outgr.size), dtype=np.float64)
+            trio_iterator = itertools.product(range(pairs.size), range(outgr.size))
+            for i, (j, k) in enumerate(trio_iterator):
+                trios[0, i] += pairs[0, j] * outgr[0, k]
+            return trios, (
+                totals,
+                singles,
+                pairs,
+            )
+
+        return (initialize, update)
+
+    def _update_running_with_edge_diff(
+        self, tree, edge_diff, running_output, running_state, running_index
+    ):
         """
-        Update ``running_weights`` to reflect ``tree`` using edge differences
-        ``edge_diff`` with the previous tree.
+        Update ``running_output`` and ``running_state`` to reflect ``tree``,
+        using edge differences ``edge_diff`` with the previous tree.
+        The dict ``running_index`` maps node IDs onto rows of the running arrays.
         """
 
         assert edge_diff.interval == tree.interval
 
-        # nodes that have been removed from tree
-        removed = {i.child for i in edge_diff.edges_out if tree.is_isolated(i.child)}
-        # TODO: What if sample is removed from tree? In that case should all
-        # nodes be updated for trio first coalescences?
+        # empty rows in the running arrays
+        available_rows = {i for i in range(self.running_array_size)}
+        available_rows -= set(running_index.values())
 
-        # nodes where descendant subtree has been altered
-        modified = {i.parent for i in edge_diff.edges_in}
-        for i in copy.deepcopy(modified):
-            while tree.parent(i) != tskit.NULL and not tree.parent(i) in modified:
+        # find internal nodes that have been removed from tree or are unary
+        removed_nodes = set()
+        for i in edge_diff.edges_out:
+            for j in [i.child, i.parent]:
+                if tree.num_children(j) < 2 and not tree.is_sample(j):
+                    removed_nodes.add(j)
+
+        # find non-unary nodes where descendant subtree has been altered
+        modified_nodes = {
+            i.parent for i in edge_diff.edges_in if tree.num_children(i.parent) > 1
+        }
+        for i in copy.deepcopy(modified_nodes):
+            while tree.parent(i) != tskit.NULL and not tree.parent(i) in modified_nodes:
                 i = tree.parent(i)
-                modified.add(i)
+                if tree.num_children(i) > 1:
+                    modified_nodes.add(i)
 
-        # recalculate weights for current tree
-        for i in removed:
-            running_weights[i, :] = 0
-        for i in modified:
-            running_weights[i, :] = self.weight_func(i, tree, self.sample_sets)
-        self.weight_func_evals += len(modified)
+        # clear running state/output for nodes that are no longer in tree
+        for i in removed_nodes:
+            if i in running_index:
+                running_state[running_index[i], :] = 0
+                running_output[running_index[i], :] = 0
+                available_rows.add(running_index.pop(i))
+
+        # recalculate state/output for nodes whose descendants have changed
+        for i in sorted(modified_nodes, key=lambda node: tree.time(node)):
+            children = []
+            for c in tree.children(i):  # skip unary children
+                while tree.num_children(c) == 1:
+                    (c,) = tree.children(c)
+                children.append(c)
+            child_index = [running_index[c] for c in children]
+
+            inputs = (
+                running_state[child_index][:, state_index]
+                for state_index in self.state_indices
+            )
+            output, state = self._update(*inputs)
+
+            # update running state/output arrays
+            if i not in running_index:
+                running_index[i] = available_rows.pop()
+            running_output[running_index[i], :] = output
+            for state_index, x in zip(self.state_indices, state):
+                running_state[running_index[i], state_index] = x
+
+        # track the number of times the weight function was called
+        self.weight_func_evals += len(modified_nodes)
 
     def _build_ecdf_table_for_window(
-        self, left, right, tree, edge_diffs, running_weights
+        self,
+        left,
+        right,
+        tree,
+        edge_diffs,
+        running_output,
+        running_state,
+        running_index,
     ):
         """
-        Construct ECDF table for genomic interval [left, right]. Update ``tree``,
-        ``edge_diffs``, and ``running_weights`` for input for next window. Trees are
-        counted as belonging to any interval with which they overlap, and thus
-        can be used in several intervals. Thus, the concatenation of ECDF
-        tables across multiple intervals is not the same as the ECDF table
-        for the union of those intervals. Trees within intervals are chunked
-        into roughly equal-sized blocks for bootstrapping.
+        Construct ECDF table for genomic interval [left, right]. Update
+        ``tree``; ``edge_diffs``; and ``running_output``, ``running_state``,
+        `running_idx``; for input for next window. Trees are counted as
+        belonging to any interval with which they overlap, and thus can be used
+        in several intervals.  Thus, the concatenation of ECDF tables across
+        multiple intervals is not the same as the ECDF table for the union of
+        those intervals. Trees within intervals are chunked into roughly
+        equal-sized blocks for bootstrapping.
         """
 
         assert tree.interval.left <= left and right > left
 
+        # TODO: if bootstrapping, block span needs to be tracked
+        #   and used to renormalise each replicate. This should be
+        #   done by the bootstrapping machinery, not here.
+
         # assign trees in window to equal-sized blocks with unique id
-        other_tree = tree.copy()
-        # TODO: is a full copy of the tree needed, given that the original is
-        # mutated below?
-        if right >= other_tree.tree_sequence.sequence_length:
-            other_tree.last()
-        else:
-            # other_tree.seek(right) won't work if `right` is recomb breakpoint
-            while other_tree.interval.right < right:
-                other_tree.next()
-        tree_idx = np.arange(tree.index, other_tree.index + 1) - tree.index
         tree_offset = tree.index
+        if right >= tree.tree_sequence.sequence_length:
+            tree.last()
+        else:
+            # tree.seek(right) won't work if `right` is recomb breakpoint
+            while tree.interval.right < right:
+                tree.next()
+        tree_idx = np.arange(tree_offset, tree.index + 1) - tree_offset
         num_blocks = min(self.num_blocks, len(tree_idx))
         tree_blocks = np.floor_divide(num_blocks * tree_idx, len(tree_idx))
 
         # calculate span weights
-        # TODO: if bootstrapping, does block span need to be tracked
-        # and used to renormalise each replicate?
-        other_tree.seek(tree.interval.left)
-        tree_span = [
-            min(other_tree.interval.right, right) - max(other_tree.interval.left, left)
-        ]
-        while other_tree.index < tree_offset + tree_idx[-1]:
-            other_tree.next()
+        tree.seek_index(tree_offset)
+        tree_span = [min(tree.interval.right, right) - max(tree.interval.left, left)]
+        while tree.index < tree_offset + tree_idx[-1]:
+            tree.next()
             tree_span.append(
-                min(other_tree.interval.right, right)
-                - max(other_tree.interval.left, left)
+                min(tree.interval.right, right) - max(tree.interval.left, left)
             )
-        tree_span = np.array(tree_span) / sum(tree_span)
+        tree_span = np.array(tree_span)
+        total_span = np.sum(tree_span)
+        assert np.isclose(
+            total_span, min(right, tree.tree_sequence.sequence_length) - left
+        )
 
         # storage if using single window, block for entire tree sequence
         buffer_size = self.buffer_size
@@ -381,48 +477,63 @@ class CoalescenceTimeDistribution:
         weights = np.zeros((table_size, self.num_weights))
 
         # assemble table of coalescence times in window
+        num_record = 0
+        accessible_span = 0.0
+        span_weight = 1.0
         indices = np.zeros(tree.tree_sequence.num_nodes, dtype=np.int32) - 1
         last_block = np.zeros(tree.tree_sequence.num_nodes, dtype=np.int32) - 1
-        num_record = 0
+        tree.seek_index(tree_offset)
         while tree.index != tskit.NULL:
             if tree.interval.right > left:
                 current_block = tree_blocks[tree.index - tree_offset]
                 if self.span_normalise:
-                    span_weight = tree_span[tree.index - tree_offset]
-                else:
-                    span_weight = 1.0
-                nodes_in_tree = np.array(
-                    [i for i in tree.nodes() if tree.is_internal(i)]
+                    span_weight = tree_span[tree.index - tree_offset] / total_span
+
+                # TODO: shouldn't need to loop over all keys (nodes) for every tree
+                internal_nodes = np.array(
+                    [i for i in running_index.keys() if not tree.is_sample(i)],
+                    dtype=np.int32,
                 )
-                # TODO this will fail if all nodes are isolated (masked tree)
-                nodes_to_add = nodes_in_tree[
-                    np.where(last_block[nodes_in_tree] != current_block)
-                ]
-                if len(nodes_to_add) > 0:
-                    idx = np.arange(num_record, num_record + len(nodes_to_add))
-                    last_block[nodes_to_add] = current_block
-                    indices[nodes_to_add] = idx
-                    if table_size < num_record + len(nodes_to_add):
-                        table_size += buffer_size
-                        time = np.pad(time, (0, buffer_size))
-                        block = np.pad(block, (0, buffer_size))
-                        weights = np.pad(weights, ((0, buffer_size), (0, 0)))
-                    time[idx] = [tree.time(i) for i in nodes_to_add]
-                    block[idx] = current_block
-                    num_record += len(nodes_to_add)
-                weights[indices[nodes_in_tree], :] += (
-                    span_weight * running_weights[nodes_in_tree, :]
-                )
+
+                if internal_nodes.size > 0:
+                    accessible_span += tree_span[tree.index - tree_offset]
+                    rows_in_running = np.array(
+                        [running_index[i] for i in internal_nodes], dtype=np.int32
+                    )
+                    nodes_to_add = internal_nodes[
+                        last_block[internal_nodes] != current_block
+                    ]
+                    if nodes_to_add.size > 0:
+                        table_idx = np.arange(
+                            num_record, num_record + len(nodes_to_add)
+                        )
+                        last_block[nodes_to_add] = current_block
+                        indices[nodes_to_add] = table_idx
+                        if table_size < num_record + len(nodes_to_add):
+                            table_size += buffer_size
+                            time = np.pad(time, (0, buffer_size))
+                            block = np.pad(block, (0, buffer_size))
+                            weights = np.pad(weights, ((0, buffer_size), (0, 0)))
+                        time[table_idx] = [tree.time(i) for i in nodes_to_add]
+                        block[table_idx] = current_block
+                        num_record += len(nodes_to_add)
+                    weights[indices[internal_nodes], :] += (
+                        span_weight * running_output[rows_in_running, :]
+                    )
 
             if tree.interval.right < right:
                 # if current tree does not cross window boundary, move to next
                 tree.next()
-                self._update_weights_by_edge_diff(
-                    tree, next(edge_diffs), running_weights
+                self._update_running_with_edge_diff(
+                    tree, next(edge_diffs), running_output, running_state, running_index
                 )
             else:
                 # use current tree as initial tree for next window
                 break
+
+        # reweight span so that weights are averaged over nonmissing trees
+        if self.span_normalise:
+            weights *= total_span / accessible_span
 
         return CoalescenceTimeTable(time, block, weights)
 
@@ -437,11 +548,35 @@ class CoalescenceTimeDistribution:
 
         tree = ts.first()
         edge_diffs = ts.edge_diffs()
-        running_weights = np.zeros((ts.num_nodes, self.num_weights))
-        self._update_weights_by_edge_diff(tree, next(edge_diffs), running_weights)
+
+        # initialize running arrays for first tree
+        running_index = {i: n for i, n in enumerate(tree.samples())}
+        running_output = np.zeros(
+            (self.running_array_size, self.num_weights),
+            dtype=np.float64,
+        )
+        running_state = np.zeros(
+            (self.running_array_size, self.num_states),
+            dtype=np.float64,
+        )
+        for node in tree.samples():
+            state = self._initialize(node, self.sample_sets)
+            for state_index, x in zip(self.state_indices, state):
+                running_state[running_index[node], state_index] = x
+
+        self._update_running_with_edge_diff(
+            tree, next(edge_diffs), running_output, running_state, running_index
+        )
+
         for left, right in zip(window_breaks[:-1], window_breaks[1:]):
             yield self._build_ecdf_table_for_window(
-                left, right, tree, edge_diffs, running_weights
+                left,
+                right,
+                tree,
+                edge_diffs,
+                running_output,
+                running_state,
+                running_index,
             )
 
     def __init__(
@@ -463,18 +598,47 @@ class CoalescenceTimeDistribution:
         self.sample_sets = sample_sets
 
         if weight_func is None or weight_func == "coalescence_events":
-            self.weight_func = self._count_coalescence_events
+            self._initialize, self._update = self._count_coalescence_events()
         elif weight_func == "pair_coalescence_events":
-            self.weight_func = self._count_pair_coalescence_events
+            self._initialize, self._update = self._count_pair_coalescence_events()
         elif weight_func == "trio_first_coalescence_events":
-            self.weight_func = self._count_trio_first_coalescence_events
+            self._initialize, self._update = self._count_trio_first_coalescence_events()
         else:
-            assert callable(weight_func)
-            self.weight_func = weight_func
-        _weight_func_eval = self.weight_func(0, ts.first(), self.sample_sets)
-        assert isinstance(_weight_func_eval, np.ndarray)
-        assert _weight_func_eval.ndim == 1
-        self.num_weights = len(_weight_func_eval)
+            # user supplies pair of callables ``(initialize, update)``
+            assert isinstance(weight_func, tuple)
+            assert len(weight_func) == 2
+            self._initialize, self._update = weight_func
+            assert callable(self._initialize)
+            assert callable(self._update)
+
+        # check initialization operation
+        _state = self._initialize(0, self.sample_sets)
+        assert isinstance(_state, tuple)
+        self.num_states = 0
+        self.state_indices = []
+        for x in _state:
+            # ``assert is_row_vector(x)``
+            assert isinstance(x, np.ndarray)
+            assert x.ndim == 2
+            assert x.shape[0] == 1
+            index = list(range(self.num_states, self.num_states + x.size))
+            self.state_indices.append(index)
+            self.num_states += x.size
+
+        # check update operation
+        _weights, _state = self._update(*_state)
+        assert isinstance(_state, tuple)
+        for state_index, x in zip(self.state_indices, _state):
+            # ``assert is_row_vector(x, len(state_index))``
+            assert isinstance(x, np.ndarray)
+            assert x.ndim == 2
+            assert x.shape[0] == 1
+            assert x.size == len(state_index)
+        # ``assert is_row_vector(_weights)``
+        assert isinstance(_weights, np.ndarray)
+        assert _weights.ndim == 2
+        assert _weights.shape[0] == 1
+        self.num_weights = _weights.size
 
         if window_breaks is None:
             window_breaks = np.array([0.0, ts.sequence_length])
@@ -499,6 +663,7 @@ class CoalescenceTimeDistribution:
         self.span_normalise = span_normalise
 
         self.buffer_size = ts.num_nodes
+        self.running_array_size = ts.num_samples * 2 - 1  # assumes no unary nodes
         self.weight_func_evals = 0
         self.tables = [table for table in self._generate_ecdf_tables(ts, window_breaks)]
 
@@ -533,13 +698,44 @@ class CoalescenceTimeDistribution:
             values[:, :, k] = table.quantile[indices, :].T
         return values
 
-    # TODO
-    #
-    # def quantile(self, times):
-    #   """
-    #   Return interpolated quantiles of coalescence times, using the same
-    #   approach as numpy.quantile(..., method="linear")
-    #   """
+    def quantile(self, quantiles):
+        """
+        Return interpolated quantiles of weighted coalescence times.
+        """
+
+        assert isinstance(quantiles, np.ndarray)
+        assert quantiles.ndim == 1
+        assert np.all(np.logical_and(quantiles >= 0, quantiles <= 1))
+
+        values = np.empty((self.num_weights, quantiles.size, self.num_windows))
+        values[:] = np.nan
+        for k, table in enumerate(self.tables):
+            # retrieve ECDF for each unique timepoint in table
+            last_index = np.flatnonzero(table.time[:-1] != table.time[1:])
+            time = np.append(table.time[last_index], table.time[-1])
+            ecdf = np.append(
+                table.quantile[last_index, :], table.quantile[[-1]], axis=0
+            )
+            for i in range(self.num_weights):
+                if not np.isnan(ecdf[-1, i]):
+                    # interpolation requires strictly increasing arguments, so
+                    # retrieve leftmost x for step-like F(x), including F(0) = 0.
+                    assert ecdf[-1, i] == 1.0
+                    assert ecdf[0, i] == 0.0
+                    delta = ecdf[1:, i] - ecdf[:-1, i]
+                    first_index = 1 + np.flatnonzero(delta > 0)
+
+                    n_eff = first_index.size
+                    weight = delta[first_index - 1]
+                    cum_weight = np.roll(ecdf[first_index, i], 1)
+                    cum_weight[0] = 0
+                    midpoint = np.arange(n_eff) * weight + (n_eff - 1) * cum_weight
+                    assert midpoint[0] == 0
+                    assert midpoint[-1] == n_eff - 1
+                    values[i, :, k] = np.interp(
+                        quantiles * (n_eff - 1), midpoint, time[first_index]
+                    )
+        return values
 
     def num_coalesced(self, times):
         """
@@ -597,11 +793,12 @@ class CoalescenceTimeDistribution:
                 values[:, k] = np.nan
             else:
                 for i in range(self.num_weights):
-                    if table.cum_weights[-1, i] > 0:
-                        multiplier = table.block_multiplier[table.block[index:]]
+                    multiplier = table.block_multiplier[table.block[index:]]
+                    weights = table.weights[index:, i] * multiplier
+                    if np.any(weights > 0):
                         values[i, k] = np.average(
                             table.time[index:] - since,
-                            weights=table.weights[index:, i] * multiplier,
+                            weights=weights,
                         )
         return values
 


### PR DESCRIPTION
Fixes #2614.

- Use a recursive update rather than traversing trees independently for each node (details below).
- For `span_normalise=True`, divide by total span of nonmissing trees rather than total sequence length.
- Add a method to get interpolated quantiles
- Ignore unary nodes during tree traversals
- Test that blocking of nodes (e.g. for bootstrapping) doesn't influence methods

The core algorithm in `CoalescenceTimeDistribution` operates by counting the number of subtrees of a particular tip labeling, that are rooted at each node in a tree. Doing this by brute force involves a lot of redundant calculations. This PR implements a recursive approach that should be a lot more efficient. 

The idea is that a topology with $n$ tips can be constructed from two smaller topologies with $i$ and $n-i$ tips, respectively. So to count the number of topologies with $n$ tips rooted at a given node, we need to know the number of topologies of size $1, \dots, n-1$ rooted at each child of this node.

This is done by splitting the weight function into two parts; `initialize` (that gets called on tips) and `update` (that gets called on internal nodes). These look like:
```
def initialize_trio_count(node, sample_sets):
    # set dimensions based on ``sample_sets``
    n_lineages = np.array(...)
    n_pairs = np.array(...)

    return (n_lineages, n_pairs)

def update_trio_count(n_lineages_in_children, n_pairs_in_children)
    # get counts of lower-order topologies rooted at node, from counts in children
    n_lineages = np.sum(n_lineages_in_children, axis=...)
    n_pairs = combinatorial_function_of(n_lineages_in_children)

    # calculate desired weight
    n_trios = combinatorial_function_of(n_lineages_in_children, n_pairs_in_children)

    return n_trios, (n_lineages, n_pairs)
```
In other words, ``initialize`` sets the dimensions of a propagated "state" (counts of lower-order topologies); while ``update`` uses the states of children to: (A) calculate the state for the parent (in this case the tuple ``(n_lineages, n_pairs)``; (B) calculate the desired weight (in this case ``n_trios``).