### PR TITLE
Error when the VCF will have a zero position site

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -2,6 +2,13 @@
 [0.5.7] - 2023-XX-XX
 --------------------
 
+**Breaking Changes**
+
+- The VCF writing methods (`ts.write_vcf`, `ts.as_vcf`) now error if a site with
+  position zero is encountered. The VCF spec does not allow zero position sites.
+  Suppress this error with the `allow_position_zero` argument.
+  (:user:`benjeffery`, :pr:`2901`, :issue:`2838`)
+
 **Features**
 
 - Add ``TreeSequence.extend_edges`` method that extends ancestral haplotypes
@@ -17,7 +24,7 @@
   `TreeSequence.allele_frequency_spectrum(mode="branch", polarised=False)`,
   which was half as big as it should have been. (:user:`petrelharp`,
   :user:`nspope`, :pr:`2933`)
-
+  
 --------------------
 [0.5.6] - 2023-10-10
 --------------------

--- a/python/tskit/cli.py
+++ b/python/tskit/cli.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2018-2022 Tskit Developers
+# Copyright (c) 2018-2024 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -137,7 +137,12 @@ def run_fasta(args):
 
 def run_vcf(args):
     tree_sequence = load_tree_sequence(args.tree_sequence)
-    tree_sequence.write_vcf(sys.stdout, ploidy=args.ploidy, contig_id=args.contig_id)
+    tree_sequence.write_vcf(
+        sys.stdout,
+        ploidy=args.ploidy,
+        contig_id=args.contig_id,
+        allow_position_zero=args.allow_position_zero,
+    )
 
 
 def add_tree_sequence_argument(parser):
@@ -222,6 +227,13 @@ def get_tskit_parser():
     )
     parser.add_argument(
         "--contig-id", "-c", type=str, default="1", help="Specify the contig id"
+    )
+    parser.add_argument(
+        "--allow-position-zero",
+        "-0",
+        action="store_true",
+        default=False,
+        help="Allow position 0 sites",
     )
     parser.set_defaults(runner=run_vcf)
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6176,6 +6176,7 @@ class TreeSequence:
         site_mask=None,
         sample_mask=None,
         isolated_as_missing=None,
+        allow_position_zero=None,
     ):
         """
         Convert the genetic variation data in this tree sequence to Variant
@@ -6302,7 +6303,13 @@ class TreeSequence:
             missing samples (i.e., isolated samples without mutations) is "."
             If False, missing samples will be assigned the ancestral allele.
             See :meth:`.variants` for more information. Default: True.
+        :param bool allow_position_zero: If True allow sites with position zero to be
+            output to the VCF, otherwise if one is present an error will be raised.
+            The VCF spec does not allow for sites at position 0. However, in practise
+            many tools will be fine with this. Default: False.
         """
+        if allow_position_zero is None:
+            allow_position_zero = False
         writer = vcf.VcfWriter(
             self,
             ploidy=ploidy,
@@ -6313,6 +6320,7 @@ class TreeSequence:
             site_mask=site_mask,
             sample_mask=sample_mask,
             isolated_as_missing=isolated_as_missing,
+            allow_position_zero=allow_position_zero,
         )
         writer.write(output)
 


### PR DESCRIPTION
Fixes #2838

Note that this is a fairly breaking change that we should think about, given that the default is for msprime output to require the new flag to `write_vcf`.