### PR TITLE
Remove tsk_bug_assertion in pair_coalescence_rates triggered by fp error

### DIFF
--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -9798,7 +9798,6 @@ pair_coalescence_rates(tsk_size_t input_dim, const double *weight, const double 
     }
     coalesced = 0.0;
     for (i = 0; i < j; i++) {
-        tsk_bug_assert(weight[i] >= 0 && weight[i] <= 1);
         a = time_windows[i];
         b = time_windows[i + 1];
         if (i + 1 == j) {


### PR DESCRIPTION
Apologies for dropping a bug fix immediately after a release (fixes #3035).

This removes an assertion from the C library that can be spuriously triggered by a floating point comparison against 1 (which should only happen in the edge case where a single time window contains all the coalescence events).
