### PR TITLE
Json struct alignment

### DIFF
--- a/c/tests/test_core.c
+++ b/c/tests/test_core.c
@@ -109,6 +109,7 @@ test_json_struct_metadata_get_blob(void)
     tsk_size_t metadata_length;
     size_t header_length;
     size_t json_length;
+    size_t padding_length;
     size_t payload_length;
     size_t total_length;
     char json_payload[] = "{\"a\":1}";
@@ -118,8 +119,9 @@ test_json_struct_metadata_get_blob(void)
     bytes = (uint8_t *) metadata;
     header_length = 4 + 1 + 8 + 8;
     json_length = strlen(json_payload);
+    padding_length = (8 - ((header_length + json_length) & 0x07)) % 8;
     payload_length = sizeof(binary_payload);
-    total_length = header_length + json_length + payload_length;
+    total_length = header_length + json_length + padding_length + payload_length;
     CU_ASSERT_FATAL(total_length <= sizeof(metadata));
     memset(metadata, 0, sizeof(metadata));
     bytes[0] = 'J';
@@ -130,40 +132,49 @@ test_json_struct_metadata_get_blob(void)
     set_u64_le(bytes + 5, (uint64_t) json_length);
     set_u64_le(bytes + 13, (uint64_t) payload_length);
     memcpy(bytes + header_length, json_payload, json_length);
-    memcpy(bytes + header_length + json_length, binary_payload, payload_length);
+    memset(bytes + header_length + json_length, 0, padding_length);
+    memcpy(bytes + header_length + json_length + padding_length, binary_payload,
+        payload_length);
     metadata_length = (tsk_size_t) total_length;
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_PTR_EQUAL(json, (char *) bytes + header_length);
+    CU_ASSERT_EQUAL(json + json_buffer_length + padding_length, blob);
     CU_ASSERT_EQUAL(json_buffer_length, (tsk_size_t) json_length);
     if (json_length > 0) {
         CU_ASSERT_EQUAL(memcmp(json, json_payload, json_length), 0);
     }
-    CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length);
+    CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length + padding_length);
     CU_ASSERT_EQUAL(blob_length, (tsk_size_t) payload_length);
     CU_ASSERT_EQUAL(memcmp(blob, binary_payload, payload_length), 0);
+    CU_ASSERT((tsk_size_t) (blob - json) < json_buffer_length + 8);
 
     payload_length = 0;
-    total_length = header_length + json_length + payload_length;
+    total_length = header_length + json_length + padding_length + payload_length;
     CU_ASSERT_FATAL(total_length <= sizeof(metadata));
     set_u64_le(bytes + 13, (uint64_t) payload_length);
     metadata_length = (tsk_size_t) total_length;
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
     CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(json + json_buffer_length + padding_length, blob);
     CU_ASSERT_PTR_EQUAL(json, (char *) bytes + header_length);
     CU_ASSERT_EQUAL(json_buffer_length, (tsk_size_t) json_length);
     CU_ASSERT_EQUAL(blob_length, (tsk_size_t) payload_length);
-    CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length);
+    CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length + padding_length);
+    CU_ASSERT((tsk_size_t) (blob - json) < json_buffer_length + 8);
 
     json_length = 0;
     payload_length = sizeof(empty_payload);
-    total_length = header_length + json_length + payload_length;
+    padding_length = (8 - ((header_length + json_length) & 0x07)) % 8;
+    total_length = header_length + json_length + padding_length + payload_length;
     CU_ASSERT_FATAL(total_length <= sizeof(metadata));
     set_u64_le(bytes + 5, (uint64_t) json_length);
     set_u64_le(bytes + 13, (uint64_t) payload_length);
-    memcpy(bytes + header_length + json_length, empty_payload, payload_length);
+    memset(bytes + header_length + json_length, 0, padding_length);
+    memcpy(bytes + header_length + json_length + padding_length, empty_payload,
+        payload_length);
     metadata_length = (tsk_size_t) total_length;
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
@@ -171,13 +182,14 @@ test_json_struct_metadata_get_blob(void)
     CU_ASSERT_PTR_EQUAL(json, (char *) bytes + header_length);
     CU_ASSERT_EQUAL(json_buffer_length, (tsk_size_t) json_length);
     CU_ASSERT_EQUAL(blob_length, (tsk_size_t) payload_length);
-    CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length);
+    CU_ASSERT_PTR_EQUAL(blob, bytes + header_length + json_length + padding_length);
     CU_ASSERT_EQUAL(memcmp(blob, empty_payload, payload_length), 0);
+    CU_ASSERT((tsk_size_t) (blob - json) < json_buffer_length + 8);
 
     blob = NULL;
     blob_length = 0;
     json = NULL;
-    json_buffer_length = 0;
+    json_length = 0;
     metadata_length = header_length - 1;
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
@@ -196,7 +208,19 @@ test_json_struct_metadata_get_blob(void)
     CU_ASSERT_EQUAL(ret, TSK_ERR_JSON_STRUCT_METADATA_BAD_VERSION);
     bytes[4] = 1;
 
-    metadata_length = (tsk_size_t) (total_length - 1);
+    set_u64_le(bytes + 5, (uint64_t) json_length + 9);
+    ret = tsk_json_struct_metadata_get_blob(
+        metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
+    CU_ASSERT_EQUAL(ret, TSK_ERR_JSON_STRUCT_METADATA_UNEXPECTED_SIZE);
+    set_u64_le(bytes + 5, (uint64_t) json_length);
+
+    bytes[header_length + 1] = 1;
+    ret = tsk_json_struct_metadata_get_blob(
+        metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
+    CU_ASSERT_EQUAL(ret, TSK_ERR_JSON_STRUCT_METADATA_NONZERO_PADDING);
+    bytes[header_length + 1] = 0;
+
+    metadata_length = (tsk_size_t) (header_length - 1);
     ret = tsk_json_struct_metadata_get_blob(
         metadata, metadata_length, &json, &json_buffer_length, &blob, &blob_length);
     CU_ASSERT_EQUAL(ret, TSK_ERR_JSON_STRUCT_METADATA_TRUNCATED);

--- a/c/tskit/core.c
+++ b/c/tskit/core.c
@@ -150,10 +150,13 @@ tsk_json_struct_metadata_get_blob(char *metadata, tsk_size_t metadata_length,
     uint64_t json_length_u64;
     uint64_t binary_length_u64;
     uint64_t header_and_json_length;
+    uint64_t padding_length;
+    uint64_t header_and_json_and_padding_length;
     uint64_t total_length;
     uint8_t *bytes;
-    char *blob_start;
     char *json_start;
+    char *padding_start;
+    char *blob_start;
 
     if (metadata == NULL || json == NULL || json_length == NULL || blob == NULL
         || blob_length == NULL) {
@@ -181,17 +184,28 @@ tsk_json_struct_metadata_get_blob(char *metadata, tsk_size_t metadata_length,
         goto out;
     }
     header_and_json_length = (uint64_t) TSK_JSON_BINARY_HEADER_SIZE + json_length_u64;
-    if (binary_length_u64 > UINT64_MAX - header_and_json_length) {
+    padding_length = (8 - (header_and_json_length & 0x07)) % 8;
+    header_and_json_and_padding_length = header_and_json_length + padding_length;
+    if (binary_length_u64 > UINT64_MAX - header_and_json_and_padding_length) {
         ret = tsk_trace_error(TSK_ERR_JSON_STRUCT_METADATA_INVALID_LENGTH);
         goto out;
     }
-    total_length = header_and_json_length + binary_length_u64;
-    if ((uint64_t) metadata_length < total_length) {
-        ret = tsk_trace_error(TSK_ERR_JSON_STRUCT_METADATA_TRUNCATED);
+    total_length = header_and_json_and_padding_length + binary_length_u64;
+    if ((uint64_t) metadata_length != total_length) {
+        ret = tsk_trace_error(TSK_ERR_JSON_STRUCT_METADATA_UNEXPECTED_SIZE);
         goto out;
     }
+    padding_start = (char *) bytes + TSK_JSON_BINARY_HEADER_SIZE + json_length_u64;
+    for (uint64_t padding_index = 0; padding_index < padding_length; ++padding_index) {
+        // require padding bytes to be zero, for a bit more safety
+        if (*(padding_start + padding_index) != (char) 0) {
+            ret = tsk_trace_error(TSK_ERR_JSON_STRUCT_METADATA_NONZERO_PADDING);
+            goto out;
+        }
+    }
     json_start = (char *) bytes + TSK_JSON_BINARY_HEADER_SIZE;
-    blob_start = (char *) bytes + TSK_JSON_BINARY_HEADER_SIZE + json_length_u64;
+    blob_start = (char *) bytes + TSK_JSON_BINARY_HEADER_SIZE + json_length_u64
+                 + padding_length;
     *json = json_start;
     *json_length = (tsk_size_t) json_length_u64;
     *blob = blob_start;
@@ -282,6 +296,14 @@ tsk_strerror_internal(int err)
         case TSK_ERR_JSON_STRUCT_METADATA_BAD_VERSION:
             ret = "JSON binary struct metadata uses an unsupported version number. "
                   "(TSK_ERR_JSON_STRUCT_METADATA_BAD_VERSION)";
+            break;
+        case TSK_ERR_JSON_STRUCT_METADATA_UNEXPECTED_SIZE:
+            ret = "JSON binary struct metadata is not equal to the expected size. "
+                  "(TSK_ERR_JSON_STRUCT_METADATA_UNEXPECTED_SIZE)";
+            break;
+        case TSK_ERR_JSON_STRUCT_METADATA_NONZERO_PADDING:
+            ret = "JSON binary struct metadata has non-zero padding bytes between the "
+                  "JSON and struct. (TSK_ERR_JSON_STRUCT_METADATA_NONZERO_PADDING)";
             break;
 
         /* Out of bounds errors */

--- a/c/tskit/core.h
+++ b/c/tskit/core.h
@@ -329,6 +329,16 @@ A length field in the JSON binary struct metadata header is invalid.
 The JSON binary struct metadata uses an unsupported version number.
 */
 #define TSK_ERR_JSON_STRUCT_METADATA_BAD_VERSION                    -109
+
+/**
+The JSON binary struct metadata is not equal to the expected size.
+*/
+#define TSK_ERR_JSON_STRUCT_METADATA_UNEXPECTED_SIZE                -110
+
+/**
+The JSON binary struct metadata padding bytes are not zeroed.
+*/
+#define TSK_ERR_JSON_STRUCT_METADATA_NONZERO_PADDING                -111
 /** @} */
 
 /**
@@ -1136,10 +1146,11 @@ int tsk_generate_uuid(char *dest, int flags);
 @brief Extract the binary payload from ``json+struct`` encoded metadata.
 
 @rst
-Metadata produced by the JSONStructCodec consists of a fixed-size
-header followed by canonical JSON bytes and an optional binary payload. This helper
-validates the framing, returning pointers to the embedded JSON and binary sections
-without copying.
+Metadata produced by the JSONStructCodec consists of a fixed-size header followed
+by canonical JSON bytes, a variable number of padding bytes (which should be zero)
+to bring the length to a multiple of 8 bytes for alignment, and finally an optional
+binary payload. This helper validates the framing, returning pointers to the
+embedded JSON and binary sections without copying.
 
 The output pointers reference memory owned by the caller and remain valid only while
 the original metadata buffer is alive.

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -671,6 +671,51 @@ class TestJSONStructCodec:
         out = ms.decode_row(encoded)
         assert out == row
 
+    def test_blob_bytes_aligned(self):
+        # test that the portion of the encoded metadata up until the struct
+        # is 8-byte aligned; we do that in the pedantic way
+        # of figuring out how much memory is being used per int
+        # in the struct part and subtracting that off
+        def schema_with_blobs(k):
+            schema = {
+                "codec": "json+struct",
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                        "count": {"type": "number"},
+                    },
+                    "required": ["label"],
+                },
+                "struct": {
+                    "type": "object",
+                    "properties": {},
+                },
+            }
+            for j in range(k):
+                schema["struct"]["properties"][f"b{j}"] = {
+                    "type": "integer",
+                    "binaryFormat": "i",
+                }
+            return tskit.MetadataSchema(schema)
+
+        k_list = (0, 1, 2, 3)
+        schemas = [schema_with_blobs(k) for k in k_list]
+        rows = []
+        for k in k_list:
+            row = {"label": "alpha", "count": 7}
+            for j in range(k):
+                row[f"b{j}"] = j
+            rows.append(row)
+        encoded = [ms.validate_and_encode_row(row) for ms, row in zip(schemas, rows)]
+        dbytes = len(encoded[2]) - len(encoded[1])
+        assert len(encoded[3]) - len(encoded[2]) == dbytes
+        for k, en in zip(k_list, encoded):
+            assert (len(en) - k * dbytes) % 8 == 0
+        for ms, en, row in zip(schemas, encoded, rows):
+            decoded = ms.decode_row(en)
+            assert decoded == row
+
     def test_json_defaults_applied(self):
         schema = {
             "codec": "json+struct",

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -294,7 +294,8 @@ class JSONStructCodec(AbstractMetadataCodec):
         header = self._HDR.pack(
             self.MAGIC, self.VERSION, len(json_bytes), len(blob_bytes)
         )
-        return header + json_bytes + blob_bytes
+        padding_bytes = bytes((-(len(header) + len(json_bytes))) % 8)
+        return header + json_bytes + padding_bytes + blob_bytes
 
     def decode(self, encoded: bytes) -> Any:
         if len(encoded) >= self._HDR.size and encoded[:4] == self.MAGIC:
@@ -302,12 +303,16 @@ class JSONStructCodec(AbstractMetadataCodec):
             if version != self.VERSION:
                 raise ValueError("Unsupported json+struct version")
             start = self._HDR.size
-            if jlen > len(encoded) - start or blen > len(encoded) - start - jlen:
+            padding_length = (-(start + jlen)) % 8
+            if (
+                jlen > len(encoded) - start
+                or blen > len(encoded) - start - jlen - padding_length
+            ):
                 raise ValueError(
                     "Invalid json+struct payload: declared lengths exceed buffer size"
                 )
             json_bytes = encoded[start : start + jlen]
-            blob_bytes = encoded[start + jlen : start + jlen + blen]
+            blob_bytes = encoded[start + jlen : start + jlen + blen + padding_length]
             json_data = self.json_codec.decode(json_bytes)
             struct_data = self.struct_codec.decode(blob_bytes)
             overlap = set(json_data).intersection(struct_data)

--- a/python/tskit/metadata.py
+++ b/python/tskit/metadata.py
@@ -201,6 +201,12 @@ class JSONStructCodec(AbstractMetadataCodec):
     The codec expects a metadata schema with separate ``json`` and ``struct``
     subschemas and produces a single dict containing the union of the keys from
     those subschemas after decoding.
+
+    The structure of the encoded metadata is as follows: first, a fixed-size
+    header that contains the number of bytes for both ``json`` and ``struct``
+    portions; next, the json; then a variable number of zeroed padding bytes
+    that brings the length to a multiple of 8 for alignment; and finally
+    the struct-encoded binary portion.
     """
 
     MAGIC = b"JBLB"


### PR DESCRIPTION
*Edit:* This is now ready. It
- closes #3423, by (a) adding the padding bytes to the C function (`tsk_json_struct_metadata_get_blob`)
- also closes #3424, [here](https://github.com/tskit-dev/tskit/pull/3437/changes#diff-9156844acd1a9912f6b2696dc3b4b078fe5c134b483f94505338d1bad052251fR194)

This is pretty straightforward. However, I got confused along the way, basically about "why aren't the C and python code being tested against each other"; and by the end I decided that it was all okay. Keep reading if you want the explanation.

Examining #3306 I see that the python code does not use the C function (`tsk_json_struct_metadata_get_blob`) at all, so we've got no good current way to test these against each other. Options that I can think of are:

1. remove the C code entirely
2. write an entirely new class of tests that reads in python-produced tree sequence files and then parses them in C and compares to what is expected
3. write a python method that uses the C function
4. not test that the C getter and the python getter do the same thing

However, (2) and (3) are ugly. (2) would break the nice clean one-way C->python arrangment we have. And (3) would leave us with two ways of doing the same thing. This leaves us with (1) or (4).

The motivation for putting the C code in here was that it's very annoying to write and it would help client code a lot to have it available. However, the setter is arguably more useful than the getter (since one does not actually decode the metadata in C), so for (4) it seems we'd still want to additionally write the setter. So, I'm leaning towards (1), out of laziness. We could perhaps document somewhere the example setter/getter code (copied from SLiM and here respectively), to make this easy for other client code, which was the goal.

*Edit:* see below for the resolution.