### PR TITLE
Fix bug in `ts.pair_coalescence_counts` when a window breakpoint falls within missing interval

### DIFF
--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -9586,8 +9586,9 @@ tsk_treeseq_pair_coalescence_stat(const tsk_treeseq_t *self, tsk_size_t num_samp
                 window_span = windows[w + 1] - windows[w] - missing_span;
                 missing_span = 0.0;
                 if (num_edges == 0) {
+                    /* missing interval, so remove overcounted missing span */
                     remaining_span = right - windows[w + 1];
-                    window_span -= remaining_span;
+                    window_span += remaining_span;
                     missing_span += remaining_span;
                 }
                 for (i = 0; i < (tsk_id_t) num_set_indexes; i++) {

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -7,6 +7,12 @@
 - ``TreeSequence.map_to_vcf_model`` now also returns the transformed positions and
   contig length. (:user:`benjeffery`, :pr:`XXXX`, :issue:`3173`)
 
+**Bugfixes**
+
+- Fix bug in ``TreeSequence.pair_coalescence_counts`` when ``span_normalise=True``
+  and a window breakpoint falls within an internal missing interval.
+  (:user:`nspope`, :pr:`3176`, :issue:`3175`)
+
 --------------------
 [0.6.4] - 2025-05-21
 --------------------


### PR DESCRIPTION
Fixes #3175 via a faulty interval intersection in the C implementation, and adds a test that would fail on main