### PR TITLE
Initial definition for TSK_TRACE_ERRORS

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -2,7 +2,11 @@
 [1.1.4] - 2024-XX-XX
 --------------------
 
+**Changes**
 
+- Added the TSK_TRACE_ERRORS macro to enable tracing of errors in the C library.
+  This is useful for debugging as errors will print to stderr when set.
+  (:user:`jeromekelleher`, :pr:`3095`).
 
 --------------------
 [1.1.3] - 2024-10-16

--- a/c/meson.build
+++ b/c/meson.build
@@ -3,6 +3,11 @@ project('tskit', ['c', 'cpp'],
     default_options: ['c_std=c99', 'cpp_std=c++11']
 )
 
+debug_c_args = []
+if get_option('buildtype').startswith('debug')
+    debug_c_args = ['-DTSK_TRACE_ERRORS']
+endif
+
 kastore_proj = subproject('kastore')
 kastore_dep = kastore_proj.get_variable('kastore_dep')
 kastore_inc = kastore_proj.get_variable('kastore_inc')
@@ -16,7 +21,7 @@ extra_c_args = [
     '-Wmissing-prototypes',  '-Wstrict-prototypes',
     '-Wconversion', '-Wshadow', '-Wpointer-arith', '-Wcast-align',
     '-Wcast-qual', '-Wwrite-strings', '-Wnested-externs',
-    '-fshort-enums', '-fno-common']
+    '-fshort-enums', '-fno-common'] + debug_c_args
 
 lib_sources = [
     'tskit/core.c', 'tskit/tables.c', 'tskit/trees.c',

--- a/c/tskit/convert.c
+++ b/c/tskit/convert.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2018-2021 Tskit Developers
+ * Copyright (c) 2018-2025 Tskit Developers
  * Copyright (c) 2015-2017 University of Oxford
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -68,11 +68,11 @@ tsk_newick_converter_run(
     const char *label_format = ms_labels ? "%d" : "n%d";
 
     if (root < 0 || root >= (tsk_id_t) self->tree->num_nodes) {
-        ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
         goto out;
     }
     if (buffer == NULL) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
     root_parent = tree->parent[root];
@@ -82,7 +82,7 @@ tsk_newick_converter_run(
         v = stack[stack_top];
         if (tree->left_child[v] != TSK_NULL && v != u) {
             if (s >= buffer_size) {
-                ret = TSK_ERR_BUFFER_OVERFLOW;
+                ret = tsk_trace_error(TSK_ERR_BUFFER_OVERFLOW);
                 goto out;
             }
             buffer[s] = '(';
@@ -104,17 +104,17 @@ tsk_newick_converter_run(
             }
             if (label != -1) {
                 if (s >= buffer_size) {
-                    ret = TSK_ERR_BUFFER_OVERFLOW;
+                    ret = tsk_trace_error(TSK_ERR_BUFFER_OVERFLOW);
                     goto out;
                 }
                 r = snprintf(buffer + s, buffer_size - s, label_format, label);
                 if (r < 0) {
-                    ret = TSK_ERR_IO;
+                    ret = tsk_trace_error(TSK_ERR_IO);
                     goto out;
                 }
                 s += (size_t) r;
                 if (s >= buffer_size) {
-                    ret = TSK_ERR_BUFFER_OVERFLOW;
+                    ret = tsk_trace_error(TSK_ERR_BUFFER_OVERFLOW);
                     goto out;
                 }
             }
@@ -123,12 +123,12 @@ tsk_newick_converter_run(
                 r = snprintf(buffer + s, buffer_size - s, ":%.*f", (int) self->precision,
                     branch_length);
                 if (r < 0) {
-                    ret = TSK_ERR_IO;
+                    ret = tsk_trace_error(TSK_ERR_IO);
                     goto out;
                 }
                 s += (size_t) r;
                 if (s >= buffer_size) {
-                    ret = TSK_ERR_BUFFER_OVERFLOW;
+                    ret = tsk_trace_error(TSK_ERR_BUFFER_OVERFLOW);
                     goto out;
                 }
                 if (v == tree->right_child[u]) {
@@ -141,7 +141,7 @@ tsk_newick_converter_run(
         }
     }
     if ((s + 1) >= buffer_size) {
-        ret = TSK_ERR_BUFFER_OVERFLOW;
+        ret = tsk_trace_error(TSK_ERR_BUFFER_OVERFLOW);
         goto out;
     }
     buffer[s] = ';';
@@ -164,7 +164,7 @@ tsk_newick_converter_init(tsk_newick_converter_t *self, const tsk_tree_t *tree,
     self->traversal_stack
         = tsk_malloc(tsk_tree_get_size_bound(tree) * sizeof(*self->traversal_stack));
     if (self->traversal_stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 out:

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2024 Tskit Developers
+ * Copyright (c) 2019-2025 Tskit Developers
  * Copyright (c) 2015-2018 University of Oxford
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -952,6 +952,21 @@ not be freed by client code.
 @return A description of the error.
 */
 const char *tsk_strerror(int err);
+
+#ifdef TSK_TRACE_ERRORS
+
+static inline int
+_tsk_trace_error(int err, int line, const char *file)
+{
+    fprintf(stderr, "tskit-trace-error: %d='%s' at line %d in %s\n", err,
+        tsk_strerror(err), line, file);
+    return err;
+}
+
+#define tsk_trace_error(err) (_tsk_trace_error(err, __LINE__, __FILE__))
+#else
+#define tsk_trace_error(err) (err)
+#endif
 
 #ifndef TSK_BUG_ASSERT_MESSAGE
 #define TSK_BUG_ASSERT_MESSAGE                                                          \

--- a/c/tskit/stats.c
+++ b/c/tskit/stats.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2018-2022 Tskit Developers
+ * Copyright (c) 2018-2025 Tskit Developers
  * Copyright (c) 2016-2017 University of Oxford
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -53,6 +53,7 @@ tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence)
 
     self->sample_buffer = tsk_malloc(self->total_samples * sizeof(*self->sample_buffer));
     if (self->sample_buffer == NULL) {
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 out:
@@ -75,14 +76,14 @@ tsk_ld_calc_check_site(tsk_ld_calc_t *TSK_UNUSED(self), const tsk_site_t *site)
     /* These are both limitations in the current implementation, there's no
      * fundamental reason why we can't support them */
     if (site->mutations_length != 1) {
-        ret = TSK_ERR_ONLY_INFINITE_SITES;
+        ret = tsk_trace_error(TSK_ERR_ONLY_INFINITE_SITES);
         goto out;
     }
     if (site->ancestral_state_length == site->mutations[0].derived_state_length
         && tsk_memcmp(site->ancestral_state, site->mutations[0].derived_state,
                site->ancestral_state_length)
                == 0) {
-        ret = TSK_ERR_SILENT_MUTATIONS_NOT_SUPPORTED;
+        ret = tsk_trace_error(TSK_ERR_SILENT_MUTATIONS_NOT_SUPPORTED);
         goto out;
     }
 out:
@@ -294,7 +295,7 @@ tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
     } else if (direction == TSK_DIR_REVERSE) {
         ret = tsk_ld_calc_run_reverse(self);
     } else {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
     }
     if (ret != 0) {
         goto out;

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2024 Tskit Developers
+ * Copyright (c) 2019-2025 Tskit Developers
  * Copyright (c) 2015-2018 University of Oxford
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -145,7 +145,7 @@ tsk_treeseq_init_sites(tsk_treeseq_t *self)
     self->tree_sites_mem = tsk_malloc(num_sites * sizeof(*self->tree_sites_mem));
     if (self->site_mutations_mem == NULL || self->site_mutations_length == NULL
         || self->site_mutations == NULL || self->tree_sites_mem == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -197,7 +197,7 @@ tsk_treeseq_init_individuals(tsk_treeseq_t *self)
     node_count = tsk_calloc(TSK_MAX(1, num_inds), sizeof(*node_count));
 
     if (self->individual_nodes_length == NULL || node_count == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -213,7 +213,7 @@ tsk_treeseq_init_individuals(tsk_treeseq_t *self)
         = tsk_malloc(TSK_MAX(1, total_node_refs) * sizeof(tsk_node_t));
     self->individual_nodes = tsk_malloc(TSK_MAX(1, num_inds) * sizeof(tsk_node_t *));
     if (self->individual_nodes_mem == NULL || self->individual_nodes == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -269,7 +269,7 @@ tsk_treeseq_init_trees(tsk_treeseq_t *self)
     self->breakpoints = tsk_malloc(num_trees_alloc * sizeof(*self->breakpoints));
     if (node_edge_map == NULL || self->tree_sites == NULL
         || self->tree_sites_length == NULL || self->breakpoints == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(
@@ -393,7 +393,7 @@ tsk_treeseq_init_nodes(tsk_treeseq_t *self)
     self->samples = tsk_malloc(self->num_samples * sizeof(tsk_id_t));
     self->sample_index_map = tsk_malloc(num_nodes * sizeof(tsk_id_t));
     if (self->samples == NULL || self->sample_index_map == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     k = 0;
@@ -434,13 +434,13 @@ tsk_treeseq_init(
     if (options & TSK_TAKE_OWNERSHIP) {
         self->tables = tables;
         if (tables->edges.options & TSK_TABLE_NO_METADATA) {
-            ret = TSK_ERR_CANT_TAKE_OWNERSHIP_NO_EDGE_METADATA;
+            ret = tsk_trace_error(TSK_ERR_CANT_TAKE_OWNERSHIP_NO_EDGE_METADATA);
             goto out;
         }
     } else {
         self->tables = tsk_malloc(sizeof(*self->tables));
         if (self->tables == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
 
@@ -513,7 +513,7 @@ tsk_treeseq_load(tsk_treeseq_t *self, const char *filename, tsk_flags_t options)
     tsk_memset(self, 0, sizeof(*self));
 
     if (tables == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -543,7 +543,7 @@ tsk_treeseq_loadf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options)
     tsk_memset(self, 0, sizeof(*self));
 
     if (tables == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -765,7 +765,7 @@ tsk_treeseq_get_individuals_population(const tsk_treeseq_t *self, tsk_id_t *outp
                 if (ind_pop == -2) {
                     ind_pop = node_population[ind.nodes[j]];
                 } else if (ind_pop != node_population[ind.nodes[j]]) {
-                    ret = TSK_ERR_INDIVIDUAL_POPULATION_MISMATCH;
+                    ret = tsk_trace_error(TSK_ERR_INDIVIDUAL_POPULATION_MISMATCH);
                     goto out;
                 }
             }
@@ -796,7 +796,7 @@ tsk_treeseq_get_individuals_time(const tsk_treeseq_t *self, double *output)
             if (j == 0) {
                 ind_time = node_time[ind.nodes[j]];
             } else if (ind_time != node_time[ind.nodes[j]]) {
-                ret = TSK_ERR_INDIVIDUAL_TIME_MISMATCH;
+                ret = tsk_trace_error(TSK_ERR_INDIVIDUAL_TIME_MISMATCH);
                 goto out;
             }
         }
@@ -876,12 +876,12 @@ tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
     /* We support a max of 8K focal sets */
     if (num_reference_sets == 0 || num_reference_sets > (INT16_MAX - 1)) {
         /* TODO: more specific error */
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
     if (parent == NULL || ref_count == NULL || reference_set_map == NULL
         || length == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -896,12 +896,12 @@ tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
         for (j = 0; j < reference_set_size[k]; j++) {
             u = reference_sets[k][j];
             if (u < 0 || u >= (tsk_id_t) num_nodes) {
-                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
                 goto out;
             }
             if (reference_set_map[u] != TSK_NULL) {
                 /* FIXME Technically inaccurate here: duplicate focal not sample */
-                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
                 goto out;
             }
             reference_set_map[u] = k;
@@ -914,7 +914,7 @@ tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
     for (j = 0; j < num_focal; j++) {
         u = focal[j];
         if (u < 0 || u >= (tsk_id_t) num_nodes) {
-            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
             goto out;
         }
     }
@@ -1055,12 +1055,12 @@ tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
 
     if (num_reference_sets == 0 || num_reference_sets > (INT32_MAX - 1)) {
         /* TODO: more specific error */
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
     if (parent == NULL || ref_count == NULL || last_update == NULL
         || total_length == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     /* TODO add check for duplicate values in the reference sets */
@@ -1073,7 +1073,7 @@ tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
         for (j = 0; j < reference_set_size[k]; j++) {
             u = reference_sets[k][j];
             if (u < 0 || u >= (tsk_id_t) num_nodes) {
-                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
                 goto out;
             }
             row = GET_2D_ROW(ref_count, K, u);
@@ -1197,11 +1197,11 @@ static int
 tsk_treeseq_check_windows(const tsk_treeseq_t *self, tsk_size_t num_windows,
     const double *windows, tsk_flags_t options)
 {
-    int ret = TSK_ERR_BAD_WINDOWS;
+    int ret = 0;
     tsk_size_t j;
 
     if (num_windows < 1) {
-        ret = TSK_ERR_BAD_NUM_WINDOWS;
+        ret = tsk_trace_error(TSK_ERR_BAD_NUM_WINDOWS);
         goto out;
     }
     if (options & TSK_REQUIRE_FULL_SPAN) {
@@ -1209,21 +1209,26 @@ tsk_treeseq_check_windows(const tsk_treeseq_t *self, tsk_size_t num_windows,
          * entire tree sequence span. This should be relaxed, so hopefully
          * this branch (and the option) can be removed at some point */
         if (windows[0] != 0) {
+            ret = tsk_trace_error(TSK_ERR_BAD_WINDOWS);
             goto out;
         }
         if (windows[num_windows] != self->tables->sequence_length) {
+            ret = tsk_trace_error(TSK_ERR_BAD_WINDOWS);
             goto out;
         }
     } else {
         if (windows[0] < 0) {
+            ret = tsk_trace_error(TSK_ERR_BAD_WINDOWS);
             goto out;
         }
         if (windows[num_windows] > self->tables->sequence_length) {
+            ret = tsk_trace_error(TSK_ERR_BAD_WINDOWS);
             goto out;
         }
     }
     for (j = 0; j < num_windows; j++) {
         if (windows[j] >= windows[j + 1]) {
+            ret = tsk_trace_error(TSK_ERR_BAD_WINDOWS);
             goto out;
         }
     }
@@ -1301,13 +1306,13 @@ tsk_treeseq_branch_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     double *zero_summary = tsk_calloc(result_dim, sizeof(*zero_state));
 
     if (self->time_uncalibrated && !(options & TSK_STAT_ALLOW_TIME_UNCALIBRATED)) {
-        ret = TSK_ERR_TIME_UNCALIBRATED;
+        ret = tsk_trace_error(TSK_ERR_TIME_UNCALIBRATED);
         goto out;
     }
 
     if (parent == NULL || branch_length == NULL || state == NULL || running_sum == NULL
         || summary == NULL || zero_state == NULL || zero_summary == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(parent, 0xff, num_nodes * sizeof(*parent));
@@ -1460,7 +1465,7 @@ get_allele_weights(const tsk_site_t *site, const double *state, tsk_size_t state
     const char *alt_allele;
 
     if (alleles == NULL || allele_lengths == NULL || allele_states == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -1543,7 +1548,7 @@ compute_general_stat_site_result(tsk_site_t *site, double *state, tsk_size_t sta
     double *result_tmp = tsk_calloc(result_dim, sizeof(*result_tmp));
 
     if (result_tmp == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(result, 0, result_dim * sizeof(*result));
@@ -1601,7 +1606,7 @@ tsk_treeseq_site_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     bool polarised = false;
 
     if (parent == NULL || state == NULL || total_weight == NULL || site_result == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(parent, 0xff, num_nodes * sizeof(*parent));
@@ -1733,7 +1738,7 @@ tsk_treeseq_node_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     double t_left, t_right, w_right;
 
     if (parent == NULL || state == NULL || node_summary == NULL || last_update == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(parent, 0xff, num_nodes * sizeof(*parent));
@@ -1921,7 +1926,7 @@ tsk_polarisable_func_general_stat(const tsk_treeseq_t *self, tsk_size_t state_di
 
         if (upargs.total_weight == NULL || upargs.total_minus_state == NULL
             || upargs.result_tmp == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
 
@@ -1971,16 +1976,16 @@ tsk_treeseq_general_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     }
     /* It's an error to specify more than one mode */
     if (stat_site + stat_branch + stat_node > 1) {
-        ret = TSK_ERR_MULTIPLE_STAT_MODES;
+        ret = tsk_trace_error(TSK_ERR_MULTIPLE_STAT_MODES);
         goto out;
     }
 
     if (state_dim < 1) {
-        ret = TSK_ERR_BAD_STATE_DIMS;
+        ret = tsk_trace_error(TSK_ERR_BAD_STATE_DIMS);
         goto out;
     }
     if (result_dim < 1) {
-        ret = TSK_ERR_BAD_RESULT_DIMS;
+        ret = tsk_trace_error(TSK_ERR_BAD_RESULT_DIMS);
         goto out;
     }
     if (windows == NULL) {
@@ -2023,7 +2028,7 @@ check_set_indexes(
 
     for (j = 0; j < num_set_indexes; j++) {
         if (set_indexes[j] < 0 || set_indexes[j] >= (tsk_id_t) num_sets) {
-            ret = TSK_ERR_BAD_SAMPLE_SET_INDEX;
+            ret = tsk_trace_error(TSK_ERR_BAD_SAMPLE_SET_INDEX);
             goto out;
         }
     }
@@ -2041,24 +2046,24 @@ tsk_treeseq_check_sample_sets(const tsk_treeseq_t *self, tsk_size_t num_sample_s
     tsk_id_t u, sample_index;
 
     if (num_sample_sets == 0) {
-        ret = TSK_ERR_INSUFFICIENT_SAMPLE_SETS;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
         goto out;
     }
     j = 0;
     for (k = 0; k < num_sample_sets; k++) {
         if (sample_set_sizes[k] == 0) {
-            ret = TSK_ERR_EMPTY_SAMPLE_SET;
+            ret = tsk_trace_error(TSK_ERR_EMPTY_SAMPLE_SET);
             goto out;
         }
         for (l = 0; l < sample_set_sizes[k]; l++) {
             u = sample_sets[j];
             if (u < 0 || u >= num_nodes) {
-                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
                 goto out;
             }
             sample_index = self->sample_index_map[u];
             if (sample_index == TSK_NULL) {
-                ret = TSK_ERR_BAD_SAMPLES;
+                ret = tsk_trace_error(TSK_ERR_BAD_SAMPLES);
                 goto out;
             }
             j++;
@@ -2115,7 +2120,7 @@ tsk_treeseq_sample_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sample_s
     }
     weights = tsk_calloc(num_samples * num_sample_sets, sizeof(*weights));
     if (weights == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     j = 0;
@@ -2125,7 +2130,7 @@ tsk_treeseq_sample_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sample_s
             sample_index = self->sample_index_map[u];
             weight_row = GET_2D_ROW(weights, num_sample_sets, sample_index);
             if (weight_row[k] != 0) {
-                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
                 goto out;
             }
             weight_row[k] = 1;
@@ -2161,7 +2166,7 @@ get_allele_samples(const tsk_site_t *site, const tsk_bit_array_t *state,
     tsk_size_t num_alleles = 1;
 
     if (alleles == NULL || allele_lengths == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -2300,7 +2305,7 @@ compute_general_two_site_stat_result(const tsk_bit_array_t *site_a_state,
     tsk_memset(&AB_samples, 0, sizeof(AB_samples));
 
     if (weights == NULL || norm == NULL || result_tmp == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -2465,7 +2470,7 @@ get_mutation_samples(const tsk_treeseq_t *ts, const tsk_id_t *sites, tsk_size_t 
         }
         tmp_nodes = tsk_realloc(nodes, tsk_tree_get_size_bound(&tree) * sizeof(*nodes));
         if (tmp_nodes == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
         nodes = tmp_nodes;
@@ -2527,7 +2532,7 @@ tsk_treeseq_two_site_count_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     row_idx = tsk_malloc(self->tables->sites.num_rows * sizeof(*row_idx));
     col_idx = tsk_malloc(self->tables->sites.num_rows * sizeof(*col_idx));
     if (sites == NULL || row_idx == NULL || col_idx == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     get_site_row_col_indices(
@@ -2538,7 +2543,7 @@ tsk_treeseq_two_site_count_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     num_alleles = tsk_malloc(n_sites * sizeof(*num_alleles));
     site_offsets = tsk_malloc(n_sites * sizeof(*site_offsets));
     if (num_alleles == NULL || site_offsets == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -2609,7 +2614,7 @@ sample_sets_to_bit_array(const tsk_treeseq_t *self, const tsk_size_t *sample_set
             sample_index = self->sample_index_map[u];
             if (tsk_bit_array_contains(
                     &bits_row, (tsk_bit_array_value_t) sample_index)) {
-                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
                 goto out;
             }
             tsk_bit_array_add_bit(&bits_row, (tsk_bit_array_value_t) sample_index);
@@ -2633,21 +2638,21 @@ check_sites(const tsk_id_t *sites, tsk_size_t num_sites, tsk_size_t num_site_row
 
     for (i = 0; i < num_sites - 1; i++) {
         if (sites[i] < 0 || sites[i] >= (tsk_id_t) num_site_rows) {
-            ret = TSK_ERR_SITE_OUT_OF_BOUNDS;
+            ret = tsk_trace_error(TSK_ERR_SITE_OUT_OF_BOUNDS);
             goto out;
         }
         if (sites[i] > sites[i + 1]) {
-            ret = TSK_ERR_STAT_UNSORTED_SITES;
+            ret = tsk_trace_error(TSK_ERR_STAT_UNSORTED_SITES);
             goto out;
         }
         if (sites[i] == sites[i + 1]) {
-            ret = TSK_ERR_STAT_DUPLICATE_SITES;
+            ret = tsk_trace_error(TSK_ERR_STAT_DUPLICATE_SITES);
             goto out;
         }
     }
     // check the last value
     if (sites[i] < 0 || sites[i] >= (tsk_id_t) num_site_rows) {
-        ret = TSK_ERR_SITE_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_SITE_OUT_OF_BOUNDS);
         goto out;
     }
 out:
@@ -2667,21 +2672,21 @@ check_positions(
 
     for (i = 0; i < num_positions - 1; i++) {
         if (positions[i] < 0 || positions[i] >= sequence_length) {
-            ret = TSK_ERR_POSITION_OUT_OF_BOUNDS;
+            ret = tsk_trace_error(TSK_ERR_POSITION_OUT_OF_BOUNDS);
             goto out;
         }
         if (positions[i] > positions[i + 1]) {
-            ret = TSK_ERR_STAT_UNSORTED_POSITIONS;
+            ret = tsk_trace_error(TSK_ERR_STAT_UNSORTED_POSITIONS);
             goto out;
         }
         if (positions[i] == positions[i + 1]) {
-            ret = TSK_ERR_STAT_DUPLICATE_POSITIONS;
+            ret = tsk_trace_error(TSK_ERR_STAT_DUPLICATE_POSITIONS);
             goto out;
         }
     }
     // check bounds of last value
     if (positions[i] < 0 || positions[i] >= sequence_length) {
-        ret = TSK_ERR_POSITION_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_POSITION_OUT_OF_BOUNDS);
         goto out;
     }
 out:
@@ -2700,7 +2705,7 @@ positions_to_tree_indexes(const tsk_treeseq_t *ts, const double *positions,
     // we must calloc, because memset will have no effect when called with size 0
     *tree_indexes = tsk_calloc(num_positions, sizeof(*tree_indexes));
     if (tree_indexes == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(*tree_indexes, TSK_NULL, num_positions * sizeof(**tree_indexes));
@@ -2727,7 +2732,7 @@ get_index_counts(
         (tsk_size_t)(indexes[num_indexes ? num_indexes - 1 : 0] - indexes[0] + 1),
         sizeof(*counts));
     if (counts == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -2770,7 +2775,7 @@ iter_state_init(iter_state *self, const tsk_treeseq_t *ts, tsk_size_t state_dim)
     }
     self->node_samples = tsk_calloc(1, sizeof(*self->node_samples));
     if (self->node_samples == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_bit_array_init(self->node_samples, ts->num_samples, state_dim * num_nodes);
@@ -2783,7 +2788,7 @@ iter_state_init(iter_state *self, const tsk_treeseq_t *ts, tsk_size_t state_dim)
     self->branch_len = tsk_calloc(num_nodes, sizeof(*self->branch_len));
     if (self->parent == NULL || self->edges_out == NULL || self->edges_in == NULL
         || self->branch_len == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 out:
@@ -2946,7 +2951,7 @@ compute_two_tree_branch_state_update(const tsk_treeseq_t *ts, tsk_id_t c,
     weights = tsk_calloc(3 * state_dim, sizeof(*weights));
     result_tmp = tsk_calloc(result_dim, sizeof(*result_tmp));
     if (weights == NULL || result_tmp == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_bit_array_init(&AB_samples, num_samples, 1);
@@ -3108,7 +3113,7 @@ tsk_treeseq_two_branch_count_stat(const tsk_treeseq_t *self, tsk_size_t state_di
     tsk_memset(&r_state, 0, sizeof(r_state));
     result_tmp = tsk_malloc(result_dim * sizeof(*result_tmp));
     if (result_tmp == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = iter_state_init(&l_state, self, state_dim);
@@ -3215,7 +3220,7 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
 
     // We do not support two-locus node stats
     if (!!(options & TSK_STAT_NODE)) {
-        ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_STAT_MODE);
         goto out;
     }
     // If no mode is specified, we default to site mode
@@ -3224,12 +3229,12 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
     }
     // It's an error to specify more than one mode
     if (stat_site + stat_branch > 1) {
-        ret = TSK_ERR_MULTIPLE_STAT_MODES;
+        ret = tsk_trace_error(TSK_ERR_MULTIPLE_STAT_MODES);
         goto out;
     }
     // TODO: impossible until we implement branch/windows
     // if (result_dim < 1) {
-    //     ret = TSK_ERR_BAD_RESULT_DIMS;
+    //     ret = tsk_trace_error(TSK_ERR_BAD_RESULT_DIMS);
     //     goto out;
     // }
     ret = tsk_treeseq_check_sample_sets(
@@ -3325,7 +3330,7 @@ tsk_treeseq_update_site_afs(const tsk_treeseq_t *self, const tsk_site_t *site,
     const tsk_size_t K = num_sample_sets + 1;
 
     if (coordinate == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = get_allele_weights(
@@ -3386,7 +3391,7 @@ tsk_treeseq_site_allele_frequency_spectrum(const tsk_treeseq_t *self,
     double *total_counts = tsk_malloc((1 + num_sample_sets) * sizeof(*total_counts));
 
     if (parent == NULL || total_counts == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(parent, 0xff, num_nodes * sizeof(*parent));
@@ -3479,7 +3484,7 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
     const tsk_size_t all_samples = (tsk_size_t) count_row[num_sample_sets];
 
     if (coordinate == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -3527,12 +3532,12 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
     const tsk_size_t K = num_sample_sets + 1;
 
     if (self->time_uncalibrated && !(options & TSK_STAT_ALLOW_TIME_UNCALIBRATED)) {
-        ret = TSK_ERR_TIME_UNCALIBRATED;
+        ret = tsk_trace_error(TSK_ERR_TIME_UNCALIBRATED);
         goto out;
     }
 
     if (parent == NULL || last_update == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(parent, 0xff, num_nodes * sizeof(*parent));
@@ -3649,7 +3654,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     double *count_row;
 
     if (stat_node) {
-        ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_STAT_MODE);
         goto out;
     }
     /* If no mode is specified, we default to site mode */
@@ -3658,7 +3663,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     }
     /* It's an error to specify more than one mode */
     if (stat_site + stat_branch > 1) {
-        ret = TSK_ERR_MULTIPLE_STAT_MODES;
+        ret = tsk_trace_error(TSK_ERR_MULTIPLE_STAT_MODES);
         goto out;
     }
     if (windows == NULL) {
@@ -3681,7 +3686,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     result_dims = tsk_malloc((num_sample_sets + 1) * sizeof(*result_dims));
     counts = tsk_calloc(num_nodes * K, sizeof(*counts));
     if (counts == NULL || result_dims == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     afs_size = 1;
@@ -3693,7 +3698,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
             u = sample_sets[j];
             count_row = GET_2D_ROW(counts, K, u);
             if (count_row[k] != 0) {
-                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
                 goto out;
             }
             count_row[k] = 1;
@@ -3786,11 +3791,11 @@ tsk_treeseq_trait_covariance(const tsk_treeseq_t *self, tsk_size_t num_weights,
     weight_stat_params_t args = { num_samples = self->num_samples };
 
     if (new_weights == NULL || means == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (num_weights == 0) {
-        ret = TSK_ERR_INSUFFICIENT_WEIGHTS;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_WEIGHTS);
         goto out;
     }
 
@@ -3859,12 +3864,12 @@ tsk_treeseq_trait_correlation(const tsk_treeseq_t *self, tsk_size_t num_weights,
     weight_stat_params_t args = { num_samples = self->num_samples };
 
     if (new_weights == NULL || means == NULL || meansqs == NULL || sds == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
     if (num_weights < 1) {
-        ret = TSK_ERR_INSUFFICIENT_WEIGHTS;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_WEIGHTS);
         goto out;
     }
 
@@ -3972,12 +3977,12 @@ tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights
     // We could do this instead here with gsl linalg.
 
     if (new_weights == NULL || V == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
     if (num_weights < 1) {
-        ret = TSK_ERR_INSUFFICIENT_WEIGHTS;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_WEIGHTS);
         goto out;
     }
 
@@ -4471,11 +4476,11 @@ check_sample_stat_inputs(tsk_size_t num_sample_sets, tsk_size_t tuple_size,
     int ret = 0;
 
     if (num_sample_sets < tuple_size) {
-        ret = TSK_ERR_INSUFFICIENT_SAMPLE_SETS;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
         goto out;
     }
     if (num_index_tuples < 1) {
-        ret = TSK_ERR_INSUFFICIENT_INDEX_TUPLES;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_INDEX_TUPLES);
         goto out;
     }
     ret = check_set_indexes(
@@ -4652,11 +4657,11 @@ tsk_treeseq_genetic_relatedness_weighted(const tsk_treeseq_t *self,
         = tsk_malloc((num_weights + 1) * num_samples * sizeof(*new_weights));
 
     if (total_weights == NULL || new_weights == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (num_weights == 0) {
-        ret = TSK_ERR_INSUFFICIENT_WEIGHTS;
+        ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_WEIGHTS);
         goto out;
     }
 
@@ -5004,7 +5009,7 @@ tsk_treeseq_simplify(const tsk_treeseq_t *self, const tsk_id_t *samples,
     tsk_table_collection_t *tables = tsk_malloc(sizeof(*tables));
 
     if (tables == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_treeseq_copy_tables(self, tables, 0);
@@ -5046,7 +5051,7 @@ tsk_treeseq_split_edges(const tsk_treeseq_t *self, double time, tsk_flags_t flag
 
     memset(output, 0, sizeof(*output));
     if (split_edge == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_treeseq_copy_tables(self, tables, 0);
@@ -5054,18 +5059,18 @@ tsk_treeseq_split_edges(const tsk_treeseq_t *self, double time, tsk_flags_t flag
         goto out;
     }
     if (tables->migrations.num_rows > 0) {
-        ret = TSK_ERR_MIGRATIONS_NOT_SUPPORTED;
+        ret = tsk_trace_error(TSK_ERR_MIGRATIONS_NOT_SUPPORTED);
         goto out;
     }
     /* We could catch this below in add_row, but it's simpler to guarantee
      * that we always catch the error in corner cases where the values
      * aren't used. */
     if (population < -1 || population >= (tsk_id_t) self->tables->populations.num_rows) {
-        ret = TSK_ERR_POPULATION_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_POPULATION_OUT_OF_BOUNDS);
         goto out;
     }
     if (!tsk_isfinite(time)) {
-        ret = TSK_ERR_TIME_NONFINITE;
+        ret = tsk_trace_error(TSK_ERR_TIME_NONFINITE);
         goto out;
     }
 
@@ -5452,12 +5457,12 @@ tsk_tree_get_node_root(const tsk_tree_t *self, tsk_id_t u)
 int TSK_WARN_UNUSED
 tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options)
 {
-    int ret = TSK_ERR_NO_MEMORY;
+    int ret = 0;
     tsk_size_t num_samples, num_nodes, N;
 
     tsk_memset(self, 0, sizeof(tsk_tree_t));
     if (tree_sequence == NULL) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
     num_nodes = tree_sequence->tables->nodes.num_rows;
@@ -5481,12 +5486,14 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
     if (self->parent == NULL || self->left_child == NULL || self->right_child == NULL
         || self->left_sib == NULL || self->right_sib == NULL
         || self->num_children == NULL || self->edge == NULL) {
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
         self->num_samples = tsk_calloc(N, sizeof(*self->num_samples));
         self->num_tracked_samples = tsk_calloc(N, sizeof(*self->num_tracked_samples));
         if (self->num_samples == NULL || self->num_tracked_samples == NULL) {
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
     }
@@ -5496,6 +5503,7 @@ tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t 
         self->next_sample = tsk_malloc(num_samples * sizeof(*self->next_sample));
         if (self->left_sample == NULL || self->right_sample == NULL
             || self->next_sample == NULL) {
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
     }
@@ -5515,13 +5523,13 @@ tsk_tree_set_root_threshold(tsk_tree_t *self, tsk_size_t root_threshold)
     int ret = 0;
 
     if (root_threshold == 0) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
     /* Don't allow the value to be set when the tree is out of the null
      * state */
     if (self->index != -1) {
-        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
         goto out;
     }
     self->root_threshold = root_threshold;
@@ -5574,7 +5582,7 @@ tsk_tree_reset_tracked_samples(tsk_tree_t *self)
     int ret = 0;
 
     if (!tsk_tree_has_sample_counts(self)) {
-        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
         goto out;
     }
     tsk_memset(self->num_tracked_samples, 0,
@@ -5604,15 +5612,15 @@ tsk_tree_set_tracked_samples(
     for (j = 0; j < num_tracked_samples; j++) {
         u = tracked_samples[j];
         if (u < 0 || u >= (tsk_id_t) self->num_nodes) {
-            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
             goto out;
         }
         if (!tsk_treeseq_is_sample(self->tree_sequence, u)) {
-            ret = TSK_ERR_BAD_SAMPLES;
+            ret = tsk_trace_error(TSK_ERR_BAD_SAMPLES);
             goto out;
         }
         if (self->num_tracked_samples[u] != 0) {
-            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
             goto out;
         }
         /* Propagate this upwards */
@@ -5639,7 +5647,7 @@ tsk_tree_track_descendant_samples(tsk_tree_t *self, tsk_id_t node)
     tsk_id_t u, v;
 
     if (nodes == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_tree_postorder_from(self, node, nodes, &num_nodes);
@@ -5683,7 +5691,7 @@ tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
         }
     }
     if (self->tree_sequence != dest->tree_sequence) {
-        ret = TSK_ERR_BAD_PARAM_VALUE;
+        ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
     dest->interval = self->interval;
@@ -5706,7 +5714,7 @@ tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
     tsk_memcpy(dest->edge, self->edge, N * sizeof(*self->edge));
     if (!(dest->options & TSK_NO_SAMPLE_COUNTS)) {
         if (self->options & TSK_NO_SAMPLE_COUNTS) {
-            ret = TSK_ERR_UNSUPPORTED_OPERATION;
+            ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
             goto out;
         }
         tsk_memcpy(dest->num_samples, self->num_samples, N * sizeof(*self->num_samples));
@@ -5715,7 +5723,7 @@ tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
     }
     if (dest->options & TSK_SAMPLE_LISTS) {
         if (!(self->options & TSK_SAMPLE_LISTS)) {
-            ret = TSK_ERR_UNSUPPORTED_OPERATION;
+            ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
             goto out;
         }
         tsk_memcpy(dest->left_sample, self->left_sample, N * sizeof(*self->left_sample));
@@ -5745,7 +5753,7 @@ tsk_tree_check_node(const tsk_tree_t *self, tsk_id_t u)
 {
     int ret = 0;
     if (u < 0 || u > (tsk_id_t) self->num_nodes) {
-        ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
     }
     return ret;
 }
@@ -5824,7 +5832,7 @@ tsk_tree_get_num_samples_by_traversal(
     tsk_id_t v;
 
     if (nodes == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_tree_preorder_from(self, u, nodes, &num_nodes);
@@ -5873,7 +5881,7 @@ tsk_tree_get_num_tracked_samples(
         goto out;
     }
     if (self->options & TSK_NO_SAMPLE_COUNTS) {
-        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
         goto out;
     }
     *num_tracked_samples = self->num_tracked_samples[u];
@@ -5973,7 +5981,7 @@ tsk_tree_get_total_branch_length(const tsk_tree_t *self, tsk_id_t node, double *
     double sum = 0;
 
     if (nodes == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_tree_preorder_from(self, node, nodes, &num_nodes);
@@ -6531,7 +6539,7 @@ tsk_tree_seek_index(tsk_tree_t *self, tsk_id_t tree, tsk_flags_t options)
     double x;
 
     if (tree < 0 || tree >= (tsk_id_t) self->tree_sequence->num_trees) {
-        ret = TSK_ERR_SEEK_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_SEEK_OUT_OF_BOUNDS);
         goto out;
     }
     x = self->tree_sequence->breakpoints[tree];
@@ -6587,7 +6595,7 @@ tsk_tree_seek(tsk_tree_t *self, double x, tsk_flags_t options)
     const double L = tsk_treeseq_get_sequence_length(self->tree_sequence);
 
     if (x < 0 || x >= L) {
-        ret = TSK_ERR_SEEK_OUT_OF_BOUNDS;
+        ret = tsk_trace_error(TSK_ERR_SEEK_OUT_OF_BOUNDS);
         goto out;
     }
 
@@ -6722,13 +6730,13 @@ tsk_tree_preorder_from(
     int stack_top;
 
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
     if ((root == -1 || root == self->virtual_root)
         && !tsk_tree_has_sample_counts(self)) {
-        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
         goto out;
     }
     if (root == -1) {
@@ -6780,7 +6788,7 @@ tsk_tree_preorder_samples_from(
     int stack_top;
 
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -6790,7 +6798,7 @@ tsk_tree_preorder_samples_from(
      */
     if (root == -1 || root == self->virtual_root) {
         if (!tsk_tree_has_sample_counts(self)) {
-            ret = TSK_ERR_UNSUPPORTED_OPERATION;
+            ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
             goto out;
         }
         stack_top = -1;
@@ -6845,13 +6853,13 @@ tsk_tree_postorder_from(
     bool is_virtual_root = root == self->virtual_root;
 
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
     if (root == -1 || is_virtual_root) {
         if (!tsk_tree_has_sample_counts(self)) {
-            ret = TSK_ERR_UNSUPPORTED_OPERATION;
+            ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_OPERATION);
             goto out;
         }
         stack_top = -1;
@@ -6919,7 +6927,7 @@ tsk_tree_sackin_index(const tsk_tree_t *self, tsk_size_t *result)
     struct stack_elem s = { .node = TSK_NULL, .depth = 0 };
 
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -6964,11 +6972,11 @@ tsk_tree_colless_index(const tsk_tree_t *self, tsk_size_t *result)
     tsk_id_t num_children, u, v;
 
     if (nodes == NULL || num_leaves == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (tsk_tree_get_num_roots(self) != 1) {
-        ret = TSK_ERR_UNDEFINED_MULTIROOT;
+        ret = tsk_trace_error(TSK_ERR_UNDEFINED_MULTIROOT);
         goto out;
     }
     ret = tsk_tree_postorder(self, nodes, &num_nodes);
@@ -6992,7 +7000,7 @@ tsk_tree_colless_index(const tsk_tree_t *self, tsk_size_t *result)
             v = right_child[u];
             total += (tsk_size_t) llabs(num_leaves[v] - num_leaves[left_sib[v]]);
         } else {
-            ret = TSK_ERR_UNDEFINED_NONBINARY;
+            ret = tsk_trace_error(TSK_ERR_UNDEFINED_NONBINARY);
             goto out;
         }
     }
@@ -7017,7 +7025,7 @@ tsk_tree_b1_index(const tsk_tree_t *self, double *result)
     tsk_id_t u, v;
 
     if (nodes == NULL || max_path_length == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = tsk_tree_postorder(self, nodes, &num_nodes);
@@ -7068,11 +7076,11 @@ tsk_tree_b2_index(const tsk_tree_t *self, double base, double *result)
     struct stack_elem s = { .node = TSK_NULL, .path_product = 1 };
 
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (tsk_tree_get_num_roots(self) != 1) {
-        ret = TSK_ERR_UNDEFINED_MULTIROOT;
+        ret = tsk_trace_error(TSK_ERR_UNDEFINED_MULTIROOT);
         goto out;
     }
 
@@ -7119,11 +7127,11 @@ tsk_tree_num_lineages(const tsk_tree_t *self, double t, tsk_size_t *result)
     double child_time, parent_time;
 
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (!tsk_isfinite(t)) {
-        ret = TSK_ERR_TIME_NONFINITE;
+        ret = tsk_trace_error(TSK_ERR_TIME_NONFINITE);
         goto out;
     }
     /* Push the roots onto the stack */
@@ -7238,12 +7246,12 @@ tsk_tree_map_mutations(tsk_tree_t *self, int32_t *genotypes,
 
     if (optimal_set == NULL || preorder_stack == NULL || transitions == NULL
         || nodes == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     for (j = 0; j < num_samples; j++) {
         if (genotypes[j] >= HARTIGAN_MAX_ALLELES || genotypes[j] < TSK_MISSING_DATA) {
-            ret = TSK_ERR_BAD_GENOTYPE;
+            ret = tsk_trace_error(TSK_ERR_BAD_GENOTYPE);
             goto out;
         }
         u = self->tree_sequence->samples[j];
@@ -7258,7 +7266,7 @@ tsk_tree_map_mutations(tsk_tree_t *self, int32_t *genotypes,
     }
 
     if (non_missing == 0) {
-        ret = TSK_ERR_GENOTYPES_ALL_MISSING;
+        ret = tsk_trace_error(TSK_ERR_GENOTYPES_ALL_MISSING);
         goto out;
     }
     num_alleles++;
@@ -7267,7 +7275,7 @@ tsk_tree_map_mutations(tsk_tree_t *self, int32_t *genotypes,
     if (options & TSK_MM_FIXED_ANCESTRAL_STATE) {
         ancestral_state = *r_ancestral_state;
         if ((ancestral_state < 0) || (ancestral_state >= HARTIGAN_MAX_ALLELES)) {
-            ret = TSK_ERR_BAD_ANCESTRAL_STATE;
+            ret = tsk_trace_error(TSK_ERR_BAD_ANCESTRAL_STATE);
             goto out;
         } else if (ancestral_state >= num_alleles) {
             num_alleles = (int32_t)(ancestral_state + 1);
@@ -7383,7 +7391,7 @@ kc_vectors_alloc(kc_vectors *self, tsk_id_t n)
     self->m = tsk_calloc((size_t)(self->N + self->n), sizeof(*self->m));
     self->M = tsk_calloc((size_t)(self->N + self->n), sizeof(*self->M));
     if (self->m == NULL || self->M == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -7469,7 +7477,7 @@ fill_kc_vectors(const tsk_tree_t *t, kc_vectors *kc_vecs)
 
     stack = tsk_malloc(tsk_tree_get_size_bound(t) * sizeof(*stack));
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -7533,11 +7541,11 @@ check_kc_distance_tree_inputs(const tsk_tree_t *self)
     int ret = 0;
 
     if (tsk_tree_get_num_roots(self) != 1) {
-        ret = TSK_ERR_MULTIPLE_ROOTS;
+        ret = tsk_trace_error(TSK_ERR_MULTIPLE_ROOTS);
         goto out;
     }
     if (!tsk_tree_has_sample_lists(self)) {
-        ret = TSK_ERR_NO_SAMPLE_LISTS;
+        ret = tsk_trace_error(TSK_ERR_NO_SAMPLE_LISTS);
         goto out;
     }
 
@@ -7545,7 +7553,7 @@ check_kc_distance_tree_inputs(const tsk_tree_t *self)
     for (u = 0; u < num_nodes; u++) {
         left_child = self->left_child[u];
         if (left_child != TSK_NULL && left_child == self->right_child[u]) {
-            ret = TSK_ERR_UNARY_NODES;
+            ret = tsk_trace_error(TSK_ERR_UNARY_NODES);
             goto out;
         }
     }
@@ -7561,7 +7569,7 @@ check_kc_distance_samples_inputs(const tsk_treeseq_t *self, const tsk_treeseq_t 
     int ret = 0;
 
     if (self->num_samples != other->num_samples) {
-        ret = TSK_ERR_SAMPLE_SIZE_MISMATCH;
+        ret = tsk_trace_error(TSK_ERR_SAMPLE_SIZE_MISMATCH);
         goto out;
     }
 
@@ -7570,7 +7578,7 @@ check_kc_distance_samples_inputs(const tsk_treeseq_t *self, const tsk_treeseq_t 
     n = (tsk_id_t) self->num_samples;
     for (i = 0; i < n; i++) {
         if (samples[i] != other_samples[i]) {
-            ret = TSK_ERR_SAMPLES_NOT_EQUAL;
+            ret = tsk_trace_error(TSK_ERR_SAMPLES_NOT_EQUAL);
             goto out;
         }
     }
@@ -7629,7 +7637,7 @@ check_kc_distance_tree_sequence_inputs(
     int ret = 0;
 
     if (self->tables->sequence_length != other->tables->sequence_length) {
-        ret = TSK_ERR_SEQUENCE_LENGTH_MISMATCH;
+        ret = tsk_trace_error(TSK_ERR_SEQUENCE_LENGTH_MISMATCH);
         goto out;
     }
 
@@ -7675,7 +7683,7 @@ update_kc_subtree_state(
 
     stack = tsk_malloc(tsk_tree_get_size_bound(t) * sizeof(*stack));
     if (stack == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -7790,7 +7798,7 @@ tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *other,
         num_nodes = tsk_treeseq_get_num_nodes(treeseqs[i]);
         depths[i] = tsk_calloc(num_nodes, sizeof(*depths[i]));
         if (depths[i] == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
     }
@@ -7890,7 +7898,7 @@ sv_tables_init(sv_tables_t *self, tsk_size_t n)
     if (self->parent == NULL || self->child == NULL || self->sib == NULL
         || self->lambda == NULL || self->tau == NULL || self->beta == NULL
         || self->alpha == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 out:
@@ -8102,11 +8110,11 @@ tsk_treeseq_divergence_matrix_branch(const tsk_treeseq_t *self,
         goto out;
     }
     if (ss_offsets == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     if (self->time_uncalibrated && !(options & TSK_STAT_ALLOW_TIME_UNCALIBRATED)) {
-        ret = TSK_ERR_TIME_UNCALIBRATED;
+        ret = tsk_trace_error(TSK_ERR_TIME_UNCALIBRATED);
         goto out;
     }
 
@@ -8277,7 +8285,7 @@ tsk_treeseq_divergence_matrix_site(const tsk_treeseq_t *self, tsk_size_t num_sam
         goto out;
     }
     if (A == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -8306,7 +8314,7 @@ tsk_treeseq_divergence_matrix_site(const tsk_treeseq_t *self, tsk_size_t num_sam
                 tsk_safe_free(allele_offsets);
                 allele_offsets = tsk_malloc((max_alleles + 1) * sizeof(*allele_offsets));
                 if (allele_offsets == NULL) {
-                    ret = TSK_ERR_NO_MEMORY;
+                    ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
                     goto out;
                 }
             }
@@ -8350,18 +8358,18 @@ get_sample_set_index_map(const tsk_treeseq_t *self, const tsk_size_t num_sample_
             u = sample_sets[i];
             i++;
             if (u < 0 || u >= (tsk_id_t) num_nodes) {
-                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
                 goto out;
             }
             /* Note: we require nodes to be samples because we have to think
              * about how to normalise by the length of genome that the node
              * is 'in' the tree for each window otherwise. */
             if (!(node_flags[u] & TSK_NODE_IS_SAMPLE)) {
-                ret = TSK_ERR_BAD_SAMPLES;
+                ret = tsk_trace_error(TSK_ERR_BAD_SAMPLES);
                 goto out;
             }
             if (node_index_map[u] != TSK_NULL) {
-                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
                 goto out;
             }
             node_index_map[u] = (tsk_id_t) j;
@@ -8417,7 +8425,7 @@ tsk_treeseq_divergence_matrix(const tsk_treeseq_t *self, tsk_size_t num_sample_s
     tsk_size_t j;
 
     if (stat_node) {
-        ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_STAT_MODE);
         goto out;
     }
     /* If no mode is specified, we default to site mode */
@@ -8426,12 +8434,12 @@ tsk_treeseq_divergence_matrix(const tsk_treeseq_t *self, tsk_size_t num_sample_s
     }
     /* It's an error to specify more than one mode */
     if (stat_site + stat_branch > 1) {
-        ret = TSK_ERR_MULTIPLE_STAT_MODES;
+        ret = tsk_trace_error(TSK_ERR_MULTIPLE_STAT_MODES);
         goto out;
     }
 
     if (options & TSK_STAT_POLARISED) {
-        ret = TSK_ERR_STAT_POLARISED_UNSUPPORTED;
+        ret = tsk_trace_error(TSK_ERR_STAT_POLARISED_UNSUPPORTED);
         goto out;
     }
 
@@ -8460,7 +8468,7 @@ tsk_treeseq_divergence_matrix(const tsk_treeseq_t *self, tsk_size_t num_sample_s
     if (sample_set_sizes_in == NULL) {
         tmp_sample_set_sizes = tsk_malloc(N * sizeof(*tmp_sample_set_sizes));
         if (tmp_sample_set_sizes == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
         for (j = 0; j < N; j++) {
@@ -8613,7 +8621,7 @@ tsk_treeseq_slide_mutation_nodes_up(
                && sites_position[mutations->site[next_mut]] < tree.interval.right) {
             t = mutations->time[next_mut];
             if (tsk_is_unknown_time(t)) {
-                ret = TSK_ERR_DISALLOWED_UNKNOWN_MUTATION_TIME;
+                ret = tsk_trace_error(TSK_ERR_DISALLOWED_UNKNOWN_MUTATION_TIME);
                 goto out;
             }
             c = mutations->node[next_mut];
@@ -8700,7 +8708,7 @@ haplotype_extender_init(haplotype_extender_t *self, const tsk_treeseq_t *ts,
         || self->last_nodes_edge == NULL || self->next_nodes_edge == NULL
         || self->parent_out == NULL || self->parent_in == NULL
         || self->not_sample == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     tsk_memset(self->last_nodes_edge, 0xff, num_nodes * sizeof(*self->last_nodes_edge));
@@ -8819,7 +8827,7 @@ haplotype_extender_next_tree(haplotype_extender_t *self, tsk_tree_position_t *tr
         if (self->near_side[e] != self->far_side[e]) {
             new_ex = tsk_blkalloc_get(&self->edge_list_heap, sizeof(*new_ex));
             if (new_ex == NULL) {
-                ret = TSK_ERR_NO_MEMORY;
+                ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
                 goto out;
             }
             edge_list_append_entry(
@@ -8839,7 +8847,7 @@ haplotype_extender_next_tree(haplotype_extender_t *self, tsk_tree_position_t *tr
         // add edge to pending_in
         new_ex = tsk_blkalloc_get(&self->edge_list_heap, sizeof(*new_ex));
         if (new_ex == NULL) {
-            ret = TSK_ERR_NO_MEMORY;
+            ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
             goto out;
         }
         edge_list_append_entry(&self->edges_in_head, &self->edges_in_tail, new_ex, e, 0);
@@ -8897,7 +8905,7 @@ haplotype_extender_add_or_extend_edge(haplotype_extender_t *self, tsk_id_t new_p
             }
             new_ex = tsk_blkalloc_get(&self->edge_list_heap, sizeof(*new_ex));
             if (new_ex == NULL) {
-                ret = TSK_ERR_NO_MEMORY;
+                ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
                 goto out;
             }
             edge_list_append_entry(
@@ -9092,7 +9100,7 @@ haplotype_extender_extend_paths(haplotype_extender_t *self)
     num_edges = self->edges->num_rows;
     keep = tsk_calloc(num_edges, sizeof(*keep));
     if (keep == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     for (e = 0; e < (tsk_id_t) num_edges - 1; e++) {
@@ -9156,11 +9164,11 @@ tsk_treeseq_extend_haplotypes(
     tsk_memset(output, 0, sizeof(*output));
 
     if (max_iter <= 0) {
-        ret = TSK_ERR_EXTEND_EDGES_BAD_MAXITER;
+        ret = tsk_trace_error(TSK_ERR_EXTEND_EDGES_BAD_MAXITER);
         goto out;
     }
     if (tsk_treeseq_get_num_migrations(self) != 0) {
-        ret = TSK_ERR_MIGRATIONS_NOT_SUPPORTED;
+        ret = tsk_trace_error(TSK_ERR_MIGRATIONS_NOT_SUPPORTED);
         goto out;
     }
 
@@ -9257,7 +9265,7 @@ check_node_bin_map(
     for (i = 0; i < num_nodes; i++) {
         index = node_bin_map[i];
         if (index < TSK_NULL) {
-            ret = TSK_ERR_BAD_NODE_BIN_MAP;
+            ret = tsk_trace_error(TSK_ERR_BAD_NODE_BIN_MAP);
             goto out;
         }
         if (index > max_index) {
@@ -9265,7 +9273,7 @@ check_node_bin_map(
         }
     }
     if (num_bins < 1 || (tsk_id_t) num_bins < max_index + 1) {
-        ret = TSK_ERR_BAD_NODE_BIN_MAP_DIM;
+        ret = tsk_trace_error(TSK_ERR_BAD_NODE_BIN_MAP_DIM);
         goto out;
     }
 out:
@@ -9371,7 +9379,7 @@ tsk_treeseq_pair_coalescence_stat(const tsk_treeseq_t *self, tsk_size_t num_samp
     /* map nodes to sample sets */
     nodes_sample_set = tsk_malloc(num_nodes * sizeof(*nodes_sample_set));
     if (nodes_sample_set == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     ret = get_sample_set_index_map(self, num_sample_sets, sample_set_sizes, sample_sets,
@@ -9395,7 +9403,7 @@ tsk_treeseq_pair_coalescence_stat(const tsk_treeseq_t *self, tsk_size_t num_samp
         || coalescing_pairs == NULL || bin_weight == NULL || bin_values == NULL
         || outside == NULL || pair_count == NULL || visited == NULL
         || total_pair == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -9687,7 +9695,7 @@ check_quantiles(const tsk_size_t num_quantiles, const double *quantiles)
     double last = -INFINITY;
     for (i = 0; i < num_quantiles; i++) {
         if (quantiles[i] <= last || quantiles[i] < 0.0 || quantiles[i] > 1.0) {
-            ret = TSK_ERR_BAD_QUANTILES;
+            ret = tsk_trace_error(TSK_ERR_BAD_QUANTILES);
             goto out;
         }
         last = quantiles[i];
@@ -9708,7 +9716,7 @@ check_sorted_node_bin_map(
     double *min_time = tsk_malloc(num_bins * sizeof(*min_time));
     double *max_time = tsk_malloc(num_bins * sizeof(*max_time));
     if (min_time == NULL || max_time == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     for (j = 0; j < (tsk_id_t) num_bins; j++) {
@@ -9733,7 +9741,7 @@ check_sorted_node_bin_map(
             continue;
         }
         if (min_time[j] < last) {
-            ret = TSK_ERR_UNSORTED_TIMES;
+            ret = tsk_trace_error(TSK_ERR_UNSORTED_TIMES);
             goto out;
         } else {
             last = max_time[j];
@@ -9821,20 +9829,20 @@ check_coalescence_rate_time_windows(const tsk_treeseq_t *self,
     tsk_id_t i, j, k;
     tsk_id_t n;
     if (num_time_windows == 0) {
-        ret = TSK_ERR_BAD_TIME_WINDOWS_DIM;
+        ret = tsk_trace_error(TSK_ERR_BAD_TIME_WINDOWS_DIM);
         goto out;
     }
     /* time windows are sorted */
     timepoint = time_windows[0];
     for (i = 0; i < (tsk_id_t) num_time_windows; i++) {
         if (time_windows[i + 1] <= timepoint) {
-            ret = TSK_ERR_BAD_TIME_WINDOWS;
+            ret = tsk_trace_error(TSK_ERR_BAD_TIME_WINDOWS);
             goto out;
         }
         timepoint = time_windows[i + 1];
     }
     if (timepoint != INFINITY) {
-        ret = TSK_ERR_BAD_TIME_WINDOWS;
+        ret = tsk_trace_error(TSK_ERR_BAD_TIME_WINDOWS);
         goto out;
     }
     /* all sample times align with start of first time window */
@@ -9843,7 +9851,7 @@ check_coalescence_rate_time_windows(const tsk_treeseq_t *self,
         for (j = 0; j < (tsk_id_t) sample_set_sizes[i]; j++) {
             n = sample_sets[k++];
             if (nodes_time[n] != time_windows[0]) {
-                ret = TSK_ERR_BAD_SAMPLE_PAIR_TIMES;
+                ret = tsk_trace_error(TSK_ERR_BAD_SAMPLE_PAIR_TIMES);
                 goto out;
             }
         }
@@ -9855,11 +9863,11 @@ check_coalescence_rate_time_windows(const tsk_treeseq_t *self,
             continue;
         }
         if (j >= (tsk_id_t) num_time_windows) {
-            ret = TSK_ERR_BAD_NODE_BIN_MAP_DIM;
+            ret = tsk_trace_error(TSK_ERR_BAD_NODE_BIN_MAP_DIM);
             goto out;
         }
         if (nodes_time[i] < time_windows[j] || nodes_time[i] >= time_windows[j + 1]) {
-            ret = TSK_ERR_BAD_NODE_TIME_WINDOW;
+            ret = tsk_trace_error(TSK_ERR_BAD_NODE_TIME_WINDOW);
             goto out;
         }
     }
@@ -9976,7 +9984,7 @@ tsk_matvec_calculator_init(tsk_matvec_calculator_t *self, const tsk_treeseq_t *t
 
     if (self->parent == NULL || self->x == NULL || self->w == NULL || self->v == NULL
         || weight_means == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -9985,7 +9993,7 @@ tsk_matvec_calculator_init(tsk_matvec_calculator_t *self, const tsk_treeseq_t *t
 
     for (j = 0; j < (tsk_id_t) num_focal_nodes; j++) {
         if (focal_nodes[j] < 0 || (tsk_size_t) focal_nodes[j] >= num_nodes) {
-            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            ret = tsk_trace_error(TSK_ERR_NODE_OUT_OF_BOUNDS);
             goto out;
         }
     }
@@ -10150,7 +10158,7 @@ tsk_matvec_calculator_write_output(tsk_matvec_calculator_t *self, double *restri
     const tsk_id_t *restrict focal_nodes = self->focal_nodes;
 
     if (out_means == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
 
@@ -10288,7 +10296,7 @@ tsk_treeseq_genetic_relatedness_vector(const tsk_treeseq_t *self, tsk_size_t num
     memset(&calc, 0, sizeof(calc));
 
     if (stat_node || stat_site) {
-        ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
+        ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_STAT_MODE);
         goto out;
     }
     ret = tsk_treeseq_check_windows(self, num_windows, windows, 0);

--- a/docs/development.md
+++ b/docs/development.md
@@ -690,6 +690,9 @@ $ cd c
 $ meson build
 ```
 
+To setup a debug build add `--buildtype=debug` to the above command. This will set the `TSK_TRACE_ERRORS`
+flag, which will print error messages to `stderr` when errors occur which is useful for debugging.
+
 To compile the code run
 
 ```bash
@@ -708,6 +711,11 @@ For vim users, the [mesonic](https://www.vim.org/scripts/script.php?script_id=53
 simplifies this process and allows code to be compiled seamlessly within the
 editor.
 
+### Compile flags
+
+If the flag `TSK_TRACE_ERRORS` is defined (by e.g. `-DTSK_TRACE_ERRORS` to gcc),
+then error messages will be printed to `stderr` when errors occur. This also allows
+breakpoints to be set in the `_tsk_trace_error` function to break on all errors.
 
 ### Unit Tests
 
@@ -785,7 +793,7 @@ failure scenarios. The following pattern is used throughout for this purpose:
 
     x = malloc(n * sizeof(double));
     if (x == NULL) {
-        ret = TSK_ERR_NO_MEMORY;
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
     // rest of function
@@ -801,6 +809,10 @@ of the declaration.
 
 Error codes are defined in `core.h`, and these can be translated into a
 message using `tsk_strerror(err)`.
+
+When setting error codes in the C code, please use the `tsk_trace_error` function.
+If `TSK_TRACE_ERRORS` is defined, this will print a message to stderr with the
+details of the error.
 
 
 #### Using assertions
@@ -938,10 +950,6 @@ checks for code quality.
   using gcc and clang, and check for memory leaks using valgrind.
 
 - [CodeCov](https://codecov.io/gh)_ tracks test coverage in Python and C.
-
-- [PyUp](https://pyup.io/) Runs monthly checks on the Python dependencies listed in the
-  requirements files, which are pinned to ensure CI reproducibility. PyUp opens one PR
-  a month with updated pins.
 
 
 (sec_development_best_practices)=


### PR DESCRIPTION
This is a proposal to address the discussion in #3094.

Essentially, we add a function-like macro ``tsk_trace_error``, and everywhere we normally do
```c
ret = TSK_ERR_X;
goto out;
```
we instead do
```c
ret = tsk_trace_error(TSK_ERR_X);
goto out;
```

We can then define ``tsk_trace_error`` to be a no-op for production code, and define a function which emits some error traces. For the changes I've made here, we get this on stderr:
```
tskit-trace-error: -701='Sequence length must be > 0. (TSK_ERR_BAD_SEQUENCE_LENGTH)' at line 11000 in ../tskit/tables.c
```

## Implementation notes

- tsk_trace_error must be a macro, otherwise we can't use __FILE__ and __LINE__ to get locations
- This structure has no change on control flow, which is essential
- It should be easy enough to sed the changes to implement this for the vast majority of the library.

I can push this through and document if folks like it.