### PR TITLE
error bound tests

### DIFF
--- a/python/tests/test_relatedness_vector.py
+++ b/python/tests/test_relatedness_vector.py
@@ -838,11 +838,12 @@ def assert_errors_bound(pca_res, D, U, w=None):
     # and there must be at least one b_i that is big (since sum_i b_i^2 = 1 - |delta|^2).
     # More concretely, let m = min_i |lambda - L_i|^2,
     # so that
-    #  epsilon > \sum_i (lambda - L_i)^2 b_i^2 + lambda^2 |delta|^2
+    #  epsilon^2 > \sum_i (lambda - L_i)^2 b_i^2 + lambda^2 |delta|^2
     #   >= m * \sum_i b_i^2 + lambda^2 |delta|^2
     #   = m * (1-|delta|^2) + lambda^2 |delta|^2.
-    # Hence, min_i |lambda-L_i|^2 = m < (epsilon - lambda^2  |delta|^2) / (1- |delta|^2).
-    # In summary: epsilon should be the bound on error in eigenvalues,
+    # Hence,
+    # min_i |lambda-L_i|^2 = m < (epsilon^2 - lambda^2  |delta|^2) / (1- |delta|^2).
+    # In summary: roughly, epsilon should be the bound on error in eigenvalues,
     # and epsilon / sigma[k+1] the L2 bound for eigenvectors
     # Below, the 'roughly/should be' translates into the factor of 5.
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -8914,7 +8914,7 @@ class TreeSequence:
                 1 + 4 * np.sqrt(2 * operator_dim / max(1, (rank - 1))),
                 1 / (2 * depth + 1),
             )
-            error_bound = np.sqrt(D[rank] * (1 + error_factor))  # note sqrt!
+            error_bound = D[rank] * (1 + error_factor)
             return U[:, :rank], D[:rank], Q, error_bound
 
         _f_high = (
@@ -10592,7 +10592,7 @@ class PCAResult:
     Eigenvalues should be correct to within (roughly) this additive factor,
     and factors should be correct to within (roughly) this factor divided by the
     next-largest eigenvalue in the Euclidean norm. These estimates are obtained from
-    a bound on the square root of the expected spectral norm between the true
-    GRM and its low-dimensional approximation, from equation 1.11 in
+    a bound on the expected L2 operator norm between the true GRM and its
+    low-dimensional approximation, from equation 1.11 in
     https://arxiv.org/pdf/0909.4061 .
     """

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -8914,7 +8914,7 @@ class TreeSequence:
                 1 + 4 * np.sqrt(2 * operator_dim / max(1, (rank - 1))),
                 1 / (2 * depth + 1),
             )
-            error_bound = D[rank] * (1 + error_factor)
+            error_bound = np.sqrt(D[rank] * (1 + error_factor))  # note sqrt!
             return U[:, :rank], D[:rank], Q, error_bound
 
         _f_high = (
@@ -10588,9 +10588,11 @@ class PCAResult:
     """
     error_bound: np.ndarray
     """
-    An estimate of the error bounds for the eigenvalues (experimental).
-    This quantifies the average reconstruction error E|G-USVt| where G is the
-    genetic relatedness matrix, U is the PC factors (scores),
-    S is the diagonal eigenvalue matrix, and V is the loadings.
-    The norm is the matrix operator norm.
+    An estimate of the error resulting from the randomized algorithm (experimental).
+    Eigenvalues should be correct to within (roughly) this additive factor,
+    and factors should be correct to within (roughly) this factor divided by the
+    next-largest eigenvalue in the Euclidean norm. These estimates are obtained from
+    a bound on the square root of the expected spectral norm between the true
+    GRM and its low-dimensional approximation, from equation 1.11 in
+    https://arxiv.org/pdf/0909.4061 .
     """


### PR DESCRIPTION
Here's a more precise description of what (we think) the error bound implies for precision, and additional tests.

I was having trouble getting this to pass, but then realized it was because the `time_window` in the test was making it so the matrix was low rank in some genomic windows. So, I removed the time windowing (we don't need to test that part here, as I don't see how it'd interact with the random approximation besides in trivial ways like this).

Also note that the error_bound is labeled "experimental" - which is good, as this is not a rigorous benchmarking.