### PR TITLE
Add isolated_as_missing to ts.alignements

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,5 +1,5 @@
 ----------------------
-[1.0.0b1] - 2025-09-24
+[1.0.0b2] - 2025-XX-XX
 ----------------------
 
 **Breaking Changes**
@@ -20,6 +20,11 @@
 
 - ``draw_svg()`` methods now associate tree branches with edge IDs
   (:user:`hyanwong`, :pr:`3193`, :issue:`557`)
+
+- ``TreeSequence.alignments`` now accepts ``isolated_as_missing=False`` so that
+  alignments can be emitted for non-sample nodes (e.g., internal ARG nodes) when
+  missing data are imputed to the ancestral state. Full missing-data support
+  remains tracked in :issue:`1896`. (:user:`benjeffery`, :issue:`3293`)
 
 - ``draw_svg()`` methods now allow the y-axis to be placed on the right-hand side
   using ``y_axis="right"`` (:user:`hyanwong`, :pr:`3201`)

--- a/python/tests/test_genotypes.py
+++ b/python/tests/test_genotypes.py
@@ -1286,6 +1286,22 @@ class TestBinaryTreeExample:
         with pytest.raises(tskit.LibraryError, match="MUST_IMPUTE_NON_SAMPLES"):
             list(ts.alignments(samples=[4]))
 
+    def test_internal_nodes_with_imputation(self):
+        ts = self.ts()
+        internal = [u for u in range(ts.num_nodes) if u not in set(ts.samples())]
+        seqs = list(ts.alignments(samples=internal, isolated_as_missing=False))
+        assert seqs == ["NNANNNNNNC", "NNANNNNNNT"]
+
+    def test_internal_and_sample_nodes_with_imputation(self):
+        ts = self.ts()
+        samples = ts.samples()
+        internal = next(u for u in range(ts.num_nodes) if u not in set(samples))
+        seqs = list(
+            ts.alignments(samples=[internal, samples[0]], isolated_as_missing=False)
+        )
+        assert seqs[0] == "NNANNNNNNC"
+        assert seqs[1] == "NNGNNNNNNT"
+
     def test_alignments_missing_data_char(self):
         A = list(self.ts().alignments(missing_data_character="x"))
         assert A[0] == "xxGxxxxxxT"


### PR DESCRIPTION
Fixes #3293 

This seemed to be quite straight-forward? Maybe when we added `isolated_as_missing` we just didn't apply it to `alignements`?