### PR TITLE
compute mutation parents on text input

### DIFF
--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -3739,13 +3739,13 @@ test_simplest_mutation_edges(void)
     const char *mutations = "0    1     1\n"
                             "0    0     1\n"
                             "0    2     1\n"
+                            "1    2     1\n"
                             "1    0     1\n"
-                            "1    1     1\n"
-                            "1    2     1\n";
+                            "1    1     1\n";
     tsk_treeseq_t ts;
     tsk_tree_t tree;
     /* We have mutations over roots, samples and just isolated nodes */
-    tsk_id_t mutation_edges[] = { -1, 0, -1, 1, -1, -1 };
+    tsk_id_t mutation_edges[] = { -1, 0, -1, -1, 1, -1 };
     tsk_size_t i, j, k, t;
     tsk_mutation_t mut;
     tsk_site_t site;

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -782,6 +782,8 @@ tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nod
         }
     }
 
+    ret = tsk_table_collection_build_index(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_compute_mutation_parents(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -782,6 +782,9 @@ tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nod
         }
     }
 
+    ret = tsk_table_collection_compute_mutation_parents(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
     ret = tsk_treeseq_init(ts, &tables, TSK_TS_INIT_BUILD_INDEXES);
     /* tsk_treeseq_print_state(ts, stdout); */
     /* printf("ret = %s\n", tsk_strerror(ret)); */


### PR DESCRIPTION
Over in #2729 we saw a bug due to not computing mutation parents on text input. This isn't really a bug, as the text input is not part of the public API, but I could easily imagine us making the same error in test code.

(More generally we ought to think about doing this as part of tree sequence instantiation; I seem to recall us having a reason not to do it, but I don't remember specifically what it was?)