### PR TITLE
edit typo

### DIFF
--- a/docs/stats.md
+++ b/docs/stats.md
@@ -422,7 +422,7 @@ we'd calculate divergence with `span_normalise=False`.
 
 Following on from above, suppose we computed the statistic `S` with
 `windows = [0, a, b]` and `span_normalise=True`,
-and then computed `T` in just the same way except with `span_normalize=False`.
+and then computed `T` in just the same way except with `span_normalise=False`.
 Then `S[0]` would be equal to `T[0] / a` and `S[1] = T[1] / (b - a)`.
 Furthermore, the value obtained with `windows = [0, b]` would be equal to `T[0] + T[1]`.
 However, you probably usually want the (default) normalized version:


### PR DESCRIPTION
Following up on https://github.com/tskit-dev/tskit/issues/2642

span_normalize=False should be span_normalise=False to be consistent with parameter names

## Description

Thanks for contributing to tskit! :heart:
A guide to the PR process is [here](https://tskit.readthedocs.io/en/latest/development.html#development_workflow_git)
Please replace this text with a summary of the change and which issue is fixed, if any. Please also include relevant motivation and context.

Fixes #(issue) <- Putting the issue number here will auto-close the issue when this PR is merged 

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
