### PR TITLE
Fix mutation ordering

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -21,6 +21,13 @@
 
 **Bugfixes**
 
+- In some tables with mutations out-of-order `TableCollection.sort` did not re-order
+  the mutations so they formed a valid TreeSequence. `TableCollection.sort` and
+  `TableCollection.canonicalise` now sort mutations by site, then time (if known),
+  then the mutation's node's time, then number of descendant mutations
+  (ensuring that parent mutations occur before children), then node, then
+  their original order in the tables. (:user:`benjeffery`, :pr:`3257`, :issue:`3253`)
+
 - Fix bug in ``TreeSequence.pair_coalescence_counts`` when ``span_normalise=True``
   and a window breakpoint falls within an internal missing interval.
   (:user:`nspope`, :pr:`3176`, :issue:`3175`)

--- a/python/tests/test_extend_haplotypes.py
+++ b/python/tests/test_extend_haplotypes.py
@@ -482,7 +482,7 @@ def extend_haplotypes(ts, max_iter=10):
             extender = HaplotypeExtender(ts, forwards=forwards)
             extender.extend_haplotypes()
             tables.edges.replace_with(extender.edges)
-            tables.sort()
+            tables.sort(mutation_start=tables.mutations.num_rows)
             tables.build_index()
             ts = tables.tree_sequence()
         if ts.num_edges == last_num_edges:
@@ -493,7 +493,6 @@ def extend_haplotypes(ts, max_iter=10):
     tables = ts.dump_tables()
     mutations = _slide_mutation_nodes_up(ts, mutations)
     tables.mutations.replace_with(mutations)
-    tables.sort()
     ts = tables.tree_sequence()
     return ts
 

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -3396,7 +3396,12 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
                 sequence_length=ts1.sequence_length,
                 strict=True,
             )
-            self.verify_approximate_equality(ts1, ts2)
+            tables1 = ts1.tables.copy()
+            # load_text performs a `sort`, which changes the order relative to
+            # the original tree sequence
+            tables1.sort()
+            ts1_sorted = tables1.tree_sequence()
+            self.verify_approximate_equality(ts1_sorted, ts2)
 
     def test_empty_files(self):
         nodes_file = io.StringIO("is_sample\ttime\n")

--- a/python/tests/test_table_transforms.py
+++ b/python/tests/test_table_transforms.py
@@ -596,6 +596,11 @@ class TestSplitEdgesExamples:
     @pytest.mark.parametrize("ts", get_example_tree_sequences())
     @pytest.mark.parametrize("population", [-1, None])
     def test_definition(self, ts, population):
+        # The python implementation of split_edges performs a sort,
+        # which changes the order relative to the original tree sequence
+        tables = ts.dump_tables()
+        tables.sort()
+        ts = tables.tree_sequence()
         time = 0 if ts.num_nodes == 0 else np.median(ts.tables.nodes.time)
         if ts.num_migrations == 0:
             ts1 = split_edges_definition(ts, time, population=population)

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -3627,10 +3627,10 @@ class TableCollection(metadata.MetadataProvider):
         Sites are sorted by position, and sites with the same position retain
         their relative ordering.
 
-        Mutations are sorted by site ID, and within the same site are sorted by time.
-        Those with equal or unknown time retain their relative ordering. This does not
-        currently rearrange tables so that mutations occur after their mutation parents,
-        which is a requirement for valid tree sequences.
+        Mutations are sorted by site, then time (if known), then the mutation's
+        node's time, then number of descendant mutations (ensuring that parent
+        mutations occur before children), then node, then original order in the
+        tables.
 
         Migrations are sorted by ``time``, ``source``, ``dest``, ``left`` and
         ``node`` values. This defines a total sort order, such that any permutation
@@ -3667,9 +3667,10 @@ class TableCollection(metadata.MetadataProvider):
         and population tables are sorted by the first node that refers to each
         (see :meth:`TreeSequence.subset`). Then, the remaining tables are sorted
         as in :meth:`.sort`, with the modification that mutations are sorted by
-        site, then time, then number of descendant mutations (ensuring that
-        parent mutations occur before children), then node, then original order
-        in the tables. This ensures that any two tables with the same information
+        site, then time (if known), then the mutation's node's time, then number
+        of descendant mutations (ensuring that parent mutations occur before
+        children), then node, then original order in the tables. This ensures
+        that any two tables with the same information
         and node order should be identical after canonical sorting (note
         that no canonical order exists for the node table).
 


### PR DESCRIPTION
Addressing #3253 

This PR changes the mutation sort order from `site->time->ID` to `site->time->node_time->num_descendants->ID`

This is required as if mutations have unknown times, and no parent info, we need to use the node time to have parents before children. For mutations at the same node, we assume the existing order is parents before children. We need to use num descendants to use parent info if it is present for mutations at the same node.

I've updated a few of the breaking Python tests to give a flavour of the impact. This PR still needs tests for the new order, and the rest of the broken tests fixing, but thought this was a good point for feedback.