### PR TITLE
Support all-nodes matching in LSHMM

### DIFF
--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -1197,7 +1197,7 @@ def check_viterbi(
     recombination=None,
     mutation=None,
     match_all_nodes=False,
-    compare_fm_ll=True,
+    compare_fm_ll=False,
     compare_lib=True,
     compare_lshmm=None,
 ):
@@ -1231,6 +1231,11 @@ def check_viterbi(
         # Compare the log-likelihood of the Viterbi path (ll_tree)
         # with the log-likelihood of the most likely path from
         # the forward matrix.
+
+        # This is not always true. If the query haplotype is one
+        # of the actual sample haplotypes it is *almost* always
+        # true, but not quite. So, a useful check for development
+        # but not all that useful in general
         fm = ls_forward_tree(
             h,
             ts,
@@ -1240,8 +1245,10 @@ def check_viterbi(
             match_all_nodes=match_all_nodes,
         )
         ll_fm = np.sum(np.log10(fm.normalisation_factor))
-        print("FMLL", ll_tree, ll_fm)
-        # np.testing.assert_allclose(ll_tree, ll_fm)
+        # print()
+        # print("vit ll", ll_tree)
+        # print("FMLL", ll_fm)
+        np.testing.assert_allclose(ll_tree, ll_fm)
 
     if compare_lshmm:
         # Check that the likelihood of the preferred path is
@@ -1339,9 +1346,10 @@ def check_forward_matrix(
         assert c.shape == (m,)
         assert np.isscalar(ll)
 
-        print(ll_tree)
-        print(F)
-        print(F2)
+        # print(ll_tree)
+        # print("lshmm fm ll:", ll)
+        # print(F)
+        # print(F2)
         nt.assert_allclose(F, F2)
         nt.assert_allclose(c, cm.normalisation_factor)
         nt.assert_allclose(ll_tree, ll)
@@ -1725,7 +1733,7 @@ class TestSimulationExamples:
         ts = msprime.simulate(
             n, length=L, recombination_rate=1, mutation_rate=1, random_seed=42
         )
-        h = np.zeros(ts.num_sites, dtype=np.int8)
+        h = ts.genotype_matrix(samples=[0])[:, 0].T
         # NOTE this is a bit slow at the moment but we can disable the Python
         # implementation once testing has been improved on smaller examples.
         # Add ``compare_py=False``to these calls.


### PR DESCRIPTION
Currently a WIP, but the idea is to support all-nodes matching a-la tsinfer in the LS HMM. 

It turns out that this is significantly different to the "samples-only" approach that is currently implemented here, because the interpretation of the likelihoods per-tree node is different. For samples only (and especially the "leaf samples only" version we have currently implemented) the internal node likelihood values are really just for compression, and there's no actual semantics to their values. Then, using standard parsimony algorithms works well because the arbitrary choices made to do compression are perfectly OK.

However, when each node of the tree has a well-defined likelihood that we want to preserve, parsimony is much more difficult.

I think the main difference then is how we compress the likelihoods, and so for now I've just put in a quick hack to do both approaches by having different compression methods for each. We could probably just use the "tsinfer-like" compression approach for samples only, as well, but I wanted to keep the parsimony version around for a while in case it's much more performant.

Other than that, things seem to be working OK, but there are definitely some tricky issues to resolve along the way, which I'll keep plugging at. The plan is to provide an option to the API at the top-level though, as ``match_all_nodes`` or ``match_samples``. I think this is flexible enough, given that you can simplify down to specific subsets of nodes if you want.

cc @szhan @astheeggeggs 