### PR TITLE
Don't fail CI on codecov error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: python
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: python-tests
           name: codecov-umbrella
           verbose: true


### PR DESCRIPTION
Fixes #2714 

This doesn't remove the push - but instead makes CI continue on a failed push. (except for circle CI which is still required)