### PR TITLE
Fix genetic_relatedness to allow single sample set with self-comparisons

### DIFF
--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -881,9 +881,6 @@ verify_two_way_stat_func_errors(
     ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         options | TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        options | TSK_STAT_SITE, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
     ret = method(ts, 2, sample_set_sizes, samples, 0, set_indexes, 0, NULL,
         options | TSK_STAT_SITE, &result);
@@ -938,12 +935,6 @@ verify_three_way_stat_func_errors(tsk_treeseq_t *ts, general_sample_stat_method 
     ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        TSK_STAT_SITE, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        TSK_STAT_SITE, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
     ret = method(ts, 3, sample_set_sizes, samples, 0, set_indexes, 0, NULL,
         TSK_STAT_SITE, &result);
@@ -970,15 +961,6 @@ verify_four_way_stat_func_errors(tsk_treeseq_t *ts, general_sample_stat_method *
     double result;
 
     ret = method(ts, 0, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        TSK_STAT_SITE, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 1, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        TSK_STAT_SITE, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 2, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
-        TSK_STAT_SITE, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
-    ret = method(ts, 3, sample_set_sizes, samples, 1, set_indexes, 0, NULL,
         TSK_STAT_SITE, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
 
@@ -3684,7 +3666,7 @@ test_two_locus_stat_input_errors(void)
         NULL, 0, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_INDEX_TUPLES);
 
-    num_sample_sets = 1;
+    num_sample_sets = 0;
     num_index_tuples = 1;
     ret = tsk_treeseq_D2_ij(&ts, num_sample_sets, sample_set_sizes, sample_sets,
         num_index_tuples, index_tuples, num_sites, row_sites, NULL, num_sites, col_sites,

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -4515,7 +4515,7 @@ check_sample_stat_inputs(tsk_size_t num_sample_sets, tsk_size_t tuple_size,
 {
     int ret = 0;
 
-    if (num_sample_sets < tuple_size) {
+    if (num_sample_sets < 1) {
         ret = tsk_trace_error(TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
         goto out;
     }

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -47,6 +47,12 @@
   when using ``TableCollection.assert_equals`` and ``Table.assert_equals``.
   (:user:`benjeffery`, :pr:`3246`, :issue:`3244`)
 
+- k-way statistics no longer require k sample sets, allowing in particular
+  "self" comparisons for `TreeSequence.genetic_relatedness`. This changes the
+  error code returned in some situations.
+  (:user:`andrewkern`, :user:`petrelharp`, :pr:`3235`, :issue:`3055`)
+  
+
 **Breaking changes** 
 
 - ``ltrim``, ``rtrim``, ``trim`` and ``shift`` raise an error if used on a tree sequence

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -1871,17 +1871,13 @@ class TestTreeSequence(LowLevelTestCase, MetadataTestMixin):
             stat_method(
                 bad_ss_sizes, bad_ss, indexes, None, None, row_pos, col_pos, "branch"
             )
-        with pytest.raises(
-            _tskit.LibraryError, match="TSK_ERR_INSUFFICIENT_SAMPLE_SETS"
-        ):
+        with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_SAMPLE_SET_INDEX"):
             bad_ss = np.array([], dtype=np.int32)
             bad_ss_sizes = np.array([0], dtype=np.uint32)
             stat_method(
                 bad_ss_sizes, bad_ss, indexes, row_sites, col_sites, None, None, "site"
             )
-        with pytest.raises(
-            _tskit.LibraryError, match="TSK_ERR_INSUFFICIENT_SAMPLE_SETS"
-        ):
+        with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_SAMPLE_SET_INDEX"):
             bad_ss = np.array([], dtype=np.int32)
             bad_ss_sizes = np.array([0], dtype=np.uint32)
             stat_method(


### PR DESCRIPTION
## Description

This PR fixes issue #3055 where `genetic_relatedness` would fail when computing self-comparisons with a single sample set. As @petrelharp pointed out there is no reason this shouldn't be allowed for certain statistics, including `genetic_relatedness`

### The Problem

Previously, calling `genetic_relatedness` with a single sample set and indexes referring to that set would raise an error:

```python
ts.genetic_relatedness([[0]], indexes=[(0,0)])
# TSK_ERR_INSUFFICIENT_SAMPLE_SETS: Insufficient sample sets provided
```

This occurred because the underlying C API validates that at least k=2 sample sets are provided for k-way statistics, even when the indexes only reference a subset of those sets.

### This PR

The fix adds an `allow_self_comparisons` parameter to the internal `__k_way_sample_set_stat` method, which is only set to `True` for `genetic_relatedness`. When enabled:

1. The method validates that all indexes reference valid sample sets
2. If fewer than k sample sets are provided, it pads the list with dummy sample sets to satisfy the C API requirement
3. The dummy sets are never accessed during computation since only the sets referenced by the indexes are used

This ensures that:
- Only `genetic_relatedness` behavior is changed
- Other statistics (like Fst) continue to enforce the minimum sample set requirement
- The C API contract is satisfied without modifying the C code

Further, this PR sets the stage for allowing for other appropriate k-way stats to be computed with self comparisons by setting a flag. 

## Testing

Added comprehensive tests for all three computation modes (site, branch, node) to verify:
- Single sample set with self-comparison works correctly
- Multiple samples within a single set work correctly  
- The fix doesn't affect other statistics

All existing tests continue to pass, but @petrelharp this would benefit from you specifically looking over what I've done to be sure you're okay with the way I've implemented `allow_self_comparisons`



Fixes #3055

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [x] Documentation including tutorial content if appropriate.
- [] Changelogs, if there are API changes.

I'm not sure if I should touch the changelogs here?
