### PR TITLE
Use more recent Sphinx

### DIFF
--- a/python/requirements/development.txt
+++ b/python/requirements/development.txt
@@ -28,7 +28,7 @@ pytest
 pytest-cov
 pytest-xdist
 si-prefix
-sphinx==4.5
+sphinx==7.4.7
 sphinx-argparse
 sphinx-autodoc-typehints>=1.18.3
 sphinx-issues


### PR DESCRIPTION
I seem to need this to get the docs compiling on my Mac laptop, which seems to require Sphinx >= 5. Is there any reason we pin to 4.5 specifically? 7.4.7 is the latest in the v7 series, and v8 is too bleeding edge to work smoothly.