### PR TITLE
Md null schema

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -24,6 +24,9 @@
   in the presence of non-ancestral material (very rare).
   (:user:`petrelharp`, :issue:`2983`, :pr:`1623`)
 
+- Printing ``tskit.MetadataSchema(schema=None)`` now shows ``"Null_schema"`` rather
+  than ``None``, to avoid confusion (:user:`hyanwong`, :pr:`2720`)
+
 **Features**
 
 - Add ``TreeSequence.extend_haplotypes`` method that extends ancestral haplotypes
@@ -110,8 +113,7 @@
 - Add ``__repr__`` for variants to return a string representation of the raw data
   without spewing megabytes of text (:user:`chriscrsmith`, :pr:`2695`, :issue:`2694`)
 
-- Add ``keep_rows`` method to table classes to support efficient in-place
-  table subsetting (:user:`jeromekelleher`, :pr:`2700`)
+**Breaking Changes**
 
 **Bugfixes**
 

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -322,7 +322,10 @@ class TestMetadataModule:
             "required": ["one", "two"],
             "additionalProperties": False,
         }
-        assert str(metadata.MetadataSchema(schema)) == pprint.pformat(schema)
+        assert (
+            str(metadata.MetadataSchema(schema))
+            == f"tskit.MetadataSchema(\n{pprint.pformat(schema)}\n)"
+        )
 
     def test_register_codec(self):
         class TestCodec(metadata.AbstractMetadataCodec):

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1396,7 +1396,7 @@ class AssertEqualsMixin:
             table2.metadata_schema = tskit.MetadataSchema({"codec": "json"})
             with pytest.raises(
                 AssertionError,
-                match=f"{type(table_5row).__name__} metadata schemas differ:",
+                match=f"{type(table_5row).__name__} metadata schemas differ: ",
             ):
                 table_5row.assert_equals(table2)
             table_5row.assert_equals(table2, ignore_metadata=True)
@@ -4089,7 +4089,7 @@ class TestTableCollectionAssertEquals:
         t2.metadata_schema = tskit.MetadataSchema(None)
         with pytest.raises(
             AssertionError,
-            match=re.escape("Metadata schemas differ"),
+            match=re.escape("Metadata schemas differ:"),
         ):
             t1.assert_equals(t2)
         t1.assert_equals(t2, ignore_metadata=True)
@@ -4193,7 +4193,7 @@ class TestTableCollectionAssertEquals:
         t2.reference_sequence.clear()
         with pytest.raises(
             AssertionError,
-            match=re.escape("Metadata schemas differ"),
+            match=re.escape("Metadata schemas differ: "),
         ):
             t1.assert_equals(t2)
         t1.assert_equals(t2, ignore_reference_sequence=True)

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -664,7 +664,14 @@ class MetadataSchema:
         return self._string
 
     def __str__(self) -> str:
-        return pprint.pformat(self._schema)
+        if isinstance(self._schema, collections.OrderedDict):
+            s = pprint.pformat(dict(self._schema))
+        else:
+            s = pprint.pformat(self._schema)
+        if "\n" in s:
+            return f"tskit.MetadataSchema(\n{s}\n)"
+        else:
+            return f"tskit.MetadataSchema({s})"
 
     def __eq__(self, other) -> bool:
         return self._string == other._string


### PR DESCRIPTION
While thinking with metadata for the `tskit` poster, I remembered this on the queue. As discussed with @benjeffery - this is mostly a documentation PR, but it also changes behaviour so that `str(tskit.MetadataSchema(schema=None))` returns `"Null_schema"` rather than `None`, which was pretty confusing, because `tskit.MetadataSchema(schema=None) is None` always returns `False`.

