### PR TITLE
implementing Variant.__repr__

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,4 +1,14 @@
 --------------------
+[0.5.5] - 2023-01-XX
+--------------------
+
+**Features**
+
+- Add ``__repr__`` for variants to return a string representation of the raw data
+  without spewing megabytes of text (:user:`chriscrsmith`, :pr:`2695`, :issue:`2694`)
+
+  
+--------------------
 [0.5.4] - 2023-01-13
 --------------------
 

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2022 Tskit Developers
+# Copyright (c) 2019-2023 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -2215,3 +2215,17 @@ class TestVariant:
         html = v._repr_html_()
         ElementTree.fromstring(html)
         assert len(html) > 1600
+
+    def test_variant_repr(self, ts_fixture):
+        v = next(ts_fixture.variants())
+        str_rep = repr(v)
+        assert len(str_rep) > 0 and len(str_rep) < 10000
+        assert re.search(r"\AVariant", str_rep)
+        assert re.search(rf"\'site\': Site\(id={v.site.id}", str_rep)
+        assert re.search(rf"position={v.position}", str_rep)
+        alleles = re.escape("'alleles': " + str(v.alleles))
+        assert re.search(rf"{alleles}", str_rep)
+        assert re.search(r"\'genotypes\': array\(\[", str_rep)
+        assert re.search(rf"position={v.position}", str_rep)
+        assert re.search(rf"\'has_missing_data\': {v.has_missing_data}", str_rep)
+        assert re.search(rf"\'isolated_as_missing\': {v.isolated_as_missing}", str_rep)

--- a/python/tskit/genotypes.py
+++ b/python/tskit/genotypes.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2018-2022 Tskit Developers
+# Copyright (c) 2018-2023 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -339,6 +339,17 @@ class Variant:
         to render a Variant.
         """
         return util.variant_html(self)
+
+    def __repr__(self):
+        d = {
+            "site": self.site,
+            "samples": self.samples,
+            "alleles": self.alleles,
+            "genotypes": self.genotypes,
+            "has_missing_data": self.has_missing_data,
+            "isolated_as_missing": self.isolated_as_missing,
+        }
+        return f"Variant({repr(d)})"
 
 
 #


### PR DESCRIPTION
## Description

Returning a string representation of the raw data for a variant without spewing megabytes of text.                                                                                 

Fixes #2694 

Notes:
- If a site has experienced many mutations (as with one of the test cases), the repr() output can be quite large (~6600 characters for one test case). I left this as is for now.
- added a test, checking that `len(repr(variant)) < 10000`
- I didn't add anything to the docs yet


# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
