### PR TITLE
add GIL release for statistics

### DIFF
--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9715,9 +9715,11 @@ TreeSequence_weighted_stat_vector_method(
     if (result_array == NULL) {
         goto out;
     }
+	Py_BEGIN_ALLOW_THREADS
     err = method(self->tree_sequence, w_shape[1], PyArray_DATA(weights_array),
         num_windows, PyArray_DATA(windows_array), num_focal_nodes,
         PyArray_DATA(focal_nodes_array), PyArray_DATA(result_array), options);
+	Py_END_ALLOW_THREADS
     if (err != 0) {
         handle_library_error(err);
         goto out;


### PR DESCRIPTION
## Description

This is a simple addition that releases GIL for a number of statistics methods including `genetic_relatedness_vector`.
Given this addition, one can use the `threading` module to enable multi-threading.

```
import tskit
import msprime
import numpy as np
import time
import matplotlib.pyplot as plt

import threading

def _genetic_relatedness_vector_threads(
        ts: tskit.TreeSequence,
        W: np.ndarray,
        num_threads: int = 4,
        ) -> np.ndarray:

    def _f(chunk, x):
        x += ts.genetic_relatedness_vector(
                W, mode='branch', centre=False, windows=chunk
            )[0]

    x = np.zeros_like(W)
    chunks = np.linspace(0, ts.sequence_length, num_threads+1)
    threads = [
            threading.Thread(target=_f, args=(chunks[j:j+2], x)) for j in range(num_threads)
            ]
    
    for t in threads:
        t.start()
    for t in threads:
        t.join()

    return x

num_cols = [1, 10, 20, 50, 100, 200, 500]
time_thread = []
time_nothread = []
for num_col in num_cols:
    W = np.random.normal(size=(ts.num_samples, num_col))
    
    # threading
    t1 = time.time()
    x = _genetic_relatedness_vector_threads(ts, W)
    t2 = time.time()
    time_thread.append(t2-t1)
    
    # nothreading
    t1 = time.time()
    x = ts.genetic_relatedness_vector(W, mode='branch', centre=False)
    t2 = time.time()
    time_nothread.append(t2-t1)

fig, ax = plt.subplots(figsize=(6,4))
ax.plot(num_cols, time_thread, label='with threading')
ax.plot(num_cols, time_nothread, label='without threading')

ax.set_xlabel('Number of matrix columns', fontsize=12)
ax.set_ylabel('Time (s)', fontsize=12)
ax.set_title('#individual=%d, sequence length=%d, #thread=4' % (num_individuals, seq_length), fontsize=12)

ax.legend(fontsize=12)
plt.show()
```


![image](https://github.com/user-attachments/assets/7de525c1-d373-40b9-afa1-de6889835fbe)


