### PR TITLE
python3 -> python in Makefile

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -71,11 +71,11 @@ an overview of how to contribute a new feature to `tskit`.
 ### Requirements
 
 To develop the Python code you will need a working C compiler and a
-development installation of Python (>= 3.8). On Debian/Ubuntu we can install these
+development installation of Python (>= 3.9). On Debian/Ubuntu we can install these
 with:
 
 ```bash
-$ sudo apt install python3-dev build-essential doxygen
+$ sudo apt install python3-dev python-is-python3 build-essential doxygen
 ```
 
 Python packages required for development are listed in `python/requirements/development.txt`.

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,12 +1,17 @@
+PYTHON := $(shell command -v python 2> /dev/null)
+ifndef PYTHON
+$(error "python is not available via the `python` executable. If you have python only via `python3` you may need to `apt install python-is-python3`")
+endif
 
 all: ext3
 
 allchecks: _tskitmodule.c
 	CFLAGS="-std=c99 --coverage -Wall -Wextra -Werror -Wno-unused-parameter -Wno-cast-function-type" \
-	python3 setup.py build_ext --inplace
+	python setup.py build_ext --inplace
 
 ext3: _tskitmodule.c
-	python3 setup.py build_ext --inplace
+	
+	python setup.py build_ext --inplace
 
 ctags:
 	ctags lib/*.c lib/*.h tskit/*.py


### PR DESCRIPTION
My installation doesn't bother defining python3 any more. I think we can assume python is v3 now
