### PR TITLE
Raise error if pop passed to samples is not an integer

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -1,4 +1,14 @@
 --------------------
+[1.0.x] - YYYY-MM-DD
+--------------------
+
+**Bugfixes**
+
+- ``ts.samples(population=...)`` now raises a ``ValueError`` if the population
+  ID is e.g. a population name, rather than silently returning no samples.
+  (:user:`hyanwong`, :pr:`3344`)
+
+--------------------
 [1.0.0] - 2025-11-27
 --------------------
 

--- a/python/tests/test_highlevel.py
+++ b/python/tests/test_highlevel.py
@@ -992,6 +992,17 @@ class TestNumpySamples:
             ]
         assert total == ts.num_samples
 
+    @pytest.mark.parametrize("pop", ["string", "", "0", np.arange(2), 0.0, 0.5, np.nan])
+    def test_bad_samples(self, pop):
+        ts = tskit.Tree.generate_balanced(4).tree_sequence
+        with pytest.raises(ValueError, match="must be an integer ID"):
+            ts.samples(population=pop)
+
+    @pytest.mark.parametrize("pop", [0, np.int32(0), np.int64(0), np.uint32(0)])
+    def test_good_samples(self, pop):
+        ts = msprime.sim_ancestry(2)
+        assert np.array_equiv(ts.samples(population=pop), ts.samples())
+
     @pytest.mark.parametrize("time", [0, 0.1, 1 / 3, 1 / 4, 5 / 7])
     def test_samples_time(self, time):
         ts = self.get_tree_sequence(num_demes=2, n=20, times=[time, 0.2, 1, 15])

--- a/python/tskit/trees.py
+++ b/python/tskit/trees.py
@@ -6533,6 +6533,9 @@ class TreeSequence:
         samples = self._ll_tree_sequence.get_samples()
         keep = np.full(shape=samples.shape, fill_value=True)
         if population is not None:
+            if not isinstance(population, numbers.Integral):
+                raise ValueError("`population` must be an integer ID")
+            population = int(population)
             sample_population = self.nodes_population[samples]
             keep = np.logical_and(keep, sample_population == population)
         if time is not None:


### PR DESCRIPTION
## Description

This has bugged me for ages: you can do `ts.samples(population="AFR")` without raising an error, although the `population` param is required to be an integer (so that snippet will always return an empty array)

I thought using `int` was the simplest way to check, as it avoids `isinstance(population, string)` or equivalent, and will deal with arrays etc, but it does allow `ts.samples(population="0")`, which maybe we don't want?

# PR Checklist:

- [x] Tests that fully cover new/changed functionality.
- [ ] Documentation including tutorial content if appropriate.
- [x] Changelogs, if there are API changes.
