### PR TITLE
Check mutation parents on tree sequence init

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -7,6 +7,32 @@
 - Remove ``tsk_diff_iter_t`` and associated functions.
   (:user:`benjeffery`, :pr:`3221`, :issue:`2797`).
 
+- ``tsk_treeseq_init`` now requires that mutation parents in the table collection
+  are correct and consistent with the topology of the tree at each mutation site.
+  Returns ``TSK_ERR_BAD_MUTATION_PARENT`` if this is not the case, or 
+  ``TSK_ERR_MUTATION_PARENT_AFTER_CHILD`` if the mutations are not in an order
+  compatible with the correct mutation parent.
+  (:user:`benjeffery`, :issue:`2729`, :issue:`2732`, :pr:`3212`).
+
+**Features**
+
+- Add ``TSK_TS_INIT_COMPUTE_MUTATION_PARENTS`` to ``tsk_treeseq_init``
+  to compute mutation parents from the tree sequence topology.
+  Note that the mutations must be in the correct order.
+  (:user:`benjeffery`, :issue:`2757`, :pr:`3212`).
+
+- Add ``TSK_CHECK_MUTATION_PARENTS`` option to ``tsk_table_collection_check_integrity``
+  to check that mutation parents are consistent with the tree sequence topology.
+  This option implies ``TSK_CHECK_TREES``.
+  (:user:`benjeffery`, :issue:`2729`, :issue:`2732`, :pr:`3212`).
+
+- Add the ``TSK_NO_CHECK_INTEGRITY`` option to ``tsk_table_collection_compute_mutation_parents``
+  to skip the integrity checks that are normally run when computing mutation parents.
+  This is useful for speeding up the computation of mutation parents when the
+  tree sequence is certainly known to be valid.
+  (:user:`benjeffery`, :pr:`3212`).
+
+
 --------------------
 [1.1.4] - 2025-03-31
 --------------------

--- a/c/tests/testlib.c
+++ b/c/tests/testlib.c
@@ -767,6 +767,8 @@ tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nod
     tsk_table_collection_t tables;
     tsk_id_t max_population_id;
     tsk_size_t j;
+    tsk_flags_t ts_flags;
+    bool all_parents_null;
 
     CU_ASSERT_FATAL(ts != NULL);
     CU_ASSERT_FATAL(nodes != NULL);
@@ -807,7 +809,21 @@ tsk_treeseq_from_text(tsk_treeseq_t *ts, double sequence_length, const char *nod
         }
     }
 
-    ret = tsk_treeseq_init(ts, &tables, TSK_TS_INIT_BUILD_INDEXES);
+    /* If all mutation.parent are TSK_NULL, use TSK_TS_COMPUTE_MUTATION_PARENTS flag too
+     */
+    ts_flags = TSK_TS_INIT_BUILD_INDEXES;
+    all_parents_null = true;
+    for (j = 0; j < tables.mutations.num_rows; j++) {
+        if (tables.mutations.parent[j] != TSK_NULL) {
+            all_parents_null = false;
+            break;
+        }
+    }
+    if (all_parents_null) {
+        ts_flags |= TSK_TS_INIT_COMPUTE_MUTATION_PARENTS;
+    }
+
+    ret = tsk_treeseq_init(ts, &tables, ts_flags);
     /* tsk_treeseq_print_state(ts, stdout); */
     if (ret != 0) {
         printf("\nret = %s\n", tsk_strerror(ret));

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -347,6 +347,12 @@ tsk_strerror_internal(int err)
                   "(TSK_ERR_DISALLOWED_UNKNOWN_MUTATION_TIME)";
             break;
 
+        case TSK_ERR_BAD_MUTATION_PARENT:
+            ret = "A mutation's parent is not consistent with the topology of the tree. "
+                  "Use compute_mutation_parents to set the parents correctly."
+                  "(TSK_ERR_BAD_MUTATION_PARENT)";
+            break;
+
         /* Migration errors */
         case TSK_ERR_UNSORTED_MIGRATIONS:
             ret = "Migrations must be sorted by time. (TSK_ERR_UNSORTED_MIGRATIONS)";

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -510,6 +510,12 @@ Some mutations have TSK_UNKNOWN_TIME in an algorithm where that's
 disallowed (use compute_mutation_times?).
 */
 #define TSK_ERR_DISALLOWED_UNKNOWN_MUTATION_TIME                    -510
+
+/** 
+A mutation's parent was not consistent with the topology of the tree.
+ */
+#define TSK_ERR_BAD_MUTATION_PARENT                                 -511
+
 /** @} */
 
 /**

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -785,6 +785,11 @@ All checks needed to define a valid tree sequence. Note that
 this implies all of the above checks.
 */
 #define TSK_CHECK_TREES (1 << 7)
+/**
+Check mutation parents are consistent with topology.
+Implies TSK_CHECK_TREES.
+*/
+#define TSK_CHECK_MUTATION_PARENTS (1 << 8)
 
 /* Leave room for more positive check flags */
 /**

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -458,10 +458,29 @@ tsk_treeseq_init(
             goto out;
         }
     }
-    num_trees = tsk_table_collection_check_integrity(self->tables, TSK_CHECK_TREES);
-    if (num_trees < 0) {
-        ret = (int) num_trees;
-        goto out;
+
+    if (options & TSK_TS_INIT_COMPUTE_MUTATION_PARENTS) {
+        /* As tsk_table_collection_compute_mutation_parents performs an
+           integrity check, and we don't wish to do that twice we perform
+           our own check here */
+        num_trees = tsk_table_collection_check_integrity(self->tables, TSK_CHECK_TREES);
+        if (num_trees < 0) {
+            ret = (int) num_trees;
+            goto out;
+        }
+
+        ret = tsk_table_collection_compute_mutation_parents(
+            self->tables, TSK_NO_CHECK_INTEGRITY);
+        if (ret != 0) {
+            goto out;
+        }
+    } else {
+        num_trees = tsk_table_collection_check_integrity(
+            self->tables, TSK_CHECK_TREES | TSK_CHECK_MUTATION_PARENTS);
+        if (num_trees < 0) {
+            ret = (int) num_trees;
+            goto out;
+        }
     }
     self->num_trees = (tsk_size_t) num_trees;
     self->discrete_genome = true;

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -71,6 +71,11 @@ when the tree sequence is initialised. Indexes are required for a valid
 tree sequence, and are not built by default for performance reasons.
 */
 #define TSK_TS_INIT_BUILD_INDEXES (1 << 0)
+/**
+If specified, mutation parents in the table collection will be overwritten
+with those computed from the topology when the tree sequence is initialised.
+*/
+#define TSK_TS_INIT_COMPUTE_MUTATION_PARENTS (1 << 1)
 /** @} */
 
 // clang-format on

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -507,13 +507,14 @@ requirements for a valid set of mutations are:
   `time` and equal to or less than the `time` of the `parent` mutation
   if this mutation has one. If one mutation on a site has `UNKNOWN_TIME` then
   all mutations at that site must, as a mixture of known and unknown is not valid.
-- `parent` must either be the null ID (-1) or a valid mutation ID within the
-  current table
+- `parent` must either be the null ID (-1), if the mutation has no parent, or a
+  valid mutation ID within the current table. 
 
 Furthermore,
 
-- If another mutation occurs on the tree above the mutation in
-  question, its ID must be listed as the `parent`.
+- The `parent` value must be consistent with the topology of the tree at the site
+  of the mutation, such that a path from the child mutation to the parent mutation
+  exists without passing through any other mutations at the same site.
 
 For simplicity and algorithmic efficiency, mutations must also:
 

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -110,8 +110,8 @@ position      ancestral_state
 mutations = """\
 site   node    derived_state    time    parent
 0      0       A                0.5     -1
+1      1       A                1.0     -1
 1      0       T                1.5     -1
-1      1       A                1.0     1
 """
 
 migrations = """\

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -2,6 +2,15 @@
 [0.6.5] - 2025-0X-XX
 --------------------
 
+**Breaking Changes**
+
+- For a tree seqeunce to be valid mutation parents in the table collection
+  must be correct and consistent with the topology of the tree at each mutation site.
+  ``TableCollection.tree_sequence()`` will raise a ``_tskit.LibraryError`` if this
+  is not the case.
+  (:user:`benjeffery`, :issue:`2729`, :issue:`2732`, :pr:`3212`).
+
+
 **Features**
 
 - ``TreeSequence.map_to_vcf_model`` now also returns the transformed positions and

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -342,6 +342,7 @@ class TestVariantGenerator:
                     site = tables.sites.add_row(position=0, ancestral_state="0")
                     tables.mutations.add_row(site=site, node=u, derived_state="1")
                     tables.mutations.add_row(site=site, node=sample, derived_state="1")
+                    tables.compute_mutation_parents()
                     ts_new = tables.tree_sequence()
                     assert all([v.genotypes[sample] == 1 for v in ts_new.variants()])
 
@@ -927,8 +928,9 @@ class TestHaplotypeGenerator:
             tables.sites.clear()
             tables.mutations.clear()
             site = tables.sites.add_row(position=0, ancestral_state="0")
-            tables.mutations.add_row(site=site, node=u, derived_state="1")
             tables.mutations.add_row(site=site, node=tree.root, derived_state="1")
+            tables.mutations.add_row(site=site, node=u, derived_state="1")
+            tables.compute_mutation_parents()
             ts_new = tables.tree_sequence()
             all(h == 1 for h in ts_new.haplotypes())
 

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -1659,9 +1659,9 @@ class TestSimplifyExamples(TopologyTestCase):
         0   0.1         0
         """
         mutations_before = """\
-        site    node    derived_state
-        0       3       2
-        0       4       1
+        site    node    derived_state parent
+        0       4       1             -1
+        0       3       2             0
         """
 
         # We sample 0 and 2
@@ -1682,9 +1682,9 @@ class TestSimplifyExamples(TopologyTestCase):
         0   0.1         0
         """
         mutations_after = """\
-        site    node    derived_state
-        0       2       1
-        0       2       2
+        site    node    derived_state parent
+        0       2       1             -1
+        0       2       2             0
         """
         self.verify_simplify(
             samples=[0, 1],
@@ -1716,10 +1716,10 @@ class TestSimplifyExamples(TopologyTestCase):
         0   1.0         0
         """
         mutations_before = """\
-        site    node    derived_state time
-        0       0       2             0
-        0       1       1             1
-        0       2       3             2
+        site    node    derived_state time parent
+        0       2       3             2    -1
+        0       1       1             1    0
+        0       0       2             0    1
         """
         # expected result without keep_input_roots
         nodes_after = """\
@@ -1730,10 +1730,10 @@ class TestSimplifyExamples(TopologyTestCase):
         left    right   parent  child
         """
         mutations_after = """\
-        site    node    derived_state time
-        0       0       2             0
-        0       0       1             1
-        0       0       3             2
+        site    node    derived_state time parent
+        0       0       3             2    -1
+        0       0       1             1    0
+        0       0       2             0    1
         """
         # expected result with keep_input_roots
         nodes_after_keep = """\
@@ -1746,10 +1746,10 @@ class TestSimplifyExamples(TopologyTestCase):
         0       2       1       0
         """
         mutations_after_keep = """\
-        site    node    derived_state time
-        0       0       2             0
-        0       0       1             1
-        0       1       3             2
+        site    node    derived_state time parent
+        0       1       3             2    -1
+        0       0       1             1    0
+        0       0       2             0    1
         """
         self.verify_simplify(
             samples=[0],
@@ -3828,6 +3828,7 @@ class TestSimplify(SimplifyTestBase):
         tables.mutations.add_row(site=0, node=7, derived_state="1")
         tables.mutations.add_row(site=0, node=5, derived_state="0")
         tables.mutations.add_row(site=0, node=1, derived_state="1")
+        tables.compute_mutation_parents()
         ts = tables.tree_sequence()
         assert ts.num_sites == 1
         assert ts.num_mutations == 3

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3701,8 +3701,8 @@ class TableCollection(metadata.MetadataProvider):
         valid, and the site and mutation tables must be sorted (see
         :meth:`TableCollection.sort`).  This will produce an error if mutations
         are not sorted (i.e., if a mutation appears before its mutation parent)
-        *unless* the two mutations occur on the same branch, in which case
-        there is no way to detect the error.
+        *unless* the two mutations occur on the same branch, and have unknown times
+        in which case there is no way to detect the error.
 
         The ``parent`` of a given mutation is the ID of the next mutation
         encountered traversing the tree upwards from that mutation, or


### PR DESCRIPTION
This PR makes tskit require that the mutation parents are correct - i.e. present and consistent with the tree topology. This can usually be done by calling `compute_mutation_parents` if the parents are not set already.