### PR TITLE
Freeze metadata

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -2,10 +2,17 @@
 [0.6.2] - 2025-04-01
 --------------------
 
+
 **Bugfixes**
 
 - Meatdata.schema was returning a modified schema, this is fixed to return a copy of
   the original schema instead (:user:`benjeffery`, :issue:`3129`, :pr:`3130`)
+
+**Breaking Changes**
+
+- To avoid confusion, metadata returned from `.metadata` accessors is now a `FrozenDict`
+  that does not allow mutation of its contents. This is because mutating the object doesn't
+  update the underlying metadata. (:user:`benjeffery`, :issue:`993`, :pr:`3140`)
 
 --------------------
 [0.6.1] - 2025-03-31


### PR DESCRIPTION
Fixes #993

Here's a suggestion for how frozen metadata could work - note that this will have a performance impact as we have to traverse the metadata structure. There is probably a way to avoid the traversal with `object_hook` in JSON and changing the decoder functions in struct. I'll do that if we think this is the right way to go.