### PR TITLE
Limit metadata HTML output

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -27,6 +27,9 @@
 - Printing ``tskit.MetadataSchema(schema=None)`` now shows ``"Null_schema"`` rather
   than ``None``, to avoid confusion (:user:`hyanwong`, :pr:`2720`)
 
+- Limit output HTML when a tree sequence is displayed that has a large amount of metadata.
+  (:user:`benjeffery`, :pr:`2999`)
+
 **Features**
 
 - Add ``TreeSequence.extend_haplotypes`` method that extends ancestral haplotypes

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -2196,6 +2196,15 @@ class TestTreeSequence(HighLevelTestCase):
         for table in ts.tables.table_name_map:
             assert f"<td>{table.capitalize()}</td>" in html
 
+    def test_html_repr_limit(self, ts_fixture):
+        tables = ts_fixture.tables
+        d = {n: n for n in range(50)}
+        d[0] = "N" * 200
+        tables.metadata = d
+        ts = tables.tree_sequence()
+        assert "... and 20 more" in ts._repr_html_()
+        assert "NN..." in ts._repr_html_()
+
     @pytest.mark.parametrize("ts", get_example_tree_sequences())
     def test_str(self, ts):
         s = str(ts)


### PR DESCRIPTION
Limit both the number of keys, and the length of strings displayed.
![Screenshot from 2024-09-25 10-58-06](https://github.com/user-attachments/assets/9b0e67d3-95ce-4e4a-a388-576885aa915d)
