### PR TITLE
Fix jsonschema validators error

### DIFF
--- a/python/tests/test_combinatorics.py
+++ b/python/tests/test_combinatorics.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2020-2022 Tskit Developers
+# Copyright (c) 2020-2023 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@ import collections
 import io
 import itertools
 import json
+import math
 import random
 
 import msprime
@@ -1057,7 +1058,7 @@ def num_leaf_labelled_binary_trees(n):
 
     https://oeis.org/A005373/
     """
-    return int(np.math.factorial(2 * n - 3) / (2 ** (n - 2) * np.math.factorial(n - 2)))
+    return int(math.factorial(2 * n - 3) / (2 ** (n - 2) * math.factorial(n - 2)))
 
 
 class TestPolytomySplitting:

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1603,13 +1603,13 @@ class FancyIndexingMixin:
             table[[5.5]]
         with pytest.raises(TypeError, match="Cannot convert"):
             table[[None]]
-        with pytest.raises(TypeError, match="not supported between instances"):
+        with pytest.raises(TypeError, match="not supported|did not contain"):
             table[["foobar"]]
         with pytest.raises(TypeError, match="Index must be integer, slice or iterable"):
             table[5.5]
         with pytest.raises(TypeError, match="Cannot convert to a rectangular array"):
             table[None]
-        with pytest.raises(TypeError, match="not supported between instances"):
+        with pytest.raises(TypeError, match="not supported|did not contain"):
             table["foobar"]
 
 

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2022 Tskit Developers
+# Copyright (c) 2020-2023 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -193,7 +193,11 @@ def binary_format_validator(validator, types, instance, schema):
     # generators of exceptions, hence the yielding
 
     # Make sure the normal type validation gets done
-    yield from jsonschema._validators.type(validator, types, instance, schema)
+    try:
+        yield from jsonschema._validators.type(validator, types, instance, schema)
+    except AttributeError:
+        # Needed since jsonschema==4.19.1
+        yield from jsonschema._keywords.type(validator, types, instance, schema)
 
     # Non-composite types must have a binaryFormat
     if validator.is_type(instance, "object"):
@@ -222,7 +226,13 @@ def binary_format_validator(validator, types, instance, schema):
 
 def required_validator(validator, required, instance, schema):
     # Do the normal validation
-    yield from jsonschema._validators.required(validator, required, instance, schema)
+    try:
+        yield from jsonschema._validators.required(
+            validator, required, instance, schema
+        )
+    except AttributeError:
+        # Needed since jsonschema==4.19.1
+        yield from jsonschema._keywords.required(validator, required, instance, schema)
 
     # For struct codec if a property is not required, then it must have a default
     for prop, sub_schema in instance["properties"].items():


### PR DESCRIPTION
Fix #2840 

A change in jsonschema 4.19.0 has moved the location of functions that we were using. This patch means both old and new versions will work.