### PR TITLE
Backwards algorithm (haploid) tree implementation and testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
             /usr/share/miniconda/envs/anaconda-client-env
             ~/osx-conda
             ~/.profile
-          key: ${{ runner.os }}-${{ matrix.python}}-conda-v11-${{ hashFiles('python/requirements/CI-tests-conda/requirements.txt') }}-${{ hashFiles('python/requirements/CI-tests-pip/requirements.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python}}-conda-v12-${{ hashFiles('python/requirements/CI-tests-conda/requirements.txt') }}-${{ hashFiles('python/requirements/CI-tests-pip/requirements.txt') }}
 
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2

--- a/python/requirements/CI-tests-pip/requirements.txt
+++ b/python/requirements/CI-tests-pip/requirements.txt
@@ -1,4 +1,4 @@
-lshmm==0.0.4; python_version < '3.11'
+lshmm==0.0.4
 numpy==1.21.6; python_version < '3.11' # Held at 1.21.6 for Python 3.7 compatibility
 numpy==1.24.1; python_version > '3.10'
 pytest==7.1.3

--- a/python/tests/test_genotype_matching_fb.py
+++ b/python/tests/test_genotype_matching_fb.py
@@ -754,7 +754,6 @@ class BackwardAlgorithm(LsHmmAlgorithm):
         query_is_missing,
     ):
         mu = self.mu[site_id]
-
         template_is_hom = np.logical_not(template_is_het)
 
         if query_is_missing:

--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2021 Tskit Developers
+# Copyright (c) 2019-2023 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,332 +20,55 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """
-Python implementation of the Li and Stephens algorithms.
+Python implementation of the Li and Stephens forwards and backwards algorithms.
 """
 import itertools
-import unittest
 
+import lshmm as ls
 import msprime
 import numpy as np
-import pytest
 
-import _tskit  # TMP
 import tskit
-from tests import tsutil
+
+MISSING = -1
 
 
-def in_sorted(values, j):
-    # Take advantage of the fact that the numpy array is sorted.
-    ret = False
-    index = np.searchsorted(values, j)
-    if index < values.shape[0]:
-        ret = values[index] == j
-    return ret
-
-
-def ls_forward_matrix_naive(h, alleles, G, rho, mu):
-    """
-    Simple matrix based method for LS forward algorithm using Python loops.
-    """
-    assert rho[0] == 0
-    m, n = G.shape
-    alleles = check_alleles(alleles, m)
-    F = np.zeros((m, n))
-    S = np.zeros(m)
-    f = np.zeros(n) + 1 / n
-
-    for el in range(0, m):
-        for j in range(n):
-            # NOTE Careful with the difference between this expression and
-            # the Viterbi algorithm below. This depends on the different
-            # normalisation approach.
-            p_t = f[j] * (1 - rho[el]) + rho[el] / n
-            p_e = mu[el]
-            if G[el, j] == h[el] or h[el] == tskit.MISSING_DATA:
-                p_e = 1 - (len(alleles[el]) - 1) * mu[el]
-            f[j] = p_t * p_e
-        S[el] = np.sum(f)
-        # TODO need to handle the 0 case.
-        assert S[el] > 0
-        f /= S[el]
-        F[el] = f
-    return F, S
-
-
-def ls_viterbi_naive(h, alleles, G, rho, mu):
-    """
-    Simple matrix based method for LS Viterbi algorithm using Python loops.
-    """
-    assert rho[0] == 0
-    m, n = G.shape
-    alleles = check_alleles(alleles, m)
-    L = np.ones(n)
-    T = [set() for _ in range(m)]
-    T_dest = np.zeros(m, dtype=int)
-
-    for el in range(m):
-        # The calculation below is undefined otherwise.
-        if len(alleles[el]) > 1:
-            assert mu[el] <= 1 / (len(alleles[el]) - 1)
-        L_next = np.zeros(n)
-        for j in range(n):
-            # NOTE Careful with the difference between this expression and
-            # the Forward algorithm above. This depends on the different
-            # normalisation approach.
-            p_no_recomb = L[j] * (1 - rho[el] + rho[el] / n)
-            p_recomb = rho[el] / n
-            if p_no_recomb > p_recomb:
-                p_t = p_no_recomb
-            else:
-                p_t = p_recomb
-                T[el].add(j)
-            p_e = mu[el]
-            if G[el, j] == h[el] or h[el] == tskit.MISSING_DATA:
-                p_e = 1 - (len(alleles[el]) - 1) * mu[el]
-            L_next[j] = p_t * p_e
-        L = L_next
-        j = np.argmax(L)
-        T_dest[el] = j
-        if L[j] == 0:
-            assert mu[el] == 0
-            raise ValueError(
-                "Trying to match non-existent allele with zero mutation rate"
-            )
-        L /= L[j]
-
-    P = np.zeros(m, dtype=int)
-    P[m - 1] = T_dest[m - 1]
-    for el in range(m - 1, 0, -1):
-        j = P[el]
-        if j in T[el]:
-            j = T_dest[el - 1]
-        P[el - 1] = j
-    return P
-
-
-def ls_viterbi_vectorised(h, alleles, G, rho, mu):
-    # We must have a non-zero mutation rate, or we'll end up with
-    # division by zero problems.
-    # assert np.all(mu > 0)
-
-    m, n = G.shape
-    alleles = check_alleles(alleles, m)
-    V = np.ones(n)
-    T = [None for _ in range(m)]
-    max_index = np.zeros(m, dtype=int)
-
-    for site in range(m):
-        # Transition
-        p_neq = rho[site] / n
-        p_t = (1 - rho[site] + rho[site] / n) * V
-        recombinations = np.where(p_neq > p_t)[0]
-        p_t[recombinations] = p_neq
-        T[site] = recombinations
-        # Emission
-        p_e = np.zeros(n) + mu[site]
-        index = G[site] == h[site]
-        if h[site] == tskit.MISSING_DATA:
-            # Missing data is considered equal to everything
-            index[:] = True
-        p_e[index] = 1 - (len(alleles[site]) - 1) * mu[site]
-        V = p_t * p_e
-        # Normalise
-        max_index[site] = np.argmax(V)
-        # print(site, ":", V)
-        if V[max_index[site]] == 0:
-            assert mu[site] == 0
-            raise ValueError(
-                "Trying to match non-existent allele with zero mutation rate"
-            )
-        V /= V[max_index[site]]
-
-    # Traceback
-    P = np.zeros(m, dtype=int)
-    site = m - 1
-    P[site] = max_index[site]
-    while site > 0:
-        j = P[site]
-        if in_sorted(T[site], j):
-            j = max_index[site - 1]
-        P[site - 1] = j
-        site -= 1
-    return P
-
-
-def check_alleles(alleles, num_sites):
+def check_alleles(alleles, m):
     """
     Checks the specified allele list and returns a list of lists
     of alleles of length num_sites.
-
     If alleles is a 1D list of strings, assume that this list is used
     for each site and return num_sites copies of this list.
-
     Otherwise, raise a ValueError if alleles is not a list of length
     num_sites.
     """
     if isinstance(alleles[0], str):
-        return [alleles for _ in range(num_sites)]
-    if len(alleles) != num_sites:
+        return [alleles for _ in range(m)], np.int8([len(alleles) for _ in range(m)])
+    if len(alleles) != m:
         raise ValueError("Malformed alleles list")
-    return alleles
+    n_alleles = np.int8([(len(alleles_site)) for alleles_site in alleles])
+    return alleles, n_alleles
 
 
-def ls_forward_matrix(h, alleles, G, rho, mu):
+def mirror_coordinates(ts):
     """
-    Simple matrix based method for LS forward algorithm using numpy vectorisation.
+    Returns a copy of the specified tree sequence in which all
+    coordinates x are transformed into L - x.
     """
-    assert rho[0] == 0
-    m, n = G.shape
-    alleles = check_alleles(alleles, m)
-    F = np.zeros((m, n))
-    S = np.zeros(m)
-    f = np.zeros(n) + 1 / n
-    p_e = np.zeros(n)
-
-    for el in range(0, m):
-        p_t = f * (1 - rho[el]) + rho[el] / n
-        eq = G[el] == h[el]
-        if h[el] == tskit.MISSING_DATA:
-            # Missing data is equal to everything
-            eq[:] = True
-        p_e[:] = mu[el]
-        p_e[eq] = 1 - (len(alleles[el]) - 1) * mu[el]
-        f = p_t * p_e
-        S[el] = np.sum(f)
-        # TODO need to handle the 0 case.
-        assert S[el] > 0
-        f /= S[el]
-        F[el] = f
-    return F, S
-
-
-def forward_matrix_log_proba(F, S):
-    """
-    Given the specified forward matrix and scaling factor array, return the
-    overall log probability of the input haplotype.
-    """
-    return np.sum(np.log(S)) - np.log(np.sum(F[-1]))
-
-
-def ls_forward_matrix_unscaled(h, alleles, G, rho, mu):
-    """
-    Simple matrix based method for LS forward algorithm.
-    """
-    assert rho[0] == 0
-    m, n = G.shape
-    alleles = check_alleles(alleles, m)
-    F = np.zeros((m, n))
-    f = np.zeros(n) + 1 / n
-
-    for el in range(0, m):
-        s = np.sum(f)
-        for j in range(n):
-            p_t = f[j] * (1 - rho[el]) + s * rho[el] / n
-            p_e = mu[el]
-            if G[el, j] == h[el] or h[el] == tskit.MISSING_DATA:
-                p_e = 1 - (len(alleles[el]) - 1) * mu[el]
-            f[j] = p_t * p_e
-        F[el] = f
-    return F
-
-
-# TODO change this to use the log_proba function below.
-def ls_path_probability(h, path, G, rho, mu):
-    """
-    Returns the probability of the specified path through the genotypes for the
-    specified haplotype.
-    """
-    # Assuming num_alleles = 2
-    assert rho[0] == 0
-    m, n = G.shape
-    # TODO It's not entirely clear why we're starting with a proba of 1 / n for the
-    # model. This was done because it made it easier to compare with an existing
-    # HMM implementation. Need to figure this one out when writing up.
-    proba = 1 / n
-    for site in range(0, m):
-        pe = mu[site]
-        if h[site] == G[site, path[site]] or h[site] == tskit.MISSING_DATA:
-            pe = 1 - mu[site]
-        pt = rho[site] / n
-        if site == 0 or path[site] == path[site - 1]:
-            pt = 1 - rho[site] + rho[site] / n
-        proba *= pt * pe
-    return proba
-
-
-def ls_path_log_probability(h, path, alleles, G, rho, mu):
-    """
-    Returns the log probability of the specified path through the genotypes for the
-    specified haplotype.
-    """
-    assert rho[0] == 0
-    m, n = G.shape
-    alleles = check_alleles(alleles, m)
-    # TODO It's not entirely clear why we're starting with a proba of 1 / n for the
-    # model. This was done because it made it easier to compare with an existing
-    # HMM implementation. Need to figure this one out when writing up.
-    log_proba = np.log(1 / n)
-    for site in range(0, m):
-        if len(alleles[site]) > 1:
-            assert mu[site] <= 1 / (len(alleles[site]) - 1)
-        pe = mu[site]
-        if h[site] == G[site, path[site]] or h[site] == tskit.MISSING_DATA:
-            pe = 1 - (len(alleles[site]) - 1) * mu[site]
-        assert 0 <= pe <= 1
-        pt = rho[site] / n
-        if site == 0 or path[site] == path[site - 1]:
-            pt = 1 - rho[site] + rho[site] / n
-        assert 0 <= pt <= 1
-        log_proba += np.log(pt) + np.log(pe)
-    return log_proba
-
-
-def ls_forward_tree(h, alleles, ts, rho, mu, precision=30, use_lib=True):
-    """
-    Forward matrix computation based on a tree sequence.
-    """
-    if use_lib:
-        acgt_alleles = tuple(alleles) == tskit.ALLELES_ACGT
-        ls_hmm = _tskit.LsHmm(
-            ts.ll_tree_sequence,
-            recombination_rate=rho,
-            mutation_rate=mu,
-            precision=precision,
-            acgt_alleles=acgt_alleles,
-        )
-        cm = _tskit.CompressedMatrix(ts.ll_tree_sequence)
-        ls_hmm.forward_matrix(h, cm)
-        return cm
-    else:
-        fa = ForwardAlgorithm(ts, rho, mu, alleles, precision=precision)
-        return fa.run(h)
-
-
-def ls_viterbi_tree(h, alleles, ts, rho, mu, precision=30, use_lib=True):
-    """
-    Viterbi path computation based on a tree sequence.
-    """
-    if use_lib:
-        acgt_alleles = tuple(alleles) == tskit.ALLELES_ACGT
-        ls_hmm = _tskit.LsHmm(
-            ts.ll_tree_sequence,
-            recombination_rate=rho,
-            mutation_rate=mu,
-            precision=precision,
-            acgt_alleles=acgt_alleles,
-        )
-        vm = _tskit.ViterbiMatrix(ts.ll_tree_sequence)
-        ls_hmm.viterbi_matrix(h, vm)
-        return vm
-    else:
-        va = ViterbiAlgorithm(ts, rho, mu, alleles, precision=precision)
-        return va.run(h)
+    L = ts.sequence_length
+    tables = ts.dump_tables()
+    left = tables.edges.left
+    right = tables.edges.right
+    tables.edges.left = L - right
+    tables.edges.right = L - left
+    tables.sites.position = L - tables.sites.position  # + 1
+    # TODO migrations.
+    tables.sort()
+    return tables.tree_sequence()
 
 
 class ValueTransition:
-    """
-    Simple struct holding value transition values.
-    """
+    """Simple struct holding value transition values."""
 
     def __init__(self, tree_node=-1, value=-1, value_index=-1):
         self.tree_node = tree_node
@@ -353,7 +76,11 @@ class ValueTransition:
         self.value_index = value_index
 
     def copy(self):
-        return ValueTransition(self.tree_node, self.value, self.value_index)
+        return ValueTransition(
+            self.tree_node,
+            self.value,
+            self.value_index,
+        )
 
     def __repr__(self):
         return repr(self.__dict__)
@@ -367,11 +94,12 @@ class LsHmmAlgorithm:
     Abstract superclass of Li and Stephens HMM algorithm.
     """
 
-    def __init__(self, ts, rho, mu, alleles, precision=10):
+    def __init__(
+        self, ts, rho, mu, alleles, n_alleles, precision=10, scale_mutation=False
+    ):
         self.ts = ts
         self.mu = mu
         self.rho = rho
-        self.alleles = check_alleles(alleles, ts.num_sites)
         self.precision = precision
         # The array of ValueTransitions.
         self.T = []
@@ -386,6 +114,10 @@ class LsHmmAlgorithm:
         self.parent = np.zeros(self.ts.num_nodes, dtype=int) - 1
         self.tree = tskit.Tree(self.ts)
         self.output = None
+        # Vector of the number of alleles at each site
+        self.n_alleles = n_alleles
+        self.alleles = alleles
+        self.scale_mutation_based_on_n_alleles = scale_mutation
 
     def check_integrity(self):
         M = [st.tree_node for st in self.T if st.tree_node != -1]
@@ -422,10 +154,6 @@ class LsHmmAlgorithm:
                 for j in range(num_values):
                     value_count[j] += child[j]
             max_value_count = np.max(value_count)
-            # NOTE: we need to set the set to zero here because we actually
-            # visit some nodes more than once during the postorder traversal.
-            # This would seem to be wasteful, so we should revisit this when
-            # cleaning up the algorithm logic.
             optimal_set[u, :] = 0
             optimal_set[u, value_count == max_value_count] = 1
 
@@ -566,9 +294,9 @@ class LsHmmAlgorithm:
         T = self.T
         alleles = self.alleles[site.id]
         allelic_state = self.allelic_state
-
         # Set the allelic_state for this site.
         allelic_state[tree.root] = alleles.index(site.ancestral_state)
+
         for mutation in site.mutations:
             u = mutation.node
             allelic_state[u] = alleles.index(mutation.derived_state)
@@ -590,8 +318,7 @@ class LsHmmAlgorithm:
                     v = tree.parent(v)
                     assert v != -1
                 match = (
-                    haplotype_state == tskit.MISSING_DATA
-                    or haplotype_state == allelic_state[v]
+                    haplotype_state == MISSING or haplotype_state == allelic_state[v]
                 )
                 st.value = self.compute_next_probability(site.id, st.value, match, u)
 
@@ -600,31 +327,41 @@ class LsHmmAlgorithm:
         for mutation in site.mutations:
             allelic_state[mutation.node] = -1
 
-    def process_site(self, site, haplotype_state):
-        # print(site.id, "num_transitions=", len(self.T))
-        self.update_probabilities(site, haplotype_state)
-        # FIXME We don't want to call compress here.
-        # What we really want to do is just call compress after
-        # the values have been normalised and rounded. However, we can't
-        # compute the normalisation factor in the forwards algorithm without
-        # the N counts (number of samples directly below each value transition
-        # in T), and these are currently computed during compress. So to make
-        # things work for now we call compress before and put up with having
-        # a slightly less than optimally compressed output matrix. It might
-        # end up that this makes no difference and compressing the
-        # pre-rounded values is basically the same thing.
-        self.compress()
-        s = self.compute_normalisation_factor()
-        for st in self.T:
-            if st.tree_node != tskit.NULL:
-                st.value /= s
-                st.value = round(st.value, self.precision)
-        # *This* is where we want to compress (and can, for viterbi).
-        # self.compress()
-        self.output.store_site(site.id, s, [(st.tree_node, st.value) for st in self.T])
+    def process_site(self, site, haplotype_state, forwards=True):
+        if forwards:
+            # Forwards algorithm, or forwards pass in Viterbi
+            self.update_probabilities(site, haplotype_state)
+            self.compress()
+            s = self.compute_normalisation_factor()
+            for st in self.T:
+                if st.tree_node != tskit.NULL:
+                    st.value /= s
+                    st.value = round(st.value, self.precision)
+            self.output.store_site(
+                site.id, s, [(st.tree_node, st.value) for st in self.T]
+            )
+        else:
+            # Backwards algorithm
+            self.output.store_site(
+                site.id,
+                self.output.normalisation_factor[site.id],
+                [(st.tree_node, st.value) for st in self.T],
+            )
+            self.update_probabilities(site, haplotype_state)
+            self.compress()
+            b_last_sum = self.compute_normalisation_factor()
+            s = self.output.normalisation_factor[site.id]
+            for st in self.T:
+                if st.tree_node != tskit.NULL:
+                    st.value = (
+                        self.rho[site.id] / self.ts.num_samples
+                    ) * b_last_sum + (1 - self.rho[site.id]) * st.value
+                    st.value /= s
+                    st.value = round(st.value, self.precision)
 
-    def run(self, h):
+    def run_forward(self, h):
         n = self.ts.num_samples
+        self.tree.clear()
         for u in self.ts.samples():
             self.T_index[u] = len(self.T)
             self.T.append(ValueTransition(tree_node=u, value=1 / n))
@@ -632,6 +369,17 @@ class LsHmmAlgorithm:
             self.update_tree()
             for site in self.tree.sites():
                 self.process_site(site, h[site.id])
+        return self.output
+
+    def run_backward(self, h):
+        self.tree.clear()
+        for u in self.ts.samples():
+            self.T_index[u] = len(self.T)
+            self.T.append(ValueTransition(tree_node=u, value=1))
+        while self.tree.next():
+            self.update_tree()
+            for site in self.tree.sites():
+                self.process_site(site, h[site.id], forwards=False)
         return self.output
 
     def compute_normalisation_factor(self):
@@ -650,12 +398,16 @@ class CompressedMatrix:
     values are on the path).
     """
 
-    def __init__(self, ts):
+    def __init__(self, ts, normalisation_factor=None):
         self.ts = ts
         self.num_sites = ts.num_sites
         self.num_samples = ts.num_samples
         self.value_transitions = [None for _ in range(self.num_sites)]
-        self.normalisation_factor = np.zeros(self.num_sites)
+        if normalisation_factor is None:
+            self.normalisation_factor = np.zeros(self.num_sites)
+        else:
+            self.normalisation_factor = normalisation_factor
+            assert len(self.normalisation_factor) == self.num_sites
 
     def store_site(self, site, normalisation_factor, value_transitions):
         self.normalisation_factor[site] = normalisation_factor
@@ -688,39 +440,11 @@ class CompressedMatrix:
 
 
 class ForwardMatrix(CompressedMatrix):
-    """
-    Class representing a compressed forward matrix.
-    """
+    """Class representing a compressed forward matrix."""
 
 
-class ForwardAlgorithm(LsHmmAlgorithm):
-    """
-    Runs the Li and Stephens forward algorithm.
-    """
-
-    def __init__(self, ts, rho, mu, alleles, precision=10):
-        super().__init__(ts, rho, mu, alleles, precision)
-        self.output = ForwardMatrix(ts)
-
-    def compute_normalisation_factor(self):
-        s = 0
-        for j, st in enumerate(self.T):
-            assert st.tree_node != tskit.NULL
-            assert self.N[j] > 0
-            s += self.N[j] * st.value
-        return s
-
-    def compute_next_probability(self, site_id, p_last, is_match, node):
-        rho = self.rho[site_id]
-        mu = self.mu[site_id]
-        alleles = self.alleles[site_id]
-        n = self.ts.num_samples
-
-        p_t = p_last * (1 - rho) + rho / n
-        p_e = mu
-        if is_match:
-            p_e = 1 - (len(alleles) - 1) * mu
-        return p_t * p_e
+class BackwardMatrix(CompressedMatrix):
+    """Class representing a compressed backward matrix."""
 
 
 class ViterbiMatrix(CompressedMatrix):
@@ -730,6 +454,8 @@ class ViterbiMatrix(CompressedMatrix):
 
     def __init__(self, ts):
         super().__init__(ts)
+        # Tuple containing the site, the node in the tree, and whether
+        # recombination is required
         self.recombination_required = [(-1, 0, False)]
 
     def add_recombination_required(self, site, node, required):
@@ -801,13 +527,144 @@ class ViterbiMatrix(CompressedMatrix):
         return match
 
 
+class ForwardAlgorithm(LsHmmAlgorithm):
+    """Runs the Li and Stephens forward algorithm."""
+
+    def __init__(
+        self, ts, rho, mu, alleles, n_alleles, scale_mutation=False, precision=10
+    ):
+        super().__init__(
+            ts,
+            rho,
+            mu,
+            alleles,
+            n_alleles,
+            precision=precision,
+            scale_mutation=scale_mutation,
+        )
+        self.output = ForwardMatrix(ts)
+
+    def compute_normalisation_factor(self):
+        s = 0
+        for j, st in enumerate(self.T):
+            assert st.tree_node != tskit.NULL
+            assert self.N[j] > 0
+            s += self.N[j] * st.value
+        return s
+
+    def compute_next_probability(
+        self, site_id, p_last, is_match, node
+    ):  # Note node only used in Viterbi
+        rho = self.rho[site_id]
+        mu = self.mu[site_id]
+        n = self.ts.num_samples
+        n_alleles = self.n_alleles[site_id]
+
+        if self.scale_mutation_based_on_n_alleles:
+            if is_match:
+                # Scale mutation based on the number of alleles
+                # - so the mutation rate is the mutation rate to one of the
+                # alleles. The overall mutation rate is then
+                # (n_alleles - 1) * mutation_rate.
+                p_e = 1 - (n_alleles - 1) * mu
+            else:
+                p_e = mu - mu * (n_alleles == 1)
+                # Added boolean in case we're at an invariant site
+        else:
+            # No scaling based on the number of alleles
+            #  - so the mutation rate is the mutation rate to anything.
+            # This means that we must rescale the mutation rate to a different
+            # allele, by the number of alleles.
+            if n_alleles == 1:  # In case we're at an invariant site
+                if is_match:
+                    p_e = 1
+                else:
+                    p_e = 0
+            else:
+                if is_match:
+                    p_e = 1 - mu
+                else:
+                    p_e = mu / (n_alleles - 1)
+
+        p_t = p_last * (1 - rho) + rho / n
+        return p_t * p_e
+
+
+class BackwardAlgorithm(LsHmmAlgorithm):
+    """Runs the Li and Stephens backward algorithm."""
+
+    def __init__(
+        self,
+        ts,
+        rho,
+        mu,
+        alleles,
+        n_alleles,
+        normalisation_factor,
+        scale_mutation=False,
+        precision=10,
+    ):
+        super().__init__(
+            ts,
+            rho,
+            mu,
+            alleles,
+            n_alleles,
+            precision=precision,
+            scale_mutation=scale_mutation,
+        )
+        self.output = BackwardMatrix(ts, normalisation_factor)
+
+    def compute_normalisation_factor(self):
+        s = 0
+        for j, st in enumerate(self.T):
+            assert st.tree_node != tskit.NULL
+            assert self.N[j] > 0
+            s += self.N[j] * st.value
+        return s
+
+    def compute_next_probability(
+        self, site_id, p_next, is_match, node
+    ):  # Note node only used in Viterbi
+        mu = self.mu[site_id]
+        n_alleles = self.n_alleles[site_id]
+
+        if self.scale_mutation_based_on_n_alleles:
+            if is_match:
+                p_e = 1 - (n_alleles - 1) * mu
+            else:
+                p_e = mu - mu * (n_alleles == 1)
+        else:
+            if n_alleles == 1:
+                if is_match:
+                    p_e = 1
+                else:
+                    p_e = 0
+            else:
+                if is_match:
+                    p_e = 1 - mu
+                else:
+                    p_e = mu / (n_alleles - 1)
+        return p_next * p_e
+
+
 class ViterbiAlgorithm(LsHmmAlgorithm):
     """
     Runs the Li and Stephens Viterbi algorithm.
     """
 
-    def __init__(self, ts, rho, mu, alleles, precision=10):
-        super().__init__(ts, rho, mu, alleles, precision)
+    def __init__(
+        self, ts, rho, mu, alleles, n_alleles, scale_mutation=False, precision=10
+    ):
+        super().__init__(
+            ts,
+            rho,
+            mu,
+            alleles,
+            n_alleles,
+            precision=precision,
+            scale_mutation=scale_mutation,
+        )
         self.output = ViterbiMatrix(ts)
 
     def compute_normalisation_factor(self):
@@ -825,8 +682,8 @@ class ViterbiAlgorithm(LsHmmAlgorithm):
     def compute_next_probability(self, site_id, p_last, is_match, node):
         rho = self.rho[site_id]
         mu = self.mu[site_id]
-        alleles = self.alleles[site_id]
         n = self.ts.num_samples
+        n_alleles = self.n_alleles[site_id]
 
         p_no_recomb = p_last * (1 - rho + rho / n)
         p_recomb = rho / n
@@ -837,474 +694,427 @@ class ViterbiAlgorithm(LsHmmAlgorithm):
             p_t = p_recomb
             recombination_required = True
         self.output.add_recombination_required(site_id, node, recombination_required)
-        p_e = mu
-        if is_match:
-            p_e = 1 - (len(alleles) - 1) * mu
+
+        if self.scale_mutation_based_on_n_alleles:
+            if is_match:
+                # Scale mutation based on the number of alleles
+                # - so the mutation rate is the mutation rate to one of the
+                # alleles. The overall mutation rate is then
+                # (n_alleles - 1) * mutation_rate.
+                p_e = 1 - (n_alleles - 1) * mu
+            else:
+                p_e = mu - mu * (n_alleles == 1)
+                # Added boolean in case we're at an invariant site
+        else:
+            # No scaling based on the number of alleles
+            #  - so the mutation rate is the mutation rate to anything.
+            # This means that we must rescale the mutation rate to a different
+            # allele, by the number of alleles.
+            if n_alleles == 1:  # In case we're at an invariant site
+                if is_match:
+                    p_e = 1
+                else:
+                    p_e = 0
+            else:
+                if is_match:
+                    p_e = 1 - mu
+                else:
+                    p_e = mu / (n_alleles - 1)
+
         return p_t * p_e
 
 
-################################################################
-# Tests
-################################################################
+def ls_forward_tree(
+    h, ts, rho, mu, precision=30, alleles=None, scale_mutation_based_on_n_alleles=False
+):
+    if alleles is None:
+        n_alleles = np.int8(
+            [
+                len(np.unique(np.append(ts.genotype_matrix()[j, :], h[j])))
+                for j in range(ts.num_sites)
+            ]
+        )
+        alleles = tskit.ALLELES_ACGT
+        if len(set(alleles).intersection(next(ts.variants()).alleles)) == 0:
+            alleles = tskit.ALLELES_01
+            if len(set(alleles).intersection(next(ts.variants()).alleles)) == 0:
+                raise ValueError(
+                    """Alleles list could not be identified.
+                    Please pass a list of lists of alleles of length m,
+                    or a list of alleles (e.g. tskit.ALLELES_ACGT)"""
+                )
+        alleles = [alleles for _ in range(ts.num_sites)]
+    else:
+        alleles, n_alleles = check_alleles(alleles, ts.num_sites)
+
+    """Forward matrix computation based on a tree sequence."""
+    fa = ForwardAlgorithm(
+        ts,
+        rho,
+        mu,
+        alleles,
+        n_alleles,
+        precision=precision,
+        scale_mutation=scale_mutation_based_on_n_alleles,
+    )
+    return fa.run_forward(h)
 
 
-class LiStephensBase:
+def ls_backward_tree(
+    h, ts_mirror, rho, mu, normalisation_factor, precision=30, alleles=None
+):
+    if alleles is None:
+        n_alleles = np.int8(
+            [
+                len(np.unique(np.append(ts_mirror.genotype_matrix()[j, :], h[j])))
+                for j in range(ts_mirror.num_sites)
+            ]
+        )
+        alleles = tskit.ALLELES_ACGT
+        if len(set(alleles).intersection(next(ts_mirror.variants()).alleles)) == 0:
+            alleles = tskit.ALLELES_01
+            if len(set(alleles).intersection(next(ts_mirror.variants()).alleles)) == 0:
+                raise ValueError(
+                    """Alleles list could not be identified.
+                    Please pass a list of lists of alleles of length m,
+                    or a list of alleles (e.g. tskit.ALLELES_ACGT)"""
+                )
+        alleles = [alleles for _ in range(ts_mirror.num_sites)]
+    else:
+        alleles, n_alleles = check_alleles(alleles, ts_mirror.num_sites)
+
+    """Backward matrix computation based on a tree sequence."""
+    ba = BackwardAlgorithm(
+        ts_mirror,
+        rho,
+        mu,
+        alleles,
+        n_alleles,
+        normalisation_factor,
+        precision=precision,
+    )
+    return ba.run_backward(h)
+
+
+def ls_viterbi_tree(
+    h, ts, rho, mu, precision=30, alleles=None, scale_mutation_based_on_n_alleles=False
+):
+    if alleles is None:
+        n_alleles = np.int8(
+            [
+                len(np.unique(np.append(ts.genotype_matrix()[j, :], h[j])))
+                for j in range(ts.num_sites)
+            ]
+        )
+        alleles = tskit.ALLELES_ACGT
+        if len(set(alleles).intersection(next(ts.variants()).alleles)) == 0:
+            alleles = tskit.ALLELES_01
+            if len(set(alleles).intersection(next(ts.variants()).alleles)) == 0:
+                raise ValueError(
+                    """Alleles list could not be identified.
+                    Please pass a list of lists of alleles of length m,
+                    or a list of alleles (e.g. tskit.ALLELES_ACGT)"""
+                )
+        alleles = [alleles for _ in range(ts.num_sites)]
+    else:
+        alleles, n_alleles = check_alleles(alleles, ts.num_sites)
     """
-    Superclass of Li and Stephens tests.
+    Viterbi path computation based on a tree sequence.
     """
+    va = ViterbiAlgorithm(
+        ts,
+        rho,
+        mu,
+        alleles,
+        n_alleles,
+        precision=precision,
+        scale_mutation=scale_mutation_based_on_n_alleles,
+    )
+    return va.run_forward(h)
 
-    def assertCompressedMatricesEqual(self, cm1, cm2):
-        """
-        Checks that the specified compressed matrices contain the same data.
-        """
-        A1 = cm1.decode()
-        A2 = cm2.decode()
-        assert np.allclose(A1, A2)
-        assert A1.shape == A2.shape
-        assert cm1.num_sites == cm2.num_sites
-        nf1 = cm1.normalisation_factor
-        nf2 = cm1.normalisation_factor
-        assert np.allclose(nf1, nf2)
-        assert nf1.shape == nf2.shape
-        # It seems that we can't rely on the number of transitions in the two
-        # implementations being equal, which seems odd given that we should
-        # be doing things identically. Still, once the decoded matrices are the
-        # same then it seems highly likely to be correct.
 
-        # if not np.array_equal(cm1.num_transitions, cm2.num_transitions):
-        #     print()
-        #     print(cm1.num_transitions)
-        #     print(cm2.num_transitions)
-        # self.assertTrue(np.array_equal(cm1.num_transitions, cm2.num_transitions))
-        # for j in range(cm1.num_sites):
-        #     s1 = dict(cm1.get_site(j))
-        #     s2 = dict(cm2.get_site(j))
-        #     self.assertEqual(set(s1.keys()), set(s2.keys()))
-        #     for key in s1.keys():
-        #         self.assertAlmostEqual(s1[key], s2[key])
+class LSBase:
+    """Superclass of Li and Stephens tests."""
 
-    def example_haplotypes(self, ts, alleles, num_random=10, seed=2):
-        rng = np.random.RandomState(seed)
-        H = ts.genotype_matrix(alleles=alleles).T
-        haplotypes = [H[0], H[-1]]
-        for _ in range(num_random):
-            # Choose a random path through H
-            p = rng.randint(0, ts.num_samples, ts.num_sites)
-            h = H[p, np.arange(ts.num_sites)]
-            haplotypes.append(h)
-        h = H[0].copy()
-        h[-1] = tskit.MISSING_DATA
-        haplotypes.append(h)
-        h = H[0].copy()
-        h[ts.num_sites // 2] = tskit.MISSING_DATA
-        haplotypes.append(h)
-        # All missing is OK tool
-        h = H[0].copy()
-        h[:] = tskit.MISSING_DATA
-        haplotypes.append(h)
-        return haplotypes
+    def example_haplotypes(self, ts):
 
-    def example_parameters(self, ts, alleles, seed=1):
-        """
-        Returns an iterator over combinations of haplotype, recombination and mutation
-        rates.
-        """
-        rng = np.random.RandomState(seed)
-        haplotypes = self.example_haplotypes(ts, alleles, seed=seed)
+        H = ts.genotype_matrix()
+        s = H[:, 0].reshape(1, H.shape[0])
+        H = H[:, 1:]
 
-        # This is the exact matching limit.
-        rho = np.zeros(ts.num_sites) + 0.01
-        mu = np.zeros(ts.num_sites)
-        rho[0] = 0
-        for h in haplotypes:
-            yield h, rho, mu
+        haplotypes = [
+            s,
+            H[:, -1].reshape(1, H.shape[0]),
+        ]
+        s_tmp = s.copy()
+        s_tmp[0, -1] = MISSING
+        haplotypes.append(s_tmp)
+        s_tmp = s.copy()
+        s_tmp[0, ts.num_sites // 2] = MISSING
+        haplotypes.append(s_tmp)
+        s_tmp = s.copy()
+        s_tmp[0, :] = MISSING
+        haplotypes.append(s_tmp)
+
+        return H, haplotypes
+
+    def example_parameters_haplotypes(self, ts, seed=42):
+        """Returns an iterator over combinations of haplotype,
+        recombination and mutation rates."""
+        np.random.seed(seed)
+        H, haplotypes = self.example_haplotypes(ts)
+        n = H.shape[1]
+        m = ts.get_num_sites()
 
         # Here we have equal mutation and recombination
-        rho = np.zeros(ts.num_sites) + 0.01
-        mu = np.zeros(ts.num_sites) + 0.01
-        rho[0] = 0
-        for h in haplotypes:
-            yield h, rho, mu
+        r = np.zeros(m) + 0.01
+        mu = np.zeros(m) + 0.01
+        r[0] = 0
+
+        for s in haplotypes:
+            yield n, H, s, r, mu
 
         # Mixture of random and extremes
-        rhos = [
-            np.zeros(ts.num_sites) + 0.999,
-            np.zeros(ts.num_sites) + 1e-6,
-            rng.uniform(0, 1, ts.num_sites),
-        ]
-        # mu can't be more than 1 / 3 if we have 4 alleles
-        mus = [
-            np.zeros(ts.num_sites) + 0.33,
-            np.zeros(ts.num_sites) + 1e-6,
-            rng.uniform(0, 0.33, ts.num_sites),
-        ]
-        for h, rho, mu in itertools.product(haplotypes, rhos, mus):
-            rho[0] = 0
-            yield h, rho, mu
+        rs = [np.zeros(m) + 0.999, np.zeros(m) + 1e-6, np.random.rand(m)]
+        mus = [np.zeros(m) + 0.33, np.zeros(m) + 1e-6, np.random.rand(m) * 0.33]
+
+        for s, r, mu in itertools.product(haplotypes, rs, mus):
+            r[0] = 0
+            yield n, H, s, r, mu
 
     def assertAllClose(self, A, B):
-        assert np.allclose(A, B)
+        """Assert that all entries of two matrices are 'close'"""
+        assert np.allclose(A, B, rtol=1e-5, atol=1e-8)
 
-    def test_simple_n_4_no_recombination(self):
-        ts = msprime.simulate(4, recombination_rate=0, mutation_rate=0.5, random_seed=1)
+    # Define a bunch of very small tree-sequences for testing a collection
+    # of parameters on
+    def test_simple_n_10_no_recombination(self):
+        ts = msprime.simulate(
+            10, recombination_rate=0, mutation_rate=0.5, random_seed=42
+        )
         assert ts.num_sites > 3
         self.verify(ts)
 
-    def test_simple_n_3(self):
-        ts = msprime.simulate(3, recombination_rate=2, mutation_rate=7, random_seed=2)
+    def test_simple_n_10_no_recombination_high_mut(self):
+        ts = msprime.simulate(10, recombination_rate=0, mutation_rate=3, random_seed=42)
+        assert ts.num_sites > 3
+        self.verify(ts)
+
+    def test_simple_n_10_no_recombination_higher_mut(self):
+        ts = msprime.simulate(20, recombination_rate=0, mutation_rate=3, random_seed=42)
+        assert ts.num_sites > 3
+        self.verify(ts)
+
+    def test_simple_n_6(self):
+        ts = msprime.simulate(6, recombination_rate=2, mutation_rate=7, random_seed=42)
         assert ts.num_sites > 5
         self.verify(ts)
 
-    def test_simple_n_7(self):
-        ts = msprime.simulate(7, recombination_rate=2, mutation_rate=5, random_seed=2)
+    def test_simple_n_8(self):
+        ts = msprime.simulate(8, recombination_rate=2, mutation_rate=5, random_seed=42)
         assert ts.num_sites > 5
         self.verify(ts)
 
     def test_simple_n_8_high_recombination(self):
-        ts = msprime.simulate(8, recombination_rate=20, mutation_rate=5, random_seed=2)
+        ts = msprime.simulate(8, recombination_rate=20, mutation_rate=5, random_seed=42)
         assert ts.num_trees > 15
         assert ts.num_sites > 5
         self.verify(ts)
 
-    def test_simple_n_15(self):
-        ts = msprime.simulate(15, recombination_rate=2, mutation_rate=5, random_seed=2)
+    def test_simple_n_16(self):
+        ts = msprime.simulate(16, recombination_rate=2, mutation_rate=5, random_seed=42)
         assert ts.num_sites > 5
         self.verify(ts)
 
-    def test_jukes_cantor_n_3(self):
-        ts = msprime.simulate(3, mutation_rate=2, random_seed=2)
-        ts = tsutil.jukes_cantor(ts, num_sites=10, mu=10, seed=4)
-        self.verify(ts, tskit.ALLELES_ACGT)
+    # # Define a bunch of very small tree-sequences for testing a collection
+    # # of parameters on
+    # def test_simple_n_10_no_recombination_blah(self):
+    #     ts = msprime.sim_ancestry(
+    #         samples=10,
+    #         recombination_rate=0,
+    #         random_seed=42,
+    #         sequence_length=10,
+    #         population_size=10000,
+    #     )
+    #     ts = msprime.sim_mutations(ts, rate=1e-5, random_seed=42)
+    #     assert ts.num_sites > 3
+    #     self.verify(ts)
 
-    def test_jukes_cantor_n_8_high_recombination(self):
-        ts = msprime.simulate(8, recombination_rate=20, random_seed=2)
-        ts = tsutil.jukes_cantor(ts, num_sites=20, mu=5, seed=4)
-        self.verify(ts, tskit.ALLELES_ACGT)
+    # def test_simple_n_6_blah(self):
+    # ts = msprime.sim_ancestry(
+    #     samples=6,
+    #     recombination_rate=1e-4,
+    #     random_seed=42,
+    #     sequence_length=40,
+    #     population_size=10000,
+    # )
+    # ts = msprime.sim_mutations(ts, rate=1e-3, random_seed=42)
+    #     assert ts.num_sites > 5
+    #     self.verify(ts)
 
-    def test_jukes_cantor_n_15(self):
-        ts = msprime.simulate(15, mutation_rate=2, random_seed=2)
-        ts = tsutil.jukes_cantor(ts, num_sites=10, mu=0.1, seed=10)
-        self.verify(ts, tskit.ALLELES_ACGT)
+    # def test_simple_n_8_blah(self):
+    #     ts = msprime.sim_ancestry(
+    #         samples=8,
+    #         recombination_rate=1e-4,
+    #         random_seed=42,
+    #         sequence_length=20,
+    #         population_size=10000,
+    #     )
+    #     ts = msprime.sim_mutations(ts, rate=1e-4, random_seed=42)
+    #     assert ts.num_sites > 5
+    #     assert ts.num_trees > 15
+    #     self.verify(ts)
 
-    def test_jukes_cantor_balanced_ternary(self):
-        ts = tskit.Tree.generate_balanced(27, arity=3).tree_sequence
-        ts = tsutil.jukes_cantor(ts, num_sites=10, mu=0.1, seed=10)
-        self.verify(ts, tskit.ALLELES_ACGT)
+    # def test_simple_n_16_blah(self):
+    #     ts = msprime.sim_ancestry(
+    #         samples=16,
+    #         recombination_rate=1e-2,
+    #         random_seed=42,
+    #         sequence_length=20,
+    #         population_size=10000,
+    #     )
+    #     ts = msprime.sim_mutations(ts, rate=1e-4, random_seed=42)
+    #     assert ts.num_sites > 5
+    #     self.verify(ts)
 
-    @pytest.mark.skip(reason="Not supporting internal samples yet")
-    def test_ancestors_n_3(self):
-        ts = msprime.simulate(3, recombination_rate=2, mutation_rate=7, random_seed=2)
-        assert ts.num_sites > 5
-        tables = ts.dump_tables()
-        print(tables.nodes)
-        tables.nodes.flags = np.ones_like(tables.nodes.flags)
-        print(tables.nodes)
-        ts = tables.tree_sequence()
-        self.verify(ts)
-
-
-@pytest.mark.slow
-class ForwardAlgorithmBase(LiStephensBase):
-    """
-    Base for forward algorithm tests.
-    """
-
-
-class TestNumpyMatrixMethod(ForwardAlgorithmBase):
-    """
-    Tests that we compute the same values from the numpy matrix method as
-    the naive algorithm.
-    """
-
-    def verify(self, ts, alleles=tskit.ALLELES_01):
-        G = ts.genotype_matrix(alleles=alleles)
-        for h, rho, mu in self.example_parameters(ts, alleles):
-            F1, S1 = ls_forward_matrix(h, alleles, G, rho, mu)
-            F2, S2 = ls_forward_matrix_naive(h, alleles, G, rho, mu)
-            self.assertAllClose(F1, F2)
-            self.assertAllClose(S1, S2)
-
-
-class ViterbiAlgorithmBase(LiStephensBase):
-    """
-    Base for viterbi algoritm tests.
-    """
+    def verify(self, ts):
+        raise NotImplementedError()
 
 
-class TestExactMatchViterbi(ViterbiAlgorithmBase):
-    def verify(self, ts, alleles=tskit.ALLELES_01):
-        G = ts.genotype_matrix(alleles=alleles)
-        H = G.T
-        # print(H)
-        rho = np.zeros(ts.num_sites) + 0.1
-        mu = np.zeros(ts.num_sites)
-        rho[0] = 0
-        for h in H:
-            p1 = ls_viterbi_naive(h, alleles, G, rho, mu)
-            p2 = ls_viterbi_vectorised(h, alleles, G, rho, mu)
-            cm1 = ls_viterbi_tree(h, alleles, ts, rho, mu, use_lib=True)
-            p3 = cm1.traceback()
-            cm2 = ls_viterbi_tree(h, alleles, ts, rho, mu, use_lib=False)
-            p4 = cm1.traceback()
-            self.assertCompressedMatricesEqual(cm1, cm2)
-
-            assert len(np.unique(p1)) == 1
-            assert len(np.unique(p2)) == 1
-            assert len(np.unique(p3)) == 1
-            assert len(np.unique(p4)) == 1
-            m1 = H[p1, np.arange(H.shape[1])]
-            assert np.array_equal(m1, h)
-            m2 = H[p2, np.arange(H.shape[1])]
-            assert np.array_equal(m2, h)
-            m3 = H[p3, np.arange(H.shape[1])]
-            assert np.array_equal(m3, h)
-            m4 = H[p3, np.arange(H.shape[1])]
-            assert np.array_equal(m4, h)
+class FBAlgorithmBase(LSBase):
+    """Base for forwards backwards algorithm tests."""
 
 
-@pytest.mark.slow
-class TestGeneralViterbi(ViterbiAlgorithmBase, unittest.TestCase):
-    def verify(self, ts, alleles=tskit.ALLELES_01):
-        # np.set_printoptions(linewidth=20000)
-        # np.set_printoptions(threshold=20000000)
-        G = ts.genotype_matrix(alleles=alleles)
-        # m, n = G.shape
-        for h, rho, mu in self.example_parameters(ts, alleles):
-            # print("h = ", h)
-            # print("rho=", rho)
-            # print("mu = ", mu)
-            p1 = ls_viterbi_vectorised(h, alleles, G, rho, mu)
-            p2 = ls_viterbi_naive(h, alleles, G, rho, mu)
-            cm1 = ls_viterbi_tree(h, alleles, ts, rho, mu, use_lib=True)
-            p3 = cm1.traceback()
-            cm2 = ls_viterbi_tree(h, alleles, ts, rho, mu, use_lib=False)
-            p4 = cm1.traceback()
-            self.assertCompressedMatricesEqual(cm1, cm2)
-            # print()
-            # m1 = H[p1, np.arange(m)]
-            # m2 = H[p2, np.arange(m)]
-            # m3 = H[p3, np.arange(m)]
-            # count = np.unique(p1).shape[0]
-            # print()
-            # print("\tp1 = ", p1)
-            # print("\tp2 = ", p2)
-            # print("\tp3 = ", p3)
-            # print("\tm1 = ", m1)
-            # print("\tm2 = ", m2)
-            # print("\t h = ", h)
-            proba1 = ls_path_log_probability(h, p1, alleles, G, rho, mu)
-            proba2 = ls_path_log_probability(h, p2, alleles, G, rho, mu)
-            proba3 = ls_path_log_probability(h, p3, alleles, G, rho, mu)
-            proba4 = ls_path_log_probability(h, p4, alleles, G, rho, mu)
-            # print("\t P = ", proba1, proba2)
-            self.assertAlmostEqual(proba1, proba2, places=6)
-            self.assertAlmostEqual(proba1, proba3, places=6)
-            self.assertAlmostEqual(proba1, proba4, places=6)
+class VitAlgorithmBase(LSBase):
+    """Base for viterbi algoritm tests."""
 
 
-class TestMissingHaplotypes(LiStephensBase):
-    def verify(self, ts, alleles=tskit.ALLELES_01):
-        G = ts.genotype_matrix(alleles=alleles)
-        H = G.T
+class TestMirroringHap(FBAlgorithmBase):
+    """Tests that mirroring the tree sequence and running forwards and backwards
+    algorithms gives the same log-likelihood of observing the data."""
 
-        rho = np.zeros(ts.num_sites) + 0.1
-        rho[0] = 0
-        mu = np.zeros(ts.num_sites) + 0.001
+    def verify(self, ts):
+        for n, H, s, r, mu in self.example_parameters_haplotypes(ts):
+            # Note, need to remove the first sample from the ts, and ensure that
+            # invariant sites aren't removed.
+            ts_check = ts.simplify(range(1, n + 1), filter_sites=False)
+            cm = ls_forward_tree(s[0, :], ts_check, r, mu)
+            ll_tree = np.sum(np.log10(cm.normalisation_factor))
 
-        # When everything is missing data we should have no recombinations.
-        h = H[0].copy()
-        h[:] = tskit.MISSING_DATA
-        path = ls_viterbi_vectorised(h, alleles, G, rho, mu)
-        assert np.all(path == 0)
-        cm = ls_viterbi_tree(h, alleles, ts, rho, mu, use_lib=True)
-        # For the tree base algorithm it's not simple which particular sample
-        # gets chosen.
-        path = cm.traceback()
-        assert len(set(path)) == 1
+            ts_check_mirror = mirror_coordinates(ts_check)
+            r_flip = np.insert(np.flip(r)[:-1], 0, 0)
+            cm_mirror = ls_forward_tree(
+                np.flip(s[0, :]), ts_check_mirror, r_flip, np.flip(mu)
+            )
+            ll_mirror_tree = np.sum(np.log10(cm_mirror.normalisation_factor))
+            self.assertAllClose(ll_tree, ll_mirror_tree)
 
-        # TODO Not clear what else we can check about missing data.
+            # Ensure that the decoded matrices are the same
+            F_mirror_matrix, c, ll = ls.forwards(
+                np.flip(H, axis=0),
+                np.flip(s, axis=1),
+                r_flip,
+                mutation_rate=np.flip(mu),
+                scale_mutation_based_on_n_alleles=False,
+            )
 
-
-class TestForwardMatrixScaling(ForwardAlgorithmBase, unittest.TestCase):
-    """
-    Tests that we get the correct values from scaling version of the matrix
-    algorithm works correctly.
-    """
-
-    def verify(self, ts, alleles=tskit.ALLELES_01):
-        G = ts.genotype_matrix(alleles=alleles)
-        computed_log_proba = False
-        for h, rho, mu in self.example_parameters(ts, alleles):
-            F_unscaled = ls_forward_matrix_unscaled(h, alleles, G, rho, mu)
-            F, S = ls_forward_matrix(h, alleles, G, rho, mu)
-            column = np.atleast_2d(np.cumprod(S)).T
-            F_scaled = F * column
-            self.assertAllClose(F_scaled, F_unscaled)
-            log_proba1 = forward_matrix_log_proba(F, S)
-            psum = np.sum(F_unscaled[-1])
-            # If the computed probability is close to zero, there's no point in
-            # computing.
-            if psum > 1e-20:
-                computed_log_proba = True
-                log_proba2 = np.log(psum)
-                self.assertAlmostEqual(log_proba1, log_proba2)
-        assert computed_log_proba
+            self.assertAllClose(F_mirror_matrix, cm_mirror.decode())
+            self.assertAllClose(ll, ll_tree)
 
 
-class TestForwardTree(ForwardAlgorithmBase):
-    """
-    Tests that the tree algorithm computes the same forward matrix as the
-    simple method.
-    """
+class TestForwardHapTree(FBAlgorithmBase):
+    """Tests that the tree algorithm computes the same forward matrix as the
+    simple method."""
 
-    def verify(self, ts, alleles=tskit.ALLELES_01):
-        G = ts.genotype_matrix(alleles=alleles)
-        for h, rho, mu in self.example_parameters(ts, alleles):
-            F, S = ls_forward_matrix(h, alleles, G, rho, mu)
-            cm1 = ls_forward_tree(h, alleles, ts, rho, mu, use_lib=True)
-            cm2 = ls_forward_tree(h, alleles, ts, rho, mu, use_lib=False)
-            self.assertCompressedMatricesEqual(cm1, cm2)
-            Ft = cm1.decode()
-            self.assertAllClose(S, cm1.normalisation_factor)
-            self.assertAllClose(F, Ft)
-
-
-class TestAllPaths(unittest.TestCase):
-    """
-    Tests that we compute the correct forward probablities if we sum over all
-    possible paths through the genotype matrix.
-    """
-
-    def verify(self, G, h):
-        m, n = G.shape
-        rho = np.zeros(m) + 0.1
-        mu = np.zeros(m) + 0.01
-        rho[0] = 0
-        proba = 0
-        for path in itertools.product(range(n), repeat=m):
-            proba += ls_path_probability(h, path, G, rho, mu)
-
-        alleles = [["0", "1"] for _ in range(m)]
-        F = ls_forward_matrix_unscaled(h, alleles, G, rho, mu)
-        forward_proba = np.sum(F[-1])
-        self.assertAlmostEqual(proba, forward_proba)
-
-    def test_n3_m4(self):
-        G = np.array(
-            [
-                # fmt: off
-                [1, 0, 0],
-                [0, 0, 1],
-                [1, 0, 1],
-                [0, 1, 1],
-                # fmt: on
-            ]
-        )
-        self.verify(G, [0, 0, 0, 0])
-        self.verify(G, [1, 1, 1, 1])
-        self.verify(G, [1, 1, 0, 0])
-
-    def test_n4_m5(self):
-        G = np.array(
-            [
-                # fmt: off
-                [1, 0, 0, 0],
-                [0, 0, 1, 1],
-                [1, 0, 1, 1],
-                [0, 1, 1, 0],
-                # fmt: on
-            ]
-        )
-        self.verify(G, [0, 0, 0, 0, 0])
-        self.verify(G, [1, 1, 1, 1, 1])
-        self.verify(G, [1, 1, 0, 0, 0])
-
-    def test_n5_m5(self):
-        G = np.zeros((5, 5), dtype=int)
-        np.fill_diagonal(G, 1)
-        self.verify(G, [0, 0, 0, 0, 0])
-        self.verify(G, [1, 1, 1, 1, 1])
-        self.verify(G, [1, 1, 0, 0, 0])
+    def verify(self, ts):
+        for n, H, s, r, mu in self.example_parameters_haplotypes(ts):
+            for scale_mutation in [False, True]:
+                F, c, ll = ls.forwards(
+                    H,
+                    s,
+                    r,
+                    mutation_rate=mu,
+                    scale_mutation_based_on_n_alleles=scale_mutation,
+                )
+                # Note, need to remove the first sample from the ts, and ensure
+                # that invariant sites aren't removed.
+                ts_check = ts.simplify(range(1, n + 1), filter_sites=False)
+                cm = ls_forward_tree(
+                    s[0, :],
+                    ts_check,
+                    r,
+                    mu,
+                    scale_mutation_based_on_n_alleles=scale_mutation,
+                )
+                self.assertAllClose(cm.decode(), F)
+                ll_tree = np.sum(np.log10(cm.normalisation_factor))
+                self.assertAllClose(ll, ll_tree)
 
 
-class TestBasicViterbi:
-    """
-    Very simple tests of the Viterbi algorithm.
-    """
+class TestForwardBackwardTree(FBAlgorithmBase):
+    """Tests that the tree algorithm computes the same forward matrix as the
+    simple method."""
 
-    def verify_exact_match(self, G, h, path):
-        m, n = G.shape
-        rho = np.zeros(m) + 1e-9
-        mu = np.zeros(m)  # Set mu to zero exact match
-        rho[0] = 0
-        alleles = [["0", "1"] for _ in range(m)]
-        path1 = ls_viterbi_naive(h, alleles, G, rho, mu)
-        path2 = ls_viterbi_vectorised(h, alleles, G, rho, mu)
-        assert list(path1) == path
-        assert list(path2) == path
+    def verify(self, ts):
+        for n, H, s, r, mu in self.example_parameters_haplotypes(ts):
+            F, c, ll = ls.forwards(
+                H, s, r, mutation_rate=mu, scale_mutation_based_on_n_alleles=False
+            )
+            B = ls.backwards(
+                H,
+                s,
+                c,
+                r,
+                mutation_rate=mu,
+                scale_mutation_based_on_n_alleles=False,
+            )
 
-    def test_n2_m6_exact(self):
-        G = np.array(
-            [
-                # fmt: off
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                # fmt: on
-            ]
-        )
-        self.verify_exact_match(G, [1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1])
-        self.verify_exact_match(G, [0, 0, 0, 0, 0, 0], [1, 1, 1, 0, 0, 0])
-        self.verify_exact_match(G, [0, 0, 0, 1, 1, 1], [1, 1, 1, 1, 1, 1])
-        self.verify_exact_match(G, [0, 0, 0, 1, 1, 0], [1, 1, 1, 1, 1, 0])
-        self.verify_exact_match(G, [0, 0, 0, 0, 1, 0], [1, 1, 1, 0, 1, 0])
+            # Note, need to remove the first sample from the ts, and ensure that
+            # invariant sites aren't removed.
+            ts_check = ts.simplify(range(1, n + 1), filter_sites=False)
+            c_f = ls_forward_tree(s[0, :], ts_check, r, mu)
+            ll_tree = np.sum(np.log10(c_f.normalisation_factor))
 
-    def test_n3_m6_exact(self):
-        G = np.array(
-            [
-                # fmt: off
-                [1, 0, 1],
-                [1, 0, 0],
-                [1, 0, 1],
-                [0, 1, 0],
-                [0, 1, 1],
-                [0, 1, 0],
-                # fmt: on
-            ]
-        )
-        self.verify_exact_match(G, [1, 1, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1])
-        self.verify_exact_match(G, [0, 0, 0, 0, 0, 0], [1, 1, 1, 0, 0, 0])
-        self.verify_exact_match(G, [0, 0, 0, 1, 1, 1], [1, 1, 1, 1, 1, 1])
-        self.verify_exact_match(G, [1, 0, 1, 0, 1, 0], [2, 2, 2, 2, 2, 2])
+            ts_check_mirror = mirror_coordinates(ts_check)
+            r_flip = np.flip(r)
+            c_b = ls_backward_tree(
+                np.flip(s[0, :]),
+                ts_check_mirror,
+                r_flip,
+                np.flip(mu),
+                np.flip(c_f.normalisation_factor),
+            )
+            B_tree = np.flip(c_b.decode(), axis=0)
+            F_tree = c_f.decode()
 
-    def test_n3_m6(self):
-        G = np.array(
-            [
-                # fmt: off
-                [1, 0, 1],
-                [1, 0, 0],
-                [1, 0, 1],
-                [0, 1, 0],
-                [0, 1, 1],
-                [0, 1, 0],
-                # fmt: on
-            ]
-        )
+            self.assertAllClose(B, B_tree)
+            self.assertAllClose(F, F_tree)
+            self.assertAllClose(ll, ll_tree)
 
-        m, n = G.shape
-        rho = np.zeros(m) + 1e-2
-        mu = np.zeros(m)
-        rho[0] = 0
-        alleles = [["0", "1"] for _ in range(m)]
-        h = np.ones(m, dtype=int)
-        path1 = ls_viterbi_naive(h, alleles, G, rho, mu)
 
-        # Add in mutation at a very low rate.
-        mu[:] = 1e-8
-        path2 = ls_viterbi_naive(h, alleles, G, rho, mu)
-        path3 = ls_viterbi_vectorised(h, alleles, G, rho, mu)
-        assert np.array_equal(path1, path2)
-        assert np.array_equal(path2, path3)
+class TestTreeViterbiHap(VitAlgorithmBase):
+    """Test that we have the same log-likelihood between tree and matrix
+    implementations"""
+
+    def verify(self, ts):
+        for n, H, s, r, mu in self.example_parameters_haplotypes(ts):
+            path, ll = ls.viterbi(
+                H, s, r, mutation_rate=mu, scale_mutation_based_on_n_alleles=False
+            )
+            ts_check = ts.simplify(range(1, n + 1), filter_sites=False)
+            cm = ls_viterbi_tree(s[0, :], ts_check, r, mu)
+            ll_tree = np.sum(np.log10(cm.normalisation_factor))
+            self.assertAllClose(ll, ll_tree)
+
+            # Now, need to ensure that the likelihood of the preferred path is
+            # the same as ll_tree (and ll).
+            path_tree = cm.traceback()
+            ll_check = ls.path_ll(
+                H,
+                s,
+                path_tree,
+                r,
+                mutation_rate=mu,
+                scale_mutation_based_on_n_alleles=False,
+            )
+            self.assertAllClose(ll, ll_check)


### PR DESCRIPTION
Added tree-based implementation of the backwards algorithm for haploid data, and include a series of tests using lshmm for testing (very similar to the diploid implementation and testing).
