### PR TITLE
Shorthand filter_all argument for simplify

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -4,6 +4,9 @@
 
 **Features**
 
+- A new ``filter_all`` parameter for simplify allows all filter_x params to be set
+  simultaneously (:user:`hyanwong`, :pr:`2681`, :issue:`2607`)
+
 - A new ``Tree.is_root`` method avoids the need to to search the potentially
   large list of ``Tree.roots`` (:user:`hyanwong`, :pr:`2669`, :issue:`2620`)
 

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2022 Tskit Developers
+# Copyright (c) 2019-2023 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -112,15 +112,22 @@ class Simplifier:
         keep_unary_in_individuals=False,
         keep_input_roots=False,
         filter_nodes=True,  # If this is False, the order in `sample` is ignored
+        filter_all=None,  # Shorthand to set all other filter args at once
     ):
         self.ts = ts
         self.n = len(sample)
         self.reduce_to_site_topology = reduce_to_site_topology
         self.sequence_length = ts.sequence_length
-        self.filter_sites = filter_sites
-        self.filter_populations = filter_populations
-        self.filter_individuals = filter_individuals
-        self.filter_nodes = filter_nodes
+        if filter_all is not None:
+            self.filter_sites = filter_all
+            self.filter_populations = filter_all
+            self.filter_individuals = filter_all
+            self.filter_nodes = filter_all
+        else:
+            self.filter_sites = filter_sites
+            self.filter_populations = filter_populations
+            self.filter_individuals = filter_individuals
+            self.filter_nodes = filter_nodes
         self.keep_unary = keep_unary
         self.keep_unary_in_individuals = keep_unary_in_individuals
         self.keep_input_roots = keep_input_roots

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2018-2022 Tskit Developers
+# Copyright (c) 2018-2023 Tskit Developers
 # Copyright (c) 2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -3349,6 +3349,7 @@ class TableCollection(metadata.MetadataProvider):
         filter_individuals=None,
         filter_sites=None,
         filter_nodes=None,
+        filter_all=None,
         keep_unary=False,
         keep_unary_in_individuals=None,
         keep_input_roots=False,
@@ -3416,6 +3417,13 @@ class TableCollection(metadata.MetadataProvider):
             potential change to the node table may be to change the node flags
             (if ``samples`` is specified and different from the existing samples).
             (Default: None, treated as True)
+        :param bool filter_all: Shorthand for simultaneously setting all the ``filter_X``
+            parameters. Set to False for minimal simplification of the tree sequence,
+            such that the only altered tables are the edge table and potentially, the
+            flags in the node table (this only if the ``samples`` change, as described
+            in the ``filter_nodes`` parameter). If None, this parameter has no effect.
+            If any other value and any ``filter_X`` parameter has been set,
+            an error will be raised. (Default: None)
         :param bool keep_unary: If True, preserve unary nodes (i.e. nodes with
             exactly one child) that exist on the path from samples to root.
             (Default: False)
@@ -3451,14 +3459,34 @@ class TableCollection(metadata.MetadataProvider):
             ].astype(np.int32)
         else:
             samples = util.safe_np_int_cast(samples, np.int32)
-        if filter_populations is None:
-            filter_populations = True
-        if filter_individuals is None:
-            filter_individuals = True
-        if filter_sites is None:
-            filter_sites = True
-        if filter_nodes is None:
-            filter_nodes = True
+        if filter_all is not None:
+            if any(
+                [
+                    filter_x is not None
+                    for filter_x in (
+                        filter_populations,
+                        filter_individuals,
+                        filter_sites,
+                        filter_nodes,
+                    )
+                ]
+            ):
+                raise ValueError(
+                    "Cannot combine `filter_all` with other `filter_X` parameters"
+                )
+            filter_populations = filter_all
+            filter_individuals = filter_all
+            filter_sites = filter_all
+            filter_nodes = filter_all
+        else:
+            if filter_populations is None:
+                filter_populations = True
+            if filter_individuals is None:
+                filter_individuals = True
+            if filter_sites is None:
+                filter_sites = True
+            if filter_nodes is None:
+                filter_nodes = True
         if keep_unary_in_individuals is None:
             keep_unary_in_individuals = False
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6516,6 +6516,7 @@ class TreeSequence:
         filter_individuals=None,
         filter_sites=None,
         filter_nodes=None,
+        filter_all=None,
         keep_unary=False,
         keep_unary_in_individuals=None,
         keep_input_roots=False,
@@ -6589,6 +6590,13 @@ class TreeSequence:
             potential change to the node table may be to change the node flags
             (if ``samples`` is specified and different from the existing samples).
             (Default: None, treated as True)
+        :param bool filter_all: Shorthand for simultaneously setting all the ``filter_X``
+            parameters. Set to False for minimal simplification of the tree sequence,
+            such that the only altered tables are the edge table and potentially, the
+            flags in the node table (this only if the ``samples`` change, as described
+            in the ``filter_nodes`` parameter). If None, this parameter has no effect.
+            If any other value and any ``filter_X`` parameter has been set,
+            an error will be raised. (Default: None)
         :param bool keep_unary: If True, preserve unary nodes (i.e., nodes with
             exactly one child) that exist on the path from samples to root.
             (Default: False)
@@ -6621,6 +6629,7 @@ class TreeSequence:
             filter_individuals=filter_individuals,
             filter_sites=filter_sites,
             filter_nodes=filter_nodes,
+            filter_all=filter_all,
             keep_unary=keep_unary,
             keep_unary_in_individuals=keep_unary_in_individuals,
             keep_input_roots=keep_input_roots,


### PR DESCRIPTION
## Description

Fixes #2607. Changed param name to `filter_all` to avoid shadowing the builtin python function, although I'm happy to change it to `filter` and ignore flake8 complaints

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
