### PR TITLE
Time windows in AFS

### DIFF
--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -872,17 +872,20 @@ verify_one_way_stat_func_errors(tsk_treeseq_t *ts, one_way_sample_stat_method *m
 typedef int one_way_sample_stat_method_tw(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
-    tsk_size_t num_time_windows, const double *time_windows,
-    tsk_flags_t options, double *result);
+    tsk_size_t num_time_windows, const double *time_windows, tsk_flags_t options,
+    double *result);
 
+// Temporary duplicate for time-windows-having methods
 static void
-verify_one_way_stat_func_errors_tw(tsk_treeseq_t *ts, one_way_sample_stat_method_tw *method)
+verify_one_way_stat_func_errors_tw(
+    tsk_treeseq_t *ts, one_way_sample_stat_method_tw *method)
 {
     int ret;
     tsk_id_t num_nodes = (tsk_id_t) tsk_treeseq_get_num_nodes(ts);
     tsk_id_t samples[] = { 0, 1, 2, 3 };
     tsk_size_t sample_set_sizes = 4;
     double windows[] = { 0, 0, 0 };
+    double time_windows[] = { 0, 0, 0 };
     double result;
 
     ret = method(ts, 0, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
@@ -920,6 +923,15 @@ verify_one_way_stat_func_errors_tw(tsk_treeseq_t *ts, one_way_sample_stat_method
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NUM_WINDOWS);
 
     ret = method(ts, 1, &sample_set_sizes, samples, 2, windows, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
+
+    /* Time window errors */
+    ret = method(
+        ts, 1, &sample_set_sizes, samples, 0, NULL, 0, time_windows, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NUM_WINDOWS);
+
+    ret = method(
+        ts, 1, &sample_set_sizes, samples, 0, NULL, 2, time_windows, 0, &result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 }
 
@@ -1261,23 +1273,24 @@ verify_afs(tsk_treeseq_t *ts)
     sample_set_sizes[0] = n - 2;
     sample_set_sizes[1] = 2;
     ret = tsk_treeseq_allele_frequency_spectrum(
-	ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, 0, result);
+        ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, 0, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-	ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_POLARISED, result);
+        ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_POLARISED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-	NULL, 0, NULL, TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
+        NULL, 0, NULL, TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-	NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
+        NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE,
+        result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-	NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_SPAN_NORMALISE, result);
+        NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     free(result);

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -23,6 +23,7 @@
  */
 
 #include "testlib.h"
+#include <math.h>
 #include <tskit/stats.h>
 
 #include <unistd.h>
@@ -885,7 +886,7 @@ verify_one_way_stat_func_errors_tw(
     tsk_id_t samples[] = { 0, 1, 2, 3 };
     tsk_size_t sample_set_sizes = 4;
     double windows[] = { 0, 0, 0 };
-    double time_windows[] = { 0, 0, 0 };
+    double time_windows[] = { -1, 0.5, INFINITY };
     double result;
 
     ret = method(ts, 0, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
@@ -928,11 +929,22 @@ verify_one_way_stat_func_errors_tw(
     /* Time window errors */
     ret = method(
         ts, 1, &sample_set_sizes, samples, 0, NULL, 0, time_windows, 0, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NUM_WINDOWS);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_TIME_WINDOWS_DIM);
 
     ret = method(
         ts, 1, &sample_set_sizes, samples, 0, NULL, 2, time_windows, 0, &result);
-    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_TIME_WINDOWS);
+
+    time_windows[0] = 0.1;
+    ret = method(
+        ts, 1, &sample_set_sizes, samples, 0, NULL, 2, time_windows, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_TIME_WINDOWS);
+
+    time_windows[0] = 0;
+    time_windows[1] = 0;
+    ret = method(
+        ts, 1, &sample_set_sizes, samples, 0, NULL, 2, time_windows, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_TIME_WINDOWS);
 }
 
 static void
@@ -2484,6 +2496,7 @@ test_paper_ex_afs_errors(void)
     tsk_size_t sample_set_sizes[] = { 2, 2 };
     tsk_id_t samples[] = { 0, 1, 2, 3 };
     double result[10]; /* not thinking too hard about the actual value needed */
+    double time_windows[] = { 0, 1 };
     int ret;
 
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
@@ -2498,6 +2511,10 @@ test_paper_ex_afs_errors(void)
     ret = tsk_treeseq_allele_frequency_spectrum(&ts, 2, sample_set_sizes, samples, 0,
         NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_SITE, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_STAT_MODES);
+
+    ret = tsk_treeseq_allele_frequency_spectrum(&ts, 2, sample_set_sizes, samples, 0,
+        NULL, 1, time_windows, TSK_STAT_SITE, result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSUPPORTED_STAT_MODE);
 
     tsk_treeseq_free(&ts);
 }

--- a/c/tests/test_stats.c
+++ b/c/tests/test_stats.c
@@ -868,6 +868,61 @@ verify_one_way_stat_func_errors(tsk_treeseq_t *ts, one_way_sample_stat_method *m
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
 }
 
+// Temporary definition for time_windows in tsk_treeseq_allele_frequency_spectrum
+typedef int one_way_sample_stat_method_tw(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
+    tsk_size_t num_time_windows, const double *time_windows,
+    tsk_flags_t options, double *result);
+
+static void
+verify_one_way_stat_func_errors_tw(tsk_treeseq_t *ts, one_way_sample_stat_method_tw *method)
+{
+    int ret;
+    tsk_id_t num_nodes = (tsk_id_t) tsk_treeseq_get_num_nodes(ts);
+    tsk_id_t samples[] = { 0, 1, 2, 3 };
+    tsk_size_t sample_set_sizes = 4;
+    double windows[] = { 0, 0, 0 };
+    double result;
+
+    ret = method(ts, 0, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_INSUFFICIENT_SAMPLE_SETS);
+
+    samples[0] = TSK_NULL;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    samples[0] = -10;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    samples[0] = num_nodes;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+    samples[0] = num_nodes + 1;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_NODE_OUT_OF_BOUNDS);
+
+    samples[0] = num_nodes - 1;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_SAMPLES);
+
+    samples[0] = 1;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_DUPLICATE_SAMPLE);
+
+    samples[0] = 0;
+    sample_set_sizes = 0;
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, NULL, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_EMPTY_SAMPLE_SET);
+
+    sample_set_sizes = 4;
+    /* Window errors */
+    ret = method(ts, 1, &sample_set_sizes, samples, 0, windows, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_NUM_WINDOWS);
+
+    ret = method(ts, 1, &sample_set_sizes, samples, 2, windows, 0, NULL, 0, &result);
+    CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_BAD_WINDOWS);
+}
+
 static void
 verify_two_way_stat_func_errors(
     tsk_treeseq_t *ts, general_sample_stat_method *method, tsk_flags_t options)
@@ -1206,23 +1261,23 @@ verify_afs(tsk_treeseq_t *ts)
     sample_set_sizes[0] = n - 2;
     sample_set_sizes[1] = 2;
     ret = tsk_treeseq_allele_frequency_spectrum(
-        ts, 2, sample_set_sizes, samples, 0, NULL, 0, result);
+	ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, 0, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        ts, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_POLARISED, result);
+	ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_POLARISED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-        NULL, TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
+	NULL, 0, NULL, TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-        NULL, TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
+	NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_POLARISED | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(ts, 2, sample_set_sizes, samples, 0,
-        NULL, TSK_STAT_BRANCH | TSK_STAT_SPAN_NORMALISE, result);
+	NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_SPAN_NORMALISE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     free(result);
@@ -2421,14 +2476,14 @@ test_paper_ex_afs_errors(void)
     tsk_treeseq_from_text(&ts, 10, paper_ex_nodes, paper_ex_edges, NULL, paper_ex_sites,
         paper_ex_mutations, paper_ex_individuals, NULL, 0);
 
-    verify_one_way_stat_func_errors(&ts, tsk_treeseq_allele_frequency_spectrum);
+    verify_one_way_stat_func_errors_tw(&ts, tsk_treeseq_allele_frequency_spectrum);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_NODE, result);
+        &ts, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_NODE, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_UNSUPPORTED_STAT_MODE);
 
     ret = tsk_treeseq_allele_frequency_spectrum(&ts, 2, sample_set_sizes, samples, 0,
-        NULL, TSK_STAT_BRANCH | TSK_STAT_SITE, result);
+        NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_SITE, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_MULTIPLE_STAT_MODES);
 
     tsk_treeseq_free(&ts);
@@ -2448,14 +2503,14 @@ test_paper_ex_afs(void)
     /* we have two singletons and one tripleton */
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts, 1, sample_set_sizes, samples, 0, NULL, 0, result);
+        &ts, 1, sample_set_sizes, samples, 0, NULL, 0, NULL, 0, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result[0], 0);
     CU_ASSERT_EQUAL_FATAL(result[1], 3.0);
     CU_ASSERT_EQUAL_FATAL(result[2], 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts, 1, sample_set_sizes, samples, 0, NULL, TSK_STAT_POLARISED, result);
+        &ts, 1, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_POLARISED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(result[0], 0);
     CU_ASSERT_EQUAL_FATAL(result[1], 2.0);

--- a/c/tests/test_trees.c
+++ b/c/tests/test_trees.c
@@ -8026,13 +8026,13 @@ test_time_uncalibrated(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts2, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_SITE, result);
+        &ts2, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_SITE, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_treeseq_allele_frequency_spectrum(
-        &ts2, 2, sample_set_sizes, samples, 0, NULL, TSK_STAT_BRANCH, result);
+        &ts2, 2, sample_set_sizes, samples, 0, NULL, 0, NULL, TSK_STAT_BRANCH, result);
     CU_ASSERT_EQUAL_FATAL(ret, TSK_ERR_TIME_UNCALIBRATED);
     ret = tsk_treeseq_allele_frequency_spectrum(&ts2, 2, sample_set_sizes, samples, 0,
-        NULL, TSK_STAT_BRANCH | TSK_STAT_ALLOW_TIME_UNCALIBRATED, result);
+        NULL, 0, NULL, TSK_STAT_BRANCH | TSK_STAT_ALLOW_TIME_UNCALIBRATED, result);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     sigma = tsk_calloc(tsk_treeseq_get_num_nodes(&ts2), sizeof(double));

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -520,7 +520,7 @@ tsk_strerror_internal(int err)
                   "(TSK_ERR_BAD_SAMPLE_PAIR_TIMES)";
             break;
         case TSK_ERR_BAD_TIME_WINDOWS:
-            ret = "Time windows must be strictly increasing and end at infinity. "
+            ret = "Time windows must be strictly increasing. "
                   "(TSK_ERR_BAD_TIME_WINDOWS)";
             break;
         case TSK_ERR_BAD_NODE_TIME_WINDOW:

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3491,6 +3491,7 @@ out:
 static int TSK_WARN_UNUSED
 tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double right,
     const double *restrict branch_length, double *restrict last_update,
+    const double *restrict time, tsk_id_t *restrict parent, const double *time_windows,
     const double *counts, tsk_size_t num_sample_sets, tsk_size_t window_index,
     const tsk_size_t *result_dims, tsk_flags_t options, double *result)
 {
@@ -3503,7 +3504,7 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
     const double *count_row = GET_2D_ROW(counts, num_sample_sets + 1, u);
     double x = (right - last_update[u]) * branch_length[u];
     const tsk_size_t all_samples = (tsk_size_t) count_row[num_sample_sets];
-
+    // time, parent, time_windows (list),
     if (coordinate == NULL) {
         ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
@@ -3529,8 +3530,8 @@ out:
 static int
 tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, double *counts, tsk_size_t num_windows,
-    const double *windows, const tsk_size_t *result_dims, tsk_flags_t options,
-    double *result)
+    tsk_size_t num_time_windows, const double *windows, const double *time_windows,
+    const tsk_size_t *result_dims, tsk_flags_t options, double *result)
 {
     int ret = 0;
     tsk_id_t u, v;
@@ -3576,15 +3577,15 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             u = edge_child[h];
             v = edge_parent[h];
             ret = tsk_treeseq_update_branch_afs(self, u, t_left, branch_length,
-                last_update, counts, num_sample_sets, window_index, result_dims, options,
-                result);
+                last_update, node_time, parent, time_windows, counts, num_sample_sets,
+                window_index, result_dims, options, result);
             if (ret != 0) {
                 goto out;
             }
             while (v != TSK_NULL) {
                 ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
-                    last_update, counts, num_sample_sets, window_index, result_dims,
-                    options, result);
+                    last_update, node_time, parent, time_windows, counts,
+                    num_sample_sets, window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3604,8 +3605,8 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             branch_length[u] = node_time[v] - node_time[u];
             while (v != TSK_NULL) {
                 ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
-                    last_update, counts, num_sample_sets, window_index, result_dims,
-                    options, result);
+                    last_update, node_time, parent, time_windows, counts,
+                    num_sample_sets, window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3628,8 +3629,8 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             for (u = 0; u < (tsk_id_t) num_nodes; u++) {
                 tsk_bug_assert(last_update[u] < w_right);
                 ret = tsk_treeseq_update_branch_afs(self, u, w_right, branch_length,
-                    last_update, counts, num_sample_sets, window_index, result_dims,
-                    options, result);
+                    last_update, node_time, parent, time_windows, counts,
+                    num_sample_sets, window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3657,13 +3658,15 @@ int
 tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
-    tsk_flags_t options, double *result)
+    tsk_size_t num_time_windows, const double *time_windows, tsk_flags_t options,
+    double *result)
 {
     int ret = 0;
     bool stat_site = !!(options & TSK_STAT_SITE);
     bool stat_branch = !!(options & TSK_STAT_BRANCH);
     bool stat_node = !!(options & TSK_STAT_NODE);
     const double default_windows[] = { 0, self->tables->sequence_length };
+    const double default_time_windows[] = { 0, INFINITY };
     const tsk_size_t num_nodes = self->tables->nodes.num_rows;
     const tsk_size_t K = num_sample_sets + 1;
     tsk_size_t j, k, l, afs_size;
@@ -3693,6 +3696,16 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     } else {
         ret = tsk_treeseq_check_windows(
             self, num_windows, windows, TSK_REQUIRE_FULL_SPAN);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (time_windows == NULL) {
+        num_time_windows = 1;
+        time_windows = default_time_windows;
+    } else {
+        ret = tsk_treeseq_check_windows(
+            self, num_time_windows, time_windows, TSK_REQUIRE_FULL_SPAN);
         if (ret != 0) {
             goto out;
         }
@@ -3740,7 +3753,8 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
             result);
     } else {
         ret = tsk_treeseq_branch_allele_frequency_spectrum(self, num_sample_sets, counts,
-            num_windows, windows, result_dims, options, result);
+            num_windows, num_time_windows, windows, time_windows, result_dims, options,
+            result);
     }
 
     if (options & TSK_STAT_SPAN_NORMALISE) {

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1237,6 +1237,35 @@ out:
     return ret;
 }
 
+static int
+tsk_treeseq_check_time_windows(const tsk_treeseq_t *self, tsk_size_t num_windows,
+    const double *windows, tsk_flags_t options)
+{
+    int ret = TSK_ERR_BAD_WINDOWS;
+    tsk_size_t j;
+
+    if (num_windows < 1) {
+        ret = TSK_ERR_BAD_NUM_WINDOWS;
+        goto out;
+    }
+
+    if (windows[0] < 0) {
+	goto out;
+    }
+    if (windows[num_windows] > INFINITY) {
+	goto out;
+    }
+
+    for (j = 0; j < num_windows; j++) {
+        if (windows[j] >= windows[j + 1]) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
 /* TODO make these functions more consistent in how the arguments are ordered */
 
 static inline void
@@ -3488,11 +3517,25 @@ out:
     return ret;
 }
 
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+
+/* int getValue_nDimensions( int * baseAddress, int * indexes, int nDimensions ) { */
+/*     int i; */
+/*     int offset = 0; */
+/*     for( i = 0; i < nDimensions; i++ ) { */
+/*         offset += pow(LEN,i) * indexes[nDimensions - (i + 1)]; */
+/*     } */
+
+/*     return *(baseAddress + offset); */
+/* } */
+
 static int TSK_WARN_UNUSED
 tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double right,
     const double *restrict branch_length, double *restrict last_update,
     const double *restrict time, tsk_id_t *restrict parent, const double *time_windows,
-    const double *counts, tsk_size_t num_sample_sets, tsk_size_t window_index,
+    const double *counts, tsk_size_t num_sample_sets, tsk_size_t num_windows,
+    tsk_size_t num_time_windows, tsk_size_t window_index, tsk_size_t time_window_index,
     const tsk_size_t *result_dims, tsk_flags_t options, double *result)
 {
     int ret = 0;
@@ -3502,24 +3545,31 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
     tsk_size_t *coordinate = tsk_malloc(num_sample_sets * sizeof(*coordinate));
     bool polarised = !!(options & TSK_STAT_POLARISED);
     const double *count_row = GET_2D_ROW(counts, num_sample_sets + 1, u);
-    double x = (right - last_update[u]) * branch_length[u];
+    /* double x = (right - last_update[u]) * branch_length[u]; */
+    double x = 0;
+    double t_v = time[parent[u]];
+    double tw_branch_length = 0;
     const tsk_size_t all_samples = (tsk_size_t) count_row[num_sample_sets];
-    // time, parent, time_windows (list),
     if (coordinate == NULL) {
         ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
-
-    if (0 < all_samples && all_samples < self->num_samples) {
-        afs_size = result_dims[num_sample_sets];
-        afs = result + afs_size * window_index;
-        for (k = 0; k < num_sample_sets; k++) {
-            coordinate[k] = (tsk_size_t) count_row[k];
-        }
-        if (!polarised) {
-            fold(coordinate, result_dims, num_sample_sets);
-        }
-        increment_nd_array_value(afs, num_sample_sets, result_dims, coordinate, x);
+    if (parent[u] != -1){
+	if (0 < all_samples && all_samples < self->num_samples) {
+	    for (time_window_index = 0; time_window_index < num_time_windows; time_window_index++){
+		afs_size = result_dims[num_sample_sets];
+		afs = result + afs_size * (window_index * num_time_windows + time_window_index);
+		for (k = 0; k < num_sample_sets; k++) {
+		    coordinate[k] = (tsk_size_t) count_row[k];
+		}
+		if (!polarised){
+		    fold(coordinate, result_dims, num_sample_sets);
+		}
+		tw_branch_length = MIN(time_windows[time_window_index + 1], t_v) - MAX(time_windows[0], time[u]);
+		x = (right - last_update[u]) * tw_branch_length;
+		increment_nd_array_value(afs, num_sample_sets, result_dims, coordinate, x);
+	    }
+	}
     }
     last_update[u] = right;
 out:
@@ -3535,7 +3585,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
 {
     int ret = 0;
     tsk_id_t u, v;
-    tsk_size_t window_index;
+    tsk_size_t window_index, time_window_index;
     tsk_size_t num_nodes = self->tables->nodes.num_rows;
     const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
     const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
@@ -3569,6 +3619,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tk = 0;
     t_left = 0;
     window_index = 0;
+    time_window_index = 0;
     while (tj < num_edges || t_left < sequence_length) {
         tsk_bug_assert(window_index < num_windows);
         while (tk < num_edges && edge_right[O[tk]] == t_left) {
@@ -3578,14 +3629,16 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             v = edge_parent[h];
             ret = tsk_treeseq_update_branch_afs(self, u, t_left, branch_length,
                 last_update, node_time, parent, time_windows, counts, num_sample_sets,
-                window_index, result_dims, options, result);
+		num_windows, num_time_windows, window_index, time_window_index,
+		result_dims, options, result);
             if (ret != 0) {
                 goto out;
             }
             while (v != TSK_NULL) {
                 ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
                     last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, window_index, result_dims, options, result);
+                    num_sample_sets, num_windows, num_time_windows, window_index,
+		    time_window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3606,7 +3659,8 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             while (v != TSK_NULL) {
                 ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
                     last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, window_index, result_dims, options, result);
+                    num_sample_sets, num_windows, num_time_windows, window_index,
+		    time_window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3630,7 +3684,8 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
                 tsk_bug_assert(last_update[u] < w_right);
                 ret = tsk_treeseq_update_branch_afs(self, u, w_right, branch_length,
                     last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, window_index, result_dims, options, result);
+                    num_sample_sets, num_windows, num_time_windows, window_index,
+		    time_window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3676,7 +3731,6 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
      * reuse code from the general_stats code paths. */
     double *counts = NULL;
     double *count_row;
-
     if (stat_node) {
         ret = tsk_trace_error(TSK_ERR_UNSUPPORTED_STAT_MODE);
         goto out;
@@ -3704,7 +3758,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         num_time_windows = 1;
         time_windows = default_time_windows;
     } else {
-        ret = tsk_treeseq_check_windows(
+        ret = tsk_treeseq_check_time_windows(
             self, num_time_windows, time_windows, TSK_REQUIRE_FULL_SPAN);
         if (ret != 0) {
             goto out;
@@ -3745,8 +3799,9 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         count_row[num_sample_sets] = 1;
     }
     result_dims[num_sample_sets] = (tsk_size_t) afs_size;
+    // Initiate memory for result array
+    tsk_memset(result, 0, num_windows * num_time_windows * afs_size * sizeof(*result));
 
-    tsk_memset(result, 0, num_windows * afs_size * sizeof(*result));
     if (stat_site) {
         ret = tsk_treeseq_site_allele_frequency_spectrum(self, num_sample_sets,
             sample_set_sizes, counts, num_windows, windows, result_dims, options,

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1240,19 +1240,19 @@ out:
 static int
 tsk_treeseq_check_time_windows(tsk_size_t num_windows, const double *windows)
 {
-    int ret = TSK_ERR_BAD_WINDOWS;
+    int ret = TSK_ERR_BAD_TIME_WINDOWS;
     tsk_size_t j;
 
     if (num_windows < 1) {
-        ret = TSK_ERR_BAD_NUM_WINDOWS;
+        ret = TSK_ERR_BAD_TIME_WINDOWS_DIM;
         goto out;
     }
 
-    if (windows[0] < 0) {
+    if (windows[0] < 0.0) {
         goto out;
     }
 
-    if (windows[0] != 0) {
+    if (windows[0] != 0.0) {
         goto out;
     }
 
@@ -3748,13 +3748,14 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         num_time_windows = 1;
         time_windows = default_time_windows;
     } else {
-        if (stat_site
-            && tsk_memcmp(time_windows, default_time_windows, sizeof(double)) != 0) {
-            ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
-            goto out;
-        }
         ret = tsk_treeseq_check_time_windows(num_time_windows, time_windows);
         if (ret != 0) {
+            goto out;
+        }
+        if (stat_site
+            && tsk_memcmp(time_windows, default_time_windows, 2 * sizeof(const double))
+                   != 0) {
+            ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
             goto out;
         }
     }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1238,8 +1238,8 @@ out:
 }
 
 static int
-tsk_treeseq_check_time_windows(const tsk_treeseq_t *self, tsk_size_t num_windows,
-    const double *windows, tsk_flags_t options)
+tsk_treeseq_check_time_windows(tsk_size_t num_windows,
+    const double *windows)
 {
     int ret = TSK_ERR_BAD_WINDOWS;
     tsk_size_t j;
@@ -3532,9 +3532,9 @@ out:
 
 static int TSK_WARN_UNUSED
 tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double right,
-    const double *restrict branch_length, double *restrict last_update,
+    double *restrict last_update,
     const double *restrict time, tsk_id_t *restrict parent, const double *time_windows,
-    const double *counts, tsk_size_t num_sample_sets, tsk_size_t num_windows,
+    const double *counts, tsk_size_t num_sample_sets,
     tsk_size_t num_time_windows, tsk_size_t window_index, tsk_size_t time_window_index,
     const tsk_size_t *result_dims, tsk_flags_t options, double *result)
 {
@@ -3627,17 +3627,17 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             tk++;
             u = edge_child[h];
             v = edge_parent[h];
-            ret = tsk_treeseq_update_branch_afs(self, u, t_left, branch_length,
+            ret = tsk_treeseq_update_branch_afs(self, u, t_left,
                 last_update, node_time, parent, time_windows, counts, num_sample_sets,
-		num_windows, num_time_windows, window_index, time_window_index,
+		num_time_windows, window_index, time_window_index,
 		result_dims, options, result);
             if (ret != 0) {
                 goto out;
             }
             while (v != TSK_NULL) {
-                ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
+                ret = tsk_treeseq_update_branch_afs(self, v, t_left,
                     last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, num_windows, num_time_windows, window_index,
+                    num_sample_sets, num_time_windows, window_index,
 		    time_window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
@@ -3657,9 +3657,9 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             parent[u] = v;
             branch_length[u] = node_time[v] - node_time[u];
             while (v != TSK_NULL) {
-                ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
+                ret = tsk_treeseq_update_branch_afs(self, v, t_left,
                     last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, num_windows, num_time_windows, window_index,
+                    num_sample_sets, num_time_windows, window_index,
 		    time_window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
@@ -3682,9 +3682,9 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             /* Flush the contributions of all nodes to the current window */
             for (u = 0; u < (tsk_id_t) num_nodes; u++) {
                 tsk_bug_assert(last_update[u] < w_right);
-                ret = tsk_treeseq_update_branch_afs(self, u, w_right, branch_length,
+                ret = tsk_treeseq_update_branch_afs(self, u, w_right,
                     last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, num_windows, num_time_windows, window_index,
+                    num_sample_sets, num_time_windows, window_index,
 		    time_window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
@@ -3759,7 +3759,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         time_windows = default_time_windows;
     } else {
         ret = tsk_treeseq_check_time_windows(
-            self, num_time_windows, time_windows, TSK_REQUIRE_FULL_SPAN);
+            num_time_windows, time_windows);
         if (ret != 0) {
             goto out;
         }

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3556,9 +3556,9 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
                 if (!polarised) {
                     fold(coordinate, result_dims, num_sample_sets);
                 }
-                tw_branch_length
-                    = fabs(TSK_MIN(time_windows[time_window_index + 1], t_v)
-                           - TSK_MAX(time_windows[time_window_index], time[u]));
+                tw_branch_length = TSK_MAX(
+                    0.0, TSK_MIN(time_windows[time_window_index + 1], t_v)
+                             - TSK_MAX(time_windows[time_window_index], time[u]));
                 x = (right - last_update[u]) * tw_branch_length;
                 increment_nd_array_value(
                     afs, num_sample_sets, result_dims, coordinate, x);
@@ -3765,7 +3765,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         goto out;
     }
 
-    /* the last element of result_dims stores the total size of the dimenensions */
+    /* the last element of result_dims stores the total size of the dimensions */
     result_dims = tsk_malloc((num_sample_sets + 1) * sizeof(*result_dims));
     counts = tsk_calloc(num_nodes * K, sizeof(*counts));
     if (counts == NULL || result_dims == NULL) {
@@ -3807,7 +3807,7 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     }
 
     if (options & TSK_STAT_SPAN_NORMALISE) {
-        span_normalise(num_windows, windows, afs_size, result);
+        span_normalise(num_windows, windows, afs_size * num_time_windows, result);
     }
 out:
     tsk_safe_free(counts);

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -3547,7 +3547,7 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
     const double *count_row = GET_2D_ROW(counts, num_sample_sets + 1, u);
     /* double x = (right - last_update[u]) * branch_length[u]; */
     double x = 0;
-    double t_v = time[parent[u]];
+    double t_v = 0;
     double tw_branch_length = 0;
     const tsk_size_t all_samples = (tsk_size_t) count_row[num_sample_sets];
     if (coordinate == NULL) {
@@ -3555,6 +3555,7 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
         goto out;
     }
     if (parent[u] != -1){
+	t_v = time[parent[u]];
 	if (0 < all_samples && all_samples < self->num_samples) {
 	    for (time_window_index = 0; time_window_index < num_time_windows; time_window_index++){
 		afs_size = result_dims[num_sample_sets];

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -1238,8 +1238,7 @@ out:
 }
 
 static int
-tsk_treeseq_check_time_windows(tsk_size_t num_windows,
-    const double *windows)
+tsk_treeseq_check_time_windows(tsk_size_t num_windows, const double *windows)
 {
     int ret = TSK_ERR_BAD_WINDOWS;
     tsk_size_t j;
@@ -1250,10 +1249,11 @@ tsk_treeseq_check_time_windows(tsk_size_t num_windows,
     }
 
     if (windows[0] < 0) {
-	goto out;
+        goto out;
     }
-    if (windows[num_windows] > INFINITY) {
-	goto out;
+
+    if (windows[0] != 0) {
+        goto out;
     }
 
     for (j = 0; j < num_windows; j++) {
@@ -3517,35 +3517,21 @@ out:
     return ret;
 }
 
-#define MAX(a,b) ((a) > (b) ? (a) : (b))
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-
-/* int getValue_nDimensions( int * baseAddress, int * indexes, int nDimensions ) { */
-/*     int i; */
-/*     int offset = 0; */
-/*     for( i = 0; i < nDimensions; i++ ) { */
-/*         offset += pow(LEN,i) * indexes[nDimensions - (i + 1)]; */
-/*     } */
-
-/*     return *(baseAddress + offset); */
-/* } */
-
 static int TSK_WARN_UNUSED
 tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double right,
-    double *restrict last_update,
-    const double *restrict time, tsk_id_t *restrict parent, const double *time_windows,
-    const double *counts, tsk_size_t num_sample_sets,
-    tsk_size_t num_time_windows, tsk_size_t window_index, tsk_size_t time_window_index,
-    const tsk_size_t *result_dims, tsk_flags_t options, double *result)
+    double *restrict last_update, const double *restrict time, tsk_id_t *restrict parent,
+    const double *time_windows, const double *counts, tsk_size_t num_sample_sets,
+    tsk_size_t num_time_windows, tsk_size_t window_index, const tsk_size_t *result_dims,
+    tsk_flags_t options, double *result)
 {
     int ret = 0;
     tsk_size_t afs_size;
     tsk_size_t k;
+    tsk_size_t time_window_index;
     double *afs;
     tsk_size_t *coordinate = tsk_malloc(num_sample_sets * sizeof(*coordinate));
     bool polarised = !!(options & TSK_STAT_POLARISED);
     const double *count_row = GET_2D_ROW(counts, num_sample_sets + 1, u);
-    /* double x = (right - last_update[u]) * branch_length[u]; */
     double x = 0;
     double t_v = 0;
     double tw_branch_length = 0;
@@ -3554,23 +3540,31 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
         ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
         goto out;
     }
-    if (parent[u] != -1){
-	t_v = time[parent[u]];
-	if (0 < all_samples && all_samples < self->num_samples) {
-	    for (time_window_index = 0; time_window_index < num_time_windows; time_window_index++){
-		afs_size = result_dims[num_sample_sets];
-		afs = result + afs_size * (window_index * num_time_windows + time_window_index);
-		for (k = 0; k < num_sample_sets; k++) {
-		    coordinate[k] = (tsk_size_t) count_row[k];
-		}
-		if (!polarised){
-		    fold(coordinate, result_dims, num_sample_sets);
-		}
-		tw_branch_length = MIN(time_windows[time_window_index + 1], t_v) - MAX(time_windows[0], time[u]);
-		x = (right - last_update[u]) * tw_branch_length;
-		increment_nd_array_value(afs, num_sample_sets, result_dims, coordinate, x);
-	    }
-	}
+    if (parent[u] != TSK_NULL) {
+        t_v = time[parent[u]];
+        if (0 < all_samples && all_samples < self->num_samples) {
+            time_window_index = 0;
+            while (time_window_index < num_time_windows
+                   && time_windows[time_window_index] < t_v) {
+                /* for (time_window_index = 0; time_window_index < num_time_windows;
+                 * time_window_index++){ */
+                afs_size = result_dims[num_sample_sets];
+                afs = result
+                      + afs_size * (window_index * num_time_windows + time_window_index);
+                for (k = 0; k < num_sample_sets; k++) {
+                    coordinate[k] = (tsk_size_t) count_row[k];
+                }
+                if (!polarised) {
+                    fold(coordinate, result_dims, num_sample_sets);
+                }
+                tw_branch_length = TSK_MIN(time_windows[time_window_index + 1], t_v)
+                                   - TSK_MAX(time_windows[0], time[u]);
+                x = (right - last_update[u]) * tw_branch_length;
+                increment_nd_array_value(
+                    afs, num_sample_sets, result_dims, coordinate, x);
+                time_window_index++;
+            }
+        }
     }
     last_update[u] = right;
 out:
@@ -3586,7 +3580,7 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
 {
     int ret = 0;
     tsk_id_t u, v;
-    tsk_size_t window_index, time_window_index;
+    tsk_size_t window_index;
     tsk_size_t num_nodes = self->tables->nodes.num_rows;
     const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
     const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
@@ -3620,7 +3614,6 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tk = 0;
     t_left = 0;
     window_index = 0;
-    time_window_index = 0;
     while (tj < num_edges || t_left < sequence_length) {
         tsk_bug_assert(window_index < num_windows);
         while (tk < num_edges && edge_right[O[tk]] == t_left) {
@@ -3628,18 +3621,16 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             tk++;
             u = edge_child[h];
             v = edge_parent[h];
-            ret = tsk_treeseq_update_branch_afs(self, u, t_left,
-                last_update, node_time, parent, time_windows, counts, num_sample_sets,
-		num_time_windows, window_index, time_window_index,
-		result_dims, options, result);
+            ret = tsk_treeseq_update_branch_afs(self, u, t_left, last_update, node_time,
+                parent, time_windows, counts, num_sample_sets, num_time_windows,
+                window_index, result_dims, options, result);
             if (ret != 0) {
                 goto out;
             }
             while (v != TSK_NULL) {
-                ret = tsk_treeseq_update_branch_afs(self, v, t_left,
-                    last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, num_time_windows, window_index,
-		    time_window_index, result_dims, options, result);
+                ret = tsk_treeseq_update_branch_afs(self, v, t_left, last_update,
+                    node_time, parent, time_windows, counts, num_sample_sets,
+                    num_time_windows, window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3658,10 +3649,9 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             parent[u] = v;
             branch_length[u] = node_time[v] - node_time[u];
             while (v != TSK_NULL) {
-                ret = tsk_treeseq_update_branch_afs(self, v, t_left,
-                    last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, num_time_windows, window_index,
-		    time_window_index, result_dims, options, result);
+                ret = tsk_treeseq_update_branch_afs(self, v, t_left, last_update,
+                    node_time, parent, time_windows, counts, num_sample_sets,
+                    num_time_windows, window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3683,10 +3673,9 @@ tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
             /* Flush the contributions of all nodes to the current window */
             for (u = 0; u < (tsk_id_t) num_nodes; u++) {
                 tsk_bug_assert(last_update[u] < w_right);
-                ret = tsk_treeseq_update_branch_afs(self, u, w_right,
-                    last_update, node_time, parent, time_windows, counts,
-                    num_sample_sets, num_time_windows, window_index,
-		    time_window_index, result_dims, options, result);
+                ret = tsk_treeseq_update_branch_afs(self, u, w_right, last_update,
+                    node_time, parent, time_windows, counts, num_sample_sets,
+                    num_time_windows, window_index, result_dims, options, result);
                 if (ret != 0) {
                     goto out;
                 }
@@ -3759,8 +3748,12 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         num_time_windows = 1;
         time_windows = default_time_windows;
     } else {
-        ret = tsk_treeseq_check_time_windows(
-            num_time_windows, time_windows);
+        if (stat_site
+            && tsk_memcmp(time_windows, default_time_windows, sizeof(double)) != 0) {
+            ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
+            goto out;
+        }
+        ret = tsk_treeseq_check_time_windows(num_time_windows, time_windows);
         if (ret != 0) {
             goto out;
         }
@@ -3800,7 +3793,6 @@ tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
         count_row[num_sample_sets] = 1;
     }
     result_dims[num_sample_sets] = (tsk_size_t) afs_size;
-    // Initiate memory for result array
     tsk_memset(result, 0, num_windows * num_time_windows * afs_size * sizeof(*result));
 
     if (stat_site) {

--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -23,6 +23,7 @@
  * SOFTWARE.
  */
 
+#include "tskit/core.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
@@ -3546,8 +3547,6 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
             time_window_index = 0;
             while (time_window_index < num_time_windows
                    && time_windows[time_window_index] < t_v) {
-                /* for (time_window_index = 0; time_window_index < num_time_windows;
-                 * time_window_index++){ */
                 afs_size = result_dims[num_sample_sets];
                 afs = result
                       + afs_size * (window_index * num_time_windows + time_window_index);
@@ -3557,8 +3556,9 @@ tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double righ
                 if (!polarised) {
                     fold(coordinate, result_dims, num_sample_sets);
                 }
-                tw_branch_length = TSK_MIN(time_windows[time_window_index + 1], t_v)
-                                   - TSK_MAX(time_windows[0], time[u]);
+                tw_branch_length
+                    = fabs(TSK_MIN(time_windows[time_window_index + 1], t_v)
+                           - TSK_MAX(time_windows[time_window_index], time[u]));
                 x = (right - last_update[u]) * tw_branch_length;
                 increment_nd_array_value(
                     afs, num_sample_sets, result_dims, coordinate, x);

--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -1058,7 +1058,8 @@ int tsk_treeseq_Y1(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
 int tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
     const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
-    tsk_flags_t options, double *result);
+    tsk_size_t num_time_windows, const double *time_windows, tsk_flags_t options,
+    double *result);
 
 typedef int general_sample_stat_method(const tsk_treeseq_t *self,
     tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9172,7 +9172,7 @@ parse_windows(
     npy_intp *shape;
 
     windows_array = (PyArrayObject *) PyArray_FROMANY(
-        windows, NPY_FLOAT64, 1, 1, NPY_ARRAY_IN_ARRAY);
+				      windows, NPY_FLOAT64, 1, 1, NPY_ARRAY_IN_ARRAY);
     if (windows_array == NULL) {
         goto out;
     }
@@ -9189,6 +9189,7 @@ out:
     *ret_windows_array = windows_array;
     return ret;
 }
+
 
 static PyArrayObject *
 TreeSequence_allocate_results_array(
@@ -9534,12 +9535,13 @@ TreeSequence_allele_frequency_spectrum(
     TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     PyObject *ret = NULL;
-    static char *kwlist[] = { "sample_set_sizes", "sample_sets", "windows", "mode",
+    static char *kwlist[] = { "sample_set_sizes", "sample_sets", "windows", "time_windows", "mode",
         "span_normalise", "polarised", NULL };
     PyObject *sample_set_sizes = NULL;
     PyObject *sample_sets = NULL;
     PyObject *windows = NULL;
-    char *mode = NULL;
+    PyObject *time_windows = NULL;
+    char *mode = "NULL";
     PyArrayObject *sample_set_sizes_array = NULL;
     PyArrayObject *sample_sets_array = NULL;
     PyArrayObject *windows_array = NULL;
@@ -9552,12 +9554,11 @@ TreeSequence_allele_frequency_spectrum(
     int polarised = 0;
     int span_normalise = 1;
     int err;
-
     if (TreeSequence_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO|sii", kwlist, &sample_set_sizes,
-            &sample_sets, &windows, &mode, &span_normalise, &polarised)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|sii", kwlist, &sample_set_sizes,
+	&sample_sets, &windows, &time_windows, &mode, &span_normalise, &polarised)) {
         goto out;
     }
     if (parse_stats_mode(mode, &options) != 0) {
@@ -9577,18 +9578,21 @@ TreeSequence_allele_frequency_spectrum(
     if (parse_windows(windows, &windows_array, &num_windows) != 0) {
         goto out;
     }
-
-    shape = PyMem_Malloc((num_sample_sets + 1) * sizeof(*shape));
+    if (parse_windows(time_windows, &time_windows_array, &num_time_windows) != 0) {
+        goto out;
+    }
+    shape = PyMem_Malloc((num_sample_sets + 1 + 1) * sizeof(*shape));
     if (shape == NULL) {
         goto out;
     }
     sizes = PyArray_DATA(sample_set_sizes_array);
     shape[0] = num_windows;
+    shape[1] = num_time_windows;
     for (k = 0; k < num_sample_sets; k++) {
-        shape[k + 1] = 1 + sizes[k];
+        shape[k + 1 + 1] = 1 + sizes[k];
     }
     result_array
-        = (PyArrayObject *) PyArray_SimpleNew(1 + num_sample_sets, shape, NPY_FLOAT64);
+        = (PyArrayObject *) PyArray_SimpleNew(1 + 1 + num_sample_sets, shape, NPY_FLOAT64);
     if (result_array == NULL) {
         goto out;
     }
@@ -9607,6 +9611,7 @@ out:
     Py_XDECREF(sample_set_sizes_array);
     Py_XDECREF(sample_sets_array);
     Py_XDECREF(windows_array);
+    Py_XDECREF(time_windows_array);
     Py_XDECREF(result_array);
     return ret;
 }

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9543,10 +9543,11 @@ TreeSequence_allele_frequency_spectrum(
     PyArrayObject *sample_set_sizes_array = NULL;
     PyArrayObject *sample_sets_array = NULL;
     PyArrayObject *windows_array = NULL;
+    PyArrayObject *time_windows_array = NULL;
     PyArrayObject *result_array = NULL;
     tsk_size_t *sizes;
     npy_intp *shape = NULL;
-    tsk_size_t k, num_windows, num_sample_sets;
+    tsk_size_t k, num_windows, num_time_windows, num_sample_sets;
     tsk_flags_t options = 0;
     int polarised = 0;
     int span_normalise = 1;
@@ -9593,7 +9594,8 @@ TreeSequence_allele_frequency_spectrum(
     }
     err = tsk_treeseq_allele_frequency_spectrum(self->tree_sequence, num_sample_sets,
         PyArray_DATA(sample_set_sizes_array), PyArray_DATA(sample_sets_array),
-        num_windows, PyArray_DATA(windows_array), options, PyArray_DATA(result_array));
+        num_windows, PyArray_DATA(windows_array), num_time_windows,
+        PyArray_DATA(time_windows_array), options, PyArray_DATA(result_array));
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -9172,7 +9172,7 @@ parse_windows(
     npy_intp *shape;
 
     windows_array = (PyArrayObject *) PyArray_FROMANY(
-				      windows, NPY_FLOAT64, 1, 1, NPY_ARRAY_IN_ARRAY);
+        windows, NPY_FLOAT64, 1, 1, NPY_ARRAY_IN_ARRAY);
     if (windows_array == NULL) {
         goto out;
     }
@@ -9189,7 +9189,6 @@ out:
     *ret_windows_array = windows_array;
     return ret;
 }
-
 
 static PyArrayObject *
 TreeSequence_allocate_results_array(
@@ -9535,13 +9534,13 @@ TreeSequence_allele_frequency_spectrum(
     TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     PyObject *ret = NULL;
-    static char *kwlist[] = { "sample_set_sizes", "sample_sets", "windows", "time_windows", "mode",
-        "span_normalise", "polarised", NULL };
+    static char *kwlist[] = { "sample_set_sizes", "sample_sets", "windows",
+        "time_windows", "mode", "span_normalise", "polarised", NULL };
     PyObject *sample_set_sizes = NULL;
     PyObject *sample_sets = NULL;
     PyObject *windows = NULL;
     PyObject *time_windows = NULL;
-    char *mode = "NULL";
+    char *mode = NULL;
     PyArrayObject *sample_set_sizes_array = NULL;
     PyArrayObject *sample_sets_array = NULL;
     PyArrayObject *windows_array = NULL;
@@ -9558,7 +9557,7 @@ TreeSequence_allele_frequency_spectrum(
         goto out;
     }
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOO|sii", kwlist, &sample_set_sizes,
-	&sample_sets, &windows, &time_windows, &mode, &span_normalise, &polarised)) {
+            &sample_sets, &windows, &time_windows, &mode, &span_normalise, &polarised)) {
         goto out;
     }
     if (parse_stats_mode(mode, &options) != 0) {
@@ -9591,8 +9590,8 @@ TreeSequence_allele_frequency_spectrum(
     for (k = 0; k < num_sample_sets; k++) {
         shape[k + 1 + 1] = 1 + sizes[k];
     }
-    result_array
-        = (PyArrayObject *) PyArray_SimpleNew(1 + 1 + num_sample_sets, shape, NPY_FLOAT64);
+    result_array = (PyArrayObject *) PyArray_SimpleNew(
+        1 + 1 + num_sample_sets, shape, NPY_FLOAT64);
     if (result_array == NULL) {
         goto out;
     }

--- a/python/tests/ibd.py
+++ b/python/tests/ibd.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2024 Tskit Developers
+# Copyright (c) 2020-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/simplify.py
+++ b/python/tests/simplify.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2024 Tskit Developers
+# Copyright (c) 2019-2025 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tests/test_avl_tree.py
+++ b/python/tests/test_avl_tree.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2021-2024 Tskit Developers
+# Copyright (c) 2021-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_balance_metrics.py
+++ b/python/tests/test_balance_metrics.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Tskit Developers
+# Copyright (c) 2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_coalrate.py
+++ b/python/tests/test_coalrate.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Tskit Developers
+# Copyright (c) 2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_distance_metrics.py
+++ b/python/tests/test_distance_metrics.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Tskit Developers
+# Copyright (c) 2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_divmat.py
+++ b/python/tests/test_divmat.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2024 Tskit Developers
+# Copyright (c) 2023-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_haplotype_matching.py
+++ b/python/tests/test_haplotype_matching.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2024 Tskit Developers
+# Copyright (c) 2019-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_intervals.py
+++ b/python/tests/test_intervals.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2024 Tskit Developers
+# Copyright (c) 2023-2025 Tskit Developers
 # Copyright (C) 2020-2022 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tests/test_ld_matrix.py
+++ b/python/tests/test_ld_matrix.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2024 Tskit Developers
+# Copyright (c) 2023-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2586,19 +2586,29 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
         ts = self.get_example_tree_sequence()
         n = ts.get_num_samples()
         result = ts.allele_frequency_spectrum(
-            [n], ts.get_samples(), [0, ts.get_sequence_length()]
+            [n],
+            ts.get_samples(),
+            [0, ts.get_sequence_length()],
+            mode="branch",
+            time_windows=[0, np.inf],
         )
-        assert result.shape == (1, n + 1)
+        assert result.shape == (1, 1, n + 1)
         result = ts.allele_frequency_spectrum(
-            [n], ts.get_samples(), [0, ts.get_sequence_length()], polarised=True
+            [n],
+            ts.get_samples(),
+            [0, ts.get_sequence_length()],
+            mode="branch",
+            time_windows=[0, np.inf],
+            polarised=True,
         )
-        assert result.shape == (1, n + 1)
+        assert result.shape == (1, 1, n + 1)
 
     def test_output_dims(self):
         ts = self.get_example_tree_sequence()
         samples = ts.get_samples()
         L = ts.get_sequence_length()
         n = len(samples)
+        time_windows = [0, np.inf]
 
         for mode in ["site", "branch"]:
             for s in [[n], [n - 2, 2], [n - 4, 2, 2], [1] * n]:
@@ -2606,13 +2616,27 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
                 windows = [0, L]
                 for windows in [[0, L], [0, L / 2, L], np.linspace(0, L, num=10)]:
                     jafs = ts.allele_frequency_spectrum(
-                        s, samples, windows, mode=mode, polarised=True
+                        s,
+                        samples,
+                        windows,
+                        mode=mode,
+                        time_windows=time_windows,
+                        polarised=True,
                     )
-                    assert jafs.shape == tuple([len(windows) - 1] + list(s + 1))
+                    assert jafs.shape == tuple(
+                        [len(windows) - 1] + [len(time_windows) - 1] + list(s + 1)
+                    )
                     jafs = ts.allele_frequency_spectrum(
-                        s, samples, windows, mode=mode, polarised=False
+                        s,
+                        samples,
+                        windows,
+                        mode=mode,
+                        time_windows=time_windows,
+                        polarised=False,
                     )
-                    assert jafs.shape == tuple([len(windows) - 1] + list(s + 1))
+                    assert jafs.shape == tuple(
+                        [len(windows) - 1] + [len(time_windows) - 1] + list(s + 1)
+                    )
 
     def test_node_mode_not_supported(self):
         ts = self.get_example_tree_sequence()
@@ -2622,7 +2646,141 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
                 ts.get_samples(),
                 [0, ts.get_sequence_length()],
                 mode="node",
+                time_windows=[0, np.inf],
             )
+
+    def test_polarised(self):
+        """
+        Temporary duplicate from class OneWaySampleStatsMixin
+        used to provide the time_windows argument.
+        """
+        # TODO move this to the top level.
+        ts, method = self.get_method()
+        samples = ts.get_samples()
+        n = len(samples)
+        windows = [0, ts.get_sequence_length()]
+        method(
+            [n],
+            samples,
+            windows,
+            time_windows=[0, np.inf],
+            mode="branch",
+            polarised=True,
+        )
+        method(
+            [n],
+            samples,
+            windows,
+            time_windows=[0, np.inf],
+            mode="branch",
+            polarised=False,
+        )
+
+    def test_polarisation(self):
+        ts, f, params = self.get_example()
+        with pytest.raises(TypeError):
+            f(polarised="sdf", time_windows=[0, np.inf], mode="branch", **params)
+        x1 = f(polarised=False, time_windows=[0, np.inf], mode="branch", **params)
+        x2 = f(polarised=True, time_windows=[0, np.inf], mode="branch", **params)
+        # Basic check just to run both code paths
+        assert x1.shape == x2.shape
+
+    def test_mode_errors(self):
+        _, f, params = self.get_example()
+        for bad_mode in ["", "not a mode", "SITE", "x" * 8192]:
+            with pytest.raises(ValueError):
+                f(mode=bad_mode, time_windows=[0, np.inf], **params)
+
+        for bad_type in [123, {}, None, [[]]]:
+            with pytest.raises(TypeError):
+                f(mode=bad_type, time_windows=[0, np.inf], **params)
+
+    def test_window_errors(self):
+        ts, f, params = self.get_example()
+        del params["windows"]
+        for bad_array in ["asdf", None, [[[[]], [[]]]], np.zeros((10, 3, 4))]:
+            with pytest.raises(ValueError):
+                f(windows=bad_array, time_windows=[0, np.inf], mode="branch", **params)
+
+        for bad_windows in [[], [0]]:
+            with pytest.raises(ValueError):
+                f(
+                    windows=bad_windows,
+                    time_windows=[0, np.inf],
+                    mode="branch",
+                    **params,
+                )
+        L = ts.get_sequence_length()
+        bad_windows = [
+            [L, 0],
+            [0.1, L],
+            [-1, L],
+            [0, L + 0.1],
+            [0, 0.1, 0.1, L],
+            [0, -1, L],
+            [0, 0.1, 0.05, 0.2, L],
+        ]
+        for bad_window in bad_windows:
+            with pytest.raises(_tskit.LibraryError):
+                f(windows=bad_window, time_windows=[0, np.inf], mode="branch", **params)
+
+    def test_windows_output(self):
+        ts, f, params = self.get_example()
+        del params["windows"]
+        for num_windows in range(1, 10):
+            windows = np.linspace(0, ts.get_sequence_length(), num=num_windows + 1)
+            assert windows.shape[0] == num_windows + 1
+            sigma = f(
+                windows=windows, time_windows=[0, np.inf], mode="branch", **params
+            )
+            assert sigma.shape[0] == num_windows
+
+    def test_bad_sample_sets(self):
+        ts, f, params = self.get_example()
+        del params["sample_set_sizes"]
+        del params["sample_sets"]
+
+        with pytest.raises(_tskit.LibraryError):
+            f(
+                sample_sets=[],
+                sample_set_sizes=[],
+                time_windows=[0, np.inf],
+                mode="branch",
+                **params,
+            )
+
+        n = ts.get_num_samples()
+        samples = ts.get_samples()
+        for bad_set_sizes in [[], [1], [n - 1], [n + 1], [n - 3, 1, 1], [1, n - 2]]:
+            with pytest.raises(ValueError):
+                f(
+                    sample_set_sizes=bad_set_sizes,
+                    sample_sets=samples,
+                    time_windows=[0, np.inf],
+                    mode="branch",
+                    **params,
+                )
+
+        N = ts.get_num_nodes()
+        for bad_node in [-1, N, N + 1, -N]:
+            with pytest.raises(_tskit.LibraryError):
+                f(
+                    sample_set_sizes=[2],
+                    sample_sets=[0, bad_node],
+                    time_windows=[0, np.inf],
+                    mode="branch",
+                    **params,
+                )
+
+        for bad_sample in [n, n + 1, N - 1]:
+            with pytest.raises(_tskit.LibraryError):
+                f(
+                    sample_set_sizes=[2],
+                    sample_sets=[0, bad_sample],
+                    time_windows=[0, np.inf],
+                    mode="branch",
+                    **params,
+                )
 
 
 class TwoWaySampleStatsMixin(SampleSetMixin):

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2610,7 +2610,7 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
         n = len(samples)
         time_windows = [0, np.inf]
 
-        for mode in ["site", "branch"]:
+        for mode in ["branch"]:
             for s in [[n], [n - 2, 2], [n - 4, 2, 2], [1] * n]:
                 s = np.array(s, dtype=np.uint32)
                 windows = [0, L]

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -2724,6 +2724,26 @@ class TestAlleleFrequencySpectrum(LowLevelTestCase, OneWaySampleStatsMixin):
             with pytest.raises(_tskit.LibraryError):
                 f(windows=bad_window, time_windows=[0, np.inf], mode="branch", **params)
 
+    def test_time_window_errors(self):
+        ts, f, params = self.get_example()
+
+        for bad_time_windows in [[], [0]]:
+            with pytest.raises(ValueError, match="must have at least 2"):
+                f(
+                    time_windows=bad_time_windows,
+                    mode="branch",
+                    **params,
+                )
+        bad_time_windows = [
+            [-1, np.inf],
+            [0, 0, np.inf],
+            [0, 10, 5, np.inf],
+            [0, np.inf, np.inf],
+        ]
+        for bad_time_window in bad_time_windows:
+            with pytest.raises(_tskit.LibraryError, match="TSK_ERR_BAD_TIME_WINDOWS"):
+                f(time_windows=bad_time_window, mode="branch", **params)
+
     def test_windows_output(self):
         ts, f, params = self.get_example()
         del params["windows"]

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (C) 2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tests/test_table_transforms.py
+++ b/python/tests/test_table_transforms.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Tskit Developers
+# Copyright (c) 2022-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (c) 2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tests/test_text_formats.py
+++ b/python/tests/test_text_formats.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2021-2024 Tskit Developers
+# Copyright (c) 2021-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (c) 2016-2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -195,7 +195,7 @@ def naive_branch_general_stat(
     else:
         out = windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
     if drop_time_windows:
-        assert out.shape[1] == 3
+        assert out.ndim == 3
         out = out[:, 0]
     return out
 

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -4084,19 +4084,21 @@ def branch_allele_frequency_spectrum(
     tree_index = 0
 
     def update_result(window_index, u, right):
-        for k_tw, _ in enumerate(time_windows[:-1]):
-            if 0 < count[u, -1] < ts.num_samples:
-                # t_v = branch_length[u] + time[u]
-                t_v = time[parent[u]]
-                tw_branch_length = min(time_windows[k_tw + 1], t_v) - max(
-                    time_windows[0], time[u]
-                )
-                x = (right - last_update[u]) * tw_branch_length
-                c = count[u, :num_sample_sets]
-                if not polarised:
-                    c = fold(c, out_dim)
-                index = tuple([window_index] + [k_tw] + list(c))
-                result[index] += x
+        if parent[u] != -1:
+            for k_tw, _ in enumerate(time_windows[:-1]):
+                if 0 < count[u, -1] < ts.num_samples:
+                    # t_v = branch_length[u] + time[u]
+                    assert parent[u] != -1
+                    t_v = time[parent[u]]
+                    tw_branch_length = min(time_windows[k_tw + 1], t_v) - max(
+                        time_windows[0], time[u]
+                    )
+                    x = (right - last_update[u]) * tw_branch_length
+                    c = count[u, :num_sample_sets]
+                    if not polarised:
+                        c = fold(c, out_dim)
+                    index = tuple([window_index] + [k_tw] + list(c))
+                    result[index] += x
         last_update[u] = right
 
     for (t_left, t_right), edges_out, edges_in in ts.edge_diffs():
@@ -4114,12 +4116,12 @@ def branch_allele_frequency_spectrum(
         for edge in edges_in:
             u = edge.child
             v = edge.parent
-            parent[u] = v
             # branch_length[u] = time[v] - time[u]
             while v != -1:
                 update_result(window_index, v, t_left)
                 count[v] += count[u]
                 v = parent[v]
+            parent[u] = edge.parent
 
         # Update the windows
         while window_index < num_windows and windows[window_index + 1] <= t_right:

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -312,7 +312,6 @@ def branch_general_stat(
                 # This interval crosses a tree boundary, so we update it again in the
                 # for the next tree
                 break
-    # print("SUM", running_sum)
     assert window_index == windows.shape[0] - 1
     if drop_time_windows:
         assert result.ndim == 3
@@ -4152,9 +4151,10 @@ def branch_allele_frequency_spectrum(
                     and time_windows[time_window_index] < t_v
                 ):
                     assert parent[u] != -1
-                    tw_branch_length = abs(
+                    tw_branch_length = max(
+                        0.0,
                         min(time_windows[time_window_index + 1], t_v)
-                        - max(time_windows[time_window_index], time[u])
+                        - max(time_windows[time_window_index], time[u]),
                     )
                     x = (right - last_update[u]) * tw_branch_length
                     c = count[u, :num_sample_sets]
@@ -7476,3 +7476,52 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # dimensions are dim1: windows ; dim2: time_windows ;
         # dim3-or-more: num_sample_sets
         assert sfs1_w_tw.ndim == 3
+
+    def test_decap_vs_tw(self):
+        ns = 2
+        time_grid = np.append(np.logspace(2, 5, 11), np.inf)[0:1]
+        ts = msprime.sim_ancestry(
+            ns,
+            recombination_rate=1e-8,
+            sequence_length=1e6,
+            population_size=1e4,
+            random_seed=1,
+        )
+        ts = msprime.sim_mutations(ts, rate=1e-8, random_seed=2)
+        sample_sets = [np.arange(ns), np.arange(ns, 2 * ns)]
+
+        time_grid = np.append(0, time_grid)
+        time_grid = np.append(time_grid, np.inf)
+
+        windows = np.array([0, 0.5, 1]) * ts.sequence_length
+        windows = None
+        test1 = ts.allele_frequency_spectrum(
+            sample_sets=sample_sets,
+            time_windows=time_grid,
+            mode="branch",
+            polarised=True,
+            span_normalise=True,
+            windows=windows,
+        ).cumsum(axis=0)
+
+        test2 = branch_allele_frequency_spectrum(
+            ts,
+            windows=windows,
+            sample_sets=sample_sets,
+            time_windows=time_grid,
+            polarised=True,
+            span_normalise=True,
+        ).cumsum(axis=0)
+
+        # manually calculate twAFS
+        twafs0 = np.zeros((time_grid.size, ns + 1, ns + 1))
+        for i, t in enumerate(time_grid):
+            tsd = ts.decapitate(t) if t < np.inf else ts
+            twafs0[i] = tsd.allele_frequency_spectrum(
+                sample_sets=sample_sets,
+                mode="branch",
+                polarised=True,
+                span_normalise=True,
+            ).squeeze()
+        self.assertArrayAlmostEqual(test1, test2)
+        self.assertArrayAlmostEqual(test2, twafs0[1:])

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -4339,7 +4339,6 @@ class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
 
             assert len(sfs1.shape) == len(sample_sets) + 1
             assert sfs1.shape == sfs2.shape
-            print("SFS1=", sfs1, "\n...SFS3=", sfs3)
             assert sfs1.shape == sfs3.shape
             if not np.allclose(sfs1, sfs3):
                 print()
@@ -7370,14 +7369,3 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # dimensions are dim1: windows ; dim2: time_windows ;
         # dim3-or-more: num_sample_sets
         assert sfs1_w_tw.ndim == 3
-
-        print(sfs1_decap_05)
-
-        sfs_c = ts.allele_frequency_spectrum(
-            sample_sets=[[0, 1, 2, 3]],
-            mode=self.mode,
-            polarised=True,
-            span_normalise=False,
-        )
-
-        print(sfs_c)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -569,6 +569,59 @@ class StatsTestCase:
     def sum_f(self, ts, k=1):
         return lambda x: np.array([sum(x) * (sum(x) < 2 * ts.num_samples)] * k)
 
+    def four_taxa_test_case(self):
+        #
+        # 1.0          7
+        # 0.7         / \                                    6
+        #            /   \                                  / \
+        # 0.5       /     5              5                 /   5
+        #          /     / \            / \__             /   / \
+        # 0.4     /     8   \          8     4           /   8   \
+        #        /     / \   \        / \   / \         /   / \   \
+        # 0.0   0     1   3   2      1   3 0   2       0   1   3   2
+        #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
+
+        nodes = io.StringIO(
+            """\
+        id      is_sample   time
+        0       1           0
+        1       1           0
+        2       1           0
+        3       1           0
+        4       0           0.4
+        5       0           0.5
+        6       0           0.7
+        7       0           1.0
+        8       0           0.4
+        """
+        )
+        edges = io.StringIO(
+            """\
+        left    right   parent  child
+        0.0     2.5     8       1,3
+        0.2     0.8     4       0,2
+        0.0     0.2     5       8,2
+        0.2     0.8     5       8,4
+        0.8     2.5     5       8,2
+        0.8     2.5     6       0,5
+        0.0     0.2     7       0,5
+        """
+        )
+        sites = io.StringIO(
+            """\
+        id  position    ancestral_state
+        """
+        )
+        mutations = io.StringIO(
+            """\
+        site    node    derived_state   parent
+        """
+        )
+        ts = tskit.load_text(
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
+        return ts
+
 
 class TopologyExamplesMixin:
     """
@@ -6248,6 +6301,7 @@ class SpecificTreesTestCase(StatsTestCase):
         #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
 
         # f4(0, 1, 2, 3): (0 -> 1)(2 -> 3)
+        ts = self.four_taxa_test_case()
         branch_true_f4_0123 = (0.1 * 0.2 + (0.1 + 0.1) * 0.6 + 0.1 * 1.7) / 2.5
         windows = [0.0, 0.4, 2.5]
         branch_true_f4_0123_windowed = np.array(
@@ -6278,46 +6332,6 @@ class SpecificTreesTestCase(StatsTestCase):
                     / (2.5 - 0.4)
                 ],
             ]
-        )
-
-        nodes = io.StringIO(
-            """\
-        id      is_sample   time
-        0       1           0
-        1       1           0
-        2       1           0
-        3       1           0
-        4       0           0.4
-        5       0           0.5
-        6       0           0.7
-        7       0           1.0
-        8       0           0.4
-        """
-        )
-        edges = io.StringIO(
-            """\
-        left    right   parent  child
-        0.0     2.5     8       1,3
-        0.2     0.8     4       0,2
-        0.0     0.2     5       8,2
-        0.2     0.8     5       8,4
-        0.8     2.5     5       8,2
-        0.8     2.5     6       0,5
-        0.0     0.2     7       0,5
-        """
-        )
-        sites = io.StringIO(
-            """\
-        id  position    ancestral_state
-        """
-        )
-        mutations = io.StringIO(
-            """\
-        site    node    derived_state   parent
-        """
-        )
-        ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
         )
 
         mode = "branch"
@@ -6994,3 +7008,27 @@ class TestGeneralStatCallbackErrors:
                 output_dim=1,
                 strict=False,
             )
+
+
+class TestTimeWindows(StatsTestCase):
+    def test_four_taxa_test_case(self):
+        # 1.0          7
+        # 0.7         / \                                    6
+        #            /   \                                  / \
+        # 0.5       /     5              5                 /   5
+        #          /     / \            / \__             /   / \
+        # 0.4     /     8   \          8     4           /   8   \
+        #        /     / \   \        / \   / \         /   / \   \
+        # 0.0   0     1   3   2      1   3 0   2       0   1   3   2
+        #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
+        ts = self.four_taxa_test_case()
+        true_x = np.array(
+            [
+                0.2 * (1.5 + 0.8)
+                + (0.8 - 0.2) * (1.0 + 0.8)
+                + (2.5 - 0.8) * (1.5 + 0.8),
+                0.2 * 1.0 + 0 + (2.5 - 0.8) * 0.4,
+            ]
+        )
+        x = ts.segregating_sites(time_windows=[0, 0.5, 2.0], span_normalise=False)
+        self.assertArrayAlmostEqual(x, true_x)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -144,6 +144,7 @@ def windowed_tree_stat(ts, stat, windows, span_normalise=True):
     return A
 
 
+# Timewindows test
 def naive_branch_general_stat(
     ts, w, f, windows=None, time_windows=None, polarised=False, span_normalise=True
 ):
@@ -196,6 +197,42 @@ def naive_branch_general_stat(
         assert out.shape[1] == 1
         out = out[:, 0]
     return out
+
+
+# Previous version without tw
+# def naive_branch_general_stat(
+#     ts, w, f, windows=None, polarised=False, span_normalise=True
+# ):
+#     if windows is None:
+#         windows = [0.0, ts.sequence_length]
+#     n, k = w.shape
+#     # hack to determine m
+#     m = len(f(w[0]))
+#     total = np.sum(w, axis=0)
+
+#     sigma = np.zeros((ts.num_trees, m))
+#     for tree in ts.trees():
+#         x = np.zeros((ts.num_nodes, k))
+#         x[ts.samples()] = w
+#         for u in tree.nodes(order="postorder"):
+#             for v in tree.children(u):
+#                 x[u] += x[v]
+#         if polarised:
+#             s = sum(tree.branch_length(u) * f(x[u]) for u in tree.nodes())
+#         else:
+#             s = sum(
+#                 tree.branch_length(u) * (f(x[u]) + f(total - x[u]))
+#                 for u in tree.nodes()
+#             )
+#         sigma[tree.index] = s * tree.span
+#     if isinstance(windows, str) and windows == "trees":
+#         # need to average across the windows
+#         if span_normalise:
+#             for j, tree in enumerate(ts.trees()):
+#                 sigma[j] /= tree.span
+#         return sigma
+#     else:
+#         return windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
 
 
 def branch_general_stat(
@@ -3893,7 +3930,12 @@ class TestFold:
 
 
 def naive_site_allele_frequency_spectrum(
-    ts, sample_sets, windows=None, polarised=False, span_normalise=True
+    ts,
+    sample_sets,
+    windows=None,
+    time_windows=None,
+    polarised=False,
+    span_normalise=True,
 ):
     """
     The joint allele frequency spectrum for sites.
@@ -3947,48 +3989,147 @@ def naive_site_allele_frequency_spectrum(
     return out
 
 
+# def naive_branch_allele_frequency_spectrum(
+#     ts, sample_sets, windows=None, polarised=False, span_normalise=True
+# ):
+#     """
+#     The joint allele frequency spectrum for branches.
+#     """
+#     windows = ts.parse_windows(windows)
+#     num_windows = len(windows) - 1
+#     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
+#     out = np.zeros([num_windows] + out_dim)
+#     for j in range(num_windows):
+#         begin = windows[j]
+#         end = windows[j + 1]
+#         S = np.zeros(out_dim)
+#         trees = [
+#             next(ts.trees(tracked_samples=sample_set)) for sample_set in sample_sets
+#         ]
+#         t = trees[0]
+#         while True:
+#             tr_len = min(end, t.interval.right) - max(begin, t.interval.left)
+#             if tr_len > 0:
+#                 for node in t.nodes():
+#                     if 0 < t.num_samples(node) < ts.num_samples:
+#                         x = [tree.num_tracked_samples(node) for tree in trees]
+#                         # Note x must be a tuple for indexing to work
+#                         if not polarised:
+#                             x = fold(x, out_dim)
+#                         S[tuple(x)] += t.branch_length(node) * tr_len
+
+#             # Advance the trees
+#             more = [tree.next() for tree in trees]
+#             assert len(set(more)) == 1
+#             if not more[0]:
+#                 break
+#         if span_normalise:
+#             S /= end - begin
+#         out[j, :] = S
+#     return out
+
+
+# time windows version
 def naive_branch_allele_frequency_spectrum(
-    ts, sample_sets, windows=None, polarised=False, span_normalise=True
+    ts,
+    sample_sets,
+    windows=None,
+    time_windows=None,
+    polarised=False,
+    span_normalise=True,
 ):
     """
     The joint allele frequency spectrum for branches.
     """
+    drop_windows = windows is None
+    if windows is None:
+        windows = [0.0, ts.sequence_length]
+    drop_time_windows = time_windows is None
+    if time_windows is None:
+        time_windows = [0.0, np.inf]
     windows = ts.parse_windows(windows)
     num_windows = len(windows) - 1
+    num_time_windows = len(time_windows) - 1
     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
     out = np.zeros([num_windows] + out_dim)
+    # print(out.shape)
+    out = np.zeros([num_windows] + [num_time_windows] + out_dim)
+    #    print(out)
+    #    print(out.shape)
     for j in range(num_windows):
         begin = windows[j]
         end = windows[j + 1]
-        S = np.zeros(out_dim)
-        trees = [
-            next(ts.trees(tracked_samples=sample_set)) for sample_set in sample_sets
-        ]
-        t = trees[0]
-        while True:
-            tr_len = min(end, t.interval.right) - max(begin, t.interval.left)
-            if tr_len > 0:
-                for node in t.nodes():
-                    if 0 < t.num_samples(node) < ts.num_samples:
-                        x = [tree.num_tracked_samples(node) for tree in trees]
-                        # Note x must be a tuple for indexing to work
-                        if not polarised:
-                            x = fold(x, out_dim)
-                        S[tuple(x)] += t.branch_length(node) * tr_len
+        for k, upper_time in enumerate(time_windows[1:]):
+            # print("TIME WINDOW=", upper_time)
+            S = np.zeros(out_dim)
 
-            # Advance the trees
-            more = [tree.next() for tree in trees]
-            assert len(set(more)) == 1
-            if not more[0]:
-                break
-        if span_normalise:
-            S /= end - begin
-        out[j, :] = S
+            if np.isfinite(upper_time):
+                decap_ts = ts.decapitate(upper_time)
+            else:
+                decap_ts = ts
+            assert np.all(list(ts.samples()) == list(decap_ts.samples()))
+
+            trees = [
+                next(decap_ts.trees(tracked_samples=sample_set))
+                for sample_set in sample_sets
+            ]
+            t = trees[0]
+            while True:
+                tr_len = min(end, t.interval.right) - max(begin, t.interval.left)
+                if tr_len > 0:
+                    for node in t.nodes():
+                        if 0 < t.num_samples(node) < decap_ts.num_samples:
+                            x = [tree.num_tracked_samples(node) for tree in trees]
+                            if not polarised:
+                                x = fold(x, out_dim)
+                            # Note x must be a tuple for indexing to work
+                            # print(t.draw_text())
+                            print(
+                                "tr_len",
+                                tr_len,
+                                "\nnode",
+                                node,
+                                "\nnum_samples under node=",
+                                t.num_samples(node),
+                                "\nSFS bin =",
+                                x,
+                                "\nseq len",
+                                tr_len,
+                                "\nbr len",
+                                t.branch_length(node),
+                                "\nbranch len * seq len",
+                                t.branch_length(node) * tr_len,
+                            )
+                            S[tuple(x)] += t.branch_length(node) * tr_len
+
+                # Advance the trees
+                more = [tree.next() for tree in trees]
+                assert len(set(more)) == 1
+                if not more[0]:
+                    break
+            if span_normalise:
+                S /= end - begin
+            out[j, k, :] = S
+
+    if drop_time_windows:
+        # beware: this assumes the first dimension is windows
+        assert out.shape[1] == 1
+        out = out[:, 0]
+    elif drop_windows:
+        # drop windows dim if only using time windows
+        out = out[0]
+        # assert out.shape[0] == 1
     return out
 
 
 def naive_allele_frequency_spectrum(
-    ts, sample_sets, windows=None, polarised=False, mode="site", span_normalise=True
+    ts,
+    sample_sets,
+    windows=None,
+    time_windows=None,
+    polarised=False,
+    mode="site",
+    span_normalise=True,
 ):
     """
     Naive definition of the generalised site frequency spectrum.
@@ -4001,6 +4142,7 @@ def naive_allele_frequency_spectrum(
         ts,
         sample_sets,
         windows=windows,
+        time_windows=time_windows,
         polarised=polarised,
         span_normalise=span_normalise,
     )
@@ -7027,7 +7169,7 @@ class TestGeneralStatCallbackErrors:
             )
 
 
-class TestTimeWindows(StatsTestCase):
+class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
     def test_four_taxa_test_case(self):
         # 1.00┊   7     ┊         ┊         ┊
         #     ┊ ┏━┻━┓   ┊         ┊         ┊
@@ -7063,3 +7205,189 @@ class TestTimeWindows(StatsTestCase):
             ts, W, f, time_windows=[0, 0.5, 2.0], span_normalise=False
         )
         self.assertArrayAlmostEqual(x, true_x)
+
+    def four_taxa_test_case(self):
+        #
+        # 1.0          7
+        # 0.7         / \                                    6
+        #            /   \                                  / \
+        # 0.5       /     5              5                 /   5
+        #          /     / \            / \__             /   / \
+        # 0.4     /     8   \          8     4           /   8   \
+        #        /     / \   \        / \   / \         /   / \   \
+        # 0.0   0     1   3   2      1   3 0   2       0   1   3   2
+        #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
+
+        nodes = io.StringIO(
+            """\
+     id      is_sample   time
+     0       1           0
+     1       1           0
+     2       1           0
+     3       1           0
+     4       0           0.4
+     5       0           0.5
+     6       0           0.7
+     7       0           1.0
+     8       0           0.40
+     """
+        )
+        edges = io.StringIO(
+            """\
+     left    right   parent  child
+     0.0     2.5     8       1,3
+     0.2     0.8     4       0,2
+     0.0     0.2     5       8,2
+     0.2     0.8     5       8,4
+     0.8     2.5     5       8,2
+     0.8     2.5     6       0,5
+     0.0     0.2     7       0,5
+     """
+        )
+        sites = io.StringIO(
+            """\
+        id  position    ancestral_state
+        0   0.05        0
+        1   0.3         0
+        2   0.9         0
+        """
+        )
+        mutations = io.StringIO(
+            """\
+        site    node    derived_state   parent
+        0       0       1               -1
+        0       0       2               0
+        0       0       0               1
+        0       1       2               -1
+        1       1       1               -1
+        1       2       1               -1
+        2       3       1               -1
+        2       1       2               6
+        2       2       3               6
+        """
+        )
+        ts = tskit.load_text(
+            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
+        )
+        return ts
+
+    def test_afs_branch(self):
+        """Tests for the Allele Frequency Spectrum stat
+        using time windows under branch mode.
+        """
+        #
+        # 1.0          7
+        # 0.7         / \                                    6
+        #            /   \                                  / \
+        # 0.5       /     5              5                 /   5
+        #          /     / \            / \__             /   / \
+        # 0.4     /     8   \          8     4           /   8   \
+        #        /     / \   \        / \   / \         /   / \   \
+        # 0.0   0     1   3   2      1   3 0   2       0   1   3   2
+        #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
+
+        ts = self.four_taxa_test_case()
+        print(ts)
+
+        self.mode = "branch"
+
+        sfs1 = naive_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+        sfs1_w = naive_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            windows=[0, 0.2, 2.5],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        sfs1_w_tw = naive_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            windows=[0, 0.2, 2.5],
+            time_windows=[0, 0.5, 0.8, 1],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        sfs1_tws = naive_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            time_windows=[0, 0.5, 0.8, 1],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+        sfs1_tw_05 = naive_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            time_windows=[0, 0.5],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+        ts_decap_05 = ts.decapitate(0.5)
+        sfs1_decap_05 = naive_allele_frequency_spectrum(
+            ts_decap_05,
+            sample_sets=[[0, 1, 2, 3]],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        sfs = [
+            [
+                # bin 0
+                0,
+                # bin 1
+                (0.4 + 0.4 + 0.5 + 1) * 0.2
+                + (0.4 + 0.4 + 0.4 + 0.4) * 0.6
+                + (0.7 + 0.4 + 0.4 + 0.5) * 1.7,
+                # bin 2
+                (0.1) * 0.2 + (0.1 + 0.1) * 0.6 + (0.1) * 1.7,
+                # bin 3
+                (0.5) * 0.2 + (0.2) * 1.7,
+                # bin 4
+                0,
+            ]
+        ]
+
+        sfs_05 = [
+            [
+                # bin 0
+                0,
+                # bin 1
+                (0.5 + 0.4 + 0.4 + 0.5) * 0.2
+                + (0.4 + 0.4 + 0.4 + 0.4) * 0.6
+                + (0.4 + 0.4 + 0.5 + 0.5) * 1.7,
+                # bin 2
+                (0.1) * 0.2 + (0.1 + 0.1) * 0.6 + (0.1) * 1.7,
+                # bin 3, no nodes are present anymore at time 0.5
+                0,
+                # bin 4
+                0,
+            ]
+        ]
+
+        # try on simple example computed "by hand"
+        # if the modified function still works as expected
+        self.assertArrayAlmostEqual(sfs, sfs1)
+        # try if time_windows before t=0.5 is
+        # like sfs on a previously decapted ts before t=0.5
+        self.assertArrayAlmostEqual(sfs1_tw_05, sfs1_decap_05)
+        # try if sfs by hand before t=0.5 is
+        # equivalent to time_windows before t=0.5
+        self.assertArrayAlmostEqual(sfs_05, sfs1_tw_05)
+
+        # Warning: when using Windows and TimeWindows,
+        # the output has three dimensions
+        print("sfs1_w", sfs1_w)
+        print("sfs1_w_tw", sfs1_w_tw)
+        print("sfs1_tws", sfs1_tws)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -4099,6 +4099,7 @@ def branch_allele_frequency_spectrum(
                         c = fold(c, out_dim)
                     index = tuple([window_index] + [k_tw] + list(c))
                     result[index] += x
+                    # print(f"x={x}, index={index}")
         last_update[u] = right
 
     for (t_left, t_right), edges_out, edges_in in ts.edge_diffs():
@@ -7369,3 +7370,6 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # dimensions are dim1: windows ; dim2: time_windows ;
         # dim3-or-more: num_sample_sets
         assert sfs1_w_tw.ndim == 3
+
+        # print(sfs1_w_tw, sfs1_w_tw.shape)
+        # print(sfs1_tws, sfs1_tws.shape)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (C) 2016 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -39,6 +39,7 @@ import tests.test_wright_fisher as wf
 import tests.tsutil as tsutil
 import tskit
 import tskit.exceptions as exceptions
+
 
 np.random.seed(5)
 
@@ -4014,8 +4015,7 @@ def naive_branch_allele_frequency_spectrum(
                     break
             if span_normalise:
                 S /= end - begin
-            out[j, k, :] = S
-
+            out[j, k, :] = S - sum(out[j, 0:k, :])
     if drop_time_windows:
         assert out.ndim == 2 + len(out_dim)
         out = out[:, 0]
@@ -4085,20 +4085,25 @@ def branch_allele_frequency_spectrum(
 
     def update_result(window_index, u, right):
         if parent[u] != -1:
-            for k_tw, _ in enumerate(time_windows[:-1]):
-                if 0 < count[u, -1] < ts.num_samples:
-                    # t_v = branch_length[u] + time[u]
+            t_v = time[parent[u]]
+            if 0 < count[u, -1] < ts.num_samples:
+                time_window_index = 0
+                while (
+                    time_window_index < num_time_windows
+                    and time_windows[time_window_index] < t_v
+                ):
                     assert parent[u] != -1
-                    t_v = time[parent[u]]
-                    tw_branch_length = min(time_windows[k_tw + 1], t_v) - max(
-                        time_windows[0], time[u]
+                    tw_branch_length = abs(
+                        min(time_windows[time_window_index + 1], t_v)
+                        - max(time_windows[time_window_index], time[u])
                     )
                     x = (right - last_update[u]) * tw_branch_length
                     c = count[u, :num_sample_sets]
                     if not polarised:
                         c = fold(c, out_dim)
-                    index = tuple([window_index] + [k_tw] + list(c))
+                    index = tuple([window_index] + [time_window_index] + list(c))
                     result[index] += x
+                    time_window_index += 1
         last_update[u] = right
 
     for (t_left, t_right), edges_out, edges_in in ts.edge_diffs():
@@ -7130,6 +7135,39 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         )
         self.assertArrayAlmostEqual(x, true_x)
 
+    def test_bad_time_windows(self):
+        time_windows = [-1]
+        ts = self.four_taxa_test_case()
+        # make a badly formatted time_windows array
+        assert (
+            branch_allele_frequency_spectrum(
+                ts,
+                sample_sets=[[0, 1, 2, 3]],
+                time_windows=time_windows,
+                windows=None,
+                polarised=True,
+                span_normalise=False,
+            ).size
+            == 0
+        )
+
+    def test_drop_dimension(self):
+        ts = self.four_taxa_test_case()
+        sample_set = [0, 1, 2, 3]
+        for tw in [None, [0, 0.5, 1, np.inf]]:
+            x = ts.allele_frequency_spectrum(
+                sample_sets=[sample_set],
+                time_windows=tw,
+                mode="branch",
+            )
+            y = ts.allele_frequency_spectrum(
+                sample_sets=[sample_set],
+                mode="branch",
+            )
+            assert x.shape[-1] == y.shape[-1]
+            assert x.shape[-1] == len(sample_set) + 1
+            assert np.all(x[0] == y[:0])
+
     def test_afs_branch(self):
         """Tests for the Allele Frequency Spectrum stat
         using time windows under branch mode.
@@ -7369,15 +7407,3 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # dimensions are dim1: windows ; dim2: time_windows ;
         # dim3-or-more: num_sample_sets
         assert sfs1_w_tw.ndim == 3
-        # make a badly formatted time_windows array
-        assert (
-            branch_allele_frequency_spectrum(
-                ts,
-                sample_sets=[[0, 1, 2, 3]],
-                time_windows=[0],
-                windows=None,
-                polarised=True,
-                span_normalise=False,
-            ).size
-            == 0
-        )

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -4099,7 +4099,6 @@ def branch_allele_frequency_spectrum(
                         c = fold(c, out_dim)
                     index = tuple([window_index] + [k_tw] + list(c))
                     result[index] += x
-                    # print(f"x={x}, index={index}")
         last_update[u] = right
 
     for (t_left, t_right), edges_out, edges_in in ts.edge_diffs():
@@ -4340,6 +4339,7 @@ class TestAlleleFrequencySpectrum(StatsTestCase, SampleSetStatsMixin):
 
             assert len(sfs1.shape) == len(sample_sets) + 1
             assert sfs1.shape == sfs2.shape
+            print("SFS1=", sfs1, "\n...SFS3=", sfs3)
             assert sfs1.shape == sfs3.shape
             if not np.allclose(sfs1, sfs3):
                 print()
@@ -7371,5 +7371,13 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # dim3-or-more: num_sample_sets
         assert sfs1_w_tw.ndim == 3
 
-        # print(sfs1_w_tw, sfs1_w_tw.shape)
-        # print(sfs1_tws, sfs1_tws.shape)
+        print(sfs1_decap_05)
+
+        sfs_c = ts.allele_frequency_spectrum(
+            sample_sets=[[0, 1, 2, 3]],
+            mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        print(sfs_c)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -144,7 +144,6 @@ def windowed_tree_stat(ts, stat, windows, span_normalise=True):
     return A
 
 
-# Timewindows test
 def naive_branch_general_stat(
     ts, w, f, windows=None, time_windows=None, polarised=False, span_normalise=True
 ):
@@ -155,6 +154,9 @@ def naive_branch_general_stat(
     drop_time_windows = time_windows is None
     if time_windows is None:
         time_windows = [0.0, np.inf]
+    else:
+        if time_windows[0] != 0:
+            time_windows = [0] + time_windows
     n, k = w.shape
     tw = len(time_windows) - 1
     # hack to determine m
@@ -182,7 +184,7 @@ def naive_branch_general_stat(
                     for u in tree.nodes()
                 )
             sigma[tree.index, j, :] = s * tree.span
-    for j in range(1, len(time_windows) - 1):
+    for j in range(1, tw):
         sigma[:, j, :] = sigma[:, j, :] - sigma[:, j - 1, :]
     if isinstance(windows, str) and windows == "trees":
         # need to average across the windows
@@ -193,46 +195,9 @@ def naive_branch_general_stat(
     else:
         out = windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
     if drop_time_windows:
-        # beware: this assumes the first dimension is windows
-        assert out.shape[1] == 1
+        assert out.shape[1] == 3
         out = out[:, 0]
     return out
-
-
-# Previous version without tw
-# def naive_branch_general_stat(
-#     ts, w, f, windows=None, polarised=False, span_normalise=True
-# ):
-#     if windows is None:
-#         windows = [0.0, ts.sequence_length]
-#     n, k = w.shape
-#     # hack to determine m
-#     m = len(f(w[0]))
-#     total = np.sum(w, axis=0)
-
-#     sigma = np.zeros((ts.num_trees, m))
-#     for tree in ts.trees():
-#         x = np.zeros((ts.num_nodes, k))
-#         x[ts.samples()] = w
-#         for u in tree.nodes(order="postorder"):
-#             for v in tree.children(u):
-#                 x[u] += x[v]
-#         if polarised:
-#             s = sum(tree.branch_length(u) * f(x[u]) for u in tree.nodes())
-#         else:
-#             s = sum(
-#                 tree.branch_length(u) * (f(x[u]) + f(total - x[u]))
-#                 for u in tree.nodes()
-#             )
-#         sigma[tree.index] = s * tree.span
-#     if isinstance(windows, str) and windows == "trees":
-#         # need to average across the windows
-#         if span_normalise:
-#             for j, tree in enumerate(ts.trees()):
-#                 sigma[j] /= tree.span
-#         return sigma
-#     else:
-#         return windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
 
 
 def branch_general_stat(
@@ -315,7 +280,6 @@ def branch_general_stat(
                 # for the next tree
                 break
 
-    # print("window_index:", window_index, windows.shape)
     assert window_index == windows.shape[0] - 1
     if span_normalise:
         for j in range(num_windows):
@@ -4003,14 +3967,19 @@ def naive_branch_allele_frequency_spectrum(
     drop_windows = windows is None
     if windows is None:
         windows = [0.0, ts.sequence_length]
+    else:
+        if windows[0] != 0:
+            windows = [0] + windows
     drop_time_windows = time_windows is None
     if time_windows is None:
         time_windows = [0.0, np.inf]
+    else:
+        if time_windows[0] != 0:
+            time_windows = [0] + time_windows
     windows = ts.parse_windows(windows)
     num_windows = len(windows) - 1
     num_time_windows = len(time_windows) - 1
     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
-    out = np.zeros([num_windows] + out_dim)
     out = np.zeros([num_windows] + [num_time_windows] + out_dim)
     for j in range(num_windows):
         begin = windows[j]
@@ -4048,15 +4017,11 @@ def naive_branch_allele_frequency_spectrum(
             out[j, k, :] = S
 
     if drop_time_windows:
-        # beware: this assumes the first dimension is windows
-        assert out.shape[1] == 1
+        assert out.ndim == 2 + len(out_dim)
         out = out[:, 0]
     elif drop_windows:
-        # drop windows dim if only using time windows
+        assert out.shape[0] == 1
         out = out[0]
-        # assert out.shape[0] == 1
-    # Warning: when using Windows and TimeWindows,
-    # the output has three dimensions
     return out
 
 
@@ -4115,14 +4080,14 @@ def branch_allele_frequency_spectrum(
     last_update = np.zeros(ts.num_nodes)
     window_index = 0
     parent = np.zeros(ts.num_nodes, dtype=np.int32) - 1
-    branch_length = np.zeros(ts.num_nodes)
+    # branch_length = np.zeros(ts.num_nodes)
     tree_index = 0
 
-    def update_result(window_index, u, right, time_windows):
+    def update_result(window_index, u, right):
         for k_tw, _ in enumerate(time_windows[:-1]):
             if 0 < count[u, -1] < ts.num_samples:
-                # interval between child and parent inside the window
-                t_v = branch_length[u] + time[u]
+                # t_v = branch_length[u] + time[u]
+                t_v = time[parent[u]]
                 tw_branch_length = min(time_windows[k_tw + 1], t_v) - max(
                     time_windows[0], time[u]
                 )
@@ -4138,21 +4103,21 @@ def branch_allele_frequency_spectrum(
         for edge in edges_out:
             u = edge.child
             v = edge.parent
-            update_result(window_index, u, t_left, time_windows)
+            update_result(window_index, u, t_left)
             while v != -1:
-                update_result(window_index, v, t_left, time_windows)
+                update_result(window_index, v, t_left)
                 count[v] -= count[u]
                 v = parent[v]
             parent[u] = -1
-            branch_length[u] = 0
+            # branch_length[u] = 0
 
         for edge in edges_in:
             u = edge.child
             v = edge.parent
             parent[u] = v
-            branch_length[u] = time[v] - time[u]
+            # branch_length[u] = time[v] - time[u]
             while v != -1:
-                update_result(window_index, v, t_left, time_windows)
+                update_result(window_index, v, t_left)
                 count[v] += count[u]
                 v = parent[v]
 
@@ -4171,7 +4136,7 @@ def branch_allele_frequency_spectrum(
             # non-zero branches, but this would add a O(log n) cost to each edge
             # insertion and removal and a lot of complexity to the C implementation.
             for u in range(ts.num_nodes):
-                update_result(window_index, u, w_right, time_windows)
+                update_result(window_index, u, w_right)
             window_index += 1
         tree_index += 1
 
@@ -4181,13 +4146,12 @@ def branch_allele_frequency_spectrum(
             result[j] /= windows[j + 1] - windows[j]
 
     if drop_time_windows:
-        # beware: this assumes the first dimension is windows
+        assert result.ndim == 2 + len(out_dim)
         assert result.shape[1] == 1
         result = result[:, 0]
     elif drop_windows:
-        # drop windows dim if only using time windows
+        assert result.shape[0] == 1
         result = result[0]
-        # assert out.shape[0] == 1
     return result
 
 
@@ -7397,6 +7361,9 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         self.assertArrayAlmostEqual(sfs1_tws, sfs1_tws_opti)
         # test if time windows and windows obtained with naive version
         # and opti are equal
-        # Warning: when using Windows and TimeWindows,
-        # the output has three dimensions
         self.assertArrayAlmostEqual(sfs1_w_tw, sfs1_w_tw_opti)
+        # dimmensions Tests
+        assert sfs1_tws.ndim == sfs1_w.ndim
+        # dimensions are dim1: windows ; dim2: time_windows ;
+        # dim3-or-more: num_sample_sets
+        assert sfs1_w_tw.ndim == 3

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -7369,3 +7369,15 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # dimensions are dim1: windows ; dim2: time_windows ;
         # dim3-or-more: num_sample_sets
         assert sfs1_w_tw.ndim == 3
+        # make a badly formatted time_windows array
+        assert (
+            branch_allele_frequency_spectrum(
+                ts,
+                sample_sets=[[0, 1, 2, 3]],
+                time_windows=[0],
+                windows=None,
+                polarised=True,
+                span_normalise=False,
+            ).size
+            == 0
+        )

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -202,7 +202,13 @@ def naive_branch_general_stat(
 
 
 def branch_general_stat(
-    ts, sample_weights, summary_func, windows=None, polarised=False, span_normalise=True
+    ts,
+    sample_weights,
+    summary_func,
+    windows=None,
+    time_windows=None,
+    polarised=False,
+    span_normalise=True,
 ):
     """
     Efficient implementation of the algorithm used as the basis for the
@@ -210,22 +216,26 @@ def branch_general_stat(
     """
     n, state_dim = sample_weights.shape
     windows = ts.parse_windows(windows)
+    drop_time_windows = time_windows is None
+    time_windows = ts.parse_time_windows(time_windows)
     num_windows = windows.shape[0] - 1
+    num_time_windows = time_windows.shape[0] - 1
 
     # Determine result_dim
     result_dim = len(summary_func(sample_weights[0]))
-    result = np.zeros((num_windows, result_dim))
+    # result = np.zeros((num_windows, result_dim))
+    result = np.zeros((num_windows, num_time_windows, result_dim))
     state = np.zeros((ts.num_nodes, state_dim))
     state[ts.samples()] = sample_weights
     total_weight = np.sum(sample_weights, axis=0)
 
     time = ts.tables.nodes.time
     parent = np.zeros(ts.num_nodes, dtype=np.int32) - 1
-    branch_length = np.zeros(ts.num_nodes)
+    branch_length = np.zeros((num_time_windows, ts.num_nodes))
     # The value of summary_func(u) for every node.
     summary = np.zeros((ts.num_nodes, result_dim))
     # The result for the current tree *not* weighted by span.
-    running_sum = np.zeros(result_dim)
+    running_sum = np.zeros((num_time_windows, result_dim))
 
     def polarised_summary(u):
         s = summary_func(state[u])
@@ -237,31 +247,48 @@ def branch_general_stat(
         summary[u] = polarised_summary(u)
 
     window_index = 0
+
+    def update_sum(u, sign):
+        time_window_index = 0
+        if parent[u] != -1:
+            while (
+                time_window_index < num_time_windows
+                and time_windows[time_window_index] < time[parent[u]]
+            ):
+                running_sum[time_window_index] += sign * (
+                    branch_length[time_window_index, u] * summary[u]
+                )
+                time_window_index += 1
+
     for (t_left, t_right), edges_out, edges_in in ts.edge_diffs():
         for edge in edges_out:
             u = edge.child
-            running_sum -= branch_length[u] * summary[u]
+            update_sum(u, sign=-1)
             u = edge.parent
             while u != -1:
-                running_sum -= branch_length[u] * summary[u]
+                update_sum(u, sign=-1)
                 state[u] -= state[edge.child]
                 summary[u] = polarised_summary(u)
-                running_sum += branch_length[u] * summary[u]
+                update_sum(u, sign=+1)
                 u = parent[u]
             parent[edge.child] = -1
-            branch_length[edge.child] = 0
+            for tw in range(num_time_windows):
+                branch_length[tw, edge.child] = 0
 
         for edge in edges_in:
             parent[edge.child] = edge.parent
-            branch_length[edge.child] = time[edge.parent] - time[edge.child]
+            for tw in range(num_time_windows):
+                branch_length[tw, edge.child] = min(
+                    time[edge.parent], time_windows[tw + 1]
+                ) - max(time[edge.child], time_windows[tw])
             u = edge.child
-            running_sum += branch_length[u] * summary[u]
+            update_sum(u, sign=+1)
             u = edge.parent
             while u != -1:
-                running_sum -= branch_length[u] * summary[u]
+                update_sum(u, sign=-1)
                 state[u] += state[edge.child]
                 summary[u] = polarised_summary(u)
-                running_sum += branch_length[u] * summary[u]
+                update_sum(u, sign=+1)
                 u = parent[u]
 
         # Update the windows
@@ -273,15 +300,23 @@ def branch_general_stat(
             right = min(t_right, w_right)
             span = right - left
             assert span > 0
-            result[window_index] += running_sum * span
+            time_window_index = 0
+            while time_window_index < num_time_windows:
+                result[window_index, time_window_index] += (
+                    running_sum[time_window_index] * span
+                )
+                time_window_index += 1
             if w_right <= t_right:
                 window_index += 1
             else:
                 # This interval crosses a tree boundary, so we update it again in the
                 # for the next tree
                 break
-
+    # print("SUM", running_sum)
     assert window_index == windows.shape[0] - 1
+    if drop_time_windows:
+        assert result.ndim == 3
+        result = result[:, 0]
     if span_normalise:
         for j in range(num_windows):
             result[j] /= windows[j + 1] - windows[j]
@@ -341,7 +376,13 @@ def naive_site_general_stat(
 
 
 def site_general_stat(
-    ts, sample_weights, summary_func, windows=None, polarised=False, span_normalise=True
+    ts,
+    sample_weights,
+    summary_func,
+    windows=None,
+    time_windows=None,
+    polarised=False,
+    span_normalise=True,
 ):
     """
     Problem: 'sites' is different that the other windowing options
@@ -444,7 +485,13 @@ def naive_node_general_stat(
 
 
 def node_general_stat(
-    ts, sample_weights, summary_func, windows=None, polarised=False, span_normalise=True
+    ts,
+    sample_weights,
+    summary_func,
+    windows=None,
+    time_windows=None,
+    polarised=False,
+    span_normalise=True,
 ):
     """
     Efficient implementation of the algorithm used as the basis for the
@@ -519,6 +566,7 @@ def general_stat(
     sample_weights,
     summary_func,
     windows=None,
+    time_windows=None,
     polarised=False,
     mode="site",
     span_normalise=True,
@@ -537,6 +585,7 @@ def general_stat(
         sample_weights,
         summary_func,
         windows=windows,
+        time_windows=time_windows,
         polarised=polarised,
         span_normalise=span_normalise,
     )
@@ -3606,7 +3655,9 @@ class TestSitef3(Testf3, MutatedTopologyExamplesMixin):
 ############################################
 
 
-def branch_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
+def branch_f4(
+    ts, sample_sets, indexes, windows=None, time_windows=None, span_normalise=True
+):
     windows = ts.parse_windows(windows)
     out = np.zeros((len(windows) - 1, len(indexes)))
     for j in range(len(windows) - 1):
@@ -3746,7 +3797,15 @@ def node_f4(ts, sample_sets, indexes, windows=None, span_normalise=True):
     return out
 
 
-def f4(ts, sample_sets, indexes=None, windows=None, mode="site", span_normalise=True):
+def f4(
+    ts,
+    sample_sets,
+    indexes=None,
+    windows=None,
+    time_windows=None,
+    mode="site",
+    span_normalise=True,
+):
     """
     Patterson's f4 statistic definitions.
     """
@@ -7099,7 +7158,7 @@ class TestGeneralStatCallbackErrors:
 
 
 class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
-    def test_four_taxa_test_case(self):
+    def test_general_stat(self):
         # 1.00┊   7     ┊         ┊         ┊
         #     ┊ ┏━┻━┓   ┊         ┊         ┊
         # 0.70┊ ┃   ┃   ┊         ┊   6     ┊
@@ -7135,6 +7194,17 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         )
         self.assertArrayAlmostEqual(x, true_x)
 
+        x0 = branch_general_stat(ts, W, f, time_windows=None, span_normalise=False)
+        x1 = naive_branch_general_stat(
+            ts, W, f, time_windows=None, span_normalise=False
+        )
+        self.assertArrayAlmostEqual(x0, x1)
+        x_tw = branch_general_stat(
+            ts, W, f, time_windows=[0, 0.5, 2.0], span_normalise=False
+        )
+
+        self.assertArrayAlmostEqual(x, x_tw)
+
     def test_bad_time_windows(self):
         time_windows = [-1]
         ts = self.four_taxa_test_case()
@@ -7153,19 +7223,18 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
 
     def test_drop_dimension(self):
         ts = self.four_taxa_test_case()
-        sample_set = [0, 1, 2, 3]
         for tw in [None, [0, 0.5, 1, np.inf]]:
             x = ts.allele_frequency_spectrum(
-                sample_sets=[sample_set],
+                sample_sets=[[0, 1, 2, 3]],
                 time_windows=tw,
                 mode="branch",
             )
             y = ts.allele_frequency_spectrum(
-                sample_sets=[sample_set],
+                sample_sets=[0, 1, 2, 3],
                 mode="branch",
             )
             assert x.shape[-1] == y.shape[-1]
-            assert x.shape[-1] == len(sample_set) + 1
+            # assert x.shape[-1] == len(sample_set) + 1
             assert np.all(x[0] == y[:0])
 
     def test_afs_branch(self):

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -145,40 +145,57 @@ def windowed_tree_stat(ts, stat, windows, span_normalise=True):
 
 
 def naive_branch_general_stat(
-    ts, w, f, windows=None, polarised=False, span_normalise=True
+    ts, w, f, windows=None, time_windows=None, polarised=False, span_normalise=True
 ):
     # NOTE: does not behave correctly for unpolarised stats
     # with non-ancestral material.
     if windows is None:
         windows = [0.0, ts.sequence_length]
+    drop_time_windows = time_windows is None
+    if time_windows is None:
+        time_windows = [0.0, np.inf]
     n, k = w.shape
+    tw = len(time_windows) - 1
     # hack to determine m
     m = len(f(w[0]))
     total = np.sum(w, axis=0)
 
-    sigma = np.zeros((ts.num_trees, m))
-    for tree in ts.trees():
-        x = np.zeros((ts.num_nodes, k))
-        x[ts.samples()] = w
-        for u in tree.nodes(order="postorder"):
-            for v in tree.children(u):
-                x[u] += x[v]
-        if polarised:
-            s = sum(tree.branch_length(u) * f(x[u]) for u in tree.nodes())
+    sigma = np.zeros((ts.num_trees, tw, m))
+    for j, upper_time in enumerate(time_windows[1:]):
+        if np.isfinite(upper_time):
+            decap_ts = ts.decapitate(upper_time)
         else:
-            s = sum(
-                tree.branch_length(u) * (f(x[u]) + f(total - x[u]))
-                for u in tree.nodes()
-            )
-        sigma[tree.index] = s * tree.span
+            decap_ts = ts
+        assert np.all(list(ts.samples()) == list(decap_ts.samples()))
+        for tree in decap_ts.trees():
+            x = np.zeros((decap_ts.num_nodes, k))
+            x[decap_ts.samples()] = w
+            for u in tree.nodes(order="postorder"):
+                for v in tree.children(u):
+                    x[u] += x[v]
+            if polarised:
+                s = sum(tree.branch_length(u) * f(x[u]) for u in tree.nodes())
+            else:
+                s = sum(
+                    tree.branch_length(u) * (f(x[u]) + f(total - x[u]))
+                    for u in tree.nodes()
+                )
+            sigma[tree.index, j, :] = s * tree.span
+    for j in range(1, len(time_windows) - 1):
+        sigma[:, j, :] = sigma[:, j, :] - sigma[:, j - 1, :]
     if isinstance(windows, str) and windows == "trees":
         # need to average across the windows
         if span_normalise:
             for j, tree in enumerate(ts.trees()):
                 sigma[j] /= tree.span
-        return sigma
+        out = sigma
     else:
-        return windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
+        out = windowed_tree_stat(ts, sigma, windows, span_normalise=span_normalise)
+    if drop_time_windows:
+        # beware: this assumes the first dimension is windows
+        assert out.shape[1] == 1
+        out = out[:, 0]
+    return out
 
 
 def branch_general_stat(
@@ -7012,23 +7029,37 @@ class TestGeneralStatCallbackErrors:
 
 class TestTimeWindows(StatsTestCase):
     def test_four_taxa_test_case(self):
-        # 1.0          7
-        # 0.7         / \                                    6
-        #            /   \                                  / \
-        # 0.5       /     5              5                 /   5
-        #          /     / \            / \__             /   / \
-        # 0.4     /     8   \          8     4           /   8   \
-        #        /     / \   \        / \   / \         /   / \   \
-        # 0.0   0     1   3   2      1   3 0   2       0   1   3   2
-        #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
+        # 1.00┊   7     ┊         ┊         ┊
+        #     ┊ ┏━┻━┓   ┊         ┊         ┊
+        # 0.70┊ ┃   ┃   ┊         ┊   6     ┊
+        #     ┊ ┃   ┃   ┊         ┊ ┏━┻━┓   ┊
+        # 0.50┊ ┃   5   ┊    5    ┊ ┃   5   ┊
+        #     ┊ ┃  ┏┻━┓ ┊  ┏━┻━┓  ┊ ┃  ┏┻━┓ ┊
+        # 0.40┊ ┃  8  ┃ ┊  4   8  ┊ ┃  8  ┃ ┊
+        #     ┊ ┃ ┏┻┓ ┃ ┊ ┏┻┓ ┏┻┓ ┊ ┃ ┏┻┓ ┃ ┊
+        # 0.00┊ 0 1 3 2 ┊ 0 2 1 3 ┊ 0 1 3 2 ┊
+        #   0.00      0.20      0.80      2.50
         ts = self.four_taxa_test_case()
         true_x = np.array(
             [
-                0.2 * (1.5 + 0.8)
-                + (0.8 - 0.2) * (1.0 + 0.8)
-                + (2.5 - 0.8) * (1.5 + 0.8),
-                0.2 * 1.0 + 0 + (2.5 - 0.8) * 0.4,
+                [
+                    [
+                        0.2 * (1 + 0.5 + 0.4)
+                        + (0.8 - 0.2) * (1 + 0.8)
+                        + (2.5 - 0.8) * (1.0 + 0.5 + 0.4)
+                    ],
+                    [0.2 * 1.0 + 0 + (2.5 - 0.8) * 0.4],
+                ]
             ]
         )
-        x = ts.segregating_sites(time_windows=[0, 0.5, 2.0], span_normalise=False)
+
+        n = ts.num_samples
+
+        def f(x):
+            return (x > 0) * (1 - x / n)
+
+        W = np.ones((ts.num_samples, 1))
+        x = naive_branch_general_stat(
+            ts, W, f, time_windows=[0, 0.5, 2.0], span_normalise=False
+        )
         self.assertArrayAlmostEqual(x, true_x)

--- a/python/tests/test_tree_stats.py
+++ b/python/tests/test_tree_stats.py
@@ -3989,47 +3989,6 @@ def naive_site_allele_frequency_spectrum(
     return out
 
 
-# def naive_branch_allele_frequency_spectrum(
-#     ts, sample_sets, windows=None, polarised=False, span_normalise=True
-# ):
-#     """
-#     The joint allele frequency spectrum for branches.
-#     """
-#     windows = ts.parse_windows(windows)
-#     num_windows = len(windows) - 1
-#     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
-#     out = np.zeros([num_windows] + out_dim)
-#     for j in range(num_windows):
-#         begin = windows[j]
-#         end = windows[j + 1]
-#         S = np.zeros(out_dim)
-#         trees = [
-#             next(ts.trees(tracked_samples=sample_set)) for sample_set in sample_sets
-#         ]
-#         t = trees[0]
-#         while True:
-#             tr_len = min(end, t.interval.right) - max(begin, t.interval.left)
-#             if tr_len > 0:
-#                 for node in t.nodes():
-#                     if 0 < t.num_samples(node) < ts.num_samples:
-#                         x = [tree.num_tracked_samples(node) for tree in trees]
-#                         # Note x must be a tuple for indexing to work
-#                         if not polarised:
-#                             x = fold(x, out_dim)
-#                         S[tuple(x)] += t.branch_length(node) * tr_len
-
-#             # Advance the trees
-#             more = [tree.next() for tree in trees]
-#             assert len(set(more)) == 1
-#             if not more[0]:
-#                 break
-#         if span_normalise:
-#             S /= end - begin
-#         out[j, :] = S
-#     return out
-
-
-# time windows version
 def naive_branch_allele_frequency_spectrum(
     ts,
     sample_sets,
@@ -4052,23 +4011,17 @@ def naive_branch_allele_frequency_spectrum(
     num_time_windows = len(time_windows) - 1
     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
     out = np.zeros([num_windows] + out_dim)
-    # print(out.shape)
     out = np.zeros([num_windows] + [num_time_windows] + out_dim)
-    #    print(out)
-    #    print(out.shape)
     for j in range(num_windows):
         begin = windows[j]
         end = windows[j + 1]
         for k, upper_time in enumerate(time_windows[1:]):
-            # print("TIME WINDOW=", upper_time)
             S = np.zeros(out_dim)
-
             if np.isfinite(upper_time):
                 decap_ts = ts.decapitate(upper_time)
             else:
                 decap_ts = ts
             assert np.all(list(ts.samples()) == list(decap_ts.samples()))
-
             trees = [
                 next(decap_ts.trees(tracked_samples=sample_set))
                 for sample_set in sample_sets
@@ -4083,23 +4036,6 @@ def naive_branch_allele_frequency_spectrum(
                             if not polarised:
                                 x = fold(x, out_dim)
                             # Note x must be a tuple for indexing to work
-                            # print(t.draw_text())
-                            print(
-                                "tr_len",
-                                tr_len,
-                                "\nnode",
-                                node,
-                                "\nnum_samples under node=",
-                                t.num_samples(node),
-                                "\nSFS bin =",
-                                x,
-                                "\nseq len",
-                                tr_len,
-                                "\nbr len",
-                                t.branch_length(node),
-                                "\nbranch len * seq len",
-                                t.branch_length(node) * tr_len,
-                            )
                             S[tuple(x)] += t.branch_length(node) * tr_len
 
                 # Advance the trees
@@ -4119,6 +4055,8 @@ def naive_branch_allele_frequency_spectrum(
         # drop windows dim if only using time windows
         out = out[0]
         # assert out.shape[0] == 1
+    # Warning: when using Windows and TimeWindows,
+    # the output has three dimensions
     return out
 
 
@@ -4149,19 +4087,24 @@ def naive_allele_frequency_spectrum(
 
 
 def branch_allele_frequency_spectrum(
-    ts, sample_sets, windows, polarised=False, span_normalise=True
+    ts, sample_sets, windows, time_windows=None, polarised=False, span_normalise=True
 ):
     """
     Efficient implementation of the algorithm used as the basis for the
     underlying C version.
     """
     num_sample_sets = len(sample_sets)
+    drop_windows = windows is None
     windows = ts.parse_windows(windows)
+    drop_time_windows = time_windows is None
+    if time_windows is None:
+        time_windows = [0.0, np.inf]
     num_windows = windows.shape[0] - 1
+    num_time_windows = len(time_windows) - 1
     out_dim = [1 + len(sample_set) for sample_set in sample_sets]
     time = ts.tables.nodes.time
 
-    result = np.zeros([num_windows] + out_dim)
+    result = np.zeros([num_windows] + [num_time_windows] + out_dim)
     # Number of nodes in sample_set j ancestral to each node u.
     count = np.zeros((ts.num_nodes, num_sample_sets + 1), dtype=np.uint32)
     for j in range(num_sample_sets):
@@ -4175,23 +4118,29 @@ def branch_allele_frequency_spectrum(
     branch_length = np.zeros(ts.num_nodes)
     tree_index = 0
 
-    def update_result(window_index, u, right):
-        if 0 < count[u, -1] < ts.num_samples:
-            x = (right - last_update[u]) * branch_length[u]
-            c = count[u, :num_sample_sets]
-            if not polarised:
-                c = fold(c, out_dim)
-            index = tuple([window_index] + list(c))
-            result[index] += x
+    def update_result(window_index, u, right, time_windows):
+        for k_tw, _ in enumerate(time_windows[:-1]):
+            if 0 < count[u, -1] < ts.num_samples:
+                # interval between child and parent inside the window
+                t_v = branch_length[u] + time[u]
+                tw_branch_length = min(time_windows[k_tw + 1], t_v) - max(
+                    time_windows[0], time[u]
+                )
+                x = (right - last_update[u]) * tw_branch_length
+                c = count[u, :num_sample_sets]
+                if not polarised:
+                    c = fold(c, out_dim)
+                index = tuple([window_index] + [k_tw] + list(c))
+                result[index] += x
         last_update[u] = right
 
     for (t_left, t_right), edges_out, edges_in in ts.edge_diffs():
         for edge in edges_out:
             u = edge.child
             v = edge.parent
-            update_result(window_index, u, t_left)
+            update_result(window_index, u, t_left, time_windows)
             while v != -1:
-                update_result(window_index, v, t_left)
+                update_result(window_index, v, t_left, time_windows)
                 count[v] -= count[u]
                 v = parent[v]
             parent[u] = -1
@@ -4203,7 +4152,7 @@ def branch_allele_frequency_spectrum(
             parent[u] = v
             branch_length[u] = time[v] - time[u]
             while v != -1:
-                update_result(window_index, v, t_left)
+                update_result(window_index, v, t_left, time_windows)
                 count[v] += count[u]
                 v = parent[v]
 
@@ -4222,7 +4171,7 @@ def branch_allele_frequency_spectrum(
             # non-zero branches, but this would add a O(log n) cost to each edge
             # insertion and removal and a lot of complexity to the C implementation.
             for u in range(ts.num_nodes):
-                update_result(window_index, u, w_right)
+                update_result(window_index, u, w_right, time_windows)
             window_index += 1
         tree_index += 1
 
@@ -4230,6 +4179,15 @@ def branch_allele_frequency_spectrum(
     if span_normalise:
         for j in range(num_windows):
             result[j] /= windows[j + 1] - windows[j]
+
+    if drop_time_windows:
+        # beware: this assumes the first dimension is windows
+        assert result.shape[1] == 1
+        result = result[:, 0]
+    elif drop_windows:
+        # drop windows dim if only using time windows
+        result = result[0]
+        # assert out.shape[0] == 1
     return result
 
 
@@ -7206,71 +7164,6 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         )
         self.assertArrayAlmostEqual(x, true_x)
 
-    def four_taxa_test_case(self):
-        #
-        # 1.0          7
-        # 0.7         / \                                    6
-        #            /   \                                  / \
-        # 0.5       /     5              5                 /   5
-        #          /     / \            / \__             /   / \
-        # 0.4     /     8   \          8     4           /   8   \
-        #        /     / \   \        / \   / \         /   / \   \
-        # 0.0   0     1   3   2      1   3 0   2       0   1   3   2
-        #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
-
-        nodes = io.StringIO(
-            """\
-     id      is_sample   time
-     0       1           0
-     1       1           0
-     2       1           0
-     3       1           0
-     4       0           0.4
-     5       0           0.5
-     6       0           0.7
-     7       0           1.0
-     8       0           0.40
-     """
-        )
-        edges = io.StringIO(
-            """\
-     left    right   parent  child
-     0.0     2.5     8       1,3
-     0.2     0.8     4       0,2
-     0.0     0.2     5       8,2
-     0.2     0.8     5       8,4
-     0.8     2.5     5       8,2
-     0.8     2.5     6       0,5
-     0.0     0.2     7       0,5
-     """
-        )
-        sites = io.StringIO(
-            """\
-        id  position    ancestral_state
-        0   0.05        0
-        1   0.3         0
-        2   0.9         0
-        """
-        )
-        mutations = io.StringIO(
-            """\
-        site    node    derived_state   parent
-        0       0       1               -1
-        0       0       2               0
-        0       0       0               1
-        0       1       2               -1
-        1       1       1               -1
-        1       2       1               -1
-        2       3       1               -1
-        2       1       2               6
-        2       2       3               6
-        """
-        )
-        ts = tskit.load_text(
-            nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False
-        )
-        return ts
-
     def test_afs_branch(self):
         """Tests for the Allele Frequency Spectrum stat
         using time windows under branch mode.
@@ -7287,7 +7180,6 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         #          (0.0, 0.2),        (0.2, 0.8),       (0.8, 2.5)
 
         ts = self.four_taxa_test_case()
-        print(ts)
 
         self.mode = "branch"
 
@@ -7298,11 +7190,20 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
             polarised=True,
             span_normalise=False,
         )
+
         sfs1_w = naive_allele_frequency_spectrum(
             ts,
             sample_sets=[[0, 1, 2, 3]],
-            windows=[0, 0.2, 2.5],
+            windows=[0, 0.2, 0.80, 2.5],
             mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        sfs1_w_opti = branch_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            windows=[0, 0.2, 0.8, 2.5],
             polarised=True,
             span_normalise=False,
         )
@@ -7310,9 +7211,18 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         sfs1_w_tw = naive_allele_frequency_spectrum(
             ts,
             sample_sets=[[0, 1, 2, 3]],
-            windows=[0, 0.2, 2.5],
+            windows=[0, 0.2, 0.8, 2.5],
             time_windows=[0, 0.5, 0.8, 1],
             mode=self.mode,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        sfs1_w_tw_opti = branch_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            time_windows=[0, 0.5, 0.8, 1],
+            windows=[0, 0.2, 0.8, 2.5],
             polarised=True,
             span_normalise=False,
         )
@@ -7325,6 +7235,16 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
             polarised=True,
             span_normalise=False,
         )
+
+        sfs1_tws_opti = branch_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            time_windows=[0, 0.5, 0.8, 1],
+            windows=None,
+            polarised=True,
+            span_normalise=False,
+        )
+
         sfs1_tw_05 = naive_allele_frequency_spectrum(
             ts,
             sample_sets=[[0, 1, 2, 3]],
@@ -7342,6 +7262,24 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
             span_normalise=False,
         )
 
+        # non-naive version
+        sfs1_opti_decap_05 = branch_allele_frequency_spectrum(
+            ts_decap_05,
+            sample_sets=[[0, 1, 2, 3]],
+            windows=None,
+            polarised=True,
+            span_normalise=False,
+        )
+
+        sfs1_opti_tw_05 = branch_allele_frequency_spectrum(
+            ts,
+            sample_sets=[[0, 1, 2, 3]],
+            time_windows=[0, 0.5],
+            windows=None,
+            polarised=True,
+            span_normalise=False,
+        )
+
         sfs = [
             [
                 # bin 0
@@ -7354,6 +7292,51 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
                 (0.1) * 0.2 + (0.1 + 0.1) * 0.6 + (0.1) * 1.7,
                 # bin 3
                 (0.5) * 0.2 + (0.2) * 1.7,
+                # bin 4
+                0,
+            ]
+        ]
+
+        sfs_w_02 = [
+            [
+                # bin 0
+                0,
+                # bin 1
+                (0.4 + 0.4 + 0.5 + 1) * 0.2,
+                # bin 2
+                (0.1) * 0.2,
+                # bin 3
+                (0.5) * 0.2,
+                # bin 4
+                0,
+            ]
+        ]
+
+        sfs_w_08 = [
+            [
+                # bin 0
+                0,
+                # bin 1
+                (0.4 + 0.4 + 0.4 + 0.4) * 0.6,
+                # bin 2
+                (0.1 + 0.1) * 0.6,
+                # bin 3
+                0,
+                # bin 4
+                0,
+            ]
+        ]
+
+        sfs_w_25 = [
+            [
+                # bin 0
+                0,
+                # bin 1
+                (0.7 + 0.4 + 0.4 + 0.5) * 1.7,
+                # bin 2
+                (0.1) * 1.7,
+                # bin 3
+                (0.2) * 1.7,
                 # bin 4
                 0,
             ]
@@ -7379,15 +7362,41 @@ class TestTimeWindows(TestBranchAlleleFrequencySpectrum):
         # try on simple example computed "by hand"
         # if the modified function still works as expected
         self.assertArrayAlmostEqual(sfs, sfs1)
+        # check if windows work as expected with naive version
+        # Window 0.0 to 0.2
+        self.assertArrayAlmostEqual(sfs1_w[0], sfs_w_02[0])
+        # Window 0.2 to 0.8
+        self.assertArrayAlmostEqual(sfs1_w[1], sfs_w_08[0])
+        # Window 0.8 to 2.5
+        self.assertArrayAlmostEqual(sfs1_w[2], sfs_w_25[0])
         # try if time_windows before t=0.5 is
         # like sfs on a previously decapted ts before t=0.5
         self.assertArrayAlmostEqual(sfs1_tw_05, sfs1_decap_05)
         # try if sfs by hand before t=0.5 is
         # equivalent to time_windows before t=0.5
         self.assertArrayAlmostEqual(sfs_05, sfs1_tw_05)
-
+        # try if the SFSs of a ts decapited before t=0.5 are
+        # not altered by naive and non-naive afs without
+        # any time_windows parameter
+        self.assertArrayAlmostEqual(sfs1_decap_05, sfs1_opti_decap_05)
+        # non-naive version
+        # Window 0.0 to 0.2
+        self.assertArrayAlmostEqual(sfs1_w_opti[0], sfs_w_02[0])
+        # Window 0.2 to 0.8
+        self.assertArrayAlmostEqual(sfs1_w_opti[1], sfs_w_08[0])
+        # Window 0.8 to 2.5
+        self.assertArrayAlmostEqual(sfs1_w_opti[2], sfs_w_25[0])
+        # try if sfs by hand before t=0.5 is
+        # equivalent to time_windows before t=0.5
+        self.assertArrayAlmostEqual(sfs_05, sfs1_opti_tw_05)
+        # try if time_windows before t=0.5 is
+        # like sfs on a previously decapted ts before t=0.5
+        self.assertArrayAlmostEqual(sfs1_opti_decap_05, sfs1_opti_tw_05)
+        # test if time windows obtained with naive version and opti
+        # are equal
+        self.assertArrayAlmostEqual(sfs1_tws, sfs1_tws_opti)
+        # test if time windows and windows obtained with naive version
+        # and opti are equal
         # Warning: when using Windows and TimeWindows,
         # the output has three dimensions
-        print("sfs1_w", sfs1_w)
-        print("sfs1_w_tw", sfs1_w_tw)
-        print("sfs1_tws", sfs1_tws)
+        self.assertArrayAlmostEqual(sfs1_w_tw, sfs1_w_tw_opti)

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/test_vcf.py
+++ b/python/tests/test_vcf.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (c) 2016 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2024 Tskit Developers
+# Copyright (c) 2020-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tests/tsutil.py
+++ b/python/tests/tsutil.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (C) 2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tskit/combinatorics.py
+++ b/python/tskit/combinatorics.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2020-2024 Tskit Developers
+# Copyright (c) 2020-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tskit/genotypes.py
+++ b/python/tskit/genotypes.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (c) 2015-2018 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tskit/provenance.py
+++ b/python/tskit/provenance.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (c) 2016-2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tskit/stats.py
+++ b/python/tskit/stats.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2018-2024 Tskit Developers
+# Copyright (c) 2018-2025 Tskit Developers
 # Copyright (c) 2017 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tskit/text_formats.py
+++ b/python/tskit/text_formats.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2021-2024 Tskit Developers
+# Copyright (c) 2021-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7959,7 +7959,6 @@ class TreeSequence:
             time_windows = [0.0, math.inf]
         return np.array(time_windows)
 
-<<<<<<< HEAD
     def __run_windowed_stat(self, windows, method, *args, **kwargs):
         strip_win = windows is None
         windows = self.parse_windows(windows)
@@ -7970,9 +7969,6 @@ class TreeSequence:
 
     # only for temporary tw version
     def __run_windowed_stat_tw(self, windows, time_windows, method, *args, **kwargs):
-=======
-    def __run_windowed_stat(self, windows, time_windows, method, *args, **kwargs):
->>>>>>> 14e1cefc (Better dimension drop with time windows)
         strip_win = windows is None
         strip_timewin = time_windows is None
         windows = self.parse_windows(windows)
@@ -8229,7 +8225,6 @@ class TreeSequence:
         sample_sets,
         indexes=None,
         windows=None,
-        time_windows=None,
         mode=None,
         span_normalise=True,
         polarised=False,
@@ -8262,7 +8257,6 @@ class TreeSequence:
             )
         stat = self.__run_windowed_stat(
             windows,
-            time_windows,
             ll_method,
             sample_set_sizes,
             flattened,
@@ -8285,7 +8279,6 @@ class TreeSequence:
         W,
         indexes=None,
         windows=None,
-        time_windows=None,
         mode=None,
         span_normalise=True,
         polarised=False,
@@ -8311,7 +8304,6 @@ class TreeSequence:
             )
         stat = self.__run_windowed_stat(
             windows,
-            time_windows,
             ll_method,
             W,
             indexes,
@@ -8995,7 +8987,6 @@ class TreeSequence:
             polarised=polarised,
             centre=centre,
         )
-
     def genetic_relatedness_vector(
         self,
         W,
@@ -9392,7 +9383,6 @@ class TreeSequence:
         pca_result = PCAResult(factors=U, eigenvalues=D, range_sketch=Q, error_bound=E)
 
         return pca_result
-
     def trait_covariance(self, W, windows=None, mode="site", span_normalise=True):
         """
         Computes the mean squared covariances between each of the columns of ``W``
@@ -9541,7 +9531,12 @@ class TreeSequence:
         return self.trait_linear_model(*args, **kwargs)
 
     def trait_linear_model(
-        self, W, Z=None, windows=None, mode="site", span_normalise=True
+        self,
+        W,
+        Z=None,
+        windows=None,
+        mode="site",
+        span_normalise=True,
     ):
         """
         Finds the relationship between trait and genotype after accounting for

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -8987,6 +8987,7 @@ class TreeSequence:
             polarised=polarised,
             centre=centre,
         )
+
     def genetic_relatedness_vector(
         self,
         W,
@@ -9383,6 +9384,7 @@ class TreeSequence:
         pca_result = PCAResult(factors=U, eigenvalues=D, range_sketch=Q, error_bound=E)
 
         return pca_result
+
     def trait_covariance(self, W, windows=None, mode="site", span_normalise=True):
         """
         Computes the mean squared covariances between each of the columns of ``W``

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7931,7 +7931,6 @@ class TreeSequence:
         # Note: need to make sure windows is a string or we try to compare the
         # target with a numpy array elementwise.
         if windows is None:
-            # initiate default spanning windows
             windows = [0.0, self.sequence_length]
         elif isinstance(windows, str):
             if windows == "trees":
@@ -7978,6 +7977,8 @@ class TreeSequence:
             stat = stat[0, :, :]
         elif strip_timewin:
             stat = stat[:, 0, :]
+        elif strip_win and strip_timewin:
+            stat = stat[0, 0, :]
         return stat
 
     def __one_way_sample_set_stat(
@@ -8077,9 +8078,7 @@ class TreeSequence:
         if drop_dimension:
             stat = stat.reshape(stat.shape[:-1])
             # TODO: Write test for this
-            if (stat.shape == () and windows is None) or (
-                stat.shape == () and time_windows is None
-            ):
+            if stat.shape == () and windows is None and time_windows is None:
                 stat = stat[()]
         return stat
 

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7931,6 +7931,7 @@ class TreeSequence:
         # Note: need to make sure windows is a string or we try to compare the
         # target with a numpy array elementwise.
         if windows is None:
+            # initiate default spanning windows
             windows = [0.0, self.sequence_length]
         elif isinstance(windows, str):
             if windows == "trees":
@@ -7952,12 +7953,31 @@ class TreeSequence:
                 )
         return np.array(windows)
 
+    def parse_time_windows(self, time_windows):
+        """Time windows intitialization"""
+        if time_windows is None:
+            time_windows = [0.0, math.inf]
+        return np.array(time_windows)
+
     def __run_windowed_stat(self, windows, method, *args, **kwargs):
-        strip_dim = windows is None
+        strip_win = windows is None
         windows = self.parse_windows(windows)
         stat = method(*args, **kwargs, windows=windows)
-        if strip_dim:
+        if strip_win:
             stat = stat[0]
+        return stat
+
+    # only for temporary tw version
+    def __run_windowed_stat_tw(self, windows, time_windows, method, *args, **kwargs):
+        strip_win = windows is None
+        strip_timewin = time_windows is None
+        windows = self.parse_windows(windows)
+        time_windows = self.parse_time_windows(time_windows)
+        stat = method(*args, **kwargs, windows=windows, time_windows=time_windows)
+        if strip_win:
+            stat = stat[0, :, :]
+        elif strip_timewin:
+            stat = stat[:, 0, :]
         return stat
 
     def __one_way_sample_set_stat(
@@ -8004,7 +8024,62 @@ class TreeSequence:
         )
         if drop_dimension:
             stat = stat.reshape(stat.shape[:-1])
+            # TODO: Write test for this
             if stat.shape == () and windows is None:
+                stat = stat[()]
+        return stat
+
+    # only for temporary tw version
+    def __one_way_sample_set_stat_tw(
+        self,
+        ll_method,
+        sample_sets,
+        windows=None,
+        time_windows=None,
+        mode=None,
+        span_normalise=True,
+        polarised=False,
+    ):
+        if sample_sets is None:
+            sample_sets = self.samples()
+
+        # First try to convert to a 1D numpy array. If it is, then we strip off
+        # the corresponding dimension from the output.
+        drop_dimension = False
+        try:
+            sample_sets = np.array(sample_sets, dtype=np.uint64)
+        except ValueError:
+            pass
+        else:
+            # If we've successfully converted sample_sets to a 1D numpy array
+            # of integers then drop the dimension
+            if len(sample_sets.shape) == 1:
+                sample_sets = [sample_sets]
+                drop_dimension = True
+
+        sample_set_sizes = np.array(
+            [len(sample_set) for sample_set in sample_sets], dtype=np.uint32
+        )
+        if np.any(sample_set_sizes == 0):
+            raise ValueError("Sample sets must contain at least one element")
+
+        flattened = util.safe_np_int_cast(np.hstack(sample_sets), np.int32)
+        stat = self.__run_windowed_stat_tw(
+            windows,
+            time_windows,
+            ll_method,
+            sample_set_sizes,
+            flattened,
+            mode=mode,
+            span_normalise=span_normalise,
+            polarised=polarised,
+        )
+        if drop_dimension:
+            stat = stat.reshape(stat.shape[:-1])
+            # TODO: Write test for this
+            if (stat.shape == () and windows is None) or (
+                stat.shape == () and time_windows is None
+            ):
                 stat = stat[()]
         return stat
 
@@ -8150,6 +8225,7 @@ class TreeSequence:
         sample_sets,
         indexes=None,
         windows=None,
+        time_windows=None,
         mode=None,
         span_normalise=True,
         polarised=False,
@@ -8182,6 +8258,7 @@ class TreeSequence:
             )
         stat = self.__run_windowed_stat(
             windows,
+            time_windows,
             ll_method,
             sample_set_sizes,
             flattened,
@@ -8204,6 +8281,7 @@ class TreeSequence:
         W,
         indexes=None,
         windows=None,
+        time_windows=None,
         mode=None,
         span_normalise=True,
         polarised=False,
@@ -8229,6 +8307,7 @@ class TreeSequence:
             )
         stat = self.__run_windowed_stat(
             windows,
+            time_windows,
             ll_method,
             W,
             indexes,
@@ -9600,6 +9679,7 @@ class TreeSequence:
         self,
         sample_sets=None,
         windows=None,
+        time_windows=None,
         mode="site",
         span_normalise=True,
         polarised=False,
@@ -9694,10 +9774,11 @@ class TreeSequence:
         """
         if sample_sets is None:
             sample_sets = [self.samples()]
-        return self.__one_way_sample_set_stat(
+        return self.__one_way_sample_set_stat_tw(
             self._ll_tree_sequence.allele_frequency_spectrum,
             sample_sets,
             windows=windows,
+            time_windows=time_windows,
             mode=mode,
             span_normalise=span_normalise,
             polarised=polarised,

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -8043,7 +8043,6 @@ class TreeSequence:
     ):
         if sample_sets is None:
             sample_sets = self.samples()
-
         # First try to convert to a 1D numpy array. If it is, then we strip off
         # the corresponding dimension from the output.
         drop_dimension = False
@@ -8057,7 +8056,6 @@ class TreeSequence:
             if len(sample_sets.shape) == 1:
                 sample_sets = [sample_sets]
                 drop_dimension = True
-
         sample_set_sizes = np.array(
             [len(sample_set) for sample_set in sample_sets], dtype=np.uint32
         )
@@ -8076,7 +8074,9 @@ class TreeSequence:
             polarised=polarised,
         )
         if drop_dimension:
-            stat = stat.reshape(stat.shape[:-1])
+            # no applicable for AFS
+            if not ll_method.__name__ == "allele_frequency_spectrum":
+                stat = stat.reshape(stat.shape[:-1])
             # TODO: Write test for this
             if stat.shape == () and windows is None and time_windows is None:
                 stat = stat[()]

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7959,6 +7959,7 @@ class TreeSequence:
             time_windows = [0.0, math.inf]
         return np.array(time_windows)
 
+<<<<<<< HEAD
     def __run_windowed_stat(self, windows, method, *args, **kwargs):
         strip_win = windows is None
         windows = self.parse_windows(windows)
@@ -7969,6 +7970,9 @@ class TreeSequence:
 
     # only for temporary tw version
     def __run_windowed_stat_tw(self, windows, time_windows, method, *args, **kwargs):
+=======
+    def __run_windowed_stat(self, windows, time_windows, method, *args, **kwargs):
+>>>>>>> 14e1cefc (Better dimension drop with time windows)
         strip_win = windows is None
         strip_timewin = time_windows is None
         windows = self.parse_windows(windows)

--- a/python/tskit/vcf.py
+++ b/python/tskit/vcf.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2019-2024 Tskit Developers
+# Copyright (c) 2019-2025 Tskit Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

This is a WIP and replaces #2948 as a more specific PR regarding time-windows in AFS.

_In fine_, users will be able to use ts.allele_frequency_spectrum(time_windows=tw), with **_tw_** being a list of any non-overlapping time intervals in {0, inf}.
