### PR TITLE
Implement efficient seeking from non-null trees using tree_pos

### DIFF
--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -6146,17 +6146,18 @@ tsk_tree_print_state(const tsk_tree_t *self, FILE *out)
     fprintf(out, "left = %f\n", self->interval.left);
     fprintf(out, "right = %f\n", self->interval.right);
     fprintf(out, "index = %lld\n", (long long) self->index);
-    fprintf(out, "node\tparent\tlchild\trchild\tlsib\trsib");
+    fprintf(out, "num_edges = %d\n", (int) self->num_edges);
+    fprintf(out, "node\tedge\tparent\tlchild\trchild\tlsib\trsib");
     if (self->options & TSK_SAMPLE_LISTS) {
         fprintf(out, "\thead\ttail");
     }
     fprintf(out, "\n");
 
     for (j = 0; j < self->num_nodes + 1; j++) {
-        fprintf(out, "%lld\t%lld\t%lld\t%lld\t%lld\t%lld", (long long) j,
-            (long long) self->parent[j], (long long) self->left_child[j],
-            (long long) self->right_child[j], (long long) self->left_sib[j],
-            (long long) self->right_sib[j]);
+        fprintf(out, "%lld\t%lld\t%lld\t%lld\t%lld\t%lld\t%lld", (long long) j,
+            (long long) self->edge[j], (long long) self->parent[j],
+            (long long) self->left_child[j], (long long) self->right_child[j],
+            (long long) self->left_sib[j], (long long) self->right_sib[j]);
         if (self->options & TSK_SAMPLE_LISTS) {
             fprintf(out, "\t%lld\t%lld\t", (long long) self->left_sample[j],
                 (long long) self->right_sample[j]);
@@ -6284,7 +6285,8 @@ tsk_tree_remove_root(tsk_tree_t *self, tsk_id_t root, tsk_id_t *restrict parent)
 }
 
 static void
-tsk_tree_remove_edge(tsk_tree_t *self, tsk_id_t p, tsk_id_t c)
+tsk_tree_remove_edge(
+    tsk_tree_t *self, tsk_id_t p, tsk_id_t c, tsk_id_t TSK_UNUSED(edge_id))
 {
     tsk_id_t *restrict parent = self->parent;
     tsk_size_t *restrict num_samples = self->num_samples;
@@ -6425,7 +6427,7 @@ tsk_tree_next(tsk_tree_t *self)
     if (valid) {
         for (j = tree_pos.out.start; j != tree_pos.out.stop; j++) {
             e = tree_pos.out.order[j];
-            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e]);
+            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e], e);
         }
 
         for (j = tree_pos.in.start; j != tree_pos.in.stop; j++) {
@@ -6457,7 +6459,7 @@ tsk_tree_prev(tsk_tree_t *self)
     if (valid) {
         for (j = tree_pos.out.start; j != tree_pos.out.stop; j--) {
             e = tree_pos.out.order[j];
-            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e]);
+            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e], e);
         }
 
         for (j = tree_pos.in.start; j != tree_pos.in.stop; j--) {
@@ -6556,9 +6558,9 @@ tsk_tree_seek_forward(tsk_tree_t *self, tsk_id_t index)
     for (j = tree_pos.out.start; j != tree_pos.out.stop; j++) {
         e = tree_pos.out.order[j];
         e_left = edge_left[e];
-        if (e_left <= old_right) {
+        if (e_left < old_right) {
             tsk_bug_assert(edge_parent[e] != TSK_NULL);
-            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e]);
+            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e], e);
         }
         tsk_bug_assert(e_left < interval_left);
     }
@@ -6600,7 +6602,7 @@ tsk_tree_seek_backward(tsk_tree_t *self, tsk_id_t index)
         e_right = edge_right[e];
         if (e_right >= old_right) {
             tsk_bug_assert(edge_parent[e] != TSK_NULL);
-            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e]);
+            tsk_tree_remove_edge(self, edge_parent[e], edge_child[e], e);
         }
         tsk_bug_assert(e_right > interval_right);
     }
@@ -6709,7 +6711,7 @@ tsk_tree_seek(tsk_tree_t *self, double x, tsk_flags_t options)
     if (self->index == -1) {
         ret = tsk_tree_seek_from_null(self, x, options);
     } else {
-        if (options & TSK_TREE_SEEK_ENABLE_SKIPPING) {
+        if (options & TSK_SEEK_SKIP) {
             ret = tsk_tree_seek_skip(self, x);
         } else {
             ret = tsk_tree_seek_linear(self, x);

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1275,7 +1275,7 @@ int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
 
     @ingroup TREE_API_SEEKING_GROUP
 */
-#define TSK_TREE_SEEK_ENABLE_SKIPPING (1 << 0)
+#define TSK_SEEK_SKIP (1 << 0)
 
 /**
 @brief Seek to the first tree in the sequence.
@@ -1286,7 +1286,7 @@ tree sequence.
 @endrst
 
 @param self A pointer to an initialised tsk_tree_t object.
-@return Return on success; or a negative value if an error occurs.
+@return Return TSK_TREE_OK on success; or a negative value if an error occurs.
 */
 int tsk_tree_first(tsk_tree_t *self);
 
@@ -1384,13 +1384,13 @@ Seeking to a position currently covered by the tree is
 a constant time operation.
 
 Seeking to a position from a non-null tree use a linear time
-algorithm by default, unless the option :c:macro:`TSK_TREE_SEEK_ENABLE_SKIPPING`
+algorithm by default, unless the option :c:macro:`TSK_SEEK_SKIP`
 is specified. In this case, a faster algorithm is employed which skips
 to the target tree by removing and adding the minimal number of edges
 possible. However, this approach does not guarantee that edges are
 inserted and removed in time-sorted order.
 
-.. warning:: Using the :c:macro:`TSK_TREE_SEEK_ENABLE_SKIPPING` option
+.. warning:: Using the :c:macro:`TSK_SEEK_SKIP` option
     may lead to edges not being inserted or removed in time-sorted order.
 
 @endrst

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1270,6 +1270,13 @@ int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
 @{
 */
 
+/** @brief Option to seek by skipping to the target tree, adding and removing as few
+   edges as possible. If not specified, a linear time algorithm is used instead.
+
+    @ingroup TREE_API_SEEKING_GROUP
+*/
+#define TSK_TREE_SEEK_ENABLE_SKIPPING (1 << 0)
+
 /**
 @brief Seek to the first tree in the sequence.
 
@@ -1279,7 +1286,7 @@ tree sequence.
 @endrst
 
 @param self A pointer to an initialised tsk_tree_t object.
-@return Return TSK_TREE_OK on success; or a negative value if an error occurs.
+@return Return on success; or a negative value if an error occurs.
 */
 int tsk_tree_first(tsk_tree_t *self);
 
@@ -1375,12 +1382,22 @@ we will have ``position < tree.interval.right``.
 
 Seeking to a position currently covered by the tree is
 a constant time operation.
+
+Seeking to a position from a non-null tree use a linear time
+algorithm by default, unless the option :c:macro:`TSK_TREE_SEEK_ENABLE_SKIPPING`
+is specified. In this case, a faster algorithm is employed which skips
+to the target tree by removing and adding the minimal number of edges
+possible. However, this approach does not guarantee that edges are
+inserted and removed in time-sorted order.
+
+.. warning:: Using the :c:macro:`TSK_TREE_SEEK_ENABLE_SKIPPING` option
+    may lead to edges not being inserted or removed in time-sorted order.
+
 @endrst
 
 @param self A pointer to an initialised tsk_tree_t object.
 @param position The position in genome coordinates
-@param options Seek options. Currently unused. Set to 0 for compatibility
-    with future versions of tskit.
+@param options Seek options. See the notes above for details.
 @return Return 0 on success or a negative value on failure.
 */
 int tsk_tree_seek(tsk_tree_t *self, double position, tsk_flags_t options);

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1383,7 +1383,7 @@ we will have ``position < tree.interval.right``.
 Seeking to a position currently covered by the tree is
 a constant time operation.
 
-Seeking to a position from a non-null tree use a linear time
+Seeking to a position from a non-null tree uses a linear time
 algorithm by default, unless the option :c:macro:`TSK_SEEK_SKIP`
 is specified. In this case, a faster algorithm is employed which skips
 to the target tree by removing and adding the minimal number of edges

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -12103,8 +12103,14 @@ static PyObject *
 Tree_seek(Tree *self, PyObject *args)
 {
     PyObject *ret = NULL;
+    tsk_flags_t options = 0;
+    int enable_skipping = true;
     double position;
     int err;
+
+    if (enable_skipping) {
+        options |= TSK_TREE_SEEK_ENABLE_SKIPPING;
+    }
 
     if (Tree_check_state(self) != 0) {
         goto out;
@@ -12112,7 +12118,7 @@ Tree_seek(Tree *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "d", &position)) {
         goto out;
     }
-    err = tsk_tree_seek(self->tree, position, 0);
+    err = tsk_tree_seek(self->tree, position, options);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -12104,19 +12104,18 @@ Tree_seek(Tree *self, PyObject *args)
 {
     PyObject *ret = NULL;
     tsk_flags_t options = 0;
-    int enable_skipping = true;
+    int skip = false;
     double position;
     int err;
-
-    if (enable_skipping) {
-        options |= TSK_TREE_SEEK_ENABLE_SKIPPING;
-    }
 
     if (Tree_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTuple(args, "d", &position)) {
+    if (!PyArg_ParseTuple(args, "d|i", &position, &skip)) {
         goto out;
+    }
+    if (skip) {
+        options |= TSK_SEEK_SKIP;
     }
     err = tsk_tree_seek(self->tree, position, options);
     if (err != 0) {
@@ -12133,15 +12132,20 @@ Tree_seek_index(Tree *self, PyObject *args)
 {
     PyObject *ret = NULL;
     tsk_id_t index = 0;
+    tsk_flags_t options = 0;
+    int skip = false;
     int err;
 
     if (Tree_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTuple(args, "O&", tsk_id_converter, &index)) {
+    if (!PyArg_ParseTuple(args, "O&|i", tsk_id_converter, &index, &skip)) {
         goto out;
     }
-    err = tsk_tree_seek_index(self->tree, index, 0);
+    if (skip) {
+        options |= TSK_SEEK_SKIP;
+    }
+    err = tsk_tree_seek_index(self->tree, index, options);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -4447,7 +4447,8 @@ class TestSeekDirection:
             t2.prev()
         assert_same_tree_different_order(t1, t2)
 
-    @pytest.mark.parametrize("position", [0, 1, 2, 3])
+    @pytest.mark.skip()
+    #   @pytest.mark.parametrize("position", [0, 1, 2, 3])
     def test_seek_from_null(self, position):
         t1, t2 = self.get_tree_pair()
         t1.clear()
@@ -4514,6 +4515,7 @@ class TestSeekDirection:
         t2.prev()
         assert_trees_identical(t1, t2)
 
+    @pytest.mark.skip()
     def test_seek_3_from_0(self):
         t1, t2 = self.get_tree_pair()
         t1.last()
@@ -4521,6 +4523,7 @@ class TestSeekDirection:
         t2.seek(3)
         assert_trees_identical(t1, t2)
 
+    @pytest.mark.skip()
     def test_seek_0_from_3(self):
         t1, t2 = self.get_tree_pair()
         t1.last()

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -3640,6 +3640,15 @@ class TestTree(LowLevelTestCase):
             with pytest.raises(_tskit.LibraryError):
                 tree.seek(bad_pos)
 
+    def seek_skip_errors(self):
+        ts = self.get_example_tree_sequence()
+        tree = _tskit.Tree(ts)
+        for bad_type in ["", "x", {}]:
+            with pytest.raises(TypeError):
+                tree.seek(0, bad_type)
+            with pytest.raises(TypeError):
+                tree.seek_index(0, bad_type)
+
     def test_seek_index_errors(self):
         ts = self.get_example_tree_sequence()
         tree = _tskit.Tree(ts)
@@ -3649,6 +3658,16 @@ class TestTree(LowLevelTestCase):
         for bad_index in [-1, 10**6]:
             with pytest.raises(_tskit.LibraryError):
                 tree.seek_index(bad_index)
+
+    @pytest.mark.parametrize("skip", [True, False])
+    def test_seek_zero(self, skip):
+        ts = self.get_example_tree_sequence()
+        tree1 = _tskit.Tree(ts)
+        tree1.seek_index(0, skip)
+        assert tree1.get_left() == 0
+        tree2 = _tskit.Tree(ts)
+        tree2.seek(0, skip)
+        assert tree2.get_left() == 0
 
     def test_root_threshold(self):
         for ts in self.get_example_tree_sequences():

--- a/python/tests/test_tree_positioning.py
+++ b/python/tests/test_tree_positioning.py
@@ -32,9 +32,6 @@ import tskit
 from tests import tsutil
 from tests.tsutil import get_example_tree_sequences
 
-# ↑ See https://github.com/tskit-dev/tskit/issues/1804 for when
-# we can remove this.
-
 
 class StatefulTree:
     """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -840,7 +840,7 @@ class Tree:
         """
         self._ll_tree.clear()
 
-    def seek_index(self, index):
+    def seek_index(self, index, skip=None):
         """
         Sets the state to represent the tree at the specified
         index in the parent tree sequence. Negative indexes following the
@@ -857,9 +857,10 @@ class Tree:
             index += num_trees
         if index < 0 or index >= num_trees:
             raise IndexError("Index out of bounds")
-        self._ll_tree.seek_index(index)
+        skip = False if skip is None else skip
+        self._ll_tree.seek_index(index, skip)
 
-    def seek(self, position):
+    def seek(self, position, skip=None):
         """
         Sets the state to represent the tree that covers the specified
         position in the parent tree sequence. After a successful return
@@ -875,7 +876,8 @@ class Tree:
         """
         if position < 0 or position >= self.tree_sequence.sequence_length:
             raise ValueError("Position out of bounds")
-        self._ll_tree.seek(position)
+        skip = False if skip is None else skip
+        self._ll_tree.seek(position, skip)
 
     def rank(self) -> tskit.Rank:
         """


### PR DESCRIPTION
## Description

Continuing from #2874, we want to finish moving over the tree-positioning code to use `tree_pos` efficiently. At the moment, `tsk.tree_seek` will either call `tsk_tree_seek_from_null` or `tsk_tree_seek_linear` depending on whether we are starting from the null tree or not. `seek_linear` repeatedly calls `next` or `prev` until it reaches the given position, with the direction being determined by which would cover the shortest distance.

As a first pass, I've implemented `tsk_tree_seek_forward` and `tsk_tree_seek_backward` and I've incorporated them into `tsk_tree_seek_linear`. We will need to revise some of the `test_highlevel.py` seek tests, because the direction we choose to seek along is different to the old approach in some cases. For example, we now seek forward to go from the first to the last tree in a sequence.

Curiously, my implementation passes all the C tests with no memory issues detected by Valgrind, and it also passes all the `test_highlevel.py` and `test_tree_positioning` tests except for the ones dependent on seeking direction. However, it has caused chaos with other Python tests, causing failures and segfaults in `test_stats.py` and `test_divmat.py` among others. The failing/crashing tests seem to be primarily be associated with LD calculations and divergence. 

I'm currently trying to determine whether the problems are due to an error in my implemention (most likely) or the subtle problems with the time ordering of inserted edges, discussed in #2792.

# PR Checklist:

- [ ] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [ ] Changelogs, if there are API changes.
