### PR TITLE
Draft governance model

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -74,7 +74,7 @@ TSC members may be removed by consensus of the remaining TSC members, or may res
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
 place in the issue trackers of the appropriate repositories or other public forums.
-Where possible decisions and discussions of the steering council should be documented as issues on the [administrative](https://github.com/tskit-dev/administrative) repository. Sensitive discussion may occur via email to admin@tskit.dev.
+Where possible decisions and discussions of the steering council should be documented as issues on the [administrative](https://github.com/tskit-dev/administrative) repository.
 
 tskit uses a "consensus-seeking" process for making decisions. The group tries to
 find a resolution that has no open objections among maintainers and the TSC. All


### PR DESCRIPTION
I've created this PR on the `tskit` repo for visibility - eventually this will live at https://github.com/tskit-dev/administrative.

Following the meeting and discussion yesterday, I've written up what I consider to be the lightest, yet focused and meaningful, governance policy for the core repositories.

Please provide your feedback on this, even if it's just a +1 if you're happy, as we'd like community consensus on this.