### PR TITLE
Allow Y axis on RHS of SVG plot

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -10,6 +10,9 @@
 - ``draw_svg()`` methods now associate tree branches with edge IDs
   (:user:`hyanwong`, :pr:`3193`, :issue:`557`)
 
+- ``draw_svg()`` methods now allow the y-axis to be placed on the right-hand side
+  using ``y_axis="right"`` (:user:`hyanwong`, :pr:`3201`)
+
 **Bugfixes**
 
 - Fix bug in ``TreeSequence.pair_coalescence_counts`` when ``span_normalise=True``

--- a/python/tests/data/svg/tree_timed_muts.svg
+++ b/python/tests/data/svg/tree_timed_muts.svg
@@ -4,35 +4,69 @@
 		<style type="text/css"><![CDATA[.background path {fill: #808080; fill-opacity: 0}.background path:nth-child(odd) {fill-opacity: .1}.x-regions rect {fill: yellow; stroke: black; opacity: 0.5}.axes {font-size: 14px}.x-axis .tick .lab {font-weight: bold; dominant-baseline: hanging}.axes, .tree {font-size: 14px; text-anchor: middle}.axes line, .edge {stroke: black; fill: none}.axes .ax-skip {stroke-dasharray: 4}.y-axis .grid {stroke: #FAFAFA}.node > .sym {fill: black; stroke: none}.site > .sym {stroke: black}.mut text {fill: red; font-style: italic}.mut.extra text {fill: hotpink}.mut line {fill: none; stroke: none}.mut .sym {fill: none; stroke: red}.mut.extra .sym {stroke: hotpink}.node .mut .sym {stroke-width: 1.5px}.tree text, .tree-sequence text {dominant-baseline: central}.plotbox .lab.lft {text-anchor: end}.plotbox .lab.rgt {text-anchor: start}.polytomy line {stroke: black; stroke-dasharray: 1px, 1px}.polytomy text {paint-order:stroke;stroke-width:0.3em;stroke:white}]]></style>
 	</defs>
 	<g class="tree t0">
+		<g class="axes">
+			<g class="y-axis">
+				<g class="title" transform="translate(200 89.1)">
+					<text class="lab" text-anchor="middle" transform="translate(-11) rotate(90)">Time ago</text>
+				</g>
+				<line class="ax-line" x1="143.2" x2="143.2" y1="168.2" y2="10"/>
+				<g class="ticks">
+					<g class="tick" transform="translate(143.2 168.2)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">0.00</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(143.2 166.992)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">0.11</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(143.2 156.486)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">1.11</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(143.2 72.4037)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">9.08</text>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
 		<g class="plotbox">
-			<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(100 72.4037)">
-				<g class="a9 c2 node n4 p0" transform="translate(-40 94.5886)">
-					<g class="a4 leaf node n0 p0 sample" transform="translate(-20 1.20761)">
-						<path class="edge e0" d="M 0 0 V -1.20761 H 20"/>
+			<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(81.6 72.4037)">
+				<g class="a9 c2 node n4 p0" transform="translate(-30.8 94.5886)">
+					<g class="a4 leaf node n0 p0 sample" transform="translate(-15.4 1.20761)">
+						<path class="edge e0" d="M 0 0 V -1.20761 H 15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">0</text>
 					</g>
-					<g class="a4 leaf node n1 p0 sample" transform="translate(20 1.20761)">
-						<path class="edge e1" d="M 0 0 V -1.20761 H -20"/>
+					<g class="a4 leaf node n1 p0 sample" transform="translate(15.4 1.20761)">
+						<path class="edge e1" d="M 0 0 V -1.20761 H -15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">1</text>
 					</g>
-					<path class="edge e12" d="M 0 0 V -94.5886 H 40"/>
+					<path class="edge e12" d="M 0 0 V -94.5886 H 30.8"/>
 					<circle class="sym" cx="0" cy="0" r="3"/>
 					<text class="lab lft" transform="translate(-3 -7)">4</text>
 				</g>
-				<g class="a9 c2 m2 node n5 p0 s0" transform="translate(40 84.0823)">
-					<g class="a5 leaf node n2 p0 sample" transform="translate(-20 11.714)">
-						<path class="edge e2" d="M 0 0 V -11.714 H 20"/>
+				<g class="a9 c2 m2 node n5 p0 s0" transform="translate(30.8 84.0823)">
+					<g class="a5 leaf node n2 p0 sample" transform="translate(-15.4 11.714)">
+						<path class="edge e2" d="M 0 0 V -11.714 H 15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">2</text>
 					</g>
-					<g class="a5 leaf node n3 p0 sample" transform="translate(20 11.714)">
-						<path class="edge e3" d="M 0 0 V -11.714 H -20"/>
+					<g class="a5 leaf node n3 p0 sample" transform="translate(15.4 11.714)">
+						<path class="edge e3" d="M 0 0 V -11.714 H -15.4"/>
 						<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 						<text class="lab" transform="translate(0 11)">3</text>
 					</g>
-					<path class="edge e13" d="M 0 0 V -84.0823 H -40"/>
+					<path class="edge e13" d="M 0 0 V -84.0823 H -30.8"/>
 					<g class="mut m2 s0" transform="translate(0 -83.206)">
 						<line x1="0" x2="0" y1="0" y2="83.206"/>
 						<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>

--- a/python/tests/data/svg/ts_mut_times.svg
+++ b/python/tests/data/svg/ts_mut_times.svg
@@ -5,18 +5,18 @@
 	</defs>
 	<g class="tree-sequence">
 		<g class="background">
-			<path d="M20,0 l192,0 l0,138.2 l-134.638,25 l0,5 l-57.3623,0 l0,-5 l0,-25 l0,-138.2z"/>
-			<path d="M212,0 l192,0 l0,138.2 l376.883,25 l0,5 l-703.52,0 l0,-5 l134.638,-25 l0,-138.2z"/>
-			<path d="M404,0 l192,0 l0,138.2 l294.091,25 l0,5 l-109.208,0 l0,-5 l-376.883,-25 l0,-138.2z"/>
-			<path d="M596,0 l192,0 l0,138.2 l105.883,25 l0,5 l-3.79176,0 l0,-5 l-294.091,-25 l0,-138.2z"/>
-			<path d="M788,0 l192,0 l0,138.2 l0,25 l0,5 l-86.1174,0 l0,-5 l-105.883,-25 l0,-138.2z"/>
+			<path d="M20,0 l184.64,0 l0,138.2 l-129.477,25 l0,5 l-55.1634,0 l0,-5 l0,-25 l0,-138.2z"/>
+			<path d="M204.64,0 l184.64,0 l0,138.2 l362.436,25 l0,5 l-676.552,0 l0,-5 l129.477,-25 l0,-138.2z"/>
+			<path d="M389.28,0 l184.64,0 l0,138.2 l282.817,25 l0,5 l-105.022,0 l0,-5 l-362.436,-25 l0,-138.2z"/>
+			<path d="M573.92,0 l184.64,0 l0,138.2 l101.824,25 l0,5 l-3.64641,0 l0,-5 l-282.817,-25 l0,-138.2z"/>
+			<path d="M758.56,0 l184.64,0 l0,138.2 l0,25 l0,5 l-82.8163,0 l0,-5 l-101.824,-25 l0,-138.2z"/>
 		</g>
 		<g class="axes">
 			<g class="x-axis">
-				<g class="title" transform="translate(500 200)">
+				<g class="title" transform="translate(481.6 200)">
 					<text class="lab" text-anchor="middle" transform="translate(0 -11)">Genome position</text>
 				</g>
-				<line class="ax-line" x1="20" x2="980" y1="163.2" y2="163.2"/>
+				<line class="ax-line" x1="20" x2="943.2" y1="163.2" y2="163.2"/>
 				<g class="ticks">
 					<g class="tick" transform="translate(20 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
@@ -24,38 +24,38 @@
 							<text class="lab">0.00</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(77.3623 163.2)">
+					<g class="tick" transform="translate(75.1634 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">0.06</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(780.883 163.2)">
+					<g class="tick" transform="translate(751.716 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">0.79</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(890.091 163.2)">
+					<g class="tick" transform="translate(856.737 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(893.883 163.2)">
+					<g class="tick" transform="translate(860.384 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">0.91</text>
 						</g>
 					</g>
-					<g class="tick" transform="translate(980 163.2)">
+					<g class="tick" transform="translate(943.2 163.2)">
 						<line x1="0" x2="0" y1="0" y2="5"/>
 						<g transform="translate(0 6)">
 							<text class="lab">1.00</text>
 						</g>
 					</g>
 				</g>
-				<g class="site s0" transform="translate(68 163.2)">
+				<g class="site s0" transform="translate(66.16 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m2">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
@@ -67,7 +67,7 @@
 						<polyline class="sym" points="2.5,-14.5 0,-9.5 -2.5,-14.5"/>
 					</g>
 				</g>
-				<g class="site s1" transform="translate(77.6 163.2)">
+				<g class="site s1" transform="translate(75.392 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m4">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
@@ -76,7 +76,7 @@
 						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
 					</g>
 				</g>
-				<g class="site s2" transform="translate(308 163.2)">
+				<g class="site s2" transform="translate(296.96 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m6">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
@@ -85,13 +85,63 @@
 						<polyline class="sym" points="2.5,-10.5 0,-5.5 -2.5,-10.5"/>
 					</g>
 				</g>
-				<g class="site s3" transform="translate(500 163.2)">
+				<g class="site s3" transform="translate(481.6 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 				</g>
-				<g class="site s4" transform="translate(893.6 163.2)">
+				<g class="site s4" transform="translate(860.112 163.2)">
 					<line class="sym" x1="0" x2="0" y1="0" y2="-10"/>
 					<g class="mut m7">
 						<polyline class="sym" points="2.5,-6.5 0,-1.5 -2.5,-6.5"/>
+					</g>
+				</g>
+			</g>
+			<g class="y-axis">
+				<g class="title" transform="translate(1000 65.7)">
+					<text class="lab" text-anchor="middle" transform="translate(-11) rotate(90)">Time ago</text>
+				</g>
+				<line class="ax-line" x1="943.2" x2="943.2" y1="121.4" y2="10"/>
+				<g class="ticks">
+					<g class="tick" transform="translate(943.2 121.4)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">0.00</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(943.2 120.55)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">0.11</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(943.2 113.151)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">1.11</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(943.2 108.403)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">1.75</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(943.2 81.9594)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">5.31</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(943.2 72.5822)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">6.57</text>
+						</g>
+					</g>
+					<g class="tick" transform="translate(943.2 53.943)">
+						<line x1="0" x2="5" y1="0" y2="0"/>
+						<g transform="translate(6 0)">
+							<text class="lab" text-anchor="start">9.08</text>
+						</g>
 					</g>
 				</g>
 			</g>
@@ -99,34 +149,34 @@
 		<g class="plotbox trees">
 			<g class="tree t0" transform="translate(20 0)">
 				<g class="plotbox">
-					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(96 53.943)">
-						<g class="a9 c2 node n4 p0" transform="translate(-38 66.6067)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
-								<path class="edge e0" d="M 0 0 V -0.850364 H 19"/>
+					<g class="c2 m0 m1 node n9 p0 root s0" transform="translate(92.32 53.943)">
+						<g class="a9 c2 node n4 p0" transform="translate(-36.16 66.6067)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 0.850364)">
+								<path class="edge e0" d="M 0 0 V -0.850364 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(19 0.850364)">
-								<path class="edge e1" d="M 0 0 V -0.850364 H -19"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.08 0.850364)">
+								<path class="edge e1" d="M 0 0 V -0.850364 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<path class="edge e12" d="M 0 0 V -66.6067 H 38"/>
+							<path class="edge e12" d="M 0 0 V -66.6067 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
-						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(38 59.2084)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
-								<path class="edge e2" d="M 0 0 V -8.24865 H 19"/>
+						<g class="a9 c2 m2 node n5 p0 s0" transform="translate(36.16 59.2084)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 8.24865)">
+								<path class="edge e2" d="M 0 0 V -8.24865 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(19 8.24865)">
-								<path class="edge e3" d="M 0 0 V -8.24865 H -19"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(18.08 8.24865)">
+								<path class="edge e3" d="M 0 0 V -8.24865 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge e13" d="M 0 0 V -59.2084 H -38"/>
+							<path class="edge e13" d="M 0 0 V -59.2084 H -36.16"/>
 							<g class="mut m2 s0" transform="translate(0 -58.5914)">
 								<line x1="0" x2="0" y1="0" y2="58.5914"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -151,21 +201,21 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t1" transform="translate(212 0)">
+			<g class="tree t1" transform="translate(204.64 0)">
 				<g class="plotbox">
-					<g class="c2 m5 node n7 p0 root s2" transform="translate(96 81.9594)">
-						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-38 38.5902)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
-								<path class="edge e0" d="M 0 0 V -0.850364 H 19"/>
+					<g class="c2 m5 node n7 p0 root s2" transform="translate(92.32 81.9594)">
+						<g class="a7 c2 m3 m4 node n4 p0 s1" transform="translate(-36.16 38.5902)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 0.850364)">
+								<path class="edge e0" d="M 0 0 V -0.850364 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(19 0.850364)">
-								<path class="edge e1" d="M 0 0 V -0.850364 H -19"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.08 0.850364)">
+								<path class="edge e1" d="M 0 0 V -0.850364 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<path class="edge e6" d="M 0 0 V -38.5902 H 38"/>
+							<path class="edge e6" d="M 0 0 V -38.5902 H 36.16"/>
 							<g class="mut m3 s1" transform="translate(0 -11.0323)">
 								<line x1="0" x2="0" y1="0" y2="11.0323"/>
 								<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -179,14 +229,14 @@
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
-						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
-								<path class="edge e2" d="M 0 0 V -8.24865 H 19"/>
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 31.1919)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 8.24865)">
+								<path class="edge e2" d="M 0 0 V -8.24865 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<g class="a5 leaf m6 node n3 p0 s2 sample" transform="translate(19 8.24865)">
-								<path class="edge e3" d="M 0 0 V -8.24865 H -19"/>
+							<g class="a5 leaf m6 node n3 p0 s2 sample" transform="translate(18.08 8.24865)">
+								<path class="edge e3" d="M 0 0 V -8.24865 H -18.08"/>
 								<g class="mut m6 s2" transform="translate(0 -7.42667)">
 									<line x1="0" x2="0" y1="0" y2="7.42667"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -195,7 +245,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge e8" d="M 0 0 V -31.1919 H -38"/>
+							<path class="edge e8" d="M 0 0 V -31.1919 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
@@ -210,36 +260,36 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t2" transform="translate(404 0)">
+			<g class="tree t2" transform="translate(389.28 0)">
 				<g class="plotbox">
-					<g class="c2 node n6 p0 root" transform="translate(96 108.403)">
-						<g class="a6 c2 node n4 p0" transform="translate(-38 12.1467)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
-								<path class="edge e0" d="M 0 0 V -0.850364 H 19"/>
+					<g class="c2 node n6 p0 root" transform="translate(92.32 108.403)">
+						<g class="a6 c2 node n4 p0" transform="translate(-36.16 12.1467)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 0.850364)">
+								<path class="edge e0" d="M 0 0 V -0.850364 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(19 0.850364)">
-								<path class="edge e1" d="M 0 0 V -0.850364 H -19"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.08 0.850364)">
+								<path class="edge e1" d="M 0 0 V -0.850364 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<path class="edge e4" d="M 0 0 V -12.1467 H 38"/>
+							<path class="edge e4" d="M 0 0 V -12.1467 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
-						<g class="a6 c2 node n5 p0" transform="translate(38 4.74841)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
-								<path class="edge e2" d="M 0 0 V -8.24865 H 19"/>
+						<g class="a6 c2 node n5 p0" transform="translate(36.16 4.74841)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 8.24865)">
+								<path class="edge e2" d="M 0 0 V -8.24865 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(19 8.24865)">
-								<path class="edge e3" d="M 0 0 V -8.24865 H -19"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(18.08 8.24865)">
+								<path class="edge e3" d="M 0 0 V -8.24865 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge e5" d="M 0 0 V -4.74841 H -38"/>
+							<path class="edge e5" d="M 0 0 V -4.74841 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
@@ -249,32 +299,32 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t3" transform="translate(596 0)">
+			<g class="tree t3" transform="translate(573.92 0)">
 				<g class="plotbox">
-					<g class="c2 node n7 p0 root" transform="translate(96 81.9594)">
-						<g class="a7 c2 node n4 p0" transform="translate(-38 38.5902)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
-								<path class="edge e0" d="M 0 0 V -0.850364 H 19"/>
+					<g class="c2 node n7 p0 root" transform="translate(92.32 81.9594)">
+						<g class="a7 c2 node n4 p0" transform="translate(-36.16 38.5902)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 0.850364)">
+								<path class="edge e0" d="M 0 0 V -0.850364 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(19 0.850364)">
-								<path class="edge e1" d="M 0 0 V -0.850364 H -19"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.08 0.850364)">
+								<path class="edge e1" d="M 0 0 V -0.850364 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<path class="edge e7" d="M 0 0 V -38.5902 H 38"/>
+							<path class="edge e7" d="M 0 0 V -38.5902 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
-						<g class="a7 c2 node n5 p0" transform="translate(38 31.1919)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
-								<path class="edge e2" d="M 0 0 V -8.24865 H 19"/>
+						<g class="a7 c2 node n5 p0" transform="translate(36.16 31.1919)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 8.24865)">
+								<path class="edge e2" d="M 0 0 V -8.24865 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<g class="a5 leaf m7 node n3 p0 s4 sample" transform="translate(19 8.24865)">
-								<path class="edge e3" d="M 0 0 V -8.24865 H -19"/>
+							<g class="a5 leaf m7 node n3 p0 s4 sample" transform="translate(18.08 8.24865)">
+								<path class="edge e3" d="M 0 0 V -8.24865 H -18.08"/>
 								<g class="mut m7 s4" transform="translate(0 -7.42667)">
 									<line x1="0" x2="0" y1="0" y2="7.42667"/>
 									<path class="sym" d="M -3,-3 l 6,6 M -3,3 l 6,-6"/>
@@ -283,7 +333,7 @@
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge e9" d="M 0 0 V -31.1919 H -38"/>
+							<path class="edge e9" d="M 0 0 V -31.1919 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>
@@ -293,36 +343,36 @@
 					</g>
 				</g>
 			</g>
-			<g class="tree t4" transform="translate(788 0)">
+			<g class="tree t4" transform="translate(758.56 0)">
 				<g class="plotbox">
-					<g class="c2 node n8 p0 root" transform="translate(96 72.5822)">
-						<g class="a8 c2 node n4 p0" transform="translate(-38 47.9674)">
-							<g class="a4 leaf node n0 p0 sample" transform="translate(-19 0.850364)">
-								<path class="edge e0" d="M 0 0 V -0.850364 H 19"/>
+					<g class="c2 node n8 p0 root" transform="translate(92.32 72.5822)">
+						<g class="a8 c2 node n4 p0" transform="translate(-36.16 47.9674)">
+							<g class="a4 leaf node n0 p0 sample" transform="translate(-18.08 0.850364)">
+								<path class="edge e0" d="M 0 0 V -0.850364 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">0</text>
 							</g>
-							<g class="a4 leaf node n1 p0 sample" transform="translate(19 0.850364)">
-								<path class="edge e1" d="M 0 0 V -0.850364 H -19"/>
+							<g class="a4 leaf node n1 p0 sample" transform="translate(18.08 0.850364)">
+								<path class="edge e1" d="M 0 0 V -0.850364 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">1</text>
 							</g>
-							<path class="edge e10" d="M 0 0 V -47.9674 H 38"/>
+							<path class="edge e10" d="M 0 0 V -47.9674 H 36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab lft" transform="translate(-3 -7)">4</text>
 						</g>
-						<g class="a8 c2 node n5 p0" transform="translate(38 40.5692)">
-							<g class="a5 leaf node n2 p0 sample" transform="translate(-19 8.24865)">
-								<path class="edge e2" d="M 0 0 V -8.24865 H 19"/>
+						<g class="a8 c2 node n5 p0" transform="translate(36.16 40.5692)">
+							<g class="a5 leaf node n2 p0 sample" transform="translate(-18.08 8.24865)">
+								<path class="edge e2" d="M 0 0 V -8.24865 H 18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">2</text>
 							</g>
-							<g class="a5 leaf node n3 p0 sample" transform="translate(19 8.24865)">
-								<path class="edge e3" d="M 0 0 V -8.24865 H -19"/>
+							<g class="a5 leaf node n3 p0 sample" transform="translate(18.08 8.24865)">
+								<path class="edge e3" d="M 0 0 V -8.24865 H -18.08"/>
 								<rect class="sym" height="6" width="6" x="-3" y="-3"/>
 								<text class="lab" transform="translate(0 11)">3</text>
 							</g>
-							<path class="edge e11" d="M 0 0 V -40.5692 H -38"/>
+							<path class="edge e11" d="M 0 0 V -40.5692 H -36.16"/>
 							<circle class="sym" cx="0" cy="0" r="3"/>
 							<text class="lab rgt" transform="translate(3 -7)">5</text>
 						</g>

--- a/python/tests/test_drawing.py
+++ b/python/tests/test_drawing.py
@@ -1578,7 +1578,7 @@ class TestDrawSvg(TestDrawSvgBase):
         svg = t.draw_svg()
         self.verify_basic_svg(svg)
 
-    @pytest.mark.parametrize("y_axis", (True, False))
+    @pytest.mark.parametrize("y_axis", ("left", "right", True, False))
     @pytest.mark.parametrize("y_label", (True, False))
     @pytest.mark.parametrize(
         "time_scale",
@@ -1769,6 +1769,12 @@ class TestDrawSvg(TestDrawSvgBase):
         svg = t.draw_svg(mutation_label_attrs={0: {"stroke": colour}})
         self.verify_basic_svg(svg)
         assert svg.count(f'stroke="{colour}"') == 1
+
+    def test_bad_y_axis(self):
+        t = self.get_binary_tree()
+        for bad_axis in ["te", "asdf", "", [], b"23"]:
+            with pytest.raises(ValueError):
+                t.draw_svg(y_axis=bad_axis)
 
     def test_bad_time_scale(self):
         t = self.get_binary_tree()
@@ -2750,7 +2756,8 @@ class TestDrawKnownSvg(TestDrawSvgBase):
 
     def test_known_svg_tree_timed_root_mut(self, overwrite_viz, draw_plotbox):
         tree = self.get_simple_ts(use_mutation_times=True).at_index(0)
-        svg = tree.draw_svg(debug_box=draw_plotbox)
+        # Also look at y_axis=right
+        svg = tree.draw_svg(debug_box=draw_plotbox, y_axis="right")
         self.verify_known_svg(svg, "tree_timed_muts.svg", overwrite_viz)
 
     def test_known_svg_ts(self, overwrite_viz, draw_plotbox):
@@ -2921,7 +2928,8 @@ class TestDrawKnownSvg(TestDrawSvgBase):
 
     def test_known_svg_ts_mutation_times(self, overwrite_viz, draw_plotbox):
         ts = self.get_simple_ts(use_mutation_times=True)
-        svg = ts.draw_svg(debug_box=draw_plotbox)
+        # also look at y_axis="right"
+        svg = ts.draw_svg(debug_box=draw_plotbox, y_axis="right")
         assert svg.count('class="site ') == ts.num_sites
         assert svg.count('class="mut ') == ts.num_mutations * 2
         self.verify_known_svg(

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7552,9 +7552,11 @@ class TreeSequence:
             draws a box, labelled with the name, on the X axis between the left and
             right positions, and can be used for annotating genomic regions (e.g.
             genes) on the X axis. If ``None`` (default) do not plot any regions.
-        :param bool y_axis: Should the plot have an Y axis line, showing time (or
-            ranked node time if ``time_scale="rank"``. If ``None`` (default)
-            do not plot a Y axis.
+        :param Union[bool, str] y_axis: Should the plot have an Y axis line, showing
+            time. If ``False`` do not plot a Y axis. If ``True``, plot the Y axis on
+            left hand side of the plot. Can also take the strings ``"left"`` or
+            ``"right"``, specifying the side of the plot on which to plot the Y axis.
+            Default: ``None``, treated as ``False``.
         :param str y_label: Place a label to the left of the plot. If ``None`` (default)
             and there is a Y axis, create and place an appropriate label.
         :param Union[list, dict] y_ticks: A list of Y values at which to plot


### PR DESCRIPTION
This is a bit trivial, but it was the easiest way to make nice tanglegram plots for sc2ts, in which trees are rotated in different directions (see below). So I thought as I had done the work, I might as well see if it is sensible to include in tskit? Otherwise I'll just keep it on my own branch.

Note that this allows `y_axis=True` or `y_axis="right"`, which is a bit yucky. No tests either, in case it seems a silly idea:

<img width="364" alt="Screenshot 2025-06-08 at 18 34 50" src="https://github.com/user-attachments/assets/afcea671-c268-4e4d-ab61-d64aecc31e35" />
