### PR TITLE
extend `union` to do "disjoint union"

### DIFF
--- a/c/tskit/tables.c
+++ b/c/tskit/tables.c
@@ -13202,6 +13202,8 @@ tsk_table_collection_union(tsk_table_collection_t *self,
     tsk_id_t *site_map = NULL;
     bool add_populations = !(options & TSK_UNION_NO_ADD_POP);
     bool check_shared_portion = !(options & TSK_UNION_NO_CHECK_SHARED);
+    bool all_edges = !!(options & TSK_UNION_ALL_EDGES);
+    bool all_mutations = !!(options & TSK_UNION_ALL_MUTATIONS);
 
     /* Not calling TSK_CHECK_TREES so casting to int is safe */
     ret = (int) tsk_table_collection_check_integrity(self, 0);
@@ -13285,7 +13287,7 @@ tsk_table_collection_union(tsk_table_collection_t *self,
     // edges
     for (k = 0; k < (tsk_id_t) other->edges.num_rows; k++) {
         tsk_edge_table_get_row_unsafe(&other->edges, k, &edge);
-        if ((other_node_mapping[edge.parent] == TSK_NULL)
+        if (all_edges || (other_node_mapping[edge.parent] == TSK_NULL)
             || (other_node_mapping[edge.child] == TSK_NULL)) {
             new_parent = node_map[edge.parent];
             new_child = node_map[edge.child];
@@ -13305,7 +13307,7 @@ tsk_table_collection_union(tsk_table_collection_t *self,
         while ((i < (tsk_id_t) other->mutations.num_rows)
                && (other->mutations.site[i] == site.id)) {
             tsk_mutation_table_get_row_unsafe(&other->mutations, i, &mut);
-            if (other_node_mapping[mut.node] == TSK_NULL) {
+            if (all_mutations || (other_node_mapping[mut.node] == TSK_NULL)) {
                 if (site_map[site.id] == TSK_NULL) {
                     ret_id = tsk_site_table_add_row(&self->sites, site.position,
                         site.ancestral_state, site.ancestral_state_length, site.metadata,

--- a/c/tskit/tables.h
+++ b/c/tskit/tables.h
@@ -858,11 +858,21 @@ equality of the subsets.
 */
 #define TSK_UNION_NO_CHECK_SHARED (1 << 0)
 /**
- By default, all nodes new to ``self`` are assigned new populations. If this
+By default, all nodes new to ``self`` are assigned new populations. If this
 option is specified, nodes that are added to ``self`` will retain the
 population IDs they have in ``other``.
  */
 #define TSK_UNION_NO_ADD_POP (1 << 1)
+/**
+By default, union only adds only edges adjacent to a newly added node;
+this option adds all edges.
+ */
+#define TSK_UNION_ALL_EDGES (1 << 2)
+/**
+By default, union only adds only mutations on newly added edges;
+this option adds all mutations.
+ */
+#define TSK_UNION_ALL_MUTATIONS (1 << 3)
 /** @} */
 
 /**
@@ -4413,6 +4423,10 @@ that are exclusive ``other`` are added to ``self``, along with:
 
 By default, populations of newly added nodes are assumed to be new populations,
 and added to the population table as well.
+
+The behavior can be changed by the flags ``TSK_UNION_ALL_EDGES`` and
+``TSK_UNION_ALL_MUTATIONS``, which will (respectively) add *all* edges
+or *all* sites and mutations instead.
 
 This operation will also sort the resulting tables, so the tables may change
 even if nothing new is added, if the original tables were not sorted.

--- a/python/_tskitmodule.c
+++ b/python/_tskitmodule.c
@@ -7069,15 +7069,18 @@ TableCollection_union(TableCollection *self, PyObject *args, PyObject *kwds)
     npy_intp *shape;
     tsk_flags_t options = 0;
     int check_shared = true;
+    int all_edges = false;
+    int all_mutations = false;
     int add_populations = true;
-    static char *kwlist[] = { "other", "other_node_mapping", "check_shared_equality",
-        "add_populations", NULL };
+    static char *kwlist[] = { "other", "other_node_mapping", "all_edges",
+        "all_mutations", "check_shared_equality", "add_populations", NULL };
 
     if (TableCollection_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O|ii", kwlist, &TableCollectionType,
-            &other, &other_node_mapping, &check_shared, &add_populations)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O|iiii", kwlist,
+            &TableCollectionType, &other, &other_node_mapping, &check_shared,
+            &add_populations)) {
         goto out;
     }
     nmap_array = (PyArrayObject *) PyArray_FROMANY(
@@ -7091,6 +7094,12 @@ TableCollection_union(TableCollection *self, PyObject *args, PyObject *kwds)
             "The length of the node mapping array should be equal to the"
             " number of nodes in the other tree sequence.");
         goto out;
+    }
+    if (all_edges) {
+        options |= TSK_UNION_ALL_EDGES;
+    }
+    if (all_mutations) {
+        options |= TSK_UNION_ALL_MUTATIONS;
     }
     if (!check_shared) {
         options |= TSK_UNION_NO_CHECK_SHARED;

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -4181,6 +4181,8 @@ class TableCollection(metadata.MetadataProvider):
         self,
         other,
         node_mapping,
+        all_edges=False,
+        all_mutations=False,
         check_shared_equality=True,
         add_populations=True,
         record_provenance=True,
@@ -4199,6 +4201,10 @@ class TableCollection(metadata.MetadataProvider):
             should be the index of the equivalent node in ``self``, or
             ``tskit.NULL`` if the node is not present in ``self`` (in which case it
             will be added to self).
+        :param bool all_edges: If True, then all edges in ``other`` are added
+            to ``self``. Must have ``check_shared_equality=False``.
+        :param bool all_mutations: If True, then all mutations in ``other`` are added
+            to ``self``. Must have ``check_shared_equality=False``.
         :param bool check_shared_equality: If True, the shared portions of the
             table collections will be checked for equality.
         :param bool add_populations: If True, nodes new to ``self`` will be
@@ -4210,6 +4216,8 @@ class TableCollection(metadata.MetadataProvider):
         self._ll_tables.union(
             other._ll_tables,
             node_mapping,
+            all_edges=all_edges,
+            all_mutations=all_mutations,
             check_shared_equality=check_shared_equality,
             add_populations=add_populations,
         )

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -7466,6 +7466,8 @@ class TreeSequence:
         self,
         other,
         node_mapping,
+        all_edges=False,
+        all_mutations=False,
         check_shared_equality=True,
         add_populations=True,
         record_provenance=True,
@@ -7513,6 +7515,10 @@ class TreeSequence:
         :param TableCollection other: Another table collection.
         :param list node_mapping: An array of node IDs that relate nodes in
             ``other`` to nodes in ``self``.
+        :param bool all_edges: If True, then all edges in ``other`` are added
+            to ``self``. Must have ``check_shared_equality=False``.
+        :param bool all_mutations: If True, then all mutations in ``other`` are added
+            to ``self``. Must have ``check_shared_equality=False``.
         :param bool check_shared_equality: If True, the shared portions of the
             tree sequences will be checked for equality. It does so by
             running :meth:`TreeSequence.subset` on both ``self`` and ``other``
@@ -7528,6 +7534,8 @@ class TreeSequence:
         tables.union(
             other_tables,
             node_mapping,
+            all_edges=all_edges,
+            all_mutations=all_mutations,
             check_shared_equality=check_shared_equality,
             add_populations=add_populations,
             record_provenance=record_provenance,


### PR DESCRIPTION
Here's the start at what we discussed in #3183. Might you have a go at putting in the python tests, @hyanwong?

Something I haven't done that we said we might in the other PR is require that if `all_edges` or `all_mutations` are True then `check_shared_overlap` is False. I don't think we actually need to require this (since in some cases all three might be true and it's fine!) but we should probably say in the docstring that the user probably *wants* this to be the case. (I just don't remember why that is right now.)

Still TODO:
- [ ] python tests
- [ ] CHANGELOG
- [ ] say something about checking shared overlap in the docs