### PR TITLE
Add textual mouseover descriptions of collapsed nodes

### DIFF
--- a/python/tests/data/svg/tree_poly_tracked.svg
+++ b/python/tests/data/svg/tree_poly_tracked.svg
@@ -15,7 +15,10 @@
 						</g>
 						<g class="polytomy">
 							<line x1="0" x2="60.12092217774324" y1="0" y2="0"/>
-							<text dy="-1.4" font-style="italic" text-anchor="end" x="60.1209">+3/𝟑</text>
+							<text dy="-1.4" font-style="italic" text-anchor="end" x="60.1209">
+								+3/𝟑
+								<title>This polytomy has 3 additional branches, leading to a total of 3 descendant samples</title>
+							</text>
 						</g>
 						<path class="edge" d="M 0 0 V -47.1333 H 48.8646"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
@@ -23,7 +26,10 @@
 					</g>
 					<g class="polytomy">
 						<line x1="0" x2="90.18138326661489" y1="0" y2="0"/>
-						<text dy="-1.4" font-style="italic" text-anchor="end" x="90.1814">+3/𝟑</text>
+						<text dy="-1.4" font-style="italic" text-anchor="end" x="90.1814">
+							+3/𝟑
+							<title>This polytomy has 3 additional branches, leading to a total of 3 descendant samples</title>
+						</text>
 					</g>
 					<path class="edge" d="M 0 0 V -47.1333 H -45.1559"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
@@ -34,7 +40,10 @@
 						<path class="edge" d="M 0 0 V -47.1333 H -112.825"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
-						<text class="lab summary" font-style="italic" transform="translate(0 12)">+2</text>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">
+							+2
+							<title>A collapsed non-sample node with 2 descendant samples in this tree</title>
+						</text>
 						<text class="lab rgt" transform="translate(3 -7)">36</text>
 					</g>
 					<g class="a40 c2 node n37" transform="translate(-18.8041 47.1333)">
@@ -93,7 +102,10 @@
 				</g>
 				<g class="polytomy">
 					<line x1="0" x2="199.0135203438602" y1="0" y2="0"/>
-					<text dy="-1.4" font-style="italic" text-anchor="end" x="199.014">+14/𝟐</text>
+					<text dy="-1.4" font-style="italic" text-anchor="end" x="199.014">
+						+14/𝟐
+						<title>This polytomy has 2 additional branches, leading to a total of 14 descendant samples</title>
+					</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab" transform="translate(0 -11)">41</text>

--- a/python/tests/data/svg/tree_poly_tracked_collapse.svg
+++ b/python/tests/data/svg/tree_poly_tracked_collapse.svg
@@ -15,7 +15,10 @@
 						</g>
 						<g class="polytomy">
 							<line x1="0" x2="69.44895759936173" y1="0" y2="0"/>
-							<text dy="-1.4" font-style="italic" text-anchor="end" x="69.449">+3/𝟑</text>
+							<text dy="-1.4" font-style="italic" text-anchor="end" x="69.449">
+								+3/𝟑
+								<title>This polytomy has 3 additional branches, leading to a total of 3 descendant samples</title>
+							</text>
 						</g>
 						<path class="edge" d="M 0 0 V -47.1333 H 56.4461"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
@@ -23,7 +26,10 @@
 					</g>
 					<g class="polytomy">
 						<line x1="0" x2="104.17343639904266" y1="0" y2="0"/>
-						<text dy="-1.4" font-style="italic" text-anchor="end" x="104.173">+3/𝟑</text>
+						<text dy="-1.4" font-style="italic" text-anchor="end" x="104.173">
+							+3/𝟑
+							<title>This polytomy has 3 additional branches, leading to a total of 3 descendant samples</title>
+						</text>
 					</g>
 					<path class="edge" d="M 0 0 V -47.1333 H -41.3013"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
@@ -34,7 +40,10 @@
 						<path class="edge" d="M 0 0 V -47.1333 H -108.608"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
-						<text class="lab summary" font-style="italic" transform="translate(0 12)">+2</text>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">
+							+2
+							<title>A collapsed non-sample node with 2 descendant samples in this tree</title>
+						</text>
 						<text class="lab rgt" transform="translate(3 -7)">36</text>
 					</g>
 					<g class="a40 c2 node n37" transform="translate(-43.4433 47.1333)">
@@ -71,7 +80,10 @@
 						<path class="edge" d="M 0 0 V -47.1333 H 108.608"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
-						<text class="lab summary" font-style="italic" transform="translate(0 12)">+3</text>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">
+							+3
+							<title>A collapsed non-sample node with 3 descendant samples in this tree</title>
+						</text>
 						<text class="lab rgt" transform="translate(3 -7)">39</text>
 					</g>
 					<path class="edge" d="M 0 0 V -47.1333 H 188.918"/>
@@ -80,7 +92,10 @@
 				</g>
 				<g class="polytomy">
 					<line x1="0" x2="219.0305567438898" y1="0" y2="0"/>
-					<text dy="-1.4" font-style="italic" text-anchor="end" x="219.031">+14/𝟐</text>
+					<text dy="-1.4" font-style="italic" text-anchor="end" x="219.031">
+						+14/𝟐
+						<title>This polytomy has 2 additional branches, leading to a total of 14 descendant samples</title>
+					</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>
 				<text class="lab" transform="translate(0 -11)">41</text>

--- a/python/tests/data/svg/tree_simple_collapsed.svg
+++ b/python/tests/data/svg/tree_simple_collapsed.svg
@@ -11,7 +11,10 @@
 						<path class="edge" d="M 0 0 V -47.1333 H 30"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
-						<text class="lab summary" font-style="italic" transform="translate(0 12)">+2</text>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">
+							+2
+							<title>A collapsed non-sample node with 2 descendant samples in this tree</title>
+						</text>
 						<text class="lab lft" transform="translate(-3 -7)">8</text>
 					</g>
 					<g class="a10 c2 node n9" transform="translate(30 47.1333)">
@@ -37,7 +40,10 @@
 					<path class="edge" d="M 0 0 V -47.1333 H -45"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
-					<text class="lab summary" font-style="italic" transform="translate(0 12)">+4</text>
+					<text class="lab summary" font-style="italic" transform="translate(0 12)">
+						+4
+						<title>A collapsed non-sample node with 4 descendant samples in this tree</title>
+					</text>
 					<text class="lab rgt" transform="translate(3 -7)">13</text>
 				</g>
 				<circle class="sym" cx="0" cy="0" r="3"/>

--- a/python/tests/data/svg/tree_subtrees_with_collapsed.svg
+++ b/python/tests/data/svg/tree_subtrees_with_collapsed.svg
@@ -11,7 +11,10 @@
 						<path class="edge" d="M 0 0 V -47.1333 H 10.9091"/>
 						<circle class="sym" cx="0" cy="0" r="3"/>
 						<polygon class="sym multi" points="3.0,0 6,6 -6,6 -3.0,0"/>
-						<text class="lab summary" font-style="italic" transform="translate(0 12)">+2</text>
+						<text class="lab summary" font-style="italic" transform="translate(0 12)">
+							+2
+							<title>A collapsed non-sample node with 2 descendant samples in this tree</title>
+						</text>
 						<text class="lab lft" transform="translate(-3 -7)">16</text>
 					</g>
 					<g class="a18 c2 node n17" transform="translate(10.9091 47.1333)">

--- a/python/tskit/drawing.py
+++ b/python/tskit/drawing.py
@@ -1990,15 +1990,20 @@ class SvgTree(SvgAxisPlot):
                         end=(x2, 0),
                     )
                 )
-                poly.add(
-                    dwg.text(
-                        f"+{info.num_samples}/{bold_integer(info.num_branches)}",
-                        font_style="italic",
-                        x=[rnd(x2)],
-                        dy=[rnd(-self.text_height / 10)],  # make the plus sign line up
-                        text_anchor="end",
+                label = dwg.text(
+                    f"+{info.num_samples}/{bold_integer(info.num_branches)}",
+                    font_style="italic",
+                    x=[rnd(x2)],
+                    dy=[rnd(-self.text_height / 10)],  # make the plus sign line up
+                    text_anchor="end",
+                )
+                label.set_desc(
+                    title=(
+                        f"This polytomy has {info.num_branches} additional branches, "
+                        f"leading to a total of {info.num_samples} descendant samples"
                     )
                 )
+                poly.add(label)
                 curr_svg_group.add(poly)
 
             # Add edge above node first => on layer underneath anything else
@@ -2092,14 +2097,18 @@ class SvgTree(SvgAxisPlot):
                 node_lab_attr["transform"] = self.text_transform("above")
             else:
                 if multi_samples is not None:
-                    curr_svg_group.add(
-                        dwg.text(
-                            text=f"+{multi_samples}",
-                            transform=self.text_transform("below", dy=1),
-                            font_style="italic",
-                            class_="lab summary",
-                        )
+                    label = dwg.text(
+                        text=f"+{multi_samples}",
+                        transform=self.text_transform("below", dy=1),
+                        font_style="italic",
+                        class_="lab summary",
                     )
+                    title = (
+                        f"A collapsed {'sample' if tree.is_sample(u) else 'non-sample'} "
+                        f"node with {multi_samples} descendant samples in this tree"
+                    )
+                    label.set_desc(title=title)
+                    curr_svg_group.add(label)
                 if u == left_child[tree.parent(u)]:
                     add_class(node_lab_attr, "lft")
                     node_lab_attr["transform"] = self.text_transform("above_left")


### PR DESCRIPTION
I realised that the numbers can be somewhat cryptic, and it's trivial to add helpful text that appears on mouseover, e.g. "This polytomy has 3 additional branches, leading to a total of 14 descendant samples"

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
