### PR TITLE
Add tree_pos to tsk_tree_t struct

### DIFF
--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4520,12 +4520,14 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
 {
     int ret = TSK_ERR_NO_MEMORY;
     tsk_size_t num_samples, num_nodes, N;
+    tsk_tree_position_t tree_pos;
 
     tsk_memset(self, 0, sizeof(tsk_tree_t));
     if (tree_sequence == NULL) {
         ret = TSK_ERR_BAD_PARAM_VALUE;
         goto out;
     }
+    tsk_memset(&tree_pos, 0, sizeof(tree_pos));
     num_nodes = tree_sequence->tables->nodes.num_rows;
     num_samples = tree_sequence->num_samples;
     self->num_nodes = num_nodes;
@@ -4534,6 +4536,7 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
     self->samples = tree_sequence->samples;
     self->options = options;
     self->root_threshold = 1;
+    self->tree_pos = tree_pos;
 
     /* Allocate space in the quintuply linked tree for the virtual root */
     N = num_nodes + 1;
@@ -4564,6 +4567,11 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
             || self->next_sample == NULL) {
             goto out;
         }
+    }
+
+    ret = tsk_tree_position_init(&tree_pos, tree_sequence, 0);
+    if (ret != 0) {
+        goto out;
     }
     ret = tsk_tree_clear(self);
 out:
@@ -4613,6 +4621,7 @@ tsk_tree_free(tsk_tree_t *self)
     tsk_safe_free(self->next_sample);
     tsk_safe_free(self->num_children);
     tsk_safe_free(self->edge);
+    tsk_safe_free(self->tree_pos);
     return 0;
 }
 

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4520,14 +4520,12 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
 {
     int ret = TSK_ERR_NO_MEMORY;
     tsk_size_t num_samples, num_nodes, N;
-    tsk_tree_position_t tree_pos;
 
     tsk_memset(self, 0, sizeof(tsk_tree_t));
     if (tree_sequence == NULL) {
         ret = TSK_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    tsk_memset(&tree_pos, 0, sizeof(tree_pos));
     num_nodes = tree_sequence->tables->nodes.num_rows;
     num_samples = tree_sequence->num_samples;
     self->num_nodes = num_nodes;
@@ -4536,7 +4534,6 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
     self->samples = tree_sequence->samples;
     self->options = options;
     self->root_threshold = 1;
-    self->tree_pos = tree_pos;
 
     /* Allocate space in the quintuply linked tree for the virtual root */
     N = num_nodes + 1;
@@ -4569,7 +4566,7 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
         }
     }
 
-    ret = tsk_tree_position_init(&tree_pos, tree_sequence, 0);
+    ret = tsk_tree_position_init(&self->tree_pos, tree_sequence, 0);
     if (ret != 0) {
         goto out;
     }
@@ -4621,7 +4618,7 @@ tsk_tree_free(tsk_tree_t *self)
     tsk_safe_free(self->next_sample);
     tsk_safe_free(self->num_children);
     tsk_safe_free(self->edge);
-    tsk_safe_free(self->tree_pos);
+    tsk_tree_position_free(&self->tree_pos);
     return 0;
 }
 

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -111,6 +111,37 @@ typedef struct {
     tsk_table_collection_t *tables;
 } tsk_treeseq_t;
 
+typedef struct {
+    tsk_id_t index;
+    struct {
+        double left;
+        double right;
+    } interval;
+    struct {
+        tsk_id_t start;
+        tsk_id_t stop;
+        const tsk_id_t *order;
+    } in;
+    struct {
+        tsk_id_t start;
+        tsk_id_t stop;
+        const tsk_id_t *order;
+    } out;
+    tsk_id_t left_current_index;
+    tsk_id_t right_current_index;
+    int direction;
+    const tsk_treeseq_t *tree_sequence;
+} tsk_tree_position_t;
+
+int tsk_tree_position_init(
+    tsk_tree_position_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+int tsk_tree_position_free(tsk_tree_position_t *self);
+int tsk_tree_position_print_state(const tsk_tree_position_t *self, FILE *out);
+bool tsk_tree_position_next(tsk_tree_position_t *self);
+bool tsk_tree_position_prev(tsk_tree_position_t *self);
+int tsk_tree_position_seek_forward(tsk_tree_position_t *self, tsk_id_t index);
+int tsk_tree_position_seek_backward(tsk_tree_position_t *self, tsk_id_t index);
+
 /**
 @brief A single tree in a tree sequence.
 
@@ -256,6 +287,7 @@ typedef struct {
     int direction;
     tsk_id_t left_index;
     tsk_id_t right_index;
+    tsk_tree_position_t tree_pos;
 } tsk_tree_t;
 
 /****************************************************************************/
@@ -1783,40 +1815,6 @@ bool tsk_tree_equals(const tsk_tree_t *self, const tsk_tree_t *other);
 
 int tsk_diff_iter_init_from_ts(
     tsk_diff_iter_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
-
-/* Temporarily putting this here to avoid problems with doxygen. Will need to
- * move up the file later when it gets incorporated into the tsk_tree_t object.
- */
-typedef struct {
-    tsk_id_t index;
-    struct {
-        double left;
-        double right;
-    } interval;
-    struct {
-        tsk_id_t start;
-        tsk_id_t stop;
-        const tsk_id_t *order;
-    } in;
-    struct {
-        tsk_id_t start;
-        tsk_id_t stop;
-        const tsk_id_t *order;
-    } out;
-    tsk_id_t left_current_index;
-    tsk_id_t right_current_index;
-    int direction;
-    const tsk_treeseq_t *tree_sequence;
-} tsk_tree_position_t;
-
-int tsk_tree_position_init(
-    tsk_tree_position_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
-int tsk_tree_position_free(tsk_tree_position_t *self);
-int tsk_tree_position_print_state(const tsk_tree_position_t *self, FILE *out);
-bool tsk_tree_position_next(tsk_tree_position_t *self);
-bool tsk_tree_position_prev(tsk_tree_position_t *self);
-int tsk_tree_position_seek_forward(tsk_tree_position_t *self, tsk_id_t index);
-int tsk_tree_position_seek_backward(tsk_tree_position_t *self, tsk_id_t index);
 
 #ifdef __cplusplus
 }

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -133,15 +133,6 @@ typedef struct {
     const tsk_treeseq_t *tree_sequence;
 } tsk_tree_position_t;
 
-int tsk_tree_position_init(
-    tsk_tree_position_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
-int tsk_tree_position_free(tsk_tree_position_t *self);
-int tsk_tree_position_print_state(const tsk_tree_position_t *self, FILE *out);
-bool tsk_tree_position_next(tsk_tree_position_t *self);
-bool tsk_tree_position_prev(tsk_tree_position_t *self);
-int tsk_tree_position_seek_forward(tsk_tree_position_t *self, tsk_id_t index);
-int tsk_tree_position_seek_backward(tsk_tree_position_t *self, tsk_id_t index);
-
 /**
 @brief A single tree in a tree sequence.
 
@@ -1815,6 +1806,15 @@ bool tsk_tree_equals(const tsk_tree_t *self, const tsk_tree_t *other);
 
 int tsk_diff_iter_init_from_ts(
     tsk_diff_iter_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+
+int tsk_tree_position_init(
+    tsk_tree_position_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+int tsk_tree_position_free(tsk_tree_position_t *self);
+int tsk_tree_position_print_state(const tsk_tree_position_t *self, FILE *out);
+bool tsk_tree_position_next(tsk_tree_position_t *self);
+bool tsk_tree_position_prev(tsk_tree_position_t *self);
+int tsk_tree_position_seek_forward(tsk_tree_position_t *self, tsk_id_t index);
+int tsk_tree_position_seek_backward(tsk_tree_position_t *self, tsk_id_t index);
 
 #ifdef __cplusplus
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -76,7 +76,7 @@ sphinx:
           ["c:identifier", "FILE"],
           ["c:identifier", "bool"],
           # This is for the anonymous interval struct embedded in the tsk_tree_t.
-          ["c:identifier", "tsk_tree_t.@1"],
+          ["c:identifier", "tsk_tree_t.@4"],
           ["c:type", "int32_t"],
           ["c:type", "uint32_t"],
           ["c:type", "uint64_t"],


### PR DESCRIPTION
## Description

This PR aims to address the first part of #2795 by adding the `tree_position` class to the `tsk_tree_t` struct. I've done a first draft of this and it passes all the unit tests without any memory issues detected by Valgrind. I'm not confident that the memory management is correct yet, though!

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
