### PR TITLE
Add individual nodes method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,10 @@ jobs:
       - name: install clang-format
         if: steps.clang_format.outputs.cache-hit != 'true'
         run: |
-          python -m venv env
-          source env/bin/activate
-          pip install clang-format==6.0.1
+          pip install setuptools clang-format==6.0.1
+          clang-format -version
+          sudo cp /opt/hostedtoolcache/Python/3.12.10/x64/bin/clang-format /opt/hostedtoolcache/Python/3.12.10/x64/bin/clang-format-6.0
+          clang-format-6.0 -version
       - uses: pre-commit/action@v3.0.1
 
   benchmark:

--- a/c/tests/test_core.c
+++ b/c/tests/test_core.c
@@ -532,7 +532,7 @@ test_bit_arrays(void)
     // NB: This test is only valid for the 32 bit implementation of bit arrays. If we
     //     were to change the chunk size of a bit array, we'd need to update these tests
     tsk_bit_array_t arr;
-    tsk_id_t items_truth[64] = {0}, items[64] = {0};
+    tsk_id_t items_truth[64] = { 0 }, items[64] = { 0 };
     tsk_size_t n_items = 0, n_items_truth = 0;
 
     // test item retrieval

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -348,7 +348,7 @@ verify_pair_coalescence_counts(tsk_treeseq_t *ts, tsk_flags_t options)
 
     /* test various bin assignments */
     for (i = 0; i < N; i++) {
-        node_bin_map[i] = ((tsk_id_t) (i % B));
+        node_bin_map[i] = ((tsk_id_t)(i % B));
     }
     ret = tsk_treeseq_pair_coalescence_counts(ts, P, sample_set_sizes, sample_sets, I,
         index_tuples, T, breakpoints, B, node_bin_map, options, C_B);
@@ -3694,8 +3694,8 @@ static void
 test_pair_coalescence_counts_missing(void)
 {
     tsk_treeseq_t ts;
-    tsk_treeseq_from_text(&ts, 5, missing_ex_nodes, missing_ex_edges, NULL,
-        NULL, NULL, NULL, NULL, 0);
+    tsk_treeseq_from_text(
+        &ts, 5, missing_ex_nodes, missing_ex_edges, NULL, NULL, NULL, NULL, NULL, 0);
     verify_pair_coalescence_counts(&ts, 0);
     verify_pair_coalescence_counts(&ts, TSK_STAT_SPAN_NORMALISE);
     tsk_treeseq_free(&ts);

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -373,31 +373,29 @@ const char *empty_ex_nodes = "1  0.0  0  -1\n"
 const char *empty_ex_edges = "";
 
 /*** An example of a tree sequence with missing marginal trees. ***/
-/*                                   
-     |     4     | |     4     |     
-     |    / \    | |    / \    |     
-     |   3   \   | |   /   3   |     
-     |  / \   \  | |  /   / \  |     
-     | 0   1   2 | | 0   1   2 |     
-   |-|-----------|-|-----------|-|   
-   0 1           2 3           4 5 
+/*
+     |     4     | |     4     |
+     |    / \    | |    / \    |
+     |   3   \   | |   /   3   |
+     |  / \   \  | |  /   / \  |
+     | 0   1   2 | | 0   1   2 |
+   |-|-----------|-|-----------|-|
+   0 1           2 3           4 5
 */
-const char *missing_ex_nodes = 
-    "1  0.0  0  -1\n"
-    "1  0.0  0  -1\n"
-    "1  0.0  0  -1\n"
-    "0  1.0  0  -1\n"
-    "0  2.0  0  -1\n";
-                                     
-const char *missing_ex_edges = 
-    "1.0  2.0  3  0\n"
-    "1.0  2.0  3  1\n"
-    "3.0  4.0  3  1\n"
-    "3.0  4.0  3  2\n"
-    "3.0  4.0  4  0\n"
-    "1.0  2.0  4  2\n"
-    "1.0  2.0  4  3\n"
-    "3.0  4.0  4  3\n";
+const char *missing_ex_nodes = "1  0.0  0  -1\n"
+                               "1  0.0  0  -1\n"
+                               "1  0.0  0  -1\n"
+                               "0  1.0  0  -1\n"
+                               "0  2.0  0  -1\n";
+
+const char *missing_ex_edges = "1.0  2.0  3  0\n"
+                               "1.0  2.0  3  1\n"
+                               "3.0  4.0  3  1\n"
+                               "3.0  4.0  3  2\n"
+                               "3.0  4.0  4  0\n"
+                               "1.0  2.0  4  2\n"
+                               "1.0  2.0  4  3\n"
+                               "3.0  4.0  4  3\n";
 
 /* Simple utilities to parse text so we can write declaritive
  * tests. This is not intended as a robust general input mechanism.

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -168,7 +168,8 @@ tsk_strerror_internal(int err)
             break;
         case TSK_ERR_FILE_VERSION_TOO_OLD:
             ret = "tskit file version too old. Please upgrade using the "
-                  "'tskit upgrade' command from tskit version<0.6.2. (TSK_ERR_FILE_VERSION_TOO_OLD)";
+                  "'tskit upgrade' command from tskit version<0.6.2. "
+                  "(TSK_ERR_FILE_VERSION_TOO_OLD)";
             break;
         case TSK_ERR_FILE_VERSION_TOO_NEW:
             ret = "tskit file version is too new for this instance. "

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,4 +1,14 @@
 --------------------
+[0.6.4] - 2025-XX-XX
+--------------------
+
+**Features**
+
+- Add ``TreeSequence.individuals_nodes`` attribute to return the nodes
+  associated with each individual as a numpy array.
+  (:user:`benjeffery`, :pr:`3153`)
+
+--------------------
 [0.6.3] - 2025-04-28
 --------------------
 

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -223,7 +223,8 @@ handle_library_error(int err)
     const char *not_kas_format_msg
         = "File not in kastore format. Either the file is corrupt or it is not a "
           "tskit tree sequence file. It may be a legacy HDF file upgradable with "
-          "`tskit upgrade` from tskit version<0.6.2 or a compressed tree sequence file that can be decompressed "
+          "`tskit upgrade` from tskit version<0.6.2 or a compressed tree sequence file "
+          "that can be decompressed "
           "with `tszip`.";
     const char *ibd_pairs_not_stored_msg
         = "Sample pairs are not stored by default "
@@ -9715,12 +9716,12 @@ TreeSequence_weighted_stat_vector_method(
     if (result_array == NULL) {
         goto out;
     }
-	Py_BEGIN_ALLOW_THREADS
-    err = method(self->tree_sequence, w_shape[1], PyArray_DATA(weights_array),
-        num_windows, PyArray_DATA(windows_array), num_focal_nodes,
-        PyArray_DATA(focal_nodes_array), PyArray_DATA(result_array), options);
-	Py_END_ALLOW_THREADS
-    if (err != 0) {
+    Py_BEGIN_ALLOW_THREADS err
+        = method(self->tree_sequence, w_shape[1], PyArray_DATA(weights_array),
+            num_windows, PyArray_DATA(windows_array), num_focal_nodes,
+            PyArray_DATA(focal_nodes_array), PyArray_DATA(result_array), options);
+    Py_END_ALLOW_THREADS if (err != 0)
+    {
         handle_library_error(err);
         goto out;
     }
@@ -10744,7 +10745,8 @@ TreeSequence_get_individuals_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     individuals = self->tree_sequence->tables->individuals;
-    ret = TreeSequence_make_array(self, individuals.metadata_length, NPY_UINT8, individuals.metadata);
+    ret = TreeSequence_make_array(
+        self, individuals.metadata_length, NPY_UINT8, individuals.metadata);
 out:
     return ret;
 }
@@ -10835,7 +10837,8 @@ TreeSequence_get_nodes_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     nodes = self->tree_sequence->tables->nodes;
-    ret = TreeSequence_make_array(self, nodes.metadata_length, NPY_UINT8, nodes.metadata);
+    ret = TreeSequence_make_array(
+        self, nodes.metadata_length, NPY_UINT8, nodes.metadata);
 out:
     return ret;
 }
@@ -10926,7 +10929,8 @@ TreeSequence_get_edges_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     edges = self->tree_sequence->tables->edges;
-    ret = TreeSequence_make_array(self, edges.metadata_length, NPY_UINT8, edges.metadata);
+    ret = TreeSequence_make_array(
+        self, edges.metadata_length, NPY_UINT8, edges.metadata);
 out:
     return ret;
 }
@@ -10941,7 +10945,8 @@ TreeSequence_get_edges_metadata_offset(TreeSequence *self, void *closure)
         goto out;
     }
     edges = self->tree_sequence->tables->edges;
-    ret = TreeSequence_make_array(self, edges.num_rows + 1, NPY_UINT64, edges.metadata_offset);
+    ret = TreeSequence_make_array(
+        self, edges.num_rows + 1, NPY_UINT64, edges.metadata_offset);
 out:
     return ret;
 }
@@ -10971,7 +10976,8 @@ TreeSequence_get_sites_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     sites = self->tree_sequence->tables->sites;
-    ret = TreeSequence_make_array(self, sites.metadata_length, NPY_UINT8, sites.metadata);
+    ret = TreeSequence_make_array(
+        self, sites.metadata_length, NPY_UINT8, sites.metadata);
 out:
     return ret;
 }
@@ -10986,7 +10992,8 @@ TreeSequence_get_sites_metadata_offset(TreeSequence *self, void *closure)
         goto out;
     }
     sites = self->tree_sequence->tables->sites;
-    ret = TreeSequence_make_array(self, sites.num_rows + 1, NPY_UINT64, sites.metadata_offset);
+    ret = TreeSequence_make_array(
+        self, sites.num_rows + 1, NPY_UINT64, sites.metadata_offset);
 out:
     return ret;
 }
@@ -11061,7 +11068,8 @@ TreeSequence_get_mutations_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     mutations = self->tree_sequence->tables->mutations;
-    ret = TreeSequence_make_array(self, mutations.metadata_length, NPY_UINT8, mutations.metadata);
+    ret = TreeSequence_make_array(
+        self, mutations.metadata_length, NPY_UINT8, mutations.metadata);
 out:
     return ret;
 }
@@ -11076,7 +11084,8 @@ TreeSequence_get_mutations_metadata_offset(TreeSequence *self, void *closure)
         goto out;
     }
     mutations = self->tree_sequence->tables->mutations;
-    ret = TreeSequence_make_array(self, mutations.num_rows + 1, NPY_UINT64, mutations.metadata_offset);
+    ret = TreeSequence_make_array(
+        self, mutations.num_rows + 1, NPY_UINT64, mutations.metadata_offset);
 out:
     return ret;
 }
@@ -11185,7 +11194,8 @@ TreeSequence_get_migrations_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     migrations = self->tree_sequence->tables->migrations;
-    ret = TreeSequence_make_array(self, migrations.metadata_length, NPY_UINT8, migrations.metadata);
+    ret = TreeSequence_make_array(
+        self, migrations.metadata_length, NPY_UINT8, migrations.metadata);
 out:
     return ret;
 }
@@ -11216,7 +11226,8 @@ TreeSequence_get_populations_metadata(TreeSequence *self, void *closure)
         goto out;
     }
     populations = self->tree_sequence->tables->populations;
-    ret = TreeSequence_make_array(self, populations.metadata_length, NPY_UINT8, populations.metadata);
+    ret = TreeSequence_make_array(
+        self, populations.metadata_length, NPY_UINT8, populations.metadata);
 out:
     return ret;
 }

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1949,6 +1949,31 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
         a2[:] = 0
         assert a3 is not a2
 
+    def test_individuals_nodes(self, ts_fixture):
+        ts_fixture = ts_fixture.ll_tree_sequence
+
+        # Properties
+        a = ts_fixture.get_individuals_nodes()
+        assert a.flags.aligned
+        assert a.flags.c_contiguous
+        assert a.flags.owndata
+        b = ts_fixture.get_individuals_nodes()
+        assert a is not b
+        assert np.all(a == b)
+
+        # Lifetime
+        a1 = ts_fixture.get_individuals_nodes()
+        a2 = a1.copy()
+        assert a1 is not a2
+        del ts_fixture
+        # Do some memory operations
+        a3 = np.ones(10**6)
+        assert np.all(a1 == a2)
+        del a1
+        # Just do something to touch memory
+        a2[:] = 0
+        assert a3 is not a2
+
 
 class StatsInterfaceMixin:
     """

--- a/python/tskit/_version.py
+++ b/python/tskit/_version.py
@@ -1,4 +1,4 @@
 # Definitive location for the version number.
 # During development, should be x.y.z.devN
 # For beta should be x.y.zbN
-tskit_version = "0.6.3"
+tskit_version = "0.6.4.dev0"

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4123,6 +4123,7 @@ class TreeSequence:
         self._individuals_time = None
         self._individuals_population = None
         self._individuals_location = None
+        self._individuals_nodes = None
         # NOTE: when we've implemented read-only access via the underlying
         # tables we can replace these arrays with reference to the read-only
         # tables here (and remove the low-level boilerplate).
@@ -5813,6 +5814,20 @@ class TreeSequence:
         return self.table_metadata_schemas.individual.structured_array_from_buffer(
             self._individuals_metadata
         )
+
+    @property
+    def individuals_nodes(self):
+        """
+        Return an array of node IDs for each individual in the tree sequence.
+
+        :return: Array of shape (num_individuals, max_ploidy) containing node IDs.
+            Values of -1 indicate unused slots for individuals with ploidy
+            less than the maximum.
+        :rtype: numpy.ndarray (dtype=np.int32)
+        """
+        if self._individuals_nodes is None:
+            self._individuals_nodes = self._ll_tree_sequence.get_individuals_nodes()
+        return self._individuals_nodes
 
     @property
     def nodes_metadata(self):


### PR DESCRIPTION
Adds a method to get an array of (individuals, ploidy) node ids.

I considered adding in the case where there are no individuals and the user specifies ploidy instead for all the sample nodes, but that seems like a separate method.

I'm also not 100% sure it is an error if a non-sample node is in an individual.