### PR TITLE
Allow multi-sample tips for Tree.draw_svg()

### DIFF
--- a/python/tests/data/svg/internal_sample_ts.svg
+++ b/python/tests/data/svg/internal_sample_ts.svg
@@ -99,16 +99,6 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="leaf node n7 root sample" transform="translate(134 63.504)">
-						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
-						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab" transform="translate(0 11)">7</text>
-					</g>
-					<g class="leaf node n8 root sample" transform="translate(159.333 49.7389)">
-						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
-						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab" transform="translate(0 11)">8</text>
-					</g>
 					<g class="c2 m0 m1 node n9 root s0" transform="translate(70.6667 22.3778)">
 						<g class="a9 c2 node n4" transform="translate(-25.3333 97.7739)">
 							<g class="a4 leaf node n0" transform="translate(-12.6667 1.24828)">
@@ -123,7 +113,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 25.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 s0" transform="translate(25.3333 86.9138)">
 							<g class="a5 leaf node n2 sample" transform="translate(-12.6667 12.1084)">
@@ -143,7 +133,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -157,7 +147,17 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
+					</g>
+					<g class="leaf node n7 root sample" transform="translate(134 63.504)">
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">7</text>
+					</g>
+					<g class="leaf node n8 root sample" transform="translate(159.333 49.7389)">
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">8</text>
 					</g>
 				</g>
 			</g>
@@ -187,7 +187,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5" transform="translate(30.4 45.7876)">
 							<g class="a5 leaf node n2 sample" transform="translate(-15.2 12.1084)">
@@ -207,7 +207,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -30.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -216,7 +216,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 					<g class="leaf node n8 root sample" transform="translate(156.8 49.7389)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
@@ -227,16 +227,6 @@
 			</g>
 			<g class="tree t2" transform="translate(404 0)">
 				<g class="plotbox">
-					<g class="leaf node n7 root sample" transform="translate(134 63.504)">
-						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
-						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab" transform="translate(0 11)">7</text>
-					</g>
-					<g class="leaf node n8 root sample" transform="translate(159.333 49.7389)">
-						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
-						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab" transform="translate(0 11)">8</text>
-					</g>
 					<g class="c2 node n6 root" transform="translate(70.6667 102.321)">
 						<g class="a6 c2 node n4" transform="translate(-25.3333 17.8305)">
 							<g class="a4 leaf node n0" transform="translate(-12.6667 1.24828)">
@@ -251,7 +241,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 25.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5" transform="translate(25.3333 6.97033)">
 							<g class="a5 leaf node n2 sample" transform="translate(-12.6667 12.1084)">
@@ -266,11 +256,21 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -25.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
+					</g>
+					<g class="leaf node n7 root sample" transform="translate(134 63.504)">
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">7</text>
+					</g>
+					<g class="leaf node n8 root sample" transform="translate(159.333 49.7389)">
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">8</text>
 					</g>
 				</g>
 			</g>
@@ -290,7 +290,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 30.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5" transform="translate(30.4 45.7876)">
 							<g class="a5 leaf node n2 sample" transform="translate(-15.2 12.1084)">
@@ -310,11 +310,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -30.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 					<g class="leaf node n8 root sample" transform="translate(156.8 49.7389)">
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
@@ -325,11 +325,6 @@
 			</g>
 			<g class="tree t4" transform="translate(788 0)">
 				<g class="plotbox">
-					<g class="leaf node n7 root sample" transform="translate(156.8 63.504)">
-						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
-						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab" transform="translate(0 11)">7</text>
-					</g>
 					<g class="c2 node n8 root sample" transform="translate(80.8 49.7389)">
 						<g class="a8 c2 node n4" transform="translate(-30.4 70.4129)">
 							<g class="a4 leaf node n0" transform="translate(-15.2 1.24828)">
@@ -344,7 +339,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 30.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5" transform="translate(30.4 59.5527)">
 							<g class="a5 leaf node n2 sample" transform="translate(-15.2 12.1084)">
@@ -359,11 +354,16 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -30.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
+					</g>
+					<g class="leaf node n7 root sample" transform="translate(156.8 63.504)">
+						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">7</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/tree.svg
+++ b/python/tests/data/svg/tree.svg
@@ -19,7 +19,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -138.937 H 40"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
 				<g class="a8 c2 node n5 p0" transform="translate(40 117.508)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 23.8921)">
@@ -34,7 +34,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -117.508 H -40"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+					<text class="lab rgt" transform="translate(3 -7)">5</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab" transform="translate(0 -11)">8</text>

--- a/python/tests/data/svg/tree_both_axes.svg
+++ b/python/tests/data/svg/tree_both_axes.svg
@@ -31,10 +31,10 @@
 				</g>
 				<line class="ax-line" x1="56.8" x2="56.8" y1="131.4" y2="10"/>
 				<g class="ticks">
-					<g class="tick" transform="translate(56.8 26.8)">
+					<g class="tick" transform="translate(56.8 131.4)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
 						<g transform="translate(-6 0)">
-							<text class="lab" text-anchor="end">6.57</text>
+							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 129.578)">
@@ -43,16 +43,16 @@
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(56.8 131.4)">
-						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6 0)">
-							<text class="lab" text-anchor="end">0.00</text>
-						</g>
-					</g>
 					<g class="tick" transform="translate(56.8 113.726)">
 						<line x1="0" x2="-5" y1="0" y2="0"/>
 						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 26.8)">
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">6.57</text>
 						</g>
 					</g>
 				</g>
@@ -73,7 +73,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -102.778 H 30.8"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
 				<g class="a8 c2 node n5 p0" transform="translate(30.8 86.9259)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-15.4 17.6741)">
@@ -88,7 +88,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -86.9259 H -30.8"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+					<text class="lab rgt" transform="translate(3 -7)">5</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab" transform="translate(0 -11)">8</text>

--- a/python/tests/data/svg/tree_muts.svg
+++ b/python/tests/data/svg/tree_muts.svg
@@ -19,7 +19,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -138.85 H 40"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
 				<g class="a9 c2 m2 node n5 p0 s0" transform="translate(40 123.427)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 17.1953)">
@@ -39,7 +39,7 @@
 						<text class="lab rgt" transform="translate(5 0)">2</text>
 					</g>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+					<text class="lab rgt" transform="translate(3 -7)">5</text>
 				</g>
 				<path class="edge" d="M 0 0 V -17.5778 H 0"/>
 				<g class="mut m0 s0 unknown_time" transform="translate(0 -11.7185)">
@@ -53,7 +53,7 @@
 					<text class="lab rgt" transform="translate(5 0)">1</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
-				<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+				<text class="lab rgt" transform="translate(3 -7)">9</text>
 			</g>
 		</g>
 	</g>

--- a/python/tests/data/svg/tree_muts_all_edge.svg
+++ b/python/tests/data/svg/tree_muts_all_edge.svg
@@ -81,7 +81,7 @@
 						<text class="lab lft" transform="translate(-5 0)">4</text>
 					</g>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
 				<g class="a7 c2 node n5 p0" transform="translate(65 225.94)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-32.5 59.7493)">
@@ -106,7 +106,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -225.94 H -65"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+					<text class="lab rgt" transform="translate(3 -7)">5</text>
 				</g>
 				<path class="edge" d="M 0 0 V -35.7111 H 0"/>
 				<g class="mut m5 s2 unknown_time" transform="translate(0 -17.8556)">
@@ -115,7 +115,7 @@
 					<text class="lab rgt" transform="translate(5 0)">5</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
-				<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+				<text class="lab rgt" transform="translate(3 -7)">7</text>
 			</g>
 		</g>
 	</g>

--- a/python/tests/data/svg/tree_simple_collapsed.svg
+++ b/python/tests/data/svg/tree_simple_collapsed.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
+	<defs>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.x-regions rect {fill: yellow; stroke: black; opacity: 0.5}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.axes .ax-skip {stroke-dasharray: 4}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+	</defs>
+	<g class="tree t0">
+		<g class="plotbox">
+			<g class="c2 node n14 root" transform="translate(115 26.8)">
+				<g class="a14 c2 node n10" transform="translate(-45 47.1333)">
+					<g class="a10 c2 node n8" transform="translate(-30 47.1333)">
+						<path class="edge" d="M 0 0 V -47.1333 H 30"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">+2</text>
+						<text class="lab lft" transform="translate(-3 -7)">8</text>
+					</g>
+					<g class="a10 c2 node n9" transform="translate(30 47.1333)">
+						<g class="a9 leaf node n2 sample" transform="translate(-20 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H 20"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">2</text>
+						</g>
+						<g class="a9 leaf node n3 sample" transform="translate(20 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H -20"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">3</text>
+						</g>
+						<path class="edge" d="M 0 0 V -47.1333 H -30"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
+					</g>
+					<path class="edge" d="M 0 0 V -47.1333 H 45"/>
+					<circle class="sym" cx="0" cy="0" r="3"/>
+					<text class="lab lft" transform="translate(-3 -7)">10</text>
+				</g>
+				<g class="a14 c2 node n13" transform="translate(45 47.1333)">
+					<path class="edge" d="M 0 0 V -47.1333 H -45"/>
+					<circle class="sym" cx="0" cy="0" r="3"/>
+					<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
+					<text class="lab summary" font-style="italic" transform="translate(0 12)">+4</text>
+					<text class="lab rgt" transform="translate(3 -7)">13</text>
+				</g>
+				<circle class="sym" cx="0" cy="0" r="3"/>
+				<text class="lab" transform="translate(0 -11)">14</text>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tests/data/svg/tree_subtree.svg
+++ b/python/tests/data/svg/tree_subtree.svg
@@ -5,55 +5,39 @@
 	</defs>
 	<g class="tree t0">
 		<g class="plotbox">
-			<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(100 72.4037)">
-				<g class="a9 c2 node n4 p0" transform="translate(-40 94.5886)">
-					<g class="a4 leaf node n0 p0 sample" transform="translate(-20 1.20761)">
-						<path class="edge" d="M 0 0 V -1.20761 H 20"/>
+			<g class="a14 c2 node n10" transform="translate(100 26.8)">
+				<g class="a10 c2 node n8" transform="translate(-40 70.7)">
+					<g class="a8 leaf node n0 sample" transform="translate(-20 70.7)">
+						<path class="edge" d="M 0 0 V -70.7 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="a4 leaf node n1 p0 sample" transform="translate(20 1.20761)">
-						<path class="edge" d="M 0 0 V -1.20761 H -20"/>
+					<g class="a8 leaf node n1 sample" transform="translate(20 70.7)">
+						<path class="edge" d="M 0 0 V -70.7 H -20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">1</text>
 					</g>
-					<path class="edge" d="M 0 0 V -94.5886 H 40"/>
+					<path class="edge" d="M 0 0 V -70.7 H 40"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">8</text>
 				</g>
-				<g class="a9 c2 m2 node n5 p0 s0" transform="translate(40 84.0823)">
-					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 11.714)">
-						<path class="edge" d="M 0 0 V -11.714 H 20"/>
+				<g class="a10 c2 node n9" transform="translate(40 70.7)">
+					<g class="a9 leaf node n2 sample" transform="translate(-20 70.7)">
+						<path class="edge" d="M 0 0 V -70.7 H 20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">2</text>
 					</g>
-					<g class="a5 leaf node n3 p0 sample" transform="translate(20 11.714)">
-						<path class="edge" d="M 0 0 V -11.714 H -20"/>
+					<g class="a9 leaf node n3 sample" transform="translate(20 70.7)">
+						<path class="edge" d="M 0 0 V -70.7 H -20"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">3</text>
 					</g>
-					<path class="edge" d="M 0 0 V -84.0823 H -40"/>
-					<g class="mut m2 s0" transform="translate(0 -83.206)">
-						<line x1="0" x2="0" y1="0" y2="83.206"/>
-						<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-						<text class="lab rgt" transform="translate(5 0)">2</text>
-					</g>
+					<path class="edge" d="M 0 0 V -70.7 H -40"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7)">5</text>
-				</g>
-				<path class="edge" d="M 0 0 V -62.4037 H 0"/>
-				<g class="mut m0 s0" transform="translate(0 -62.4037)">
-					<line x1="0" x2="0" y1="0" y2="62.4037"/>
-					<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-					<text class="lab rgt" transform="translate(5 0)">0</text>
-				</g>
-				<g class="mut m1 s0" transform="translate(0 -0.178416)">
-					<line x1="0" x2="0" y1="0" y2="0.178416"/>
-					<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-					<text class="lab rgt" transform="translate(5 0)">1</text>
+					<text class="lab rgt" transform="translate(3 -7)">9</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
-				<text class="lab rgt" transform="translate(3 -7)">9</text>
+				<text class="lab" transform="translate(0 -11)">10</text>
 			</g>
 		</g>
 	</g>

--- a/python/tests/data/svg/tree_subtrees_with_collapsed.svg
+++ b/python/tests/data/svg/tree_subtrees_with_collapsed.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="200" version="1.1" width="200">
+	<defs>
+		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.x-regions rect {fill: yellow; stroke: black; opacity: 0.5}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.axes .ax-skip {stroke-dasharray: 4}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}]]></style>
+	</defs>
+	<g class="tree t0">
+		<g class="plotbox">
+			<g class="a30 c2 node n22" transform="translate(65.4545 26.8)">
+				<g class="a22 c2 node n18" transform="translate(-27.2727 47.1333)">
+					<g class="a18 c2 node n16" transform="translate(-10.9091 47.1333)">
+						<path class="edge" d="M 0 0 V -47.1333 H 10.9091"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">+2</text>
+						<text class="lab lft" transform="translate(-3 -7)">16</text>
+					</g>
+					<g class="a18 c2 node n17" transform="translate(10.9091 47.1333)">
+						<g class="a17 leaf node n2 sample" transform="translate(-7.27273 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H 7.27273"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">2</text>
+						</g>
+						<g class="a17 leaf node n3 sample" transform="translate(7.27273 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H -7.27273"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">3</text>
+						</g>
+						<path class="edge" d="M 0 0 V -47.1333 H -10.9091"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7)">17</text>
+					</g>
+					<path class="edge" d="M 0 0 V -47.1333 H 27.2727"/>
+					<circle class="sym" cx="0" cy="0" r="3"/>
+					<text class="lab lft" transform="translate(-3 -7)">18</text>
+				</g>
+				<g class="a22 c2 node n21" transform="translate(27.2727 47.1333)">
+					<g class="a21 c2 node n19" transform="translate(-14.5455 47.1333)">
+						<g class="a19 leaf node n4 sample" transform="translate(-7.27273 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H 7.27273"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">4</text>
+						</g>
+						<g class="a19 leaf node n5 sample" transform="translate(7.27273 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H -7.27273"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">5</text>
+						</g>
+						<path class="edge" d="M 0 0 V -47.1333 H 14.5455"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab lft" transform="translate(-3 -7)">19</text>
+					</g>
+					<g class="a21 c2 node n20" transform="translate(14.5455 47.1333)">
+						<g class="a20 leaf node n6 sample" transform="translate(-7.27273 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H 7.27273"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">6</text>
+						</g>
+						<g class="a20 leaf node n7 sample" transform="translate(7.27273 47.1333)">
+							<path class="edge" d="M 0 0 V -47.1333 H -7.27273"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">7</text>
+						</g>
+						<path class="edge" d="M 0 0 V -47.1333 H -14.5455"/>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab rgt" transform="translate(3 -7)">20</text>
+					</g>
+					<path class="edge" d="M 0 0 V -47.1333 H -27.2727"/>
+					<circle class="sym" cx="0" cy="0" r="3"/>
+					<text class="lab rgt" transform="translate(3 -7)">21</text>
+				</g>
+				<circle class="sym" cx="0" cy="0" r="3"/>
+				<text class="lab" transform="translate(0 -11)">22</text>
+			</g>
+			<g class="a29 c2 node n25" transform="translate(150.909 73.9333)">
+				<g class="a25 c2 node n23" transform="translate(-14.5455 47.1333)">
+					<g class="a23 leaf node n8 sample" transform="translate(-7.27273 47.1333)">
+						<path class="edge" d="M 0 0 V -47.1333 H 7.27273"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">8</text>
+					</g>
+					<g class="a23 leaf node n9 sample" transform="translate(7.27273 47.1333)">
+						<path class="edge" d="M 0 0 V -47.1333 H -7.27273"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">9</text>
+					</g>
+					<path class="edge" d="M 0 0 V -47.1333 H 14.5455"/>
+					<circle class="sym" cx="0" cy="0" r="3"/>
+					<text class="lab lft" transform="translate(-3 -7)">23</text>
+				</g>
+				<g class="a25 c2 node n24" transform="translate(14.5455 47.1333)">
+					<g class="a24 leaf node n10 sample" transform="translate(-7.27273 47.1333)">
+						<path class="edge" d="M 0 0 V -47.1333 H 7.27273"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">10</text>
+					</g>
+					<g class="a24 leaf node n11 sample" transform="translate(7.27273 47.1333)">
+						<path class="edge" d="M 0 0 V -47.1333 H -7.27273"/>
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">11</text>
+					</g>
+					<path class="edge" d="M 0 0 V -47.1333 H -14.5455"/>
+					<circle class="sym" cx="0" cy="0" r="3"/>
+					<text class="lab rgt" transform="translate(3 -7)">24</text>
+				</g>
+				<circle class="sym" cx="0" cy="0" r="3"/>
+				<text class="lab" transform="translate(0 -11)">25</text>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/python/tests/data/svg/tree_x_axis.svg
+++ b/python/tests/data/svg/tree_x_axis.svg
@@ -72,7 +72,7 @@
 						<text class="lab lft" transform="translate(-5 0)">4</text>
 					</g>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
 				<g class="a7 c2 node n5 p0" transform="translate(90 85.3425)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-45 22.5686)">
@@ -92,7 +92,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -85.3425 H -90"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+					<text class="lab rgt" transform="translate(3 -7)">5</text>
 				</g>
 				<path class="edge" d="M 0 0 V -13.4889 H 0"/>
 				<g class="mut m5 s2 unknown_time" transform="translate(0 -6.74444)">
@@ -101,7 +101,7 @@
 					<text class="lab rgt" transform="translate(5 0)">5</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
-				<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+				<text class="lab rgt" transform="translate(3 -7)">7</text>
 			</g>
 		</g>
 	</g>

--- a/python/tests/data/svg/tree_y_axis_rank.svg
+++ b/python/tests/data/svg/tree_y_axis_rank.svg
@@ -11,11 +11,11 @@
 				</g>
 				<line class="ax-line" x1="56.8" x2="56.8" y1="168.2" y2="10"/>
 				<g class="ticks">
-					<g class="tick" transform="translate(56.8 49.55)">
+					<g class="tick" transform="translate(56.8 168.2)">
 						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
 						<g transform="translate(-6 0)">
-							<text class="lab" text-anchor="end">5.31</text>
+							<text class="lab" text-anchor="end">0.00</text>
 						</g>
 					</g>
 					<g class="tick" transform="translate(56.8 128.65)">
@@ -25,18 +25,18 @@
 							<text class="lab" text-anchor="end">0.11</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(56.8 168.2)">
-						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
-						<line x1="0" x2="-5" y1="0" y2="0"/>
-						<g transform="translate(-6 0)">
-							<text class="lab" text-anchor="end">0.00</text>
-						</g>
-					</g>
 					<g class="tick" transform="translate(56.8 89.1)">
 						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
 						<line x1="0" x2="-5" y1="0" y2="0"/>
 						<g transform="translate(-6 0)">
 							<text class="lab" text-anchor="end">1.11</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(56.8 49.55)">
+						<line class="grid" x1="0" x2="123.2" y1="0" y2="0"/>
+						<line x1="0" x2="-5" y1="0" y2="0"/>
+						<g transform="translate(-6 0)">
+							<text class="lab" text-anchor="end">5.31</text>
 						</g>
 					</g>
 				</g>
@@ -67,7 +67,7 @@
 						<text class="lab lft" transform="translate(-5 0)">4</text>
 					</g>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
 				<g class="a7 c2 node n5 p0" transform="translate(30.8 39.55)">
 					<g class="a5 leaf node n2 p0 sample" transform="translate(-15.4 79.1)">
@@ -87,7 +87,7 @@
 					</g>
 					<path class="edge" d="M 0 0 V -39.55 H -30.8"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
-					<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+					<text class="lab rgt" transform="translate(3 -7)">5</text>
 				</g>
 				<path class="edge" d="M 0 0 V -39.55 H 0"/>
 				<g class="mut m5 s2 unknown_time" transform="translate(0 -19.775)">
@@ -96,7 +96,7 @@
 					<text class="lab rgt" transform="translate(5 0)">5</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
-				<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+				<text class="lab rgt" transform="translate(3 -7)">7</text>
 			</g>
 		</g>
 	</g>

--- a/python/tests/data/svg/ts.svg
+++ b/python/tests/data/svg/ts.svg
@@ -113,7 +113,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -133,7 +133,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -147,7 +147,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -177,7 +177,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -197,7 +197,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -206,7 +206,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -226,7 +226,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -241,11 +241,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -265,7 +265,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -285,11 +285,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -309,7 +309,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -324,11 +324,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_max_trees.svg
+++ b/python/tests/data/svg/ts_max_trees.svg
@@ -157,11 +157,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -10.0352 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -37.8156 H -36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<g class="a33 c2 node n16 p0" transform="translate(-36.8 30.6026)">
 							<g class="a16 i0 leaf node n0 p0 sample" transform="translate(-18.4 18.4673)">
@@ -182,11 +182,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -12.9626 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+								<text class="lab rgt" transform="translate(3 -7)">8</text>
 							</g>
 							<path class="edge" d="M 0 0 V -30.6026 H 36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
+							<text class="lab lft" transform="translate(-3 -7)">16</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">33</text>
@@ -215,11 +215,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -10.0352 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -28.3085 H -36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<g class="a25 c2 node n16 p0" transform="translate(-36.8 21.0956)">
 							<g class="a16 i0 leaf node n0 p0 sample" transform="translate(-18.4 18.4673)">
@@ -240,11 +240,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -12.9626 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+								<text class="lab rgt" transform="translate(3 -7)">8</text>
 							</g>
 							<path class="edge" d="M 0 0 V -21.0956 H 36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
+							<text class="lab lft" transform="translate(-3 -7)">16</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">25</text>
@@ -273,11 +273,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -10.0352 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -33.6434 H -36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<g class="a30 c2 node n16 p0" transform="translate(-36.8 26.4305)">
 							<g class="a16 i0 leaf node n0 p0 sample" transform="translate(-18.4 18.4673)">
@@ -303,11 +303,11 @@
 									<text class="lab rgt" transform="translate(5 0)">1</text>
 								</g>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+								<text class="lab rgt" transform="translate(3 -7)">8</text>
 							</g>
 							<path class="edge" d="M 0 0 V -26.4305 H 36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
+							<text class="lab lft" transform="translate(-3 -7)">16</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">30</text>
@@ -357,15 +357,15 @@
 									</g>
 									<path class="edge" d="M 0 0 V -0.8489 H 18.4"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
-									<text class="lab lft" transform="translate(-3 -7.0)">6</text>
+									<text class="lab lft" transform="translate(-3 -7)">6</text>
 								</g>
 								<path class="edge" d="M 0 0 V -8.03462 H -27.6"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -57.8103 H 41.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">10</text>
+							<text class="lab lft" transform="translate(-3 -7)">10</text>
 						</g>
 						<g class="a42 c2 node n15 p0" transform="translate(41.4 48.8921)">
 							<g class="a15 i1 leaf node n2 p0 sample" transform="translate(-12.2667 18.1721)">
@@ -380,7 +380,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -48.8921 H -41.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">15</text>
+							<text class="lab rgt" transform="translate(3 -7)">15</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">42</text>
@@ -415,11 +415,11 @@
 									</g>
 									<path class="edge" d="M 0 0 V -0.8489 H 18.4"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
-									<text class="lab lft" transform="translate(-3 -7.0)">6</text>
+									<text class="lab lft" transform="translate(-3 -7)">6</text>
 								</g>
 								<path class="edge" d="M 0 0 V -8.03462 H -27.6"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -48.0218 H 41.4"/>
 							<g class="mut m9 s9" transform="translate(0 -38.5128)">
@@ -428,7 +428,7 @@
 								<text class="lab lft" transform="translate(-5 0)">9</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">10</text>
+							<text class="lab lft" transform="translate(-3 -7)">10</text>
 						</g>
 						<g class="a39 c2 node n15 p0" transform="translate(41.4 39.1036)">
 							<g class="a15 i1 leaf node n2 p0 sample" transform="translate(-12.2667 18.1721)">
@@ -443,7 +443,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -39.1036 H -41.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">15</text>
+							<text class="lab rgt" transform="translate(3 -7)">15</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">39</text>

--- a/python/tests/data/svg/ts_max_trees_treewise.svg
+++ b/python/tests/data/svg/ts_max_trees_treewise.svg
@@ -131,11 +131,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -2.97724 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -20.8093 H -36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<g class="a33 c2 node n16 p0" transform="translate(-36.8 18.1703)">
 							<g class="a16 i0 leaf node n0 p0 sample" transform="translate(-18.4 5.9307)">
@@ -156,11 +156,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -4.43354 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+								<text class="lab rgt" transform="translate(3 -7)">8</text>
 							</g>
 							<path class="edge" d="M 0 0 V -18.1703 H 36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
+							<text class="lab lft" transform="translate(-3 -7)">16</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">33</text>
@@ -189,11 +189,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -2.97724 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -13.6556 H -36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<g class="a25 c2 node n16 p0" transform="translate(-36.8 11.0166)">
 							<g class="a16 i0 leaf node n0 p0 sample" transform="translate(-18.4 5.9307)">
@@ -214,11 +214,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -4.43354 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+								<text class="lab rgt" transform="translate(3 -7)">8</text>
 							</g>
 							<path class="edge" d="M 0 0 V -11.0166 H 36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
+							<text class="lab lft" transform="translate(-3 -7)">16</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">25</text>
@@ -247,11 +247,11 @@
 								</g>
 								<path class="edge" d="M 0 0 V -2.97724 H -18.4"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -17.4644 H -36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<g class="a30 c2 node n16 p0" transform="translate(-36.8 14.8254)">
 							<g class="a16 i0 leaf node n0 p0 sample" transform="translate(-18.4 5.9307)">
@@ -277,11 +277,11 @@
 									<text class="lab rgt" transform="translate(5 0)">1</text>
 								</g>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+								<text class="lab rgt" transform="translate(3 -7)">8</text>
 							</g>
 							<path class="edge" d="M 0 0 V -14.8254 H 36.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">16</text>
+							<text class="lab lft" transform="translate(-3 -7)">16</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">30</text>
@@ -331,15 +331,15 @@
 									</g>
 									<path class="edge" d="M 0 0 V -0.21993 H 18.4"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
-									<text class="lab lft" transform="translate(-3 -7.0)">6</text>
+									<text class="lab lft" transform="translate(-3 -7)">6</text>
 								</g>
 								<path class="edge" d="M 0 0 V -2.32404 H -27.6"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -40.5232 H 41.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">10</text>
+							<text class="lab lft" transform="translate(-3 -7)">10</text>
 						</g>
 						<g class="a42 c2 node n15 p0" transform="translate(41.4 37.3484)">
 							<g class="a15 i1 leaf node n2 p0 sample" transform="translate(-12.2667 5.81331)">
@@ -354,7 +354,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -37.3484 H -41.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">15</text>
+							<text class="lab rgt" transform="translate(3 -7)">15</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">42</text>
@@ -389,11 +389,11 @@
 									</g>
 									<path class="edge" d="M 0 0 V -0.21993 H 18.4"/>
 									<circle class="sym" cx="0" cy="0" r="3"/>
-									<text class="lab lft" transform="translate(-3 -7.0)">6</text>
+									<text class="lab lft" transform="translate(-3 -7)">6</text>
 								</g>
 								<path class="edge" d="M 0 0 V -2.32404 H -27.6"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+								<text class="lab rgt" transform="translate(3 -7)">7</text>
 							</g>
 							<path class="edge" d="M 0 0 V -29.1254 H 41.4"/>
 							<g class="mut m9 s9" transform="translate(0 -20.3807)">
@@ -402,7 +402,7 @@
 								<text class="lab lft" transform="translate(-5 0)">9</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">10</text>
+							<text class="lab lft" transform="translate(-3 -7)">10</text>
 						</g>
 						<g class="a39 c2 node n15 p0" transform="translate(41.4 25.9506)">
 							<g class="a15 i1 leaf node n2 p0 sample" transform="translate(-12.2667 5.81331)">
@@ -417,7 +417,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -25.9506 H -41.4"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">15</text>
+							<text class="lab rgt" transform="translate(3 -7)">15</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">39</text>

--- a/python/tests/data/svg/ts_multiroot.svg
+++ b/python/tests/data/svg/ts_multiroot.svg
@@ -229,7 +229,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+							<text class="lab rgt" transform="translate(3 -7)">6</text>
 						</g>
 						<g class="a15 c2 i6 node n11 p0" transform="translate(-31.3333 56.76)">
 							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.5333 37.84)">
@@ -244,7 +244,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.76 H 31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">11</text>
+							<text class="lab lft" transform="translate(-3 -7)">11</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">15</text>
@@ -253,25 +253,6 @@
 			</g>
 			<g class="tree t1" transform="translate(247.2 0)">
 				<g class="plotbox">
-					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
-						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">2</text>
-						</g>
-						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(0.0 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 0.0"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">4</text>
-						</g>
-						<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.0667 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">5</text>
-						</g>
-						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab" transform="translate(0 -11)">6</text>
-					</g>
 					<g class="c2 i3 node n12 p0 root" transform="translate(51.3333 64.64)">
 						<g class="a12 i10 leaf m3 node n0 p0 s4 sample" transform="translate(-18.8 56.76)">
 							<path class="edge" d="M 0 0 V -56.76 H 18.8"/>
@@ -296,10 +277,29 @@
 							</g>
 							<path class="edge" d="M 0 0 V -18.92 H -18.8"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">11</text>
+							<text class="lab rgt" transform="translate(3 -7)">11</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">12</text>
+					</g>
+					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
+						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">2</text>
+						</g>
+						<g class="a6 i14 leaf node n4 p0 sample" transform="translate(0.0 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 0.0"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">4</text>
+						</g>
+						<g class="a6 i15 leaf node n5 p0 sample" transform="translate(25.0667 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -25.0667"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">5</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
 				</g>
 			</g>
@@ -333,7 +333,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -75.68 H -31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+							<text class="lab rgt" transform="translate(3 -7)">6</text>
 						</g>
 						<g class="a14 c2 i6 node n11 p0" transform="translate(-31.3333 56.76)">
 							<g class="a11 i11 leaf node n1 p0 sample" transform="translate(-12.5333 37.84)">
@@ -348,7 +348,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.76 H 31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">11</text>
+							<text class="lab lft" transform="translate(-3 -7)">11</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">14</text>
@@ -380,7 +380,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -75.68 H -31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+							<text class="lab rgt" transform="translate(3 -7)">6</text>
 						</g>
 						<g class="a14 c2 i8 node n7 p0" transform="translate(-31.3333 75.68)">
 							<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
@@ -395,7 +395,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -75.68 H 31.3333"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">7</text>
+							<text class="lab lft" transform="translate(-3 -7)">7</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">14</text>
@@ -404,20 +404,6 @@
 			</g>
 			<g class="tree t4" transform="translate(818.4 0)">
 				<g class="plotbox">
-					<g class="c2 i8 node n7 p0 root" transform="translate(145.333 102.48)">
-						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">1</text>
-						</g>
-						<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.5333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">3</text>
-						</g>
-						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab" transform="translate(0 -11)">7</text>
-					</g>
 					<g class="c2 i2 node n13 p0 root" transform="translate(60.7333 45.72)">
 						<g class="a13 i10 leaf m5 node n0 p0 s7 sample" transform="translate(-28.2 75.68)">
 							<path class="edge" d="M 0 0 V -75.68 H 28.2"/>
@@ -453,20 +439,16 @@
 								</g>
 								<path class="edge" d="M 0 0 V -18.92 H 18.8"/>
 								<circle class="sym" cx="0" cy="0" r="3"/>
-								<text class="lab lft" transform="translate(-3 -7.0)">6</text>
+								<text class="lab lft" transform="translate(-3 -7)">6</text>
 							</g>
 							<path class="edge" d="M 0 0 V -37.84 H -28.2"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">10</text>
+							<text class="lab rgt" transform="translate(3 -7)">10</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">13</text>
 					</g>
-				</g>
-			</g>
-			<g class="tree t5" transform="translate(1008.8 0)">
-				<g class="plotbox">
-					<g class="c2 i8 node n7 p0 root" transform="translate(95.2 102.48)">
+					<g class="c2 i8 node n7 p0 root" transform="translate(145.333 102.48)">
 						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
 							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
@@ -480,6 +462,10 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
+				</g>
+			</g>
+			<g class="tree t5" transform="translate(1008.8 0)">
+				<g class="plotbox">
 					<g class="c2 i2 node n13 p0 root" transform="translate(45.0667 45.72)">
 						<g class="a13 i10 leaf node n0 p0 sample" transform="translate(-12.5333 75.68)">
 							<path class="edge" d="M 0 0 V -75.68 H 12.5333"/>
@@ -493,6 +479,20 @@
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">13</text>
+					</g>
+					<g class="c2 i8 node n7 p0 root" transform="translate(95.2 102.48)">
+						<g class="a7 i11 leaf node n1 p0 sample" transform="translate(-12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">1</text>
+						</g>
+						<g class="a7 i13 leaf node n3 p0 sample" transform="translate(12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">3</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab" transform="translate(0 -11)">7</text>
 					</g>
 					<g class="c2 i7 node n6 p0 root" transform="translate(145.333 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-12.5333 18.92)">
@@ -512,6 +512,29 @@
 			</g>
 			<g class="tree t6" transform="translate(1199.2 0)">
 				<g class="plotbox">
+					<g class="c2 i9 node n8 p0 root" transform="translate(45.0667 102.48)">
+						<g class="a8 i10 leaf m8 node n0 p0 s8 sample" transform="translate(-12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
+							<g class="mut m8 s8 unknown_time" transform="translate(0 -9.46)">
+								<line x1="0" x2="0" y1="0" y2="9.46"/>
+								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
+								<text class="lab lft" transform="translate(-5 0)">8</text>
+							</g>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">0</text>
+						</g>
+						<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.5333 18.92)">
+							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">5</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab" transform="translate(0 -11)">8</text>
+					</g>
+					<g class="i11 leaf node n1 p0 root sample" transform="translate(82.6667 121.4)">
+						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+						<text class="lab" transform="translate(0 11)">1</text>
+					</g>
 					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
 						<g class="a6 i12 leaf node n2 p0 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
@@ -536,33 +559,34 @@
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
 					</g>
-					<g class="i11 leaf node n1 p0 root sample" transform="translate(82.6667 121.4)">
-						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-						<text class="lab" transform="translate(0 11)">1</text>
-					</g>
-					<g class="c2 i9 node n8 p0 root" transform="translate(45.0667 102.48)">
-						<g class="a8 i10 leaf m8 node n0 p0 s8 sample" transform="translate(-12.5333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
-							<g class="mut m8 s8 unknown_time" transform="translate(0 -9.46)">
-								<line x1="0" x2="0" y1="0" y2="9.46"/>
-								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
-								<text class="lab lft" transform="translate(-5 0)">8</text>
-							</g>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">0</text>
-						</g>
-						<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.5333 18.92)">
-							<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">5</text>
-						</g>
-						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab" transform="translate(0 -11)">8</text>
-					</g>
 				</g>
 			</g>
 			<g class="tree t7" transform="translate(1389.6 0)">
 				<g class="plotbox">
+					<g class="c2 i4 node n9 p0 root" transform="translate(63.8667 83.56)">
+						<g class="a9 i11 leaf node n1 p0 sample" transform="translate(18.8 37.84)">
+							<path class="edge" d="M 0 0 V -37.84 H -18.8"/>
+							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+							<text class="lab" transform="translate(0 11)">1</text>
+						</g>
+						<g class="a9 c2 i9 node n8 p0" transform="translate(-18.8 18.92)">
+							<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.5333 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">0</text>
+							</g>
+							<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.5333 18.92)">
+								<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
+								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
+								<text class="lab" transform="translate(0 11)">5</text>
+							</g>
+							<path class="edge" d="M 0 0 V -18.92 H 18.8"/>
+							<circle class="sym" cx="0" cy="0" r="3"/>
+							<text class="lab lft" transform="translate(-3 -7)">8</text>
+						</g>
+						<circle class="sym" cx="0" cy="0" r="3"/>
+						<text class="lab" transform="translate(0 -11)">9</text>
+					</g>
 					<g class="c3 i7 node n6 p0 root" transform="translate(132.8 102.48)">
 						<g class="a6 i12 leaf m9 node n2 p0 s9 sample" transform="translate(-25.0667 18.92)">
 							<path class="edge" d="M 0 0 V -18.92 H 25.0667"/>
@@ -586,30 +610,6 @@
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<text class="lab" transform="translate(0 -11)">6</text>
-					</g>
-					<g class="c2 i4 node n9 p0 root" transform="translate(63.8667 83.56)">
-						<g class="a9 i11 leaf node n1 p0 sample" transform="translate(18.8 37.84)">
-							<path class="edge" d="M 0 0 V -37.84 H -18.8"/>
-							<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-							<text class="lab" transform="translate(0 11)">1</text>
-						</g>
-						<g class="a9 c2 i9 node n8 p0" transform="translate(-18.8 18.92)">
-							<g class="a8 i10 leaf node n0 p0 sample" transform="translate(-12.5333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H 12.5333"/>
-								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-								<text class="lab" transform="translate(0 11)">0</text>
-							</g>
-							<g class="a8 i15 leaf node n5 p0 sample" transform="translate(12.5333 18.92)">
-								<path class="edge" d="M 0 0 V -18.92 H -12.5333"/>
-								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
-								<text class="lab" transform="translate(0 11)">5</text>
-							</g>
-							<path class="edge" d="M 0 0 V -18.92 H 18.8"/>
-							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">8</text>
-						</g>
-						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab" transform="translate(0 -11)">9</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_mut_highlight.svg
+++ b/python/tests/data/svg/ts_mut_highlight.svg
@@ -113,7 +113,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -133,7 +133,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -147,7 +147,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -177,7 +177,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -197,7 +197,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -206,7 +206,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -226,7 +226,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -241,11 +241,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -265,7 +265,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -285,11 +285,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -309,7 +309,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -324,11 +324,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_mut_times.svg
+++ b/python/tests/data/svg/ts_mut_times.svg
@@ -113,7 +113,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -66.6067 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 59.2084)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -133,7 +133,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -43.943 H 0"/>
 						<g class="mut m0 s0" transform="translate(0 -43.943)">
@@ -147,7 +147,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -177,7 +177,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -197,7 +197,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -31.1919 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -34.8261 H 0"/>
 						<g class="mut m5 s2" transform="translate(0 -34.8261)">
@@ -206,7 +206,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -226,7 +226,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -12.1467 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 4.74841)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -241,11 +241,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -4.74841 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.925 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -265,7 +265,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -38.5902 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -285,11 +285,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -31.1919 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.925 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -309,7 +309,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -47.9674 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 40.5692)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -324,11 +324,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -40.5692 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.925 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_mut_times_logscale.svg
+++ b/python/tests/data/svg/ts_mut_times_logscale.svg
@@ -113,7 +113,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -87.1271 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 61.8645)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
@@ -133,7 +133,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -18.2656 H 0"/>
 						<g class="mut m0 s0" transform="translate(0 -18.2656)">
@@ -147,7 +147,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -177,7 +177,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 43.3264)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
@@ -197,7 +197,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -43.3264 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -21.9812 H 0"/>
 						<g class="mut m5 s2" transform="translate(0 -21.9812)">
@@ -206,7 +206,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -226,7 +226,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -35.7303 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 10.4677)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
@@ -241,11 +241,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -10.4677 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.2144 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -265,7 +265,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -68.589 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 43.3264)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
@@ -285,11 +285,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -43.3264 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.2144 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -309,7 +309,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -75.8041 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 50.5416)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 29.5511)">
@@ -324,11 +324,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -50.5416 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.2144 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_mut_times_titles.svg
+++ b/python/tests/data/svg/ts_mut_times_titles.svg
@@ -135,7 +135,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe4!</title>
 							</circle>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 59.2084)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -163,7 +163,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe5!</title>
 							</circle>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -43.943 H 0"/>
 						<g class="mut m0 s0" transform="translate(0 -43.943)">
@@ -183,7 +183,7 @@
 						<circle class="sym" cx="0" cy="0" r="3">
 							<title>NoDe9!</title>
 						</circle>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -223,7 +223,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe4!</title>
 							</circle>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -251,7 +251,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe5!</title>
 							</circle>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -34.8261 H 0"/>
 						<g class="mut m5 s2" transform="translate(0 -34.8261)">
@@ -264,7 +264,7 @@
 						<circle class="sym" cx="0" cy="0" r="3">
 							<title>NoDe7!</title>
 						</circle>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -290,7 +290,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe4!</title>
 							</circle>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 4.74841)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -311,13 +311,13 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe5!</title>
 							</circle>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.925 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3">
 							<title>NoDe6!</title>
 						</circle>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -343,7 +343,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe4!</title>
 							</circle>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -371,13 +371,13 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe5!</title>
 							</circle>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.925 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3">
 							<title>NoDe7!</title>
 						</circle>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -403,7 +403,7 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe4!</title>
 							</circle>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 40.5692)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
@@ -424,13 +424,13 @@
 							<circle class="sym" cx="0" cy="0" r="3">
 								<title>NoDe5!</title>
 							</circle>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -13.925 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3">
 							<title>NoDe8!</title>
 						</circle>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_no_axes.svg
+++ b/python/tests/data/svg/ts_no_axes.svg
@@ -21,7 +21,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -130.073 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 115.625)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
@@ -41,7 +41,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -16.4667 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -10.9778)">
@@ -55,7 +55,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -85,7 +85,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 60.9131)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
@@ -105,7 +105,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -60.9131 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -16.4667 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -8.23333)">
@@ -114,7 +114,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -134,7 +134,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -23.7206 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 9.27292)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
@@ -149,11 +149,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -9.27292 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -16.4667 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -173,7 +173,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -75.3608 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 60.9131)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
@@ -193,11 +193,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -60.9131 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -16.4667 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -217,7 +217,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -93.6731 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 79.2254)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 16.1084)">
@@ -232,11 +232,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -79.2254 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -16.4667 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_plain.svg
+++ b/python/tests/data/svg/ts_plain.svg
@@ -67,7 +67,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -87,7 +87,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -101,7 +101,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -131,7 +131,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -151,7 +151,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -160,7 +160,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -180,7 +180,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -195,11 +195,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -219,7 +219,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -239,11 +239,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -263,7 +263,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -278,11 +278,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_plain_no_xlab.svg
+++ b/python/tests/data/svg/ts_plain_no_xlab.svg
@@ -64,7 +64,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -112.519 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 100.021)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
@@ -84,7 +84,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -14.2444 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -9.4963)">
@@ -98,7 +98,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -128,7 +128,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 52.6927)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
@@ -148,7 +148,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -52.6927 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -14.2444 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -7.12222)">
@@ -157,7 +157,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -177,7 +177,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -20.5195 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 8.02152)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
@@ -192,11 +192,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -8.02152 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -14.2444 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -216,7 +216,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -65.1907 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 52.6927)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
@@ -236,11 +236,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -52.6927 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -14.2444 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -260,7 +260,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -81.0317 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 68.5337)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 13.9345)">
@@ -275,11 +275,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -68.5337 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -14.2444 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_plain_y.svg
+++ b/python/tests/data/svg/ts_plain_y.svg
@@ -96,7 +96,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -116,7 +116,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -130,7 +130,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -160,7 +160,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -180,7 +180,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -189,7 +189,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -209,7 +209,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(36.16 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -224,11 +224,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -248,7 +248,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -268,11 +268,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -292,7 +292,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(36.16 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -307,11 +307,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_rank.svg
+++ b/python/tests/data/svg/ts_rank.svg
@@ -163,7 +163,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -79.5714 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 63.6571)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
@@ -183,7 +183,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -15.9143 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -10.6095)">
@@ -197,7 +197,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -227,7 +227,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 31.8286)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
@@ -247,7 +247,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -31.8286 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -15.9143 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -7.95714)">
@@ -256,7 +256,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -276,7 +276,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -31.8286 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(36.16 15.9143)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
@@ -291,11 +291,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -15.9143 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -15.9143 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -315,7 +315,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -47.7429 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 31.8286)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
@@ -335,11 +335,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -31.8286 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -15.9143 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -359,7 +359,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -63.6571 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(36.16 47.7429)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 31.8286)">
@@ -374,11 +374,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -47.7429 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -15.9143 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_x_lim.svg
+++ b/python/tests/data/svg/ts_x_lim.svg
@@ -69,7 +69,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 36.6667"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 node n5 p0" transform="translate(36.6667 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
@@ -84,11 +84,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -86.9138 H -36.6667"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -118,7 +118,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.6667 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
@@ -138,7 +138,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.6667"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -147,7 +147,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -167,7 +167,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 36.6667"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(36.6667 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.3333 12.1084)">
@@ -182,11 +182,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -36.6667"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_xlabel.svg
+++ b/python/tests/data/svg/ts_xlabel.svg
@@ -113,7 +113,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -133,7 +133,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -147,7 +147,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -177,7 +177,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -197,7 +197,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -206,7 +206,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -226,7 +226,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(38 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -241,11 +241,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -265,7 +265,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(38 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -285,11 +285,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -309,7 +309,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(38 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 12.1084)">
@@ -324,11 +324,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -38"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_y_axis.svg
+++ b/python/tests/data/svg/ts_y_axis.svg
@@ -163,7 +163,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -183,7 +183,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -197,7 +197,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -227,7 +227,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -247,7 +247,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -256,7 +256,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -276,7 +276,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(36.16 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -291,11 +291,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -315,7 +315,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -335,11 +335,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -359,7 +359,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(36.16 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -374,11 +374,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_y_axis_log.svg
+++ b/python/tests/data/svg/ts_y_axis_log.svg
@@ -163,7 +163,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -94.3769 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 67.0122)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
@@ -183,7 +183,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -9.59208 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.63554)">
@@ -197,7 +197,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -227,7 +227,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 46.9316)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
@@ -247,7 +247,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -46.9316 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -10.1593 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -10.1593)">
@@ -256,7 +256,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -276,7 +276,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -38.7034 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(36.16 11.3388)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
@@ -291,11 +291,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -11.3388 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -9.59208 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -315,7 +315,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -74.2963 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 46.9316)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
@@ -335,11 +335,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -46.9316 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -9.59208 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -359,7 +359,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -82.1118 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(36.16 54.7471)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 32.01)">
@@ -374,11 +374,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -54.7471 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -9.59208 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tests/data/svg/ts_y_axis_regular.svg
+++ b/python/tests/data/svg/ts_y_axis_regular.svg
@@ -191,7 +191,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -97.7739 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 86.9138)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -211,7 +211,7 @@
 								<text class="lab rgt" transform="translate(5 0)">2</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m0 s0 unknown_time" transform="translate(0 -8.25185)">
@@ -225,7 +225,7 @@
 							<text class="lab rgt" transform="translate(5 0)">1</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">9</text>
+						<text class="lab rgt" transform="translate(3 -7)">9</text>
 					</g>
 				</g>
 			</g>
@@ -255,7 +255,7 @@
 								<text class="lab lft" transform="translate(-5 0)">4</text>
 							</g>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -275,7 +275,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<g class="mut m5 s2 unknown_time" transform="translate(0 -6.18889)">
@@ -284,7 +284,7 @@
 							<text class="lab rgt" transform="translate(5 0)">5</text>
 						</g>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -304,7 +304,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -17.8305 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a6 c2 node n5 p0" transform="translate(36.16 6.97033)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -319,11 +319,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -6.97033 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">6</text>
+						<text class="lab rgt" transform="translate(3 -7)">6</text>
 					</g>
 				</g>
 			</g>
@@ -343,7 +343,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -56.6478 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a7 c2 node n5 p0" transform="translate(36.16 45.7876)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -363,11 +363,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -45.7876 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">7</text>
+						<text class="lab rgt" transform="translate(3 -7)">7</text>
 					</g>
 				</g>
 			</g>
@@ -387,7 +387,7 @@
 							</g>
 							<path class="edge" d="M 0 0 V -70.4129 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab lft" transform="translate(-3 -7.0)">4</text>
+							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
 						<g class="a8 c2 node n5 p0" transform="translate(36.16 59.5527)">
 							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 12.1084)">
@@ -402,11 +402,11 @@
 							</g>
 							<path class="edge" d="M 0 0 V -59.5527 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
-							<text class="lab rgt" transform="translate(3 -7.0)">5</text>
+							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
 						<path class="edge" d="M 0 0 V -12.3778 H 0"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
-						<text class="lab rgt" transform="translate(3 -7.0)">8</text>
+						<text class="lab rgt" transform="translate(3 -7)">8</text>
 					</g>
 				</g>
 			</g>

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -1949,7 +1949,7 @@ class Tree:
             mutation_titles=mutation_titles,
             root_svg_attributes=root_svg_attributes,
             style=style,
-            order=order,
+            order=order,  # NB undocumented: Tree.draw_svg can also take an iterable here
             force_root_branch=force_root_branch,
             symbol_size=symbol_size,
             x_axis=x_axis,


### PR DESCRIPTION
As discussed with @benjeffery, these are induced by passing a different (postorder) list as the `order` parameter. This additional use of "order" is deliberately not documented. Here's an example:

<img width="167" alt="Screenshot 2024-10-07 at 15 28 01" src="https://github.com/user-attachments/assets/75e969f8-4e0e-4e36-975e-06132a54cebb">

The stored SVGs have changed because as part of the refactoring I properly rounded some floating point values, so now e.g. positions like `7.0` are stored as simply `7` in the SVG, for clarity and efficiency.