### PR TITLE
Metadata samples

### DIFF
--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -2,6 +2,11 @@
 [1.0.x] - YYYY-MM-DD
 --------------------
 
+**Features**
+
+- ``ts.samples(population=...)`` now accepts dictionaries to filter samples
+  by population metadata. (:user:`hyanwong`, :issue:`1697` :pr:`3345`)
+
 **Bugfixes**
 
 - ``ts.samples(population=...)`` now raises a ``ValueError`` if the population


### PR DESCRIPTION
While fixing #3344 I thought I might as well address this long standing issue (which is still open). This allows 

```python
samples = ts.samples(population={"name": "pop_0"})
# or shorten to
samples = ts.samples({"name": "pop_0"})
```

It doesn't promote "name" (or any other metadata key) to any special status, but simply matches the passed in dictionary against the metadata for each population, which seems neater to me than having to define special metadata fields. So you can equally do:

```python
samples = ts.samples(population={"description": "Population zero"})
```

(Fixes https://github.com/tskit-dev/tskit/issues/1697)