### PR TITLE
Add fixed-length arrays in metadata

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -532,6 +532,17 @@ types above. `L` is the default. As an example:
 
 Will result in an array of 2 byte integers, prepended by a single-byte array-length.
 
+For arrays with a known fixed size, you can specify the `length` property instead:
+```
+{"type": "array", "length": 3, "items": {"type":"number", "binaryFormat":"i"}}
+```
+This creates a fixed-length array of exactly 3 integers, without storing the array length in the encoded data. 
+Fixed-length arrays are more space-efficient since they don't need to store the length prefix.
+
+When using fixed-length arrays:
+1. The `arrayLengthFormat` property should not be specified
+2. Arrays provided for encoding must match the specified length exactly
+
 For dealing with legacy encodings that do not store the
 length of the array, setting `noLengthEncodingExhaustBuffer` to `true` will read
 elements of the array until the metadata buffer is exhausted. As such an array

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -16,6 +16,11 @@
 - Fix to ``TreeSequence.pair_coalescence_rates`` causing an
   assertion to be triggered by floating point error, when all coalescence events are inside a single time window (:user:`natep`, :issue:`3035`, :pr:`3038`)
 
+**Features**
+
+- Add support for fixed-length arrays in metadata struct codec using the ``length`` property.
+  (:user:`benjeffery`, :issue:`3088`,:pr:`3090`)
+
 --------------------
 [0.6.0] - 2024-10-16
 --------------------

--- a/python/requirements/development.yml
+++ b/python/requirements/development.yml
@@ -17,6 +17,7 @@ dependencies:
   - jsonschema>=3.0.0
   - jupyter-book>=0.12.1
   - kastore
+  - lshmm>=0.0.8
   - matplotlib
   - meson>=0.61.0
   - msprime>=1.0.0
@@ -36,12 +37,14 @@ dependencies:
   - sphinx-argparse
   - sphinx-autodoc-typehints>=1.18.3
   - sphinx-issues
+  - sphinx-jupyterbook-latex
+  - sphinxcontrib-prettyspecialmethods
   - sphinx-book-theme
+  - pydata_sphinx_theme>=0.7.2
   - svgwrite>=1.1.10
   - tqdm
   - tszip
   - pip:
-    - lshmm>=0.0.8
     - newick
     - xmlunittest
     - msgpack>=1.0.0


### PR DESCRIPTION
Fixes #3088 

This turned out to be very straightforward so I went ahead and finished it.