### PR TITLE
added github button to docs and updated docs text

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,6 +46,12 @@ sphinx:
       html_theme_options:
         pygments_dark_style: monokai
         navigation_with_keys: false
+        repository_url: https://github.com/tskit-dev/tskit
+        repository_branch: main
+        path_to_docs: docs
+        use_repository_button: true
+        use_edit_page_button: true
+        use_issues_button: true
       pygments_style: monokai
       myst_enable_extensions:
       - colon_fence

--- a/docs/development.md
+++ b/docs/development.md
@@ -340,16 +340,14 @@ on GitHub, and help us fix any, or add issues for anything that's wrong or missi
 If you see a typo or some other small problem that you'd like to fix,
 this is most easily done through the GitHub UI.
 
-If the typo is in a large section of text (like this page), go to the
-top of the page and click on the "Edit on GitHub" link at the top
-right. This will bring you to the page on GitHub for the RST
-source file in question. Then, click on the pencil icon on the
-right hand side. This will open a web editor allowing you to
+Mouse over the GitHub icon at the top right of the page and 
+click on the "Suggest edit" button. This will bring you to a web 
+editor on GitHub for the source file in question, allowing you to
 quickly fix the typo and submit a pull request with the changes.
-Fix the typo, add a commit message like "Fixed typo" and click
-on the green "Propose file change" button. Then follow the dialogues
-until you've created a new pull request with your changes,
-so that we can incorporate them.
+Fix the typo, click the "Commit changes", add a commit message like 
+"Fixed typo" and click on the green "Propose file change" button. 
+Then follow the dialogues until you've created a new pull request 
+with your changes, so that we can incorporate them.
 
 If the change you'd like to make is in the API documentation
 for a particular function, then you'll need to find where this


### PR DESCRIPTION
## Description

- Add GitHub button to the docs
- Update docs text to reflect the GitHub button

Fixes https://github.com/tskit-dev/tskit/issues/3123

Screenshot of local build:
<img width="1557" alt="Screenshot 2025-03-28 at 4 46 05 PM" src="https://github.com/user-attachments/assets/6c65085c-13cd-4d0c-8bca-f62f3247452a" />


# PR Checklist:

- [ ] Tests that fully cover new/changed functionality. _NA_
- [ ] Documentation including tutorial content if appropriate. _NA_
- [ ] Changelogs, if there are API changes. _NA_
