### PR TITLE
Minor svg rejig

### DIFF
--- a/python/tests/data/svg/internal_sample_ts.svg
+++ b/python/tests/data/svg/internal_sample_ts.svg
@@ -99,17 +99,17 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="leaf node n7 root sample" transform="translate(32.6667 63.504)">
+					<g class="leaf node n7 root sample" transform="translate(134 63.504)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">7</text>
 					</g>
-					<g class="leaf node n8 root sample" transform="translate(58 49.7389)">
+					<g class="leaf node n8 root sample" transform="translate(159.333 49.7389)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">8</text>
 					</g>
-					<g class="c2 m0 m1 node n9 root s0" transform="translate(121.333 22.3778)">
+					<g class="c2 m0 m1 node n9 root s0" transform="translate(70.6667 22.3778)">
 						<g class="a9 c2 node n4" transform="translate(-25.3333 97.7739)">
 							<g class="a4 leaf node n0" transform="translate(-12.6667 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 12.6667"/>
@@ -227,17 +227,17 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="leaf node n7 root sample" transform="translate(32.6667 63.504)">
+					<g class="leaf node n7 root sample" transform="translate(134 63.504)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">7</text>
 					</g>
-					<g class="leaf node n8 root sample" transform="translate(58 49.7389)">
+					<g class="leaf node n8 root sample" transform="translate(159.333 49.7389)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">8</text>
 					</g>
-					<g class="c2 node n6 root" transform="translate(121.333 102.321)">
+					<g class="c2 node n6 root" transform="translate(70.6667 102.321)">
 						<g class="a6 c2 node n4" transform="translate(-25.3333 17.8305)">
 							<g class="a4 leaf node n0" transform="translate(-12.6667 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 12.6667"/>
@@ -325,12 +325,12 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="leaf node n7 root sample" transform="translate(35.2 63.504)">
+					<g class="leaf node n7 root sample" transform="translate(156.8 63.504)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">7</text>
 					</g>
-					<g class="c2 node n8 root sample" transform="translate(111.2 49.7389)">
+					<g class="c2 node n8 root sample" transform="translate(80.8 49.7389)">
 						<g class="a8 c2 node n4" transform="translate(-30.4 70.4129)">
 							<g class="a4 leaf node n0" transform="translate(-15.2 1.24828)">
 								<path class="edge" d="M 0 0 V -1.24828 H 15.2"/>

--- a/python/tests/data/svg/ts_multiroot.svg
+++ b/python/tests/data/svg/ts_multiroot.svg
@@ -253,7 +253,7 @@
 			</g>
 			<g class="tree t1" transform="translate(247.2 0)">
 				<g class="plotbox">
-					<g class="c3 i7 node n6 p0 root" transform="translate(57.6 102.48)">
+					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -272,7 +272,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="c2 i3 node n12 p0 root" transform="translate(126.533 64.64)">
+					<g class="c2 i3 node n12 p0 root" transform="translate(51.3333 64.64)">
 						<g class="a12 i10 leaf m3 node n0 p0 s4 sample" transform="translate(-18.8 56.76)">
 							<path class="edge" d="M 0 0 V -56.76 H 18.8"/>
 							<g class="mut m3 s4 unknown_time" transform="translate(0 -28.38)">
@@ -404,7 +404,7 @@
 			</g>
 			<g class="tree t4" transform="translate(818.4 0)">
 				<g class="plotbox">
-					<g class="c2 i8 node n7 p0 root" transform="translate(45.0667 102.48)">
+					<g class="c2 i8 node n7 p0 root" transform="translate(145.333 102.48)">
 						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -418,7 +418,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
-					<g class="c2 i2 node n13 p0 root" transform="translate(110.867 45.72)">
+					<g class="c2 i2 node n13 p0 root" transform="translate(60.7333 45.72)">
 						<g class="a13 i10 leaf m5 node n0 p0 s7 sample" transform="translate(-28.2 75.68)">
 							<path class="edge" d="M 0 0 V -75.68 H 28.2"/>
 							<g class="mut m5 s7 unknown_time" transform="translate(0 -37.84)">
@@ -466,7 +466,7 @@
 			</g>
 			<g class="tree t5" transform="translate(1008.8 0)">
 				<g class="plotbox">
-					<g class="c2 i8 node n7 p0 root" transform="translate(45.0667 102.48)">
+					<g class="c2 i8 node n7 p0 root" transform="translate(95.2 102.48)">
 						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -480,7 +480,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
-					<g class="c2 i2 node n13 p0 root" transform="translate(95.2 45.72)">
+					<g class="c2 i2 node n13 p0 root" transform="translate(45.0667 45.72)">
 						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-12.5333 75.68)">
 							<path class="edge" d="M 0 0 V -75.68 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -512,7 +512,7 @@
 			</g>
 			<g class="tree t6" transform="translate(1199.2 0)">
 				<g class="plotbox">
-					<g class="c3 i7 node n6 p0 root" transform="translate(57.6 102.48)">
+					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -536,11 +536,11 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="i11 leaf node n1 p0 root sample" transform="translate(107.733 121.4)">
+					<g class="i11 leaf node n1 p0 root sample" transform="translate(82.6667 121.4)">
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">1</text>
 					</g>
-					<g class="c2 i9 node n8 p0 root" transform="translate(145.333 102.48)">
+					<g class="c2 i9 node n8 p0 root" transform="translate(45.0667 102.48)">
 						<g class="a8 i10 leaf m8 node n0 p0 s8 sample" transform="translate(-12.5333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<g class="mut m8 s8 unknown_time" transform="translate(0 -9.46)">
@@ -563,7 +563,7 @@
 			</g>
 			<g class="tree t7" transform="translate(1389.6 0)">
 				<g class="plotbox">
-					<g class="c3 i7 node n6 p0 root" transform="translate(57.6 102.48)">
+					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
 						<g class="a6 i12 leaf m9 node n2 p0 s9 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
 							<g class="mut m9 s9 unknown_time" transform="translate(0 -9.46)">
@@ -587,7 +587,7 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="c2 i4 node n9 p0 root" transform="translate(139.067 83.56)">
+					<g class="c2 i4 node n9 p0 root" transform="translate(63.8667 83.56)">
 						<g class="a9 i11 leaf node n1 p0 sample" transform="translate(18.8 37.84)">
 							<path class="edge" d="M 0 0 V -37.84 H -18.8"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -1686,19 +1686,18 @@ class SvgTree(SvgAxisPlot):
         # Set up x positions for nodes
         node_x_coord = {}
         leaf_x = 0  # First leaf starts at x=1, to give some space between Y axis & leaf
-        for root in self.tree.roots:
-            for u in self.tree.nodes(root, order=self.traversal_order):
-                if self.tree.is_leaf(u):
-                    leaf_x += 1
-                    node_x_coord[u] = leaf_x
+        for u in self.tree.nodes(order=self.traversal_order):
+            if self.tree.is_leaf(u):
+                leaf_x += 1
+                node_x_coord[u] = leaf_x
+            else:
+                child_coords = [node_x_coord[c] for c in self.tree.children(u)]
+                if len(child_coords) == 1:
+                    node_x_coord[u] = child_coords[0]
                 else:
-                    child_coords = [node_x_coord[c] for c in self.tree.children(u)]
-                    if len(child_coords) == 1:
-                        node_x_coord[u] = child_coords[0]
-                    else:
-                        a = min(child_coords)
-                        b = max(child_coords)
-                        node_x_coord[u] = a + (b - a) / 2
+                    a = min(child_coords)
+                    b = max(child_coords)
+                    node_x_coord[u] = a + (b - a) / 2
         # Now rescale to the plot width: leaf_x is the maximum value of the last leaf
         if len(node_x_coord) > 0:
             scale = self.plotbox.width / leaf_x


### PR DESCRIPTION
## Description

This makes the code simpler, and lays the ground for being able to omit nodes when drawing an SVG tree. No extra functionality is produced yet, and it removes lines of code, so I haven't added any tests.

The simpler minlex_postorder function, which doesn't depend on `tree.parent()` but instead stores a "visited" boolean works slightly faster than the previous one, and was the version suggested by Claude. Derivations of this will be useful for visiting a subset of the nodes in the tree, so I wanted to have a simpler base from which to derive more complex traversals.