### PR TITLE
Add resources to provenance

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -80,13 +80,19 @@ To make things more concrete, let's consider an example:
       "version": "#31~16.04.1-Ubuntu SMP Wed Jul 18 08:54:04 UTC 2018",
       "machine": "x86_64"
     }
+  },
+  "resources": {
+    "elapsed_time": 12.34,
+    "user_time": 10.56,
+    "sys_time": 1.78,
+    "max_memory": 1048576
   }
 }
 ```
 
 This information records the provenance for a very simple msprime simulation. The record is a JSON
-object with three mandatory fields ("software", "parameters" and "environment")
-which we discuss separately in the following sections.
+object with three mandatory fields ("software", "parameters" and "environment") and one optional
+("resources") which we discuss separately in the following sections.
 
 (sec_provenance_software)=
 
@@ -220,6 +226,19 @@ function:
 The `libraries` section captures information about important libraries that the
 primary software links against. There is no required structure.
 
+
+## Resources
+
+The resources section captures details about the computational resources used during the execution of the software. This section is optional and has the following fields, each of which is optional and may not be filled depending on os support:
+
+
+- `elapsed_time`: The total elapsed time in seconds.
+- `user_time`: The total user CPU time in seconds.
+- `sys_time`: The total system CPU time in seconds.
+- `max_memory`: The maximum memory usage in bytes.
+
+Including this information makes it easy for users of tree-sequence producing software to
+account for resource usage across pipelines of tools.
 
 (sec_provenance_schema)=
 

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -90,6 +90,9 @@
 - Add comma separation to all display numbers. (:user:`benjeffery`, :issue:`3017`, :pr:`3018`)
 
 
+- Add ``resources`` section to provenance schema. (:user:`benjeffery`, :pr:`3016`)
+
+
 --------------------
 [0.5.8] - 2024-06-27
 --------------------

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -43,9 +43,6 @@ import tskit
 import tskit.provenance as provenance
 
 
-_start_time = time.time()
-
-
 def get_provenance(
     software_name="x",
     software_version="y",
@@ -231,11 +228,12 @@ class TestGetResources:
 
     def test_get_resources_values(self):
         delta = 0.1
-        resources = provenance.get_resources(time.time() - delta)
+        t = time.time()
+        resources = provenance.get_resources(t - delta)
         assert isinstance(resources["elapsed_time"], float)
         assert isinstance(resources["user_time"], float)
         assert isinstance(resources["sys_time"], float)
-        assert resources["elapsed_time"] >= delta
+        assert resources["elapsed_time"] >= delta - 0.001
         assert resources["user_time"] > 0
         assert resources["sys_time"] > 0
         if resource is not None:
@@ -272,7 +270,7 @@ class TestGetSchema:
     def test_form(self):
         s = provenance.get_schema()
         assert s["schema"] == "http://json-schema.org/draft-07/schema#"
-        assert s["version"] == "1.0.0"
+        assert s["version"] == "1.1.0"
 
 
 class TestTreeSeqEditMethods:

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -32,7 +32,7 @@ import time
 try:
     import resource
 except ImportError:
-    resource = None  # resource.getrusage absent on windows
+    resource = None  # resource absent on windows
 
 
 import msprime
@@ -221,28 +221,29 @@ class TestEnvironment:
 
 
 class TestGetResources:
-    def test_used_resources_keys(self):
-        resources = provenance.get_resources(_start_time)
+    def test_get_resources_keys(self):
+        resources = provenance.get_resources(0)
         assert "elapsed_time" in resources
         assert "user_time" in resources
         assert "sys_time" in resources
         if resource is not None:
             assert "max_memory" in resources
 
-    def test_used_resources_values(self):
-        resources = provenance.get_resources(_start_time)
+    def test_get_resources_values(self):
+        delta = 0.1
+        resources = provenance.get_resources(time.time() - delta)
         assert isinstance(resources["elapsed_time"], float)
         assert isinstance(resources["user_time"], float)
         assert isinstance(resources["sys_time"], float)
-        assert resources["elapsed_time"] > 0.0001
-        assert resources["user_time"] > 0.0001
-        assert resources["sys_time"] > 0.0001
+        assert resources["elapsed_time"] >= delta
+        assert resources["user_time"] > 0
+        assert resources["sys_time"] > 0
         if resource is not None:
             assert isinstance(resources["max_memory"], int)
             assert resources["max_memory"] > 1024
 
-    def test_used_resources_platform(self):
-        resources = provenance.get_resources(_start_time)
+    def test_get_resources_platform(self):
+        resources = provenance.get_resources(0)
         if sys.platform != "darwin" and resource is not None:
             assert resources["max_memory"] % 1024 == 0
 

--- a/python/tskit/provenance.py
+++ b/python/tskit/provenance.py
@@ -88,11 +88,10 @@ def get_resources(start_time):
         "sys_time": times.system + times.children_system,
     }
     if resource is not None:
-        # Don't report max memory on Windows. We could do this using the psutil lib, via
-        # psutil.Process(os.getpid()).get_ext_memory_info().peak_wset if demand exists
+        # Don't report max memory on Windows, we would need an external dep like psutil
         ret["max_memory"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         if sys.platform != "darwin":
-            ret["max_memory"] *= 1024  # Linux, freeBSD et al reports in KB, not bytes
+            ret["max_memory"] *= 1024  # Linux, freeBSD et al reports in KiB, not bytes
 
     return ret
 

--- a/python/tskit/provenance.py
+++ b/python/tskit/provenance.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2023 Tskit Developers
+# Copyright (c) 2018-2024 Tskit Developers
 # Copyright (c) 2016-2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -27,6 +27,13 @@ of various dependencies and the OS.
 import json
 import os.path
 import platform
+import sys
+import time
+
+try:
+    import resource
+except ImportError:
+    resource = None  # resource.getrusage absent on windows
 
 import jsonschema
 
@@ -70,6 +77,24 @@ def get_environment(extra_libs=None, include_tskit=True):
         libs.update(extra_libs)
     env["libraries"] = libs
     return env
+
+
+def get_resources(start_time):
+    # Returns a dict describing the resources used by the current process
+    times = os.times()
+    ret = {
+        "elapsed_time": time.time() - start_time,
+        "user_time": times.user + times.children_user,
+        "sys_time": times.system + times.children_system,
+    }
+    if resource is not None:
+        # Don't report max memory on Windows. We could do this using the psutil lib, via
+        # psutil.Process(os.getpid()).get_ext_memory_info().peak_wset if demand exists
+        ret["max_memory"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if sys.platform != "darwin":
+            ret["max_memory"] *= 1024  # Linux, freeBSD et al reports in KB, not bytes
+
+    return ret
 
 
 def get_provenance_dict(parameters=None):

--- a/python/tskit/provenance.schema.json
+++ b/python/tskit/provenance.schema.json
@@ -1,6 +1,6 @@
 {
   "schema": "http://json-schema.org/draft-07/schema#",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "title": "tskit provenance",
   "description": "The combination of software, parameters and environment that produced a tree sequence",
   "type": "object",

--- a/python/tskit/provenance.schema.json
+++ b/python/tskit/provenance.schema.json
@@ -45,6 +45,28 @@
           "type": "object"
         }
       }
+    },
+    "resources": {
+      "description": "Resources used by this operation.",
+      "type": "object",
+      "properties": {
+        "elapsed_time": {
+          "description": "Wall clock time in used in seconds.",
+          "type": "number"
+        },
+        "user_time": {
+          "description": "User time used in seconds.",
+          "type": "number"
+        },
+        "sys_time": {
+          "description": "System time used in seconds.",
+          "type": "number"
+        },
+        "max_memory": {
+          "description": "Maximum memory used in bytes.",
+          "type": "number"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Add optional `resources` to provenances along with a helper method to populate the field. This is intended for long-running processed such as tsinfer, where measuring the resources used across distributed pipelines is awkward and easier to do in the actual process that makes the tree sequence.

# PR Checklist:

- [X] Tests that fully cover new/changed functionality.
- [X] Documentation including tutorial content if appropriate.
- [X] Changelogs, if there are API changes.
