### PR TITLE
Add `numpy_dtype` method to metadata codecs.

### DIFF
--- a/python/requirements/development.yml
+++ b/python/requirements/development.yml
@@ -17,7 +17,6 @@ dependencies:
   - jsonschema>=3.0.0
   - jupyter-book>=0.12.1
   - kastore
-  - lshmm>=0.0.8
   - matplotlib
   - meson>=0.61.0
   - msprime>=1.0.0
@@ -37,14 +36,12 @@ dependencies:
   - sphinx-argparse
   - sphinx-autodoc-typehints>=1.18.3
   - sphinx-issues
-  - sphinx-jupyterbook-latex
-  - sphinxcontrib-prettyspecialmethods
   - sphinx-book-theme
-  - pydata_sphinx_theme>=0.7.2
   - svgwrite>=1.1.10
   - tqdm
   - tszip
   - pip:
+    - lshmm>=0.0.8
     - newick
     - xmlunittest
     - msgpack>=1.0.0

--- a/python/requirements/development.yml
+++ b/python/requirements/development.yml
@@ -17,6 +17,7 @@ dependencies:
   - jsonschema>=3.0.0
   - jupyter-book>=0.12.1
   - kastore
+  - lshmm>=0.0.8
   - matplotlib
   - meson>=0.61.0
   - msprime>=1.0.0
@@ -36,12 +37,14 @@ dependencies:
   - sphinx-argparse
   - sphinx-autodoc-typehints>=1.18.3
   - sphinx-issues
+  - sphinx-jupyterbook-latex
+  - sphinxcontrib-prettyspecialmethods
   - sphinx-book-theme
+  - pydata_sphinx_theme>=0.7.2
   - svgwrite>=1.1.10
   - tqdm
   - tszip
   - pip:
-    - lshmm>=0.0.8
     - newick
     - xmlunittest
     - msgpack>=1.0.0


### PR DESCRIPTION
This will need other infrastructure around it, but this function gives a numpy structured dtype for `struct`  metadata schemas, allowing fast, copy-free decoding of metadata buffers!

Stacked on #3090  - see https://github.com/tskit-dev/tskit/commit/6ea9b7e8a26fd9b9ef7a5ab6d308a8b204e90d14 for the clean diff.

