### PR TITLE
Switch parent_index to a count sort

### DIFF
--- a/python/tests/test_jit.py
+++ b/python/tests/test_jit.py
@@ -152,7 +152,7 @@ def test_parent_index_correctness(ts):
                 expected_parents.append(edge_id)
 
         if len(expected_parents) == 0:
-            assert start == -1 and stop == -1
+            assert start == stop
         else:
             assert stop > start
             actual_parent_edge_ids = []


### PR DESCRIPTION
Changes `NumbaTreeSequence.parent_index` to a count based sort.

The plot below shows the performance for the two different approaches with `msprime.sim_ancestry` tree sequences and one data point of chromosome 21 of the Quebecois dataset.

Generally the `count` method in this PR is faster - but that declines at higher edge counts. Likely due to the edge insertion being a random write.

Supporting this idea is the fact that the performance cliff at ~10^6 is also the point where the size of the working set of `edges_child` and `edge_index` exceeds my machine's 12MB L3 cache!

<img width="3554" height="2350" alt="parent_index_performance_comparison" src="https://github.com/user-attachments/assets/7e3751ab-3a8b-4c9d-85b5-e21305c8abba" />

