### PR TITLE
Correct module name in  _config.yml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,7 +44,7 @@ sphinx:
     config:
       html_theme: sphinx_book_theme
       html_theme_options:
-        pygment_dark_style: monokai
+        pygments_dark_style: monokai
         navigation_with_keys: false
       pygments_style: monokai
       myst_enable_extensions:


### PR DESCRIPTION
The new theme is pygments (with an s): this PR simply removes a warning.
