### PR TITLE
Catch case when windows do not span entire sequence for pair coalescence stats

### DIFF
--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -373,34 +373,34 @@ verify_pair_coalescence_counts(tsk_treeseq_t *ts, tsk_flags_t options)
 
     index_tuples[0] = (tsk_id_t) P;
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
-        index_tuples, 1, breakpoints, N, node_bin_map, options, C);
+        index_tuples, T, breakpoints, N, node_bin_map, options, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLE_SET_INDEX);
     index_tuples[0] = 0;
 
     tsk_size_t tmp = sample_set_sizes[0];
     sample_set_sizes[0] = 0;
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
-        index_tuples, 1, breakpoints, N, node_bin_map, options, C);
+        index_tuples, T, breakpoints, N, node_bin_map, options, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EMPTY_SAMPLE_SET);
     sample_set_sizes[0] = tmp;
 
     sample_sets[1] = 0;
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
-        index_tuples, 1, breakpoints, N, node_bin_map, options, C);
+        index_tuples, T, breakpoints, N, node_bin_map, options, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
     sample_sets[1] = 1;
 
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
-        index_tuples, 1, breakpoints, N - 1, node_bin_map, options, C);
+        index_tuples, T, breakpoints, N - 1, node_bin_map, options, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NODE_BIN_MAP_DIM);
 
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
-        index_tuples, 1, breakpoints, 0, node_bin_map, options, C);
+        index_tuples, T, breakpoints, 0, node_bin_map, options, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NODE_BIN_MAP_DIM);
 
     node_bin_map[0] = -2;
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
-        index_tuples, 1, breakpoints, N, node_bin_map, options, C);
+        index_tuples, T, breakpoints, N, node_bin_map, options, C);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NODE_BIN_MAP);
     node_bin_map[0] = 0;
 }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -9371,7 +9371,7 @@ tsk_treeseq_pair_coalescence_stat(const tsk_treeseq_t *self, tsk_size_t num_samp
     tsk_memset(&tree_pos, 0, sizeof(tree_pos));
 
     /* check inputs */
-    ret = tsk_treeseq_check_windows(self, num_windows, windows, options);
+    ret = tsk_treeseq_check_windows(self, num_windows, windows, TSK_REQUIRE_FULL_SPAN);
     if (ret != 0) {
         goto out;
     }

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -4402,8 +4402,8 @@ class TestPairCoalescenceCountsErrors:
     def test_c_tsk_err_bad_windows(self):
         ts = self.example_ts()
         L = ts.get_sequence_length()
-        with pytest.raises(_tskit.LibraryError, match="BAD_WINDOWS"):
-            self.pair_coalescence_counts(ts, windows=[-1.0, L])
+        with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_WINDOWS"):
+            self.pair_coalescence_counts(ts, windows=[1.0, L])
 
     def test_c_tsk_err_bad_node_bin_map(self):
         ts = self.example_ts()
@@ -4525,6 +4525,11 @@ class TestPairCoalescenceQuantilesErrors:
         node_bin_map = node_bin_map.astype(np.int32)
         with pytest.raises(_tskit.LibraryError, match="TSK_ERR_UNSORTED_TIMES"):
             self.pair_coalescence_quantiles(ts, node_bin_map=node_bin_map)
+
+    def test_c_tsk_err_bad_windows(self):
+        ts = self.example_ts()
+        with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_WINDOWS"):
+            self.pair_coalescence_quantiles(ts, windows=[1.0, ts.get_sequence_length()])
 
     @pytest.mark.parametrize("bad_ss_size", [-1, 1000])
     def test_cpy_bad_sample_sets(self, bad_ss_size):
@@ -4654,6 +4659,11 @@ class TestPairCoalescenceRatesErrors:
         with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_SAMPLE_PAIR_TIMES"):
             self.pair_coalescence_rates(ts, time_windows=np.array([-1.0, np.inf]))
 
+    def test_c_tsk_err_bad_windows(self):
+        ts = self.example_ts()
+        with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_WINDOWS"):
+            self.pair_coalescence_rates(ts, windows=[1.0, ts.get_sequence_length()])
+
     @pytest.mark.parametrize("bad_ss_size", [-1, 1000])
     def test_cpy_bad_sample_sets(self, bad_ss_size):
         ts = self.example_ts()
@@ -4664,11 +4674,6 @@ class TestPairCoalescenceRatesErrors:
             self.pair_coalescence_rates(
                 ts, sample_set_sizes=[bad_ss_size, ts.get_num_samples()]
             )
-
-    def test_cpy_bad_windows(self):
-        ts = self.example_ts()
-        with pytest.raises(ValueError, match="at least 2"):
-            self.pair_coalescence_rates(ts, windows=[0.0])
 
     @pytest.mark.parametrize("indexes", [[(0, 0, 0)], np.zeros((0, 2), dtype=np.int32)])
     def test_cpy_bad_indexes(self, indexes):


### PR DESCRIPTION
Fixes issue reported here: https://github.com/tskit-dev/tskit/issues/2986#issuecomment-2361134470
