### PR TITLE
remove consts from tsk_json_struct_metadata_get_blob (closes #3425)

### DIFF
--- a/c/tests/test_core.c
+++ b/c/tests/test_core.c
@@ -101,9 +101,9 @@ test_json_struct_metadata_get_blob(void)
 {
     int ret;
     char metadata[128];
-    const char *json;
+    char *json;
     tsk_size_t json_buffer_length;
-    const char *blob;
+    char *blob;
     tsk_size_t blob_length;
     uint8_t *bytes;
     tsk_size_t metadata_length;
@@ -111,9 +111,9 @@ test_json_struct_metadata_get_blob(void)
     size_t json_length;
     size_t payload_length;
     size_t total_length;
-    const char json_payload[] = "{\"a\":1}";
-    const uint8_t binary_payload[] = { 0x01, 0x02, 0x03, 0x04 };
-    const uint8_t empty_payload[] = { 0 };
+    char json_payload[] = "{\"a\":1}";
+    uint8_t binary_payload[] = { 0x01, 0x02, 0x03, 0x04 };
+    uint8_t empty_payload[] = { 0 };
 
     bytes = (uint8_t *) metadata;
     header_length = 4 + 1 + 8 + 8;
@@ -135,7 +135,7 @@ test_json_struct_metadata_get_blob(void)
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_PTR_EQUAL(json, (const char *) bytes + header_length);
+    CU_ASSERT_PTR_EQUAL(json, (char *) bytes + header_length);
     CU_ASSERT_EQUAL(json_buffer_length, (tsk_size_t) json_length);
     if (json_length > 0) {
         CU_ASSERT_EQUAL(memcmp(json, json_payload, json_length), 0);
@@ -152,7 +152,7 @@ test_json_struct_metadata_get_blob(void)
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_PTR_EQUAL(json, (const char *) bytes + header_length);
+    CU_ASSERT_PTR_EQUAL(json, (char *) bytes + header_length);
     CU_ASSERT_EQUAL(json_buffer_length, (tsk_size_t) json_length);
     CU_ASSERT_EQUAL(blob_length, (tsk_size_t) payload_length);
     CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length);
@@ -168,7 +168,7 @@ test_json_struct_metadata_get_blob(void)
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_PTR_EQUAL(json, (const char *) bytes + header_length);
+    CU_ASSERT_PTR_EQUAL(json, (char *) bytes + header_length);
     CU_ASSERT_EQUAL(json_buffer_length, (tsk_size_t) json_length);
     CU_ASSERT_EQUAL(blob_length, (tsk_size_t) payload_length);
     CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length);

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -142,9 +142,8 @@ out:
 }
 
 int
-tsk_json_struct_metadata_get_blob(const char *metadata, tsk_size_t metadata_length,
-    const char **json, tsk_size_t *json_length, const char **blob,
-    tsk_size_t *blob_length)
+tsk_json_struct_metadata_get_blob(char *metadata, tsk_size_t metadata_length,
+    char **json, tsk_size_t *json_length, char **blob, tsk_size_t *blob_length)
 {
     int ret;
     uint8_t version;
@@ -152,16 +151,16 @@ tsk_json_struct_metadata_get_blob(const char *metadata, tsk_size_t metadata_leng
     uint64_t binary_length_u64;
     uint64_t header_and_json_length;
     uint64_t total_length;
-    const uint8_t *bytes;
-    const char *blob_start;
-    const char *json_start;
+    uint8_t *bytes;
+    char *blob_start;
+    char *json_start;
 
     if (metadata == NULL || json == NULL || json_length == NULL || blob == NULL
         || blob_length == NULL) {
         ret = tsk_trace_error(TSK_ERR_BAD_PARAM_VALUE);
         goto out;
     }
-    bytes = (const uint8_t *) metadata;
+    bytes = (uint8_t *) metadata;
     if (metadata_length < TSK_JSON_BINARY_HEADER_SIZE) {
         ret = tsk_trace_error(TSK_ERR_JSON_STRUCT_METADATA_TRUNCATED);
         goto out;
@@ -191,8 +190,8 @@ tsk_json_struct_metadata_get_blob(const char *metadata, tsk_size_t metadata_leng
         ret = tsk_trace_error(TSK_ERR_JSON_STRUCT_METADATA_TRUNCATED);
         goto out;
     }
-    json_start = (const char *) bytes + TSK_JSON_BINARY_HEADER_SIZE;
-    blob_start = (const char *) bytes + TSK_JSON_BINARY_HEADER_SIZE + json_length_u64;
+    json_start = (char *) bytes + TSK_JSON_BINARY_HEADER_SIZE;
+    blob_start = (char *) bytes + TSK_JSON_BINARY_HEADER_SIZE + json_length_u64;
     *json = json_start;
     *json_length = (tsk_size_t) json_length_u64;
     *blob = blob_start;

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -1153,9 +1153,8 @@ the original metadata buffer is alive.
 @param[out] blob_length On success, set to the payload length in bytes.
 @return Return 0 on success or a negative value on failure.
 */
-int tsk_json_struct_metadata_get_blob(const char *metadata, tsk_size_t metadata_length,
-    const char **json, tsk_size_t *json_length, const char **blob,
-    tsk_size_t *blob_length);
+int tsk_json_struct_metadata_get_blob(char *metadata, tsk_size_t metadata_length,
+    char **json, tsk_size_t *json_length, char **blob, tsk_size_t *blob_length);
 
 /* TODO most of these can probably be macros so they compile out as no-ops.
  * Lets do the 64 bit tsk_size_t switch first though. */


### PR DESCRIPTION
As discussed in #3425, it is maybe helpful to remove the `const` from some of the arguments to [`tsk_json_struct_metadata_get_blob`](https://github.com/tskit-dev/tskit/blob/1835ea3bbb51e4b5dff698dcae43c917873c73bc/c/tskit/core.c#L145).

My superficial understanding of the issue is as follows: suppose you have a function that accepts a pointer, say `*blob`, and doesn't modify the stuff that pointer points at. Then it's fine to define your function to accept `const foo *blob` but then pass it in a non-const `foo *blob` from somewhere else, since `const` is supposed to mean "we don't change this *here*" not "we don't change this *anywhere*".  **However** if it takes a pointer-to-a-pointer, say `const foo **blob` then [there are ways](https://isocpp.org/wiki/faq/const-correctness#constptrptr-conversion) that you'd actually be able to modify the contents being ultimately pointed at without, like, noticing. So it is *not* cool to pass in `foo **blob`.

So, I agree - seems like we should indeed remove the `const`.

According to [this page](https://isocpp.org/wiki/faq/const-correctness#constptrptr-conversion) the "most common solution" is to declare it like `const foo* const *blob`; however, I *think* this means you can't change the pointer `*blob` either and we do indeed need to do that in this function. And I tried it and it doesn't seem to work.

So here I've removed the `const` from `**blob`. This meant I also needed to remove `const` from `**json` *and* `*metadata`, since these are all pointing at the same chunk of memory.