### PR TITLE
Show metadata size

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -8,6 +8,11 @@
   ID is e.g. a population name, rather than silently returning no samples.
   (:user:`hyanwong`, :pr:`3344`)
 
+**Features**
+
+- Displaying a summary of the tree sequence now shows the metadata codec and
+  size of the metadata for each table. (:user:`hyanwong`, :pr:`3343`, :issue:`2637`)
+
 --------------------
 [1.0.0] - 2025-11-27
 --------------------

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -4476,7 +4476,7 @@ class TreeSequence:
             ["Sample Nodes", util.format_number(self.num_samples, sep=",")],
             ["Total Size", util.naturalsize(self.nbytes)],
         ]
-        header = ["Table", "Rows", "Size", "Has Metadata"]
+        header = ["Table", "Rows", "Size", "Metadata", "Metadata size"]
         table_rows = []
         for name, table in self.tables.table_name_map.items():
             table_rows.append(
@@ -4484,11 +4484,8 @@ class TreeSequence:
                     name.capitalize(),
                     f"{util.format_number(table.num_rows, sep=',')}",
                     util.naturalsize(table.nbytes),
-                    (
-                        "Yes"
-                        if hasattr(table, "metadata") and len(table.metadata) > 0
-                        else "No"
-                    ),
+                    util.metadata_codec(table),
+                    util.metadata_size(table),
                 ]
             )
         return util.unicode_table(ts_rows, title="TreeSequence") + util.unicode_table(

--- a/python/tskit/util.py
+++ b/python/tskit/util.py
@@ -534,6 +534,20 @@ def html_table(rows, *, header):
     """
 
 
+def metadata_codec(table):
+    if hasattr(table, "metadata_schema"):
+        schema = table.metadata_schema.schema
+        return "raw" if schema is None else schema.get("codec", "unknown")
+    return ""
+
+
+def metadata_size(table):
+    if hasattr(table, "metadata"):
+        frac = len(table.metadata) / table.nbytes
+        return f"{naturalsize(len(table.metadata))} ({frac:.0%})"
+    return ""
+
+
 def tree_sequence_html(ts):
     table_rows = "".join(
         f"""
@@ -541,10 +555,8 @@ def tree_sequence_html(ts):
                 <td>{name.capitalize()}</td>
                 <td>{format_number(table.num_rows)}</td>
                 <td>{naturalsize(table.nbytes)}</td>
-                <td style="text-align: center;">
-                    {'✅' if hasattr(table, "metadata") and len(table.metadata) > 0
-                     else ''}
-                </td>
+                <td style="text-align: center;">{metadata_codec(table)}</td>
+                <td>{metadata_size(table)}</td>
             </tr>
         """
         for name, table in ts.tables.table_name_map.items()
@@ -637,7 +649,8 @@ def tree_sequence_html(ts):
                                 <th style="line-height:21px;">Table</th>
                                 <th>Rows</th>
                                 <th>Size</th>
-                                <th>Has Metadata</th>
+                                <th>Metadata</th>
+                                <th>Metadata size</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Fixes https://github.com/tskit-dev/tskit/issues/2637 - I remembered this issue when writing some recent tutorial material.

I went for the absolute size rather than percentage, and simply appended the codec type, rather than having a separate column, as it seems simpler:

I will add tests if this seems like the right format:

<img width="653" height="675" alt="Screenshot 2025-11-28 at 21 06 21" src="https://github.com/user-attachments/assets/3c74532e-7231-429d-bdad-f2f56e04ff92" />
