### PR TITLE
Add link-ancestors to TreeSequence and ImmutableTableCollection

### DIFF
--- a/python/tests/test_immutable_table_collection.py
+++ b/python/tests/test_immutable_table_collection.py
@@ -128,6 +128,27 @@ class TestCollectionParity:
         s = str(immutable)
         assert "ImmutableTableCollection" in s
 
+    def test_link_ancestors_parity(self, ts):
+        # Can't link ancestors when edges have metadata.
+        if ts.tables.edges.metadata_schema != tskit.MetadataSchema(schema=None):
+            pytest.skip("link_ancestors does not support edges with metadata")
+
+        mutable, immutable = get_mutable_and_immutable(ts)
+        samples = ts.samples()
+        if len(samples) == 0:
+            pytest.skip("Tree sequence has no samples")
+
+        ancestor_nodes = [u.id for u in ts.nodes() if not u.is_sample()]
+        if len(ancestor_nodes) == 0:
+            ancestor_nodes = list(samples)
+
+        samples = samples[: min(len(samples), 10)]
+        ancestors = ancestor_nodes[: min(len(ancestor_nodes), 10)]
+
+        mutable_result = mutable.link_ancestors(samples, ancestors)
+        immutable_result = immutable.link_ancestors(samples, ancestors)
+        assert mutable_result == immutable_result
+
 
 @pytest.mark.parametrize("ts", tsutil.get_example_tree_sequences())
 class TestTablesParity:

--- a/python/tests/test_topology.py
+++ b/python/tests/test_topology.py
@@ -4901,6 +4901,10 @@ class TestMapToAncestors:
         if compare_lib:
             lib_result = ts.dump_tables().link_ancestors(samples, ancestors)
             assert ancestor_table == lib_result
+            ts_result = ts.link_ancestors(samples, ancestors)
+            assert ancestor_table == ts_result
+            tables_result = ts.tables.link_ancestors(samples, ancestors)
+            assert ancestor_table == tables_result
         return ancestor_table
 
     def test_deprecated_name(self):
@@ -4914,6 +4918,10 @@ class TestMapToAncestors:
         tss = s.link_ancestors()
         lib_result = ts.dump_tables().map_ancestors(samples, ancestors)
         assert tss == lib_result
+        ts_result = ts.link_ancestors(samples, ancestors)
+        assert tss == ts_result
+        immutable_result = ts.tables.map_ancestors(samples, ancestors)
+        assert tss == immutable_result
         assert list(tss.parent) == [8, 8, 8, 8, 8]
         assert list(tss.child) == [0, 1, 2, 3, 4]
         assert all(tss.left) == 0

--- a/python/tskit/tables.py
+++ b/python/tskit/tables.py
@@ -4780,6 +4780,21 @@ class ImmutableTableCollection(metadata.MetadataProvider):
             ]
         )
 
+    def link_ancestors(self, samples, ancestors):
+        """
+        See :meth:`TableCollection.link_ancestors`.
+        """
+        samples = util.safe_np_int_cast(samples, np.int32)
+        ancestors = util.safe_np_int_cast(ancestors, np.int32)
+        ll_edge_table = self._llts.link_ancestors(samples, ancestors)
+        return EdgeTable(ll_table=ll_edge_table)
+
+    def map_ancestors(self, *args, **kwargs):
+        """
+        Deprecated alias for :meth:`link_ancestors`.
+        """
+        return self.link_ancestors(*args, **kwargs)
+
     _MUTATOR_METHODS = {
         "clear",
         "sort",
@@ -4803,8 +4818,6 @@ class ImmutableTableCollection(metadata.MetadataProvider):
         "ibd_segments",
         "fromdict",
         "simplify",
-        "link_ancestors",
-        "map_ancestors",
     }
 
     def copy(self):

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4393,6 +4393,22 @@ class TreeSequence:
         self._ll_tree_sequence.dump_tables(ll_tables)
         return tables.TableCollection(ll_tables=ll_tables)
 
+    def link_ancestors(self, samples, ancestors):
+        """
+        Equivalent to :meth:`TableCollection.link_ancestors`; see that method for full
+        documentation and parameter semantics.
+
+        :param list[int] samples: Node IDs to retain as samples.
+        :param list[int] ancestors: Node IDs to treat as ancestors.
+        :return: An :class:`tables.EdgeTable` containing the genealogical links between
+            the supplied ``samples`` and ``ancestors``.
+        :rtype: tables.EdgeTable
+        """
+        samples = util.safe_np_int_cast(samples, np.int32)
+        ancestors = util.safe_np_int_cast(ancestors, np.int32)
+        ll_edge_table = self._ll_tree_sequence.link_ancestors(samples, ancestors)
+        return tables.EdgeTable(ll_table=ll_edge_table)
+
     def dump_text(
         self,
         nodes=None,


### PR DESCRIPTION
Fixes #3311 
As this method doesn't mutate tables - shouldn't it be on `TreeSequence` and `ImmutableTC`?