### PR TITLE
Skip empty

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,9 @@
 
 **Features**
 
+- A new ``Tree.is_empty`` method can be used to determine if a tree is empty
+  for 2 definitions of emptiness (:user:`hyanwong`, :pr:`2668`, :issue:`2640`)
+
 - The ``TreeSequence`` object now has the attributes ``min_time`` and ``max_time``,
   which are the minimum and maximum among the node times and mutation times,
   respectively. (:user:`szhan`, :pr:`2612`, :issue:`2271`)

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -851,6 +851,35 @@ class Tree:
             raise ValueError("Position out of bounds")
         self._ll_tree.seek(position)
 
+    def is_empty(self, check_roots=None) -> bool:
+        """
+        Check if this tree is "empty" (i.e. has no topology). A tree is empty if it has
+        no edges. However, it may also be considered empty if it contains edges which
+        represent :ref:`dead branches<sec_data_model_tree_dead_leaves_and_branches>`
+        (i.e. not reachable from the :meth:`~Tree.roots` of the tree). To consider such
+        a tree as empty too, which is more involved, specify ``check_roots=True``.
+
+        Note that this is purely a property of the topology. An "empty" tree can still
+        contain sites and there may even be mutations on those sites.
+
+        :param bool check_roots: Should we also consider a tree empty if it has
+            topology but the topology is unconnected to any of the roots of the tree?
+            Default: ``None`` treated as ``False``.
+        :return: ``True`` if this tree is empty, ``False`` otherwise.
+        """
+        if self.num_edges == 0:
+            return True
+
+        if not check_roots:
+            return False
+
+        # Exhaustively check the roots: it's not simply enough to check that the roots
+        # are all samples, as they could still have children
+        for u in self.roots:
+            if self.num_children(u) != 0:
+                return False
+        return True
+
     def rank(self) -> tskit.Rank:
         """
         Produce the rank of this tree in the enumeration of all leaf-labelled


### PR DESCRIPTION
## Description

Based off #2668, and fixes #2600. I'm not sure if storing the `skip_empty` value as a python attribute in the `Tree` class is the right approach (it's not what's done for root_threshold) but from the tests it appears as if the call signature of `Tree()` and `ts.trees()` should be the same. Otherwise I would just have this as a parameter sent to the `TreeIterator` iterator class from the `ts.trees()` method, and not bother storing it in the `Tree` class itself.

Suggestions for other approaches welcome

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
