### PR TITLE
Fix obsure error if structured metadata is fetched from a NullCodec s…

### DIFF
--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -5485,3 +5485,9 @@ class TestStructuredNumpyMetadata:
             assert row["name"] == b"name"
             assert row["value"] == 1.0
             assert row["active"]
+
+    @pytest.mark.parametrize("table_name", metadata_tables)
+    def test_error_if_no_schema(self, table_name):
+        ts = msprime.simulate(10)
+        with pytest.raises(NotImplementedError):
+            getattr(ts, f"{table_name}_metadata")

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -787,6 +787,7 @@ class MetadataSchema:
             self.encode_row = NOOPCodec({}).encode
             self.decode_row = NOOPCodec({}).decode
             self.empty_value = b""
+            self.codec_instance = NOOPCodec({})
         else:
             try:
                 TSKITMetadataSchemaValidator.check_schema(schema)


### PR DESCRIPTION
If the user called e.g.`ts.individuals_metadata` when the table had no codec set there was an obscure error, now raises `NotImplementedError` instead.