### PR TITLE
Create C api for two-locus branch stats

### DIFF
--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -226,6 +226,9 @@ tsk_strerror_internal(int err)
             ret = "One of the kept rows in the table refers to a deleted row. "
                   "(TSK_ERR_KEEP_ROWS_MAP_TO_DELETED)";
             break;
+        case TSK_ERR_POSITION_OUT_OF_BOUNDS:
+            ret = "Position out of bounds. (TSK_ERR_POSITION_OUT_OF_BOUNDS)";
+            break;
 
         /* Edge errors */
         case TSK_ERR_NULL_PARENT:
@@ -500,6 +503,24 @@ tsk_strerror_internal(int err)
             break;
         case TSK_ERR_UNSORTED_TIMES:
             ret = "Times must be strictly increasing. (TSK_ERR_UNSORTED_TIMES)";
+            break;
+
+        /* Two locus errors */
+        case TSK_ERR_STAT_UNSORTED_POSITIONS:
+            ret = "The provided positions are not sorted in strictly increasing "
+                  "order. (TSK_ERR_STAT_UNSORTED_POSITIONS)";
+            break;
+        case TSK_ERR_STAT_DUPLICATE_POSITIONS:
+            ret = "The provided positions contain duplicates. "
+                  "(TSK_ERR_STAT_DUPLICATE_POSITIONS)";
+            break;
+        case TSK_ERR_STAT_UNSORTED_SITES:
+            ret = "The provided sites are not sorted in strictly increasing position "
+                  "order. (TSK_ERR_STAT_UNSORTED_SITES)";
+            break;
+        case TSK_ERR_STAT_DUPLICATE_SITES:
+            ret = "The provided sites contain duplicated entries. "
+                  "(TSK_ERR_STAT_DUPLICATE_SITES)";
             break;
 
         /* Mutation mapping errors */

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -370,6 +370,11 @@ One of the rows in the retained table refers to a row that has been
 deleted.
 */
 #define TSK_ERR_KEEP_ROWS_MAP_TO_DELETED                            -212
+/**
+A genomic position was less than zero or greater equal to the sequence
+length
+*/
+#define TSK_ERR_POSITION_OUT_OF_BOUNDS                              -213
 
 /** @} */
 
@@ -710,6 +715,22 @@ The vector of quantiles is out of bounds or in nonascending order.
 Times are not in ascending order
 */
 #define TSK_ERR_UNSORTED_TIMES                                      -917
+/*
+The provided positions are not provided in strictly increasing order
+*/
+#define TSK_ERR_STAT_UNSORTED_POSITIONS                             -918
+/**
+The provided positions are not unique
+*/
+#define TSK_ERR_STAT_DUPLICATE_POSITIONS                            -919
+/**
+The provided sites are not provided in strictly increasing position order
+*/
+#define TSK_ERR_STAT_UNSORTED_SITES                                 -920
+/**
+The provided sites are not unique
+*/
+#define TSK_ERR_STAT_DUPLICATE_SITES                                -921
 /** @} */
 
 /**

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1073,36 +1073,59 @@ int tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self,
 typedef int two_locus_count_stat_method(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_rows, const tsk_id_t *row_sites,
-    tsk_size_t num_cols, const tsk_id_t *col_sites, tsk_flags_t options, double *result);
+    const double *row_positions, tsk_size_t num_cols, const tsk_id_t *col_sites,
+    const double *col_positions, tsk_flags_t options, double *result);
 
 int tsk_treeseq_D(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 int tsk_treeseq_D2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 int tsk_treeseq_r2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 int tsk_treeseq_D_prime(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 int tsk_treeseq_r(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 int tsk_treeseq_Dz(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 int tsk_treeseq_pi2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
     const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
-    const tsk_id_t *row_sites, tsk_size_t num_cols, const tsk_id_t *col_sites,
-    tsk_flags_t options, double *result);
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
+int tsk_treeseq_D2_unbiased(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
+int tsk_treeseq_Dz_unbiased(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
+int tsk_treeseq_pi2_unbiased(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets, tsk_size_t num_rows,
+    const tsk_id_t *row_sites, const double *row_positions, tsk_size_t num_cols,
+    const tsk_id_t *col_sites, const double *col_positions, tsk_flags_t options,
+    double *result);
 
 /* Three way sample set stats */
 int tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,


### PR DESCRIPTION
Adds a C implementation of two-locus branch statistics. It mirrors the python implementation except where we iterate over edge differences and collect them for updating the stat. We use tree_seek_index to seek to arbitrary positions and tsk_tree_next to move from tree to tree. The tricky part was getting backwards iteration correct. All tests agree with the python prototype.

In addition, I had to fix a bug in the python implementation where node ids were being added to our TreeState object instead of sample ids (encoded in the sample index map). The python tests have also been updated to remove the slow naive version (after validating that it agrees with the python and c implementation -- on test cases where the runtime was reasonable). Python tests have been trimmed for runtime.

The CPython code has been updated to parse positions in addition to sites.

I also found the need to clean up some of the bounds checking code to return reasonable error messages to the user (also updated in the two-locus site stats).

Finally, I added a few unbiased statistics for use in validating this code.