### PR TITLE
Fix return doc typo for file uuid function

### DIFF
--- a/c/tskit/trees.h
+++ b/c/tskit/trees.h
@@ -663,7 +663,7 @@ sequence.
 @endrst
 
 @param self A pointer to a tsk_treeseq_t object.
-@return Returns a pointer to the time units.
+@return Returns a pointer to the null-terminated file uuid.
 */
 const char *tsk_treeseq_get_file_uuid(const tsk_treeseq_t *self);
 


### PR DESCRIPTION
Fix typo for tsk_treeseq_get_file_uuid function.

Spotted this one when looking at what getters are available